### PR TITLE
adding missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "ext-ffi": "*",
     "ext-pcntl": "*",
     "symfony/console": "^5.0",
-    "php-di/php-di": "^6.1"
+    "php-di/php-di": "^6.1",
+    "ext-filter": "*"
   },
   "require-dev": {
     "ext-posix": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae33faf31d016e2ee04b31555c5573c4",
+    "content-hash": "9f56127f3785817d0c614b1f94e81ef2",
     "packages": [
         {
             "name": "jeremeamia/superclosure",
@@ -3941,9 +3941,11 @@
     "platform": {
         "php": "^7.4",
         "ext-ffi": "*",
-        "ext-pcntl": "*"
+        "ext-pcntl": "*",
+        "ext-filter": "*"
     },
     "platform-dev": {
         "ext-posix": "*"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
`ext-filter` is missing 

```
$ composer-require-checker
ComposerRequireChecker 2.1.0@0c66698d487fcb5c66cf07108e2180c818fb2e72
The following unknown symbols were found:
+---------------------+--------------------+
| unknown symbol      | guessed dependency |
+---------------------+--------------------+
| FILTER_VALIDATE_INT | ext-filter         |
| filter_var          | ext-filter         |
+---------------------+--------------------+
```