### PR TITLE
Test enhancement for assertion call and usages

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,10 +3,10 @@ name: PHP Coding Style Checker
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,10 +3,10 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,10 +3,10 @@ name: PHP Static Analysis
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 

--- a/tests/Inspector/Daemon/Dispatcher/TargetProcessListTest.php
+++ b/tests/Inspector/Daemon/Dispatcher/TargetProcessListTest.php
@@ -26,13 +26,13 @@ class TargetProcessListTest extends TestCase
         $picked[] = $target_process_list->pickOne();
         sort($picked);
         $this->assertSame([1, 2, 3], $picked);
-        $this->assertSame(null, $target_process_list->pickOne());
+        $this->assertNull($target_process_list->pickOne());
     }
 
     public function testPutOne(): void
     {
         $target_process_list = new TargetProcessList();
-        $this->assertSame(null, $target_process_list->pickOne());
+        $this->assertNull($target_process_list->pickOne());
         $target_process_list->putOne(1);
         $this->assertSame(1, $target_process_list->pickOne());
         $target_process_list->putOne(1);

--- a/tests/Inspector/Daemon/Dispatcher/WorkerPoolTest.php
+++ b/tests/Inspector/Daemon/Dispatcher/WorkerPoolTest.php
@@ -74,7 +74,7 @@ class WorkerPoolTest extends TestCase
                 $worker_pool->getFreeWorker()
             ]
         );
-        $this->assertSame(null, $worker_pool->getFreeWorker());
+        $this->assertNull($worker_pool->getFreeWorker());
     }
 
     public function testGetReadableWorker()

--- a/tests/Inspector/Daemon/Reader/Context/PhpReaderContextTest.php
+++ b/tests/Inspector/Daemon/Reader/Context/PhpReaderContextTest.php
@@ -39,8 +39,8 @@ final class PhpReaderContextTest extends TestCase
         $context->expects()->isRunning()->andReturn(true);
         $context->expects()->isRunning()->andReturn(false);
         $php_reader_context = new PhpReaderContext($context);
-        $this->assertSame(true, $php_reader_context->isRunning());
-        $this->assertSame(false, $php_reader_context->isRunning());
+        $this->assertTrue($php_reader_context->isRunning());
+        $this->assertFalse($php_reader_context->isRunning());
     }
 
     public function testSendSettings(): void

--- a/tests/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInputTest.php
@@ -36,7 +36,7 @@ class DaemonSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('threads')->andReturns(null);
         $input->expects()->getOption('target-regex')->andReturns(null);
         $this->expectException(DaemonSettingsException::class);
-        $settings = (new DaemonSettingsFromConsoleInput())->createSettings($input);
+        (new DaemonSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputThreadsNotInteger(): void
@@ -45,7 +45,7 @@ class DaemonSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('threads')->andReturns('abc');
         $input->expects()->getOption('target-regex')->andReturns(null);
         $this->expectException(DaemonSettingsException::class);
-        $settings = (new DaemonSettingsFromConsoleInput())->createSettings($input);
+        (new DaemonSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputTargetRegexNotString(): void
@@ -54,6 +54,6 @@ class DaemonSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('threads')->andReturns(null);
         $input->expects()->getOption('target-regex')->andReturns(1);
         $this->expectException(DaemonSettingsException::class);
-        $settings = (new DaemonSettingsFromConsoleInput())->createSettings($input);
+        (new DaemonSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
@@ -42,6 +42,6 @@ class GetTraceSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('depth')->andReturns('abc');
         $this->expectException(GetTraceSettingsException::class);
-        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
@@ -45,7 +45,7 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-version')->andReturns(null);
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPhpVersionNotSupported(): void
@@ -57,7 +57,7 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPhpRegexNonString(): void
@@ -69,7 +69,7 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPthreadRegexNonString(): void
@@ -81,7 +81,7 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPhpPathNonString(): void
@@ -93,7 +93,7 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-path')->andReturns(1);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPthreadPathNonString(): void
@@ -105,6 +105,6 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(1);
         $this->expectException(TargetPhpSettingsException::class);
-        $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
+        (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Inspector/Settings/TargetProcessSettings/TargetProcessSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TargetProcessSettings/TargetProcessSettingsFromConsoleInputTest.php
@@ -34,7 +34,7 @@ class TargetProcessSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('pid')->andReturns(null);
         $this->expectException(TargetProcessSettingsException::class);
-        $settings = (new TargetProcessSettingsFromConsoleInput())->createSettings($input);
+        (new TargetProcessSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputPidNotInterger(): void
@@ -42,6 +42,6 @@ class TargetProcessSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('pid')->andReturns('abc');
         $this->expectException(TargetProcessSettingsException::class);
-        $settings = (new TargetProcessSettingsFromConsoleInput())->createSettings($input);
+        (new TargetProcessSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
@@ -37,7 +37,7 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('sleep-ns')->andReturns(null);
         $input->expects()->getOption('max-retries')->andReturns(null);
-        $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputSleepNsNotInteger(): void
@@ -46,7 +46,7 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('sleep-ns')->andReturns('abc');
         $input->expects()->getOption('max-retries')->andReturns(null);
         $this->expectException(TraceLoopSettingsException::class);
-        $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputMaxRetriesNotInteger(): void
@@ -55,6 +55,6 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input->expects()->getOption('sleep-ns')->andReturns(null);
         $input->expects()->getOption('max-retries')->andReturns('abc');
         $this->expectException(TraceLoopSettingsException::class);
-        $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
@@ -131,8 +131,7 @@ class ProcessModuleSymbolReaderCreatorTest extends TestCase
         );
         $process_memory_map = new ProcessMemoryMap([]);
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $symbol_reader_creator->createModuleReaderByNameRegex(
                 1,
                 $process_memory_map,

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
@@ -113,13 +113,11 @@ class ProcessModuleSymbolReaderTest extends TestCase
             null
         );
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $process_symbol_reader->resolveAddress('test_symbol')
         );
 
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $process_symbol_reader->read('test_symbol')
         );
     }

--- a/tests/Lib/Loop/AsyncLoopMiddleware/CallableMiddlewareAsyncTest.php
+++ b/tests/Lib/Loop/AsyncLoopMiddleware/CallableMiddlewareAsyncTest.php
@@ -28,6 +28,6 @@ class CallableMiddlewareAsyncTest extends TestCase
         $result = $generator->current();
         $this->assertSame(42, $result);
         $result = $generator->send(null);
-        $this->assertSame(null, $result);
+        $this->assertNull($result);
     }
 }

--- a/tests/Lib/Loop/LoopMiddleware/CallableLoopTest.php
+++ b/tests/Lib/Loop/LoopMiddleware/CallableLoopTest.php
@@ -24,7 +24,7 @@ class CallableLoopTest extends TestCase
             $side_effect = true;
             return true;
         });
-        $this->assertSame(true, $loop->invoke());
-        $this->assertSame(true, $side_effect);
+        $this->assertTrue($loop->invoke());
+        $this->assertTrue($side_effect);
     }
 }

--- a/tests/Lib/Loop/LoopMiddleware/KeyboardCancelLoopTest.php
+++ b/tests/Lib/Loop/LoopMiddleware/KeyboardCancelLoopTest.php
@@ -33,9 +33,9 @@ class KeyboardCancelLoopTest extends TestCase
             $this->cancel_key = 'q';
             $this->keyboard_input = $keyboard_input_stream;
         })->bindTo($keyboard_cancel_loop, $keyboard_cancel_loop)();
-        $this->assertSame(true, $keyboard_cancel_loop->invoke());
+        $this->assertTrue($keyboard_cancel_loop->invoke());
         fwrite($keyboard_input_stream, 'q');
         rewind($keyboard_input_stream);
-        $this->assertSame(false, $keyboard_cancel_loop->invoke());
+        $this->assertFalse($keyboard_cancel_loop->invoke());
     }
 }

--- a/tests/Lib/Loop/LoopMiddleware/NanoSleepLoopTest.php
+++ b/tests/Lib/Loop/LoopMiddleware/NanoSleepLoopTest.php
@@ -20,12 +20,12 @@ class NanoSleepLoopTest extends TestCase
 {
     public function testReturnFalseIfChainFailed(): void
     {
-        $time = time();
+        time();
         $nano_sleep_loop = new NanoSleepMiddleware(
             0,
             new CallableMiddleware(fn () => false)
         );
-        $this->assertSame(false, $nano_sleep_loop->invoke());
+        $this->assertFalse($nano_sleep_loop->invoke());
     }
 
     public function testSleepBeforeChainInvoked(): void
@@ -47,6 +47,6 @@ class NanoSleepLoopTest extends TestCase
             0,
             new CallableMiddleware(fn () => true)
         );
-        $this->assertSame(true, $nano_sleep_loop->invoke());
+        $this->assertTrue($nano_sleep_loop->invoke());
     }
 }

--- a/tests/Lib/Loop/LoopMiddleware/RetryOnExceptionLoopTest.php
+++ b/tests/Lib/Loop/LoopMiddleware/RetryOnExceptionLoopTest.php
@@ -23,9 +23,9 @@ class RetryOnExceptionLoopTest extends TestCase
     public function testReturnIfChainReturn(): void
     {
         $loop = new RetryOnExceptionMiddleware(0, [Exception::class], new CallableMiddleware(fn () => true));
-        $this->assertSame(true, $loop->invoke());
+        $this->assertTrue($loop->invoke());
         $loop = new RetryOnExceptionMiddleware(0, [Exception::class], new CallableMiddleware(fn () => false));
-        $this->assertSame(false, $loop->invoke());
+        $this->assertFalse($loop->invoke());
     }
 
     public function testRetryIfChainThrows(): void
@@ -43,7 +43,7 @@ class RetryOnExceptionLoopTest extends TestCase
                 }
             )
         );
-        $this->assertSame(true, $loop->invoke());
+        $this->assertTrue($loop->invoke());
         $this->assertSame(2, $counter);
     }
 
@@ -62,7 +62,7 @@ class RetryOnExceptionLoopTest extends TestCase
                 }
             )
         );
-        $this->assertSame(false, $loop->invoke());
+        $this->assertFalse($loop->invoke());
         $this->assertSame(1, $counter);
     }
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ExecutorGlobalsReaderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ExecutorGlobalsReaderTest.php
@@ -33,7 +33,7 @@ class ExecutorGlobalsReaderTest extends TestCase
     /** @var resource|null */
     private $child = null;
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (!is_null($this->child)) {
             $child_status = proc_get_status($this->child);

--- a/tests/Lib/Process/MemoryMap/ProcessMemoryAreaTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessMemoryAreaTest.php
@@ -31,12 +31,12 @@ class ProcessMemoryAreaTest extends TestCase
             ),
             'test'
         );
-        $this->assertSame(false, $process_memory_area->isInRange(0x00000000));
-        $this->assertSame(false, $process_memory_area->isInRange(0x0fffffff));
-        $this->assertSame(true, $process_memory_area->isInRange(0x10000000));
-        $this->assertSame(true, $process_memory_area->isInRange(0x10000001));
-        $this->assertSame(true, $process_memory_area->isInRange(0x1fffffff));
-        $this->assertSame(true, $process_memory_area->isInRange(0x20000000));
-        $this->assertSame(false, $process_memory_area->isInRange(0x20000001));
+        $this->assertFalse($process_memory_area->isInRange(0x00000000));
+        $this->assertFalse($process_memory_area->isInRange(0x0fffffff));
+        $this->assertTrue($process_memory_area->isInRange(0x10000000));
+        $this->assertTrue($process_memory_area->isInRange(0x10000001));
+        $this->assertTrue($process_memory_area->isInRange(0x1fffffff));
+        $this->assertTrue($process_memory_area->isInRange(0x20000000));
+        $this->assertFalse($process_memory_area->isInRange(0x20000001));
     }
 }

--- a/tests/Lib/Process/MemoryMap/ProcessMemoryMapParserTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessMemoryMapParserTest.php
@@ -35,25 +35,25 @@ class ProcessMemoryMapParserTest extends TestCase
         $this->assertSame('55fd8397f000', $all[0]->end);
         $this->assertSame('00000000', $all[0]->file_offset);
         $this->assertSame('/usr/bin/php', $all[0]->name);
-        $this->assertSame(true, $all[0]->attribute->read);
-        $this->assertSame(false, $all[0]->attribute->execute);
-        $this->assertSame(false, $all[0]->attribute->write);
-        $this->assertSame(true, $all[0]->attribute->protected);
+        $this->assertTrue($all[0]->attribute->read);
+        $this->assertFalse($all[0]->attribute->execute);
+        $this->assertFalse($all[0]->attribute->write);
+        $this->assertTrue($all[0]->attribute->protected);
         $this->assertSame('55fd83a49000', $all[2]->begin);
         $this->assertSame('55fd83e94000', $all[2]->end);
         $this->assertSame('00200000', $all[2]->file_offset);
         $this->assertSame('/usr/bin/php', $all[2]->name);
-        $this->assertSame(true, $all[2]->attribute->read);
-        $this->assertSame(true, $all[2]->attribute->execute);
-        $this->assertSame(false, $all[2]->attribute->write);
-        $this->assertSame(true, $all[2]->attribute->protected);
+        $this->assertTrue($all[2]->attribute->read);
+        $this->assertTrue($all[2]->attribute->execute);
+        $this->assertFalse($all[2]->attribute->write);
+        $this->assertTrue($all[2]->attribute->protected);
         $this->assertSame('55fd84c49000', $all[4]->begin);
         $this->assertSame('55fd84c4e000', $all[4]->end);
         $this->assertSame('01200000', $all[4]->file_offset);
         $this->assertSame('/usr/bin/php', $all[4]->name);
-        $this->assertSame(true, $all[4]->attribute->read);
-        $this->assertSame(false, $all[4]->attribute->execute);
-        $this->assertSame(true, $all[4]->attribute->write);
-        $this->assertSame(true, $all[4]->attribute->protected);
+        $this->assertTrue($all[4]->attribute->read);
+        $this->assertFalse($all[4]->attribute->execute);
+        $this->assertTrue($all[4]->attribute->write);
+        $this->assertTrue($all[4]->attribute->protected);
     }
 }

--- a/tests/Lib/Process/MemoryMap/ProcessModuleMemoryMapTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessModuleMemoryMapTest.php
@@ -86,19 +86,19 @@ class ProcessModuleMemoryMapTest extends TestCase
                 $this->createProcessMemoryArea('0x30000000', '0x40000000', '0x10000000'),
             ]
         );
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x00000000));
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x00000001));
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x0fffffff));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x10000000));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x10000001));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x1fffffff));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x20000000));
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x20000001));
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x2fffffff));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x30000000));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x30000001));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x3fffffff));
-        $this->assertSame(true, $process_module_memory_map->isInRange(0x40000000));
-        $this->assertSame(false, $process_module_memory_map->isInRange(0x40000001));
+        $this->assertFalse($process_module_memory_map->isInRange(0x00000000));
+        $this->assertFalse($process_module_memory_map->isInRange(0x00000001));
+        $this->assertFalse($process_module_memory_map->isInRange(0x0fffffff));
+        $this->assertTrue($process_module_memory_map->isInRange(0x10000000));
+        $this->assertTrue($process_module_memory_map->isInRange(0x10000001));
+        $this->assertTrue($process_module_memory_map->isInRange(0x1fffffff));
+        $this->assertTrue($process_module_memory_map->isInRange(0x20000000));
+        $this->assertFalse($process_module_memory_map->isInRange(0x20000001));
+        $this->assertFalse($process_module_memory_map->isInRange(0x2fffffff));
+        $this->assertTrue($process_module_memory_map->isInRange(0x30000000));
+        $this->assertTrue($process_module_memory_map->isInRange(0x30000001));
+        $this->assertTrue($process_module_memory_map->isInRange(0x3fffffff));
+        $this->assertTrue($process_module_memory_map->isInRange(0x40000000));
+        $this->assertFalse($process_module_memory_map->isInRange(0x40000001));
     }
 }

--- a/tests/Lib/Process/ProcFileSystem/CommandLineEnumeratorTest.php
+++ b/tests/Lib/Process/ProcFileSystem/CommandLineEnumeratorTest.php
@@ -20,7 +20,7 @@ class CommandLineEnumeratorTest extends TestCase
     /** @var resource|null */
     private $child = null;
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (!is_null($this->child)) {
             $child_status = proc_get_status($this->child);

--- a/tests/Lib/Process/Search/ProcessSearcherTest.php
+++ b/tests/Lib/Process/Search/ProcessSearcherTest.php
@@ -20,7 +20,7 @@ class ProcessSearcherTest extends TestCase
     /** @var resource|null */
     private $child = null;
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (!is_null($this->child)) {
             $child_status = proc_get_status($this->child);


### PR DESCRIPTION
# Changed log

- Using the `*` to let all branch name can be triggered on GitHub Actions.
- Remove `$settings` variable because it's assigned, but not used.
- Using the `assertNull` to assert expected is `null`.
- Using the `assertFalse` to assert expected is `false`.
- Using the `assertTrue` to assert expected is `true`.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), the `setUp` method is `protected function setUp(): void` and the `tearDown` method is `protected function teaDown(): void`.