### PR TITLE
add a command line option to stop target process while reading its trace

### DIFF
--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettings.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettings.php
@@ -25,7 +25,8 @@ final class TraceLoopSettings
     public function __construct(
         public int $sleep_nano_seconds,
         public string $cancel_key,
-        public int $max_retries
+        public int $max_retries,
+        public bool $stop_process,
     ) {
     }
 }

--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsException.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsException.php
@@ -19,9 +19,11 @@ final class TraceLoopSettingsException extends InspectorSettingsException
 {
     public const SLEEP_NS_IS_NOT_INTEGER = 1;
     public const MAX_RETRY_IS_NOT_INTEGER = 2;
+    public const STOP_PROCESS_IS_NOT_BOOLEAN = 3;
 
     protected const ERRORS = [
         self::SLEEP_NS_IS_NOT_INTEGER => 'sleep-ns is not integer',
         self::MAX_RETRY_IS_NOT_INTEGER => 'max-retries is not integer',
+        self::STOP_PROCESS_IS_NOT_BOOLEAN => 'stop-process is not boolean',
     ];
 }

--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
@@ -39,6 +39,12 @@ final class TraceLoopSettingsFromConsoleInput
                 InputOption::VALUE_OPTIONAL,
                 'max retries on contiguous errors of read (default: 10)'
             )
+            ->addOption(
+                'stop-process',
+                'S',
+                InputOption::VALUE_OPTIONAL,
+                'stop the target process while reading its trace (default: off)'
+            )
         ;
     }
 
@@ -71,6 +77,22 @@ final class TraceLoopSettingsFromConsoleInput
             );
         }
 
-        return new TraceLoopSettings($sleep_nano_seconds, TraceLoopSettings::CANCEL_KEY_DEFAULT, $max_retries);
+        $stop_process = NullableCast::toString($input->getOption('stop-process'));
+        if (is_null($stop_process)) {
+            $stop_process = false;
+        }
+        $stop_process = filter_var($stop_process, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($stop_process === null) {
+            throw TraceLoopSettingsException::create(
+                TraceLoopSettingsException::STOP_PROCESS_IS_NOT_BOOLEAN
+            );
+        }
+
+        return new TraceLoopSettings(
+            $sleep_nano_seconds,
+            TraceLoopSettings::CANCEL_KEY_DEFAULT,
+            $max_retries,
+            $stop_process,
+        );
     }
 }

--- a/src/Lib/Process/ProcessStopper/ProcessStopper.php
+++ b/src/Lib/Process/ProcessStopper/ProcessStopper.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\Process\ProcessStopper;
+
+use FFI\CInteger;
+
+final class ProcessStopper
+{
+    private \FFI $ffi;
+
+    private const PTRACE_ATTACH = 16;
+    private const PTRACE_DETACH = 17;
+
+    public function __construct()
+    {
+        $this->ffi = \FFI::cdef('
+           struct user_regs_struct {
+               unsigned long r15;
+               unsigned long r14;
+               unsigned long r13;
+               unsigned long r12;
+               unsigned long bp;
+               unsigned long bx;
+               unsigned long r11;
+               unsigned long r10;
+               unsigned long r9;
+               unsigned long r8;
+               unsigned long ax;
+               unsigned long cx;
+               unsigned long dx;
+               unsigned long si;
+               unsigned long di;
+               unsigned long orig_ax;
+               unsigned long ip;
+               unsigned long cs;
+               unsigned long flags;
+               unsigned long sp;
+               unsigned long ss;
+               unsigned long fs_base;
+               unsigned long gs_base;
+               unsigned long ds;
+               unsigned long es;
+               unsigned long fs;
+               unsigned long gs;
+           };
+           typedef int pid_t;
+           enum __ptrace_request
+           {
+               PTRACE_TRACEME = 0,
+               PTRACE_PEEKTEXT = 1,
+               PTRACE_PEEKDATA = 2,
+               PTRACE_PEEKUSER = 3,
+               PTRACE_POKETEXT = 4,
+               PTRACE_POKEDATA = 5,
+               PTRACE_POKEUSER = 6,
+               PTRACE_CONT = 7,
+               PTRACE_KILL = 8,
+               PTRACE_SINGLESTEP = 9,
+               PTRACE_GETREGS = 12,
+               PTRACE_SETREGS = 13,
+               PTRACE_GETFPREGS = 14,
+               PTRACE_SETFPREGS = 15,
+               PTRACE_ATTACH = 16,
+               PTRACE_DETACH = 17,
+               PTRACE_GETFPXREGS = 18,
+               PTRACE_SETFPXREGS = 19,
+               PTRACE_SYSCALL = 24,
+               PTRACE_SETOPTIONS = 0x4200,
+               PTRACE_GETEVENTMSG = 0x4201,
+               PTRACE_GETSIGINFO = 0x4202,
+               PTRACE_SETSIGINFO = 0x4203
+           };
+           long ptrace(enum __ptrace_request request, pid_t pid, void *addr, void *data);
+           int errno;
+       ', 'libc.so.6');
+    }
+
+    public function stop(int $pid): bool
+    {
+        /** @var CInteger $zero */
+        $zero = $this->ffi->new('long');
+        $zero->cdata = 0;
+        $null = \FFI::cast('void *', $zero);
+
+        /** @var \FFI\Libc\ptrace_ffi $this->ffi */
+        $attach = $this->ffi->ptrace(self::PTRACE_ATTACH, $pid, $null, $null);
+
+        if ($attach === -1) {
+            /** @var int $errno */
+            $errno = $this->ffi->errno;
+            if ($errno) {
+                return false;
+            }
+        }
+        pcntl_waitpid($pid, $status, WUNTRACED);
+        return true;
+    }
+
+    public function resume(int $pid): void
+    {
+        /** @var CInteger $zero */
+        $zero = $this->ffi->new('long');
+        $zero->cdata = 0;
+        $null = \FFI::cast('void *', $zero);
+
+        /** @var \FFI\Libc\ptrace_ffi $this->ffi */
+        $detach = $this->ffi->ptrace(self::PTRACE_DETACH, $pid, $null, $null);
+        if ($detach === -1) {
+            /** @var int $errno */
+            $errno = $this->ffi->errno;
+            if ($errno) {
+                return;
+            }
+        }
+    }
+}

--- a/tests/Inspector/Daemon/Dispatcher/DispatchTableTest.php
+++ b/tests/Inspector/Daemon/Dispatcher/DispatchTableTest.php
@@ -38,7 +38,7 @@ class DispatchTableTest extends TestCase
         $dispatch_table = new DispatchTable(
             $worker_pool,
             new TargetPhpSettings(),
-            new TraceLoopSettings(1, 'test', 1),
+            new TraceLoopSettings(1, 'test', 1, false),
             new GetTraceSettings(1)
         );
 

--- a/tests/Inspector/Daemon/Dispatcher/WorkerPoolTest.php
+++ b/tests/Inspector/Daemon/Dispatcher/WorkerPoolTest.php
@@ -27,7 +27,7 @@ class WorkerPoolTest extends TestCase
     public function testCreate()
     {
         $php_settings = new TargetPhpSettings();
-        $trace_settings = new TraceLoopSettings(1, 'q', 1);
+        $trace_settings = new TraceLoopSettings(1, 'q', 1, false);
         $get_trace_settings = new GetTraceSettings(1);
 
         $reader_context = Mockery::mock(PhpReaderControllerInterface::class);

--- a/tests/Inspector/Daemon/Reader/Controller/PhpReaderControllerTest.php
+++ b/tests/Inspector/Daemon/Reader/Controller/PhpReaderControllerTest.php
@@ -47,7 +47,7 @@ final class PhpReaderControllerTest extends TestCase
     public function testSendSettings(): void
     {
         $target_php_settings = new TargetPhpSettings();
-        $trace_loop_settings = new TraceLoopSettings(1, 'q', 1);
+        $trace_loop_settings = new TraceLoopSettings(1, 'q', 1, false);
         $get_trace_settings = new GetTraceSettings(1);
 
         $expected = new SetSettingsMessage(

--- a/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
+++ b/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
@@ -48,7 +48,7 @@ class PhpReaderEntryPointTest extends TestCase
                     $this->assertEquals(
                         [
                             new TargetProcessSettings(123),
-                            new TraceLoopSettings(1, 'q', 10),
+                            new TraceLoopSettings(1, 'q', 10, false),
                             new TargetPhpSettings(),
                             new GetTraceSettings(PHP_INT_MAX),
                         ],
@@ -111,7 +111,7 @@ class PhpReaderEntryPointTest extends TestCase
         $promise = $generator->send(
             new SetSettingsMessage(
                 new TargetPhpSettings(),
-                new TraceLoopSettings(1, 'q', 10),
+                new TraceLoopSettings(1, 'q', 10, false),
                 new GetTraceSettings(PHP_INT_MAX)
             )
         );

--- a/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
@@ -24,12 +24,14 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('sleep-ns')->andReturns(20000000);
         $input->expects()->getOption('max-retries')->andReturns(20);
+        $input->expects()->getOption('stop-process')->andReturns('off');
 
         $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
 
         $this->assertSame(20000000, $settings->sleep_nano_seconds);
         $this->assertSame(20, $settings->max_retries);
         $this->assertSame('q', $settings->cancel_key);
+        $this->assertSame(false, $settings->stop_process);
     }
 
     public function testFromConsoleInputDefault(): void
@@ -37,6 +39,7 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('sleep-ns')->andReturns(null);
         $input->expects()->getOption('max-retries')->andReturns(null);
+        $input->expects()->getOption('stop-process')->andReturns(null);
         (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }
 
@@ -45,6 +48,7 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('sleep-ns')->andReturns('abc');
         $input->expects()->getOption('max-retries')->andReturns(null);
+        $input->expects()->getOption('stop-process')->andReturns(null);
         $this->expectException(TraceLoopSettingsException::class);
         (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }
@@ -54,6 +58,17 @@ class TraceLoopSettingsFromConsoleInputTest extends TestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('sleep-ns')->andReturns(null);
         $input->expects()->getOption('max-retries')->andReturns('abc');
+        $input->expects()->getOption('stop-process')->andReturns(null);
+        $this->expectException(TraceLoopSettingsException::class);
+        (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputStopProcessNotBoolean(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('sleep-ns')->andReturns(null);
+        $input->expects()->getOption('max-retries')->andReturns(null);
+        $input->expects()->getOption('stop-process')->andReturns('abc');
         $this->expectException(TraceLoopSettingsException::class);
         (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
     }


### PR DESCRIPTION
- Related to #27 and #30
- Use this via `--stop-process` or `-S` as the following
```
php ./php-profiler inspector:daemon -P "regex_to_find_the_target" --template=phpspy_with_opcode --stop-process=on
php ./php-profiler inspector:trace -p <target_pid> --template=phpspy_with_opcode -S=on
```
- Equivalent of `-S` in phpspy
- Without stopping the target process, it will be difficult to get accurate traces because the state of the target process will change fast while the trace is being read. 