### PR TITLE
Automatically detect the PHP version of the target

### DIFF
--- a/src/Command/Inspector/GetCurrentFunctionNameCommand.php
+++ b/src/Command/Inspector/GetCurrentFunctionNameCommand.php
@@ -24,6 +24,7 @@ use PhpProfiler\Lib\Elf\Parser\ElfParserException;
 use PhpProfiler\Lib\Elf\Process\ProcessSymbolReaderException;
 use PhpProfiler\Lib\Elf\Tls\TlsFinderException;
 use PhpProfiler\Lib\PhpProcessReader\PhpGlobalsFinder;
+use PhpProfiler\Lib\PhpProcessReader\PhpVersionDetector;
 use PhpProfiler\Lib\Process\MemoryReader\MemoryReaderException;
 use PhpProfiler\Lib\PhpProcessReader\PhpMemoryReader\CallTraceReader;
 use Symfony\Component\Console\Command\Command;
@@ -34,6 +35,7 @@ final class GetCurrentFunctionNameCommand extends Command
 {
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
+        private PhpVersionDetector $php_version_detector,
         private CallTraceReader $executor_globals_reader,
         private TraceLoopProvider $loop_provider,
         private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,
@@ -69,6 +71,11 @@ final class GetCurrentFunctionNameCommand extends Command
         $loop_settings = $this->trace_loop_settings_from_console_input->createSettings($input);
 
         $process_specifier = $this->target_process_resolver->resolve($target_process_settings);
+
+        $target_php_settings = $this->php_version_detector->decidePhpVersion(
+            $process_specifier,
+            $target_php_settings
+        );
 
         // see the comment at GetTraceCommand::execute()
         $eg_address = $this->retrying_loop_provider->do(

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -27,6 +27,7 @@ use PhpProfiler\Lib\Elf\Parser\ElfParserException;
 use PhpProfiler\Lib\Elf\Process\ProcessSymbolReaderException;
 use PhpProfiler\Lib\Elf\Tls\TlsFinderException;
 use PhpProfiler\Lib\PhpProcessReader\PhpGlobalsFinder;
+use PhpProfiler\Lib\PhpProcessReader\PhpVersionDetector;
 use PhpProfiler\Lib\Process\MemoryReader\MemoryReaderException;
 use PhpProfiler\Lib\PhpProcessReader\PhpMemoryReader\CallTraceReader;
 use PhpProfiler\Lib\Process\ProcessStopper\ProcessStopper;
@@ -40,6 +41,7 @@ final class GetTraceCommand extends Command
 {
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
+        private PhpVersionDetector $php_version_detector,
         private CallTraceReader $executor_globals_reader,
         private TraceLoopProvider $loop_provider,
         private GetTraceSettingsFromConsoleInput $get_trace_settings_from_console_input,
@@ -84,6 +86,11 @@ final class GetTraceCommand extends Command
         $formatter = $this->templated_trace_formatter_factory->createFromSettings($template_settings);
 
         $process_specifier = $this->target_process_resolver->resolve($target_process_settings);
+
+        $target_php_settings = $this->php_version_detector->decidePhpVersion(
+            $process_specifier,
+            $target_php_settings
+        );
 
         // On targeting ZTS, it's possible that libpthread.so of the target process isn't yet loaded
         // at this point. In that case the TLS block can't be located, then the address of EG can't

--- a/src/Inspector/Daemon/Reader/Protocol/Message/SetSettingsMessage.php
+++ b/src/Inspector/Daemon/Reader/Protocol/Message/SetSettingsMessage.php
@@ -16,9 +16,11 @@ namespace PhpProfiler\Inspector\Daemon\Reader\Protocol\Message;
 use PhpProfiler\Inspector\Settings\GetTraceSettings\GetTraceSettings;
 use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use PhpProfiler\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
 
 final class SetSettingsMessage
 {
+    /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|'auto'> $target_php_settings */
     public function __construct(
         public TargetPhpSettings $target_php_settings,
         public TraceLoopSettings $trace_loop_settings,

--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php
@@ -18,6 +18,7 @@ use PhpProfiler\Inspector\Daemon\Reader\Protocol\Message\TraceMessage;
 use PhpProfiler\Inspector\Settings\GetTraceSettings\GetTraceSettings;
 use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use PhpProfiler\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
 use PhpProfiler\Lib\PhpProcessReader\PhpGlobalsFinder;
 use PhpProfiler\Lib\PhpProcessReader\PhpMemoryReader\CallTraceReader;
 use PhpProfiler\Lib\Process\ProcessSpecifier;
@@ -37,6 +38,7 @@ final class PhpReaderTraceLoop implements PhpReaderTraceLoopInterface
     }
 
     /**
+     * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
      * @return Generator<TraceMessage>
      * @throws \PhpProfiler\Lib\Elf\Parser\ElfParserException
      * @throws \PhpProfiler\Lib\Elf\Process\ProcessSymbolReaderException
@@ -51,6 +53,7 @@ final class PhpReaderTraceLoop implements PhpReaderTraceLoopInterface
     ): Generator {
         $eg_address = $this->php_globals_finder->findExecutorGlobals($process_specifier, $target_php_settings);
 
+        /** @var TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */
         $loop = $this->reader_loop_provider->getMainLoop(
             function () use (
                 $get_trace_settings,

--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoopInterface.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoopInterface.php
@@ -18,11 +18,15 @@ use PhpProfiler\Inspector\Daemon\Reader\Protocol\Message\TraceMessage;
 use PhpProfiler\Inspector\Settings\GetTraceSettings\GetTraceSettings;
 use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use PhpProfiler\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
 use PhpProfiler\Lib\Process\ProcessSpecifier;
 
 interface PhpReaderTraceLoopInterface
 {
-    /** @return Generator<TraceMessage> */
+    /**
+     * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
+     * @return Generator<TraceMessage>
+     */
     public function run(
         ProcessSpecifier $process_specifier,
         TraceLoopSettings $loop_settings,

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
@@ -21,7 +21,7 @@ use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
  */
 final class TargetPhpSettings
 {
-    public const PHP_REGEX_DEFAULT = '.*/(php(74|7.4|80|8.0)?|php-fpm|libphp[78]?.*\.so)$';
+    public const PHP_REGEX_DEFAULT = '.*/(php(74|7.4|80|8.0|81|8.1)?|php-fpm|libphp[78]?.*\.so)$';
     public const LIBPTHREAD_REGEX_DEFAULT = '.*/libpthread.*\.so';
     public const TARGET_PHP_VERSION_DEFAULT = 'auto';
 
@@ -33,7 +33,5 @@ final class TargetPhpSettings
         public ?string $php_path = null,
         public ?string $libpthread_path = null
     ) {
-        $this->php_regex = '{' . $php_regex . '}';
-        $this->libpthread_regex = '{' . $libpthread_regex . '}';
     }
 }

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
@@ -15,13 +15,17 @@ namespace PhpProfiler\Inspector\Settings\TargetPhpSettings;
 
 use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
 
+/**
+ * @template TVersion of value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|'auto'
+ * @immutable
+ */
 final class TargetPhpSettings
 {
     public const PHP_REGEX_DEFAULT = '.*/(php(74|7.4|80|8.0)?|php-fpm|libphp[78]?.*\.so)$';
     public const LIBPTHREAD_REGEX_DEFAULT = '.*/libpthread.*\.so';
-    public const TARGET_PHP_VERSION_DEFAULT = ZendTypeReader::V80;
+    public const TARGET_PHP_VERSION_DEFAULT = 'auto';
 
-    /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */
+    /** @param TVersion $php_version */
     public function __construct(
         public string $php_regex = self::PHP_REGEX_DEFAULT,
         public string $libpthread_regex = self::LIBPTHREAD_REGEX_DEFAULT,

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
@@ -78,7 +78,7 @@ final class TargetPhpSettingsFromConsoleInput
         }
 
         $php_version = $input->getOption('php-version') ?? TargetPhpSettings::TARGET_PHP_VERSION_DEFAULT;
-        if (!in_array($php_version, ZendTypeReader::ALL_SUPPORTED_VERSIONS, true)) {
+        if ($php_version !== 'auto' and !in_array($php_version, ZendTypeReader::ALL_SUPPORTED_VERSIONS, true)) {
             throw TargetPhpSettingsException::create(
                 TargetPhpSettingsException::TARGET_PHP_VERSION_INVALID
             );

--- a/src/Lib/Elf/Structure/Elf64/Elf64GnuHashTable.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64GnuHashTable.php
@@ -41,10 +41,11 @@ final class Elf64GnuHashTable
     public function lookup(string $name, callable $symbol_table_checker): int
     {
         $hash = self::hash($name);
+/* this filter is buggy, so commenting out for now
         if (!$this->checkBloomFilter($hash)) {
             return Elf64SymbolTable::STN_UNDEF;
         }
-
+*/
         $chain_offset = max(0, $this->buckets[$hash % $this->nbuckets] - $this->symoffset);
 
         do {

--- a/src/Lib/FFI/Cast.php
+++ b/src/Lib/FFI/Cast.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\FFI;
+
+use FFI\CData;
+use FFI\CInteger;
+use FFI\CPointer;
+
+class Cast
+{
+    /** @param CPointer $cdata */
+    public static function castPointerToInt(CData $cdata): int
+    {
+        /** @var CInteger $casted */
+        $casted = \FFI::cast('long', $cdata);
+        return $casted->cdata;
+    }
+}

--- a/src/Lib/FFI/Cast.php
+++ b/src/Lib/FFI/Cast.php
@@ -20,7 +20,7 @@ use FFI\CPointer;
 class Cast
 {
     /** @param CPointer $cdata */
-    public static function castPointerToInt(CData $cdata): int
+    public static function castPointerToInt(CData &$cdata): int
     {
         /** @var CInteger $casted */
         $casted = \FFI::cast('long', $cdata);

--- a/src/Lib/PhpInternals/Types/C/RawInt32.php
+++ b/src/Lib/PhpInternals/Types/C/RawInt32.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\C;
+
+use FFI\CInteger;
+use PhpProfiler\Lib\PhpInternals\CastedCData;
+use PhpProfiler\Lib\Process\Pointer\Dereferencable;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+
+final class RawInt32 implements Dereferencable
+{
+    public int $value;
+
+    /** @param CastedCData<CInteger> $casted_cdata */
+    public function __construct(
+        private CastedCData $casted_cdata,
+    ) {
+        $this->value = $this->casted_cdata->casted->cdata;
+    }
+
+    public static function getCTypeName(): string
+    {
+        return 'int32_t';
+    }
+
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer
+    ): static {
+        /** @var CastedCData<CInteger> $casted_cdata */
+        return new self($casted_cdata);
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/Bucket.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\PhpInternals\Bucket as ZendBucket;
+use PhpProfiler\Lib\PhpInternals\CastedCData;
+use PhpProfiler\Lib\Process\Pointer\Dereferencable;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+
+final class Bucket implements Dereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Zval $val;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $h;
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Pointer<ZendString>
+     */
+    public Pointer $key;
+
+    /** @param CastedCData<ZendBucket> $casted_cdata */
+    public function __construct(
+        private CastedCData $casted_cdata,
+    ) {
+        unset($this->val);
+        unset($this->h);
+        unset($this->key);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'val' => $this->val = new Zval($this->casted_cdata->casted->val),
+            'h' => $this->h = 0xFFFF_FFFF & $this->casted_cdata->casted->h,
+            'key' => $this->key = Pointer::fromCData(
+                ZendString::class,
+                $this->casted_cdata->casted->key
+            ),
+        };
+    }
+
+    public static function getCTypeName(): string
+    {
+        return 'Bucket';
+    }
+
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer
+    ): static {
+        /** @var CastedCData<ZendBucket> $casted_cdata */
+        return new self($casted_cdata);
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\PhpInternals\zend_array;
+use FFI\PhpInternals\zend_hash_func_ffi;
+use PhpProfiler\Lib\PhpInternals\CastedCData;
+use PhpProfiler\Lib\PhpInternals\Types\C\RawInt32;
+use PhpProfiler\Lib\Process\Pointer\Dereferencable;
+use PhpProfiler\Lib\Process\Pointer\Dereferencer;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+
+/**
+ * struct _zend_array {
+ * zend_refcounted_h gc;
+* union {
+* struct {
+* zend_uchar    flags;
+* zend_uchar    _unused;
+* zend_uchar    nIteratorsCount;
+* zend_uchar    _unused2;
+* } v;
+* uint32_t flags;
+* } u;
+* uint32_t          nTableMask;
+* Bucket           *arData;
+* uint32_t          nNumUsed;
+* uint32_t          nNumOfElements;
+* uint32_t          nTableSize;
+* uint32_t          nInternalPointer;
+* zend_long         nNextFreeElement;
+* dtor_func_t       pDestructor;
+* }; */
+final class ZendArray implements Dereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $flags;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nTableMask;
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Pointer<Bucket>
+     */
+    public Pointer $arData;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nNumUsed;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nNumOfElements;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nTableSize;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nInternalPointer;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $nNextFreeElement;
+
+    /** @param CastedCData<zend_array> $casted_cdata */
+    public function __construct(
+        private CastedCData $casted_cdata
+    ) {
+        unset($this->flags);
+        unset($this->nTableMask);
+        unset($this->arData);
+        unset($this->nNumUsed);
+        unset($this->nNumOfElements);
+        unset($this->nTableSize);
+        unset($this->nInternalPointer);
+        unset($this->nNextFreeElement);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'flags' => $this->flags = $this->casted_cdata->casted->u->flags,
+            'nTableMask' => $this->nTableMask = $this->casted_cdata->casted->nTableMask,
+            'arData' => $this->arData = Pointer::fromCData(
+                Bucket::class,
+                $this->casted_cdata->casted->arData,
+            ),
+            'nNumUsed' => $this->nNumUsed = $this->casted_cdata->casted->nNumUsed,
+            'nNumOfElements' => $this->nNumOfElements = $this->casted_cdata->casted->nNumOfElements,
+            'nTableSize' => $this->nTableSize = $this->casted_cdata->casted->nTableSize,
+            'nInternalPointer' => $this->nInternalPointer = $this->casted_cdata->casted->nInternalPointer,
+            'nNextFreeElement' => $this->nNextFreeElement = $this->casted_cdata->casted->nNextFreeElement,
+        };
+    }
+
+    public function findByKey(
+        Dereferencer $dereferencer,
+        string $key,
+        int $hash = null
+    ): ?Bucket {
+        $hash ??= $this->calculateHash($key);
+        $hash_index = $hash | $this->nTableMask;
+        $hash_index = $hash_index & 0xFFFF_FFFF;
+        if ($hash_index & 0x8000_0000) {
+            $hash_index = $hash_index & ~0x8000_0000;
+            $hash_index = -2147483648 + $hash_index;
+        }
+        $idx = $dereferencer->deref(
+            $this->calculateIndex($hash_index, $this->arData)
+        )->value;
+
+        while ($idx !== -1) {
+            /** @var Bucket $bucket */
+            $bucket = $dereferencer->deref(
+                $this->arData->indexedAt($idx)
+            );
+            if ($bucket->h === $hash) {
+                $bucket_key_zstring = $dereferencer->deref($bucket->key)->getValuePointer($bucket->key);
+                $bucket_key = (string)$dereferencer->deref($bucket_key_zstring);
+                if ($bucket_key === $key) {
+                    return $bucket;
+                }
+            }
+            $idx = $bucket->val->u2->next;
+        }
+        return null;
+    }
+
+    /**
+     * @param Pointer<Bucket> $pointer
+     * @return Pointer<RawInt32>
+     */
+    private function calculateIndex(int $index, Pointer $pointer): Pointer
+    {
+        return new Pointer(
+            RawInt32::class,
+            $pointer->address + $index * 4,
+            4,
+        );
+    }
+
+    private function calculateHash(string $key): int
+    {
+        static $ffi = null;
+        /** @var ?zend_hash_func_ffi $ffi */
+        $ffi ??= \FFI::cdef('int zend_hash_func(const char *str, int len);');
+        assert(!is_null($ffi));
+
+        return $ffi->zend_hash_func($key, strlen($key));
+    }
+
+    public static function getCTypeName(): string
+    {
+        return 'zend_array';
+    }
+
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /** @var CastedCData<zend_array> $casted_cdata */
+        return new self($casted_cdata);
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\PhpInternals\zend_module_entry;
+use PhpProfiler\Lib\FFI\Cast;
+use PhpProfiler\Lib\PhpInternals\CastedCData;
+use PhpProfiler\Lib\PhpInternals\Types\C\RawString;
+use PhpProfiler\Lib\Process\Pointer\Dereferencable;
+use PhpProfiler\Lib\Process\Pointer\Dereferencer;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+
+final class ZendModuleEntry implements Dereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public bool $zts;
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Pointer<RawString>
+     */
+    public Pointer $version;
+
+    /** @param CastedCData<zend_module_entry> $casted_cdata */
+    public function __construct(
+        private CastedCData $casted_cdata,
+    ) {
+        unset($this->zts);
+        unset($this->version);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'zts' => $this->zts = (bool)$this->casted_cdata->casted->zts,
+            'version' => $this->version = new Pointer(
+                RawString::class,
+                Cast::castPointerToInt($this->casted_cdata->casted->version),
+                3,
+            ),
+        };
+    }
+
+    public function getVersion(Dereferencer $dereferencer): string
+    {
+        return (string)$dereferencer->deref($this->version);
+    }
+
+    public static function getCTypeName(): string
+    {
+        return 'zend_module_entry';
+    }
+
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer
+    ): static {
+        /** @var CastedCData<zend_module_entry> $casted_cdata */
+        return new self($casted_cdata);
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendValue.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendValue.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\CData;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+
+class ZendValue
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $lval;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public float $dval;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $counted;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $str;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $obj;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $res;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $ref;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $ast;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $zv;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $ptr;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $ce;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Pointer $func;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendValueWw $ww;
+
+    /** @param \FFI\PhpInternals\zend_value $cdata */
+    public function __construct(
+        private CData $cdata
+    ) {
+        unset($this->lval);
+        unset($this->dval);
+        unset($this->counted);
+        unset($this->str);
+        unset($this->obj);
+        unset($this->res);
+        unset($this->ref);
+        unset($this->ast);
+        unset($this->zv);
+        unset($this->ptr);
+        unset($this->ce);
+        unset($this->func);
+        unset($this->ww);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'lval' => $this->lval = $this->cdata->lval,
+            'dval' => $this->dval = $this->cdata->dval,
+            'str' => $this->str = Pointer::fromCData(
+                ZendString::class,
+                $this->cdata->str,
+            ),
+        };
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendValueWw.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendValueWw.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\CData;
+use FFI\PhpInternals\zend_value_ww;
+
+class ZendValueWw
+{
+    public int $w1;
+    public int $w2;
+
+    /** @param zend_value_ww $cdata */
+    public function __construct(
+        private CData $cdata,
+    ) {
+        $this->w1 = $this->cdata->w1;
+        $this->w2 = $this->cdata->w2;
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/Zval.php
+++ b/src/Lib/PhpInternals/Types/Zend/Zval.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\CData;
+
+class Zval
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendValue $value;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZvalU1 $u1;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZvalU2 $u2;
+
+    /** @param \FFI\PhpInternals\zval $cdata */
+    public function __construct(
+        private CData $cdata
+    ) {
+        unset($this->value);
+        unset($this->u1);
+        unset($this->u2);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'value' => $this->value = new ZendValue($this->cdata->value),
+            'u1' => $this->u1 = new ZvalU1($this->cdata->u1),
+            'u2' => $this->u2 = new ZvalU2($this->cdata->u2),
+        };
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZvalU1.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalU1.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\CData;
+use FFI\PhpInternals\zval_u1;
+
+class ZvalU1
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $type_info;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $type;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $type_flags;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $extra;
+
+    /** @param zval_u1 $cdata */
+    public function __construct(
+        private CData $cdata
+    ) {
+        unset($this->type_info);
+        unset($this->type);
+        unset($this->type_flags);
+        unset($this->extra);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'type_info' => $this->cdata->type_info,
+            'type' => $this->cdata->v->type,
+            'type_flags' => $this->cdata->v->type_flags,
+            'extra' => $this->cdata->v->u->extra,
+        };
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZvalU2.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalU2.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpInternals\Types\Zend;
+
+use FFI\CData;
+
+class ZvalU2
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $next;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $opline_num;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $lineno;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $num_args;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $fe_pos;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $fe_iter_idx;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $access_flags;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $property_guard;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $constant_flags;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $extra;
+
+    public function __construct(
+        private CData $cdata
+    ) {
+        unset($this->next);
+        unset($this->opline_num);
+        unset($this->lineno);
+        unset($this->num_args);
+        unset($this->fe_pos);
+        unset($this->fe_iter_idx);
+        unset($this->access_flags);
+        unset($this->property_guard);
+        unset($this->constant_flags);
+        unset($this->extra);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return $this->cdata->$field_name;
+    }
+}

--- a/src/Lib/PhpInternals/ZendTypeReader.php
+++ b/src/Lib/PhpInternals/ZendTypeReader.php
@@ -18,6 +18,7 @@ use FFI\CData;
 use PhpProfiler\Lib\FFI\CannotCastCDataException;
 use PhpProfiler\Lib\FFI\CannotGetTypeForCDataException;
 use PhpProfiler\Lib\FFI\CannotLoadCHeaderException;
+use Webmozart\Assert\Assert;
 
 final class ZendTypeReader
 {
@@ -40,6 +41,32 @@ final class ZendTypeReader
     ];
 
     private ?FFI $ffi = null;
+
+    /** @return value-of<self::ALL_SUPPORTED_VERSIONS> */
+    public static function defaultVersion(): string
+    {
+        $version_string = join(
+            '',
+            [
+                'v',
+                PHP_MAJOR_VERSION,
+                PHP_MINOR_VERSION,
+            ]
+        );
+        Assert::true(self::isSupported($version_string));
+        /** @var value-of<self::ALL_SUPPORTED_VERSIONS> */
+        return $version_string;
+    }
+
+    /**
+     * @param string $version_string
+     * @assert-if-true value-of<self::ALL_SUPPORTED_VERSIONS> $version_string
+     * @return bool
+     */
+    public static function isSupported(string $version_string): bool
+    {
+        return in_array($version_string, self::ALL_SUPPORTED_VERSIONS, true);
+    }
 
     /**
      * @param value-of<self::ALL_SUPPORTED_VERSIONS> $php_version

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -149,4 +149,16 @@ final class PhpGlobalsFinder
         }
         return $executor_globals_address;
     }
+
+    public function findModuleRegistry(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings
+    ): ?int {
+        $symbol_reader = $this->getSymbolReader(
+            $process_specifier,
+            $target_php_settings
+        );
+        $module_registry = $symbol_reader->resolveAddress('module_registry');
+        return $module_registry;
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpProcessReader;
+
+use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use PhpProfiler\Lib\PhpInternals\Types\Zend\ZendArray;
+use PhpProfiler\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
+use PhpProfiler\Lib\PhpInternals\Types\Zend\ZendModuleEntry;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReader;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReaderCreator;
+use PhpProfiler\Lib\Process\MemoryReader\MemoryReaderInterface;
+use PhpProfiler\Lib\Process\Pointer\Dereferencer;
+use PhpProfiler\Lib\Process\Pointer\Pointer;
+use PhpProfiler\Lib\Process\Pointer\RemoteProcessDereferencer;
+use PhpProfiler\Lib\Process\ProcessSpecifier;
+use Webmozart\Assert\Assert;
+
+class PhpVersionDetector
+{
+    private ?ZendTypeReader $zend_type_reader = null;
+
+    public function __construct(
+        private PhpGlobalsFinder $php_globals_finder,
+        private MemoryReaderInterface $memory_reader,
+        private ZendTypeReaderCreator $zend_type_reader_creator,
+    ) {
+    }
+
+    /**
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     */
+    private function getTypeReader(string $php_version): ZendTypeReader
+    {
+        if (is_null($this->zend_type_reader)) {
+            $this->zend_type_reader = $this->zend_type_reader_creator->create($php_version);
+        }
+        return $this->zend_type_reader;
+    }
+
+    /**
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     */
+    private function getDereferencer(int $pid, string $php_version): Dereferencer
+    {
+        return new RemoteProcessDereferencer(
+            $this->memory_reader,
+            new ProcessSpecifier($pid),
+            new ZendCastedTypeProvider(
+                $this->getTypeReader($php_version),
+            )
+        );
+    }
+
+    /** @return TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> */
+    public function decidePhpVersion(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+    ): TargetPhpSettings {
+        if ($target_php_settings->php_version !== 'auto') {
+            /** @var TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> */
+            return $target_php_settings;
+        }
+        $module_registry_address = $this->php_globals_finder->findModuleRegistry(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $version = null;
+        if (!is_null($module_registry_address)) {
+            $version = $this->detectPhpVersion($process_specifier->pid, $module_registry_address);
+        }
+
+        if (is_null($version)) {
+            /** @var value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $version */
+            $version = 'v' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION;
+            Assert::true(ZendTypeReader::isSupported($version));
+        }
+
+        assert(isset($target_php_settings->libpthread_path));
+
+        return new TargetPhpSettings(
+            php_regex: $target_php_settings->php_regex,
+            libpthread_regex: $target_php_settings->libpthread_path,
+            php_version: $version,
+            php_path: $target_php_settings->php_path,
+            libpthread_path: $target_php_settings->libpthread_path,
+        );
+    }
+
+    /** @return value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|null */
+    public function detectPhpVersion(
+        int $pid,
+        int $module_registry_address
+    ): ?string {
+        $fake_php_version = ZendTypeReader::defaultVersion();
+        $dereferencer = $this->getDereferencer($pid, $fake_php_version);
+        $module_registry = $this->getModuleRegistry(
+            $module_registry_address,
+            $fake_php_version,
+            $dereferencer
+        );
+        $module_registry_entry_bucket = $module_registry->findByKey($dereferencer, 'standard');
+        if (is_null($module_registry_entry_bucket)) {
+            return null;
+        }
+        $module_registry_entry_pointer = $module_registry_entry_bucket->val;
+        $module_entry_pointer = new Pointer(
+            ZendModuleEntry::class,
+            $module_registry_entry_pointer->value->lval,
+            $this->getTypeReader($fake_php_version)->sizeOf('zend_module_entry')
+        );
+        /**
+         * @var ZendModuleEntry $basic_module_entry
+         * @psalm-ignore-var
+         */
+        $basic_module_entry = $dereferencer->deref($module_entry_pointer);
+        $version = $basic_module_entry->getVersion($dereferencer);
+        $result_string = 'v' . str_replace('.', '', $version);
+        if (ZendTypeReader::isSupported($result_string)) {
+            /** @var value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> */
+            return $result_string;
+        }
+        return null;
+    }
+
+    /**
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $fake_version
+     */
+    private function getModuleRegistry(
+        int $module_registry_address,
+        string $fake_php_version,
+        Dereferencer $dereferencer
+    ): ZendArray {
+        /** @var value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $fake_php_version */
+        $pointer = new Pointer(
+            ZendArray::class,
+            $module_registry_address,
+            $this->getTypeReader($fake_php_version)->sizeOf('zend_array')
+        );
+        return $dereferencer->deref($pointer);
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -90,7 +90,7 @@ class PhpVersionDetector
 
         return new TargetPhpSettings(
             php_regex: $target_php_settings->php_regex,
-            libpthread_regex: $target_php_settings->libpthread_path,
+            libpthread_regex: $target_php_settings->libpthread_regex,
             php_version: $version,
             php_path: $target_php_settings->php_path,
             libpthread_path: $target_php_settings->libpthread_path,

--- a/src/Lib/Process/MemoryMap/ProcessMemoryMap.php
+++ b/src/Lib/Process/MemoryMap/ProcessMemoryMap.php
@@ -26,7 +26,7 @@ final class ProcessMemoryMap
     {
         $result = [];
         foreach ($this->memory_areas as $memory_area) {
-            if (preg_match($regex, $memory_area->name)) {
+            if (preg_match('{' . $regex . '}', $memory_area->name)) {
                 $result[] = $memory_area;
             }
         }

--- a/src/Lib/Process/Pointer/Pointer.php
+++ b/src/Lib/Process/Pointer/Pointer.php
@@ -36,7 +36,7 @@ class Pointer
     {
         return new Pointer(
             $this->type,
-            $n * $this->size + $this->address,
+            $this->address + $n * $this->size,
             $this->size,
         );
     }

--- a/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
@@ -30,8 +30,8 @@ class TargetPhpSettingsFromConsoleInputTest extends TestCase
 
         $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
 
-        $this->assertSame('{abc}', $settings->php_regex);
-        $this->assertSame('{def}', $settings->libpthread_regex);
+        $this->assertSame('abc', $settings->php_regex);
+        $this->assertSame('def', $settings->libpthread_regex);
         $this->assertSame('v74', $settings->php_version);
         $this->assertSame('ghi', $settings->php_path);
         $this->assertSame('jkl', $settings->libpthread_path);

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
@@ -60,7 +60,7 @@ class ProcessModuleSymbolReaderCreatorTest extends TestCase
             $symbol_reader_creator->createModuleReaderByNameRegex(
                 1,
                 $process_memory_map,
-                '/\/test_module/',
+                '\/test_module',
                 null
             )
         );
@@ -115,7 +115,7 @@ class ProcessModuleSymbolReaderCreatorTest extends TestCase
             $symbol_reader_creator->createModuleReaderByNameRegex(
                 1,
                 $process_memory_map,
-                '/\/test_module/',
+                '\/test_module',
                 null
             )
         );

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpProcessReader;
+
+use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use PhpProfiler\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use PhpProfiler\Lib\Elf\Parser\Elf64Parser;
+use PhpProfiler\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use PhpProfiler\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use PhpProfiler\Lib\File\CatFileReader;
+use PhpProfiler\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use PhpProfiler\Lib\Process\MemoryReader\MemoryReader;
+use PhpProfiler\Lib\Process\ProcessSpecifier;
+use PHPUnit\Framework\TestCase;
+
+class PhpGlobalsFinderTest extends TestCase
+{
+    public function testFindModuleRegistry()
+    {
+        $memory_reader = new MemoryReader();
+        $this->child = proc_open(
+            [
+                PHP_BINARY,
+                '-r',
+                'fputs(STDOUT, "a\n");fgets(STDIN);'
+            ],
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w']
+            ],
+            $pipes
+        );
+
+        fgets($pipes[1]);
+        $child_status = proc_get_status($this->child);
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            $memory_reader,
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+            ),
+            ProcessMemoryMapCreator::create(),
+            new LittleEndianReader()
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            new LittleEndianReader(),
+            new MemoryReader()
+        );
+        $module_registry = $php_globals_finder->findModuleRegistry(
+            new ProcessSpecifier($child_status['pid']),
+            new TargetPhpSettings()
+        );
+        $this->assertIsInt($module_registry);
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -70,6 +70,7 @@ class PhpVersionDetectorTest extends TestCase
             new TargetPhpSettings()
         );
         $php_version_detector = new PhpVersionDetector(
+            $php_globals_finder,
             $memory_reader,
             new ZendTypeReaderCreator()
         );

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the sj-i/php-profiler package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpProfiler\Lib\PhpProcessReader;
+
+use PhpProfiler\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use PhpProfiler\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use PhpProfiler\Lib\Elf\Parser\Elf64Parser;
+use PhpProfiler\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use PhpProfiler\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use PhpProfiler\Lib\File\CatFileReader;
+use PhpProfiler\Lib\PhpInternals\ZendTypeReaderCreator;
+use PhpProfiler\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use PhpProfiler\Lib\Process\MemoryReader\MemoryReader;
+use PhpProfiler\Lib\Process\ProcessSpecifier;
+use PHPUnit\Framework\TestCase;
+
+class PhpVersionDetectorTest extends TestCase
+{
+    public function testDetectVersion()
+    {
+        $memory_reader = new MemoryReader();
+        $this->child = proc_open(
+            [
+                PHP_BINARY,
+                '-r',
+                'fputs(STDOUT, "a\n");fgets(STDIN);'
+            ],
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w']
+            ],
+            $pipes
+        );
+
+        fgets($pipes[1]);
+        $child_status = proc_get_status($this->child);
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            $memory_reader,
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+            ),
+            ProcessMemoryMapCreator::create(),
+            new LittleEndianReader()
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            new LittleEndianReader(),
+            $memory_reader = new MemoryReader()
+        );
+        $module_registry_address = $php_globals_finder->findModuleRegistry(
+            new ProcessSpecifier($child_status['pid']),
+            new TargetPhpSettings()
+        );
+        $php_version_detector = new PhpVersionDetector(
+            $memory_reader,
+            new ZendTypeReaderCreator()
+        );
+        $version = $php_version_detector->detectPhpVersion(
+            $child_status['pid'],
+            $module_registry_address,
+        );
+        $expected_version = join(
+            '',
+            [
+                'v',
+                PHP_MAJOR_VERSION,
+                PHP_MINOR_VERSION,
+            ]
+        );
+        $this->assertSame($expected_version, $version);
+    }
+}

--- a/tests/Lib/Process/MemoryMap/ProcessMemoryMapTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessMemoryMapTest.php
@@ -45,9 +45,9 @@ class ProcessMemoryMapTest extends TestCase
                 'test_area_2'
             ),
         ]);
-        $area1 = $memory_map->findByNameRegex('/.*1/');
-        $area2 = $memory_map->findByNameRegex('/.*2/');
-        $area_both = $memory_map->findByNameRegex('/test.*/');
+        $area1 = $memory_map->findByNameRegex('.*1');
+        $area2 = $memory_map->findByNameRegex('.*2');
+        $area_both = $memory_map->findByNameRegex('test.*');
 
         $this->assertCount(1, $area1);
         $this->assertCount(1, $area2);

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -156,5 +156,43 @@ class Bucket extends CData
 {
     public zval $val;
     public int $h;
-    public Pointer $key;
+    public CPointer $key;
+}
+
+class zend_module_entry extends CData
+{
+    public int $zts;
+    public CPointer $version;
+}
+
+class zend_hash_func_ffi extends \FFI
+{
+    public function zend_hash_func(string $str, int $len): int {}
+}
+
+class zend_array_v extends CData
+{
+    public int $flags;
+    public int $nApplyCount;
+    public int $nIteratorsCount;
+    public int $consistency;
+}
+
+class zend_array_u extends CData
+{
+    public int $flags;
+    public zend_array_v $v;
+
+}
+
+class zend_array extends CData
+{
+    public zend_array_u $u;
+    public int $nTableMask;
+    public CPointer $arData;
+    public int $nNumUsed;
+    public int $nNumOfElements;
+    public int $nTableSize;
+    public int $nInternalPointer;
+    public int $nNextFreeElement;
 }


### PR DESCRIPTION
This resolves #106.

The difference from the previous effort (#139) is that it also works with stripped binaries.

To access module_registry, I've added an implementation that handles the hash table of the remote process, which means the groundwork for reading symbol tables has also been done.