### PR TITLE
Replace null characters with whitespaces in command lines

### DIFF
--- a/src/Lib/Process/ProcFileSystem/CommandLineEnumerator.php
+++ b/src/Lib/Process/ProcFileSystem/CommandLineEnumerator.php
@@ -41,7 +41,7 @@ final class CommandLineEnumerator implements IteratorAggregate
             if (!is_numeric(basename($item->getPath()))) {
                 continue;
             }
-            yield (int)basename($item->getPath()) => $command_line;
+            yield (int)basename($item->getPath()) => preg_replace('/\0/', ' ', $command_line);
         }
     }
 }


### PR DESCRIPTION
In linux / unix environments, command lines are parsed by the shell and used to launch the process with its argument list broken down into null terminated strings.

When reading the command line from procfs, the null character is also used to separate each argv[i].

Since this is inconvenient for searching processes, I decided to replace the null character with a whitespace character when readling the command line.