### PR TITLE
Exclude the own pid from targets in the daemon mode

### DIFF
--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -81,6 +81,7 @@ final class DaemonCommand extends Command
             $searcher_context->sendTarget(
                 $daemon_settings->target_regex,
                 $target_php_settings,
+                getmypid(),
             )
         );
 

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -79,6 +79,7 @@ final class TopLikeCommand extends Command
             $searcher_context->sendTarget(
                 $daemon_settings->target_regex,
                 $target_php_settings,
+                getmypid(),
             )
         );
 

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
@@ -32,13 +32,17 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
         return $this->context->start();
     }
 
-    public function sendTarget(string $regex, TargetPhpSettings $target_php_settings): Promise
-    {
+    public function sendTarget(
+        string $regex,
+        TargetPhpSettings $target_php_settings,
+        int $pid,
+    ): Promise {
         return $this->context->getProtocol()
             ->sendTargetRegex(
                 new TargetPhpSettingsMessage(
                     $regex,
                     $target_php_settings,
+                    $pid
                 )
             )
         ;

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
@@ -23,7 +23,7 @@ interface PhpSearcherControllerInterface
     public function start(): Promise;
 
     /** @return Promise<int> */
-    public function sendTarget(string $regex, TargetPhpSettings $target_php_settings): Promise;
+    public function sendTarget(string $regex, TargetPhpSettings $target_php_settings, int $pid): Promise;
 
     /** @return Promise<UpdateTargetProcessMessage> */
     public function receivePidList(): Promise;

--- a/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
+++ b/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
@@ -22,6 +22,7 @@ final class TargetPhpSettingsMessage
     public function __construct(
         public string $regex,
         public TargetPhpSettings $target_php_settings,
+        public int $parent_pid,
     ) {
     }
 }

--- a/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
+++ b/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Daemon\Dispatcher\TargetProcessList;
 use Reli\Inspector\Daemon\Searcher\Protocol\Message\TargetPhpSettingsMessage;
 use Reli\Inspector\Daemon\Searcher\Protocol\PhpSearcherWorkerProtocolInterface;
 use Reli\Lib\Amphp\WorkerEntryPointInterface;
+use Reli\Lib\Process\ProcFileSystem\ThreadEnumerator;
 use Reli\Lib\Process\Search\ProcessSearcherInterface;
 
 use function sleep;
@@ -29,6 +30,7 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
         private PhpSearcherWorkerProtocolInterface $protocol,
         private ProcessSearcherInterface $process_searcher,
         private ProcessDescriptorRetriever $process_descriptor_retriever,
+        private ThreadEnumerator $thread_enumerator,
     ) {
     }
 
@@ -42,8 +44,15 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
         $cache = new ProcessDescriptorCache();
 
         while (1) {
-            $searched_pids = $this->process_searcher->searchByRegex(
-                $target_php_settings_message->regex
+            $searched_pids = array_diff(
+                $this->process_searcher->searchByRegex(
+                    $target_php_settings_message->regex
+                ),
+                [
+                    ...$this->thread_enumerator->getThreadIds(
+                        $target_php_settings_message->parent_pid
+                    )
+                ],
             );
             $cache->removeDisappeared(...$searched_pids);
 

--- a/tests/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerTest.php
+++ b/tests/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerTest.php
@@ -54,7 +54,8 @@ class PhpSearcherControllerTest extends TestCase
             Promise::class,
             $php_searcher_context->sendTarget(
                 'abcdefg',
-                new TargetPhpSettings()
+                new TargetPhpSettings(),
+                getmypid(),
             )
         );
     }

--- a/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
+++ b/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
@@ -22,6 +22,7 @@ use Reli\Inspector\Daemon\Dispatcher\TargetProcessList;
 use Reli\Inspector\Daemon\Searcher\Protocol\PhpSearcherWorkerProtocolInterface;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\ProcFileSystem\ThreadEnumerator;
 use Reli\Lib\Process\Search\ProcessSearcherInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -58,6 +59,7 @@ class PhpSearcherEntryPointTest extends TestCase
             $protcol,
             $process_searcher,
             $process_descriptor_retriever,
+            new ThreadEnumerator()
         );
 
         $generator = $entry_point->run();
@@ -73,6 +75,7 @@ class PhpSearcherEntryPointTest extends TestCase
             new TargetPhpSettingsMessage(
                 'regex_to_search_process',
                 new TargetPhpSettings(),
+                getmypid(),
             )
         );
         $this->assertInstanceOf(Success::class, $promise);


### PR DESCRIPTION
This enables use of more simplified regex in the daemon mode