### PR TITLE
Add callgrind converter

### DIFF
--- a/src/Command/Converter/CallgrindCommand.php
+++ b/src/Command/Converter/CallgrindCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Converter;
+
+use Reli\Converter\Callgrind\FunctionEntry;
+use Reli\Converter\Callgrind\Profile;
+use Reli\Converter\ParsedCallTrace;
+use Reli\Converter\PhpSpyCompatibleParser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CallgrindCommand extends Command
+{
+    public function configure(): void
+    {
+        $this->setName('converter:callgrind')
+            ->setDescription('convert traces to the callgrind file format')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $parser = new PhpSpyCompatibleParser();
+        $output->writeln('# format callgrind');
+        $output->writeln('events: Samples');
+        $output->writeln('');
+
+        $profile = new Profile();
+        foreach ($parser->parseFile(STDIN) as $trace) {
+            $profile->addTrace($trace);
+        }
+        foreach ($profile->functions as $function) {
+            $output->writeln('fl=' . $function->file_name);
+            $output->writeln('fn=' . $function->function_name);
+            foreach ($function->lineno_samples as $lineno => $samples) {
+                $output->writeln($lineno . ' ' . $samples);
+            }
+            foreach ($function->calls as $call) {
+                $output->writeln('cfl=' . $call->callee->file_name);
+                $output->writeln('cfn=' . $call->callee->function_name);
+                // We don't know how many calls were made, only the number of samples.
+                // We also don't know the start line of the callee.
+                $output->writeln('calls=-1 -1');
+                $output->writeln($call->caller_lineno . ' ' . $call->samples);
+            }
+            $output->writeln('');
+        }
+        return 0;
+    }
+}

--- a/src/Converter/Callgrind/CallEntry.php
+++ b/src/Converter/Callgrind/CallEntry.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter\Callgrind;
+
+final class CallEntry
+{
+    public int $samples = 0;
+
+    public function __construct(
+        public FunctionEntry $callee,
+        public int $caller_lineno,
+    ) {
+    }
+}

--- a/src/Converter/Callgrind/FunctionEntry.php
+++ b/src/Converter/Callgrind/FunctionEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter\Callgrind;
+
+final class FunctionEntry
+{
+    /** @var array<int, int> Line number to number of samples map. */
+    public array $lineno_samples = [];
+
+    /** @var array<string, CallEntry> Callee name and caller lineno to call entry map. */
+    public array $calls = [];
+
+    public function __construct(
+        public string $function_name,
+        public string $file_name,
+    ) {
+    }
+
+    public function addSample(int $lineno, ?FunctionEntry $callee): void
+    {
+        if ($callee === null) {
+            $this->lineno_samples[$lineno] ??= 0;
+            ++$this->lineno_samples[$lineno];
+        } else {
+            $key = $callee->function_name . '@' . $lineno;
+            $this->calls[$key] ??= new CallEntry($callee, $lineno);
+            ++$this->calls[$key]->samples;
+        }
+    }
+}

--- a/src/Converter/Callgrind/Profile.php
+++ b/src/Converter/Callgrind/Profile.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter\Callgrind;
+
+use Reli\Converter\ParsedCallFrame;
+use Reli\Converter\ParsedCallTrace;
+
+final class Profile
+{
+    /** @var array<string, FunctionEntry> */
+    public array $functions = [];
+
+    public function addTrace(ParsedCallTrace $trace): void
+    {
+        $calleeEntry = null;
+        foreach ($trace->call_frames as $frame) {
+            $entry = $this->getFunctionEntry($frame->function_name, $frame->file_name);
+            $entry->addSample($frame->lineno, $calleeEntry);
+            $calleeEntry = $entry;
+        }
+    }
+
+    private function getFunctionEntry(string $function_name, string $file_name): FunctionEntry
+    {
+        $this->functions[$function_name] ??= new FunctionEntry($function_name, $file_name);
+        return $this->functions[$function_name];
+    }
+}

--- a/src/Converter/ParsedCallFrame.php
+++ b/src/Converter/ParsedCallFrame.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+/** @psalm-immutable */
+final class ParsedCallFrame
+{
+    public function __construct(
+        public string $function_name,
+        public string $file_name,
+        public int $lineno,
+    ) {
+    }
+}

--- a/src/Converter/ParsedCallTrace.php
+++ b/src/Converter/ParsedCallTrace.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+/** @psalm-immutable */
+final class ParsedCallTrace
+{
+    /** @var ParsedCallFrame[] */
+    public array $call_frames;
+
+    public function __construct(
+        ParsedCallFrame ...$call_frames
+    ) {
+        $this->call_frames = $call_frames;
+    }
+}

--- a/src/Converter/PhpSpyCompatibleParser.php
+++ b/src/Converter/PhpSpyCompatibleParser.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+use PhpCast\Cast;
+
+final class PhpSpyCompatibleParser
+{
+    /**
+     * @param resource $fp
+     * @return iterable<ParsedCallTrace>
+     */
+    public function parseFile($fp): iterable
+    {
+        $buffer = [];
+        while (($line = fgets($fp)) !== false) {
+            $line = trim($line);
+            if ($line !== '') {
+                $buffer[] = $line;
+                continue;
+            }
+            yield $this->parsePhpSpyCompatible($buffer);
+            $buffer = [];
+        }
+    }
+
+    /** @param string[] $buffer */
+    private function parsePhpSpyCompatible(array $buffer): ParsedCallTrace
+    {
+        $frames = [];
+        foreach ($buffer as $line_buffer) {
+            $result = explode(' ', $line_buffer);
+            [$depth, $name, $file_line] = $result;
+            if ($depth === '#') { // comment
+                continue;
+            }
+            [$file, $line] = explode(':', $file_line);
+            $frames[] = new ParsedCallFrame(
+                $name,
+                $file,
+                Cast::toInt($line),
+            );
+        }
+        return new ParsedCallTrace(...$frames);
+    }
+}


### PR DESCRIPTION
This adds a converter from the phpspy compatible to the callgrind format. We are missing information on the number of calls, but this is still useful for looking at profiles in kcachegrind.

Main issue I noticed (unrelated to callgrind format) is that all closures in a file get lumped together, because they have the same name.