### PR TITLE
Add support for dereferencing types using a subtype of dereferencables

### DIFF
--- a/src/Lib/Process/Pointer/PointedTypeResolver.php
+++ b/src/Lib/Process/Pointer/PointedTypeResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+interface PointedTypeResolver
+{
+    /**
+     * @template T of Dereferencable
+     * @param class-string<T> $type_name
+     * @return class-string<T>
+     */
+    public function resolve(string $type_name): string;
+}

--- a/src/Lib/Process/Pointer/Pointer.php
+++ b/src/Lib/Process/Pointer/Pointer.php
@@ -17,9 +17,7 @@ use FFI\CData;
 use FFI\CInteger;
 use FFI\CPointer;
 
-/**
- * @template T of \Reli\Lib\Process\Pointer\Dereferencable
- */
+/** @template-covariant T of Dereferencable */
 class Pointer
 {
     /** @param class-string<T> $type */

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -25,6 +25,7 @@ class RemoteProcessDereferencer implements Dereferencer
         private MemoryReaderInterface $memory_reader,
         private ProcessSpecifier $process_specifier,
         private CastedTypeProvider $ctype_provider,
+        private ?PointedTypeResolver $pointed_type_resolver = null,
     ) {
     }
 
@@ -61,7 +62,11 @@ class RemoteProcessDereferencer implements Dereferencer
         CastedCData $casted_cdata,
         Pointer $pointer
     ): mixed {
-        $type = $pointer->type;
+        if (!is_null($this->pointed_type_resolver)) {
+            $type = $this->pointed_type_resolver->resolve($pointer->type);
+        } else {
+            $type = $pointer->type;
+        }
         return $type::fromCastedCData($casted_cdata, $pointer);
     }
 }


### PR DESCRIPTION
This enables polymorhisms in Dereferencable. So differences of the internal structures between PHP versions can be represented as separate subtypes if needed.