### PR TITLE
add getPointer() to Dereferencable

### DIFF
--- a/src/Lib/PhpInternals/Types/C/RawDouble.php
+++ b/src/Lib/PhpInternals/Types/C/RawDouble.php
@@ -25,6 +25,7 @@ final class RawDouble implements Dereferencable
     /** @param CastedCData<CInteger> $casted_cdata */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         $this->value = $this->casted_cdata->casted->cdata;
     }
@@ -39,6 +40,11 @@ final class RawDouble implements Dereferencable
         Pointer $pointer
     ): static {
         /** @var CastedCData<CInteger> $casted_cdata */
-        return new self($casted_cdata);
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/C/RawInt32.php
+++ b/src/Lib/PhpInternals/Types/C/RawInt32.php
@@ -25,6 +25,7 @@ final class RawInt32 implements Dereferencable
     /** @param CastedCData<CInteger> $casted_cdata */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         $this->value = $this->casted_cdata->casted->cdata;
     }
@@ -39,6 +40,11 @@ final class RawInt32 implements Dereferencable
         Pointer $pointer
     ): static {
         /** @var CastedCData<CInteger> $casted_cdata */
-        return new self($casted_cdata);
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/C/RawString.php
+++ b/src/Lib/PhpInternals/Types/C/RawString.php
@@ -27,6 +27,7 @@ final class RawString implements Dereferencable
     public function __construct(
         private CastedCData $cdata,
         private int $len,
+        private Pointer $pointer,
     ) {
         unset($this->value);
     }
@@ -57,6 +58,11 @@ final class RawString implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        return new self($casted_cdata, $pointer->size);
+        return new self($casted_cdata, $pointer->size, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Php/SapiGlobalsStruct.php
+++ b/src/Lib/PhpInternals/Types/Php/SapiGlobalsStruct.php
@@ -26,6 +26,7 @@ final class SapiGlobalsStruct implements Dereferencable
     /** @param CastedCData<sapi_globals_struct> $casted_cdata */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->global_request_time);
     }
@@ -45,6 +46,11 @@ final class SapiGlobalsStruct implements Dereferencable
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
         /** @var CastedCData<sapi_globals_struct> $casted_cdata */
-        return new self($casted_cdata);
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/Bucket.php
@@ -30,9 +30,13 @@ final class Bucket implements Dereferencable
      */
     public Pointer $key;
 
-    /** @param CastedCData<ZendBucket> $casted_cdata */
+    /**
+     * @param CastedCData<\FFI\PhpInternals\Bucket> $casted_cdata
+     * @param Pointer<Bucket> $pointer
+     */
     public function __construct(
-        private CastedCData $casted_cdata,
+        protected CastedCData $casted_cdata,
+        protected Pointer $pointer,
     ) {
         unset($this->val);
         unset($this->h);
@@ -60,7 +64,16 @@ final class Bucket implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<ZendBucket> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\Bucket> $casted_cdata
+         * @var Pointer<Bucket> $pointer
+         */
+        return new static($casted_cdata, $pointer);
+    }
+
+    /** @return Pointer<Bucket> */
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -42,7 +42,8 @@ use Reli\Lib\Process\Pointer\Pointer;
 * zend_long         nNextFreeElement;
 * dtor_func_t       pDestructor;
 * }; */
-final class ZendArray implements Dereferencable
+/** @psalm-consistent-constructor */
+class ZendArray implements Dereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $flags;
@@ -64,9 +65,13 @@ final class ZendArray implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $nNextFreeElement;
 
-    /** @param CastedCData<zend_array> $casted_cdata */
+    /**
+     * @param CastedCData<zend_array> $casted_cdata
+     * @param Pointer<ZendArray> $pointer,
+     */
     public function __construct(
-        private CastedCData $casted_cdata
+        protected CastedCData $casted_cdata,
+        protected Pointer $pointer,
     ) {
         unset($this->flags);
         unset($this->nTableMask);
@@ -158,7 +163,15 @@ final class ZendArray implements Dereferencable
 
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /** @var CastedCData<zend_array> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_array> $casted_cdata
+         * @var Pointer<ZendArray> $pointer
+         */
+        return new static($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -27,9 +27,13 @@ final class ZendClassEntry implements Dereferencable
      */
     public Pointer $name;
 
-    /** @param CastedCData<zend_class_entry> $casted_cdata */
+    /**
+     * @param CastedCData<zend_class_entry> $casted_cdata
+     * @param Pointer<ZendClassEntry> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->name);
     }
@@ -53,8 +57,16 @@ final class ZendClassEntry implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_class_entry> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_class_entry> $casted_cdata
+         * @var Pointer<ZendClassEntry> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 
     public function getClassName(Dereferencer $dereferencer): string

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -30,9 +30,13 @@ final class ZendExecuteData implements Dereferencable
     /** @var Pointer<ZendOp>|null */
     public ?Pointer $opline;
 
-    /** @param CastedCData<zend_execute_data> $casted_cdata */
+    /**
+     * @param CastedCData<zend_execute_data> $casted_cdata
+     * @param Pointer<ZendExecuteData> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->func);
         unset($this->prev_execute_data);
@@ -78,8 +82,17 @@ final class ZendExecuteData implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_execute_data> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_execute_data> $casted_cdata
+         * @var Pointer<ZendExecuteData> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    /** @return Pointer<ZendExecuteData> */
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 
     public function getFunctionName(Dereferencer $dereferencer): ?string

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -23,9 +23,13 @@ final class ZendExecutorGlobals implements Dereferencable
     /** @var Pointer<ZendExecuteData>|null */
     public ?Pointer $current_execute_data;
 
-    /** @param CastedCData<zend_executor_globals> $casted_cdata */
+    /**
+     * @param CastedCData<zend_executor_globals> $casted_cdata
+     * @param Pointer<ZendExecutorGlobals> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->current_execute_data);
     }
@@ -52,7 +56,16 @@ final class ZendExecutorGlobals implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_executor_globals> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_executor_globals> $casted_cdata
+         * @var Pointer<ZendExecutorGlobals> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    /** @return Pointer<ZendExecutorGlobals> */
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -41,9 +41,11 @@ final class ZendFunction implements Dereferencable
 
     /**
      * @param CastedCData<zend_function> $casted_cdata
+     * @param Pointer<ZendFunction> $pointer
      */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->type);
         unset($this->function_name);
@@ -84,8 +86,17 @@ final class ZendFunction implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_function> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_function> $casted_cdata
+         * @var Pointer<ZendFunction> $pointer
+         */
+        return new static($casted_cdata, $pointer);
+    }
+
+    /** @return Pointer<ZendFunction> */
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 
     public function getFullyQualifiedFunctionName(Dereferencer $dereferencer): string

--- a/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
@@ -31,9 +31,13 @@ final class ZendModuleEntry implements Dereferencable
      */
     public Pointer $version;
 
-    /** @param CastedCData<zend_module_entry> $casted_cdata */
+    /**
+     * @param CastedCData<zend_module_entry> $casted_cdata
+     * @param Pointer<ZendModuleEntry> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->zts);
         unset($this->version);
@@ -65,7 +69,15 @@ final class ZendModuleEntry implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_module_entry> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_module_entry> $casted_cdata
+         * @var Pointer<ZendModuleEntry> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -39,9 +39,13 @@ final class ZendOp implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $extended_value;
 
-    /** @param CastedCData<zend_op> $casted_cdata */
+    /**
+     * @param CastedCData<zend_op> $casted_cdata
+     * @param Pointer<ZendOp> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
+        private Pointer $pointer,
     ) {
         unset($this->op1);
         unset($this->op2);
@@ -79,7 +83,15 @@ final class ZendOp implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_op> $casted_cdata */
-        return new self($casted_cdata);
+        /**
+         * @var CastedCData<zend_op> $casted_cdata
+         * @var Pointer<ZendOp> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -31,10 +31,14 @@ final class ZendString implements Dereferencable
      */
     public Pointer $val;
 
-    /** @param CastedCData<zend_string> $casted_cdata */
+    /**
+     * @param CastedCData<zend_string> $casted_cdata
+     * @param Pointer<ZendString> $pointer
+     */
     public function __construct(
         private CastedCData $casted_cdata,
         private int $offset_to_val,
+        private Pointer $pointer,
     ) {
         unset($this->h);
         unset($this->len);
@@ -62,16 +66,17 @@ final class ZendString implements Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static {
-        /** @var CastedCData<zend_string> $casted_cdata */
-        /*
-        $head_addr = \FFI::cast('long', \FFI::addr($cdata))->cdata;
-        $val_addr = \FFI::cast('long', \FFI::addr($cdata->val))->cdata;
-        $offset_to_val = $val_addr - $head_addr;
-
-        return new self($cdata, $offset_to_val);
-        */
+        /**
+         * @var CastedCData<zend_string> $casted_cdata
+         * @var Pointer<ZendString> $pointer
+         */
         // an almost safe assumption I think
-        return new self($casted_cdata, 24);
+        return new self($casted_cdata, 24, $pointer);
+    }
+
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
     }
 
     /**

--- a/src/Lib/Process/Pointer/Dereferencable.php
+++ b/src/Lib/Process/Pointer/Dereferencable.php
@@ -29,4 +29,6 @@ interface Dereferencable
         CastedCData $casted_cdata,
         Pointer $pointer
     ): static;
+
+    public function getPointer(): Pointer;
 }

--- a/tests/Lib/PhpInternals/Types/Zend/ZendStringTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendStringTest.php
@@ -33,7 +33,12 @@ class ZendStringTest extends TestCase
                     'val' => $string_addr,
                 ],
             ),
-            24
+            24,
+            new Pointer(
+                ZendString::class,
+                147,
+                255,
+            )
         );
         $this->assertSame(123, $zend_string->h);
         $this->assertSame(234, $zend_string->len);
@@ -56,7 +61,12 @@ class ZendStringTest extends TestCase
                     'val' => $string_addr,
                 ],
             ),
-            24
+            24,
+            new Pointer(
+                ZendString::class,
+                152,
+                280,
+            )
         );
         $value_pointer = $zend_string->getValuePointer(
             new Pointer(RawString::class, 123, 16)


### PR DESCRIPTION
Some internal structures like zend_object or zend_string uses C struct hack heavily. And the implementation of the memory profiler often needs to know the remote address and it's size of structures. So it's convenient if we can always get the original remote address and size used to dereference the objects.