### PR TITLE
Append the file name and start/end line to the function name to distinguish closures in the same file.

### DIFF
--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV70 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = 0x100000;
     public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV71 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = 0x100000;
     public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV72 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = 0x100000;
     public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV73 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = (1 << 20);
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 30);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV74 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = (1 << 20);
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV80.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV80.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV80 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = (1 << 22);
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV81.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV81.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV81 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = (1 << 22);
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV82.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV82.php
@@ -15,5 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV82 extends VersionAwareConstants
 {
+    public const ZEND_ACC_CLOSURE = (1 << 20);
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 }

--- a/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
+++ b/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
@@ -18,6 +18,9 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
 abstract class VersionAwareConstants
 {
     /** @var int */
+    public const ZEND_ACC_CLOSURE = (1 << 22);
+
+    /** @var int */
     public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 
     /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -154,13 +154,15 @@ final class ZendExecuteData implements Dereferencable
         return (bool)($this->This->u1->type_info & (1 << 27));
     }
 
-    public function getFunctionName(Dereferencer $dereferencer): ?string
-    {
+    public function getFunctionName(
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+    ): ?string {
         if (is_null($this->func)) {
             return null;
         }
         $func = $dereferencer->deref($this->func);
-        return $func->getFullyQualifiedFunctionName($dereferencer);
+        return $func->getFullyQualifiedFunctionName($dereferencer, $zend_type_reader);
     }
 
     /** @return iterable<int, ZendExecuteData> */

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -151,7 +151,10 @@ final class CallTraceReader
             }
             $current_function = $cached_dereferencer->deref($current_execute_data->func);
 
-            $function_name = $current_function->getFunctionName($cached_dereferencer) ?? '<main>';
+            $function_name = $current_function->getFunctionName(
+                $cached_dereferencer,
+                $this->getTypeReader($php_version),
+            ) ?? '<main>';
             $class_name = $current_function->getClassName($cached_dereferencer) ?? '';
             $file_name = $current_function->getFileName($cached_dereferencer) ?? '<unknown>';
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -660,7 +660,10 @@ final class MemoryLocationsCollector
             if (is_null($execute_data->func)) {
                 continue;
             }
-            $function_name = $execute_data->getFunctionName($dereferencer);
+            $function_name = $execute_data->getFunctionName(
+                $dereferencer,
+                $zend_type_reader,
+            );
             $call_frame_context = new CallFrameContext(
                 $function_name ?? '<main>',
             );
@@ -1057,7 +1060,8 @@ final class MemoryLocationsCollector
         ContextPools $context_pools
     ): UserFunctionDefinitionContext {
         $function_name = $func->getFullyQualifiedFunctionName(
-            $dereferencer
+            $dereferencer,
+            $zend_type_reader,
         );
         $op_array_header_memory_location = ZendOpArrayHeaderMemoryLocation::fromZendFunction(
             $func,


### PR DESCRIPTION
Using the address of its op_array is stricter, but this is probably more useful in most cases.