### PR TITLE
Pretend PHP 7.0 for finding the module registry

### DIFF
--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -100,7 +100,7 @@ class PhpVersionDetector
         int $pid,
         int $module_registry_address
     ): ?string {
-        $fake_php_version = ZendTypeReader::defaultVersion();
+        $fake_php_version = ZendTypeReader::V70;
         $dereferencer = $this->getDereferencer($pid, $fake_php_version);
         $module_registry = $this->getModuleRegistry(
             $module_registry_address,


### PR DESCRIPTION
Using the version of the executing VM causes error in running this tool on unsupported target version of PHP.