### PR TITLE
Fix error on the latest interpreter

### DIFF
--- a/src/Lib/PhpInternals/Types/C/PointerArray.php
+++ b/src/Lib/PhpInternals/Types/C/PointerArray.php
@@ -108,7 +108,6 @@ final class PointerArray implements Dereferencable
         ZendTypeReader $zend_type_reader,
         ?int $size = null,
     ): Pointer {
-        assert(isset($this->casted_cdata->casted[$offset]));
         return new Pointer(
             $class_name,
             Cast::toInt($this->casted_cdata->casted[$offset]),


### PR DESCRIPTION
I don't know the details, but the latest interpreter seems to raise an error when this assertion is present, assuming that an array access to an object has been performed on CData.
Removing the assertion at least avoids the problem.