### PR TITLE
Suppresses error output due to intended cancellations in the daemon mode

### DIFF
--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Command\Inspector;
 
+use Amp\CancelledException;
 use Amp\DeferredCancellation;
 use Reli\Inspector\Daemon\Dispatcher\DispatchTable;
 use Reli\Inspector\Daemon\Reader\Protocol\Message\TraceMessage;
@@ -138,7 +139,12 @@ final class DaemonCommand extends Command
                 }
             );
         }
-        await($futures, $cancellation->getCancellation());
+
+        try {
+            await($futures, $cancellation->getCancellation());
+        } catch (CancelledException $e) {
+            Log::debug('cancelled', ['exception' => $e->getMessage()]);
+        }
 
         return 0;
     }

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Command\Inspector;
 
+use Amp\CancelledException;
 use Amp\DeferredCancellation;
 use Reli\Inspector\Daemon\Dispatcher\DispatchTable;
 use Reli\Inspector\Daemon\Dispatcher\WorkerPool;
@@ -139,7 +140,12 @@ final class TopLikeCommand extends Command
                 }
             );
         }
-        await($futures, $cancellation->getCancellation());
+
+        try {
+            await($futures, $cancellation->getCancellation());
+        } catch (CancelledException $e) {
+            Log::debug('cancelled', ['exception' => $e->getMessage()]);
+        }
 
         return 0;
     }


### PR DESCRIPTION
The daemon mode had exited with erroring when hitting the cancel key 'q'.
This may mess the output and bother converters working properly.