### PR TITLE
Add an ability to get the real stack trace on memory_limit violations

### DIFF
--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryLimitErrorDetails.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryLimitErrorDetails.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\MemoryProfilerSettings;
+
+final class MemoryLimitErrorDetails
+{
+    public function __construct(
+        public string $file,
+        public int $line,
+        public int $max_challenge_depth,
+    ) {
+    }
+}

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\MemoryProfilerSettings;
+
+final class MemoryProfilerSettings
+{
+    public function __construct(
+        public bool $stop_process,
+        public bool $pretty_print,
+        public ?MemoryLimitErrorDetails $memory_exhaustion_error_details = null,
+    ) {
+    }
+}

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsException.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\MemoryProfilerSettings;
+
+use Reli\Inspector\Settings\InspectorSettingsException;
+
+class MemoryProfilerSettingsException extends InspectorSettingsException
+{
+    public const MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER = 1;
+    public const MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER = 2;
+
+    protected const ERRORS = [
+        self::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
+            => 'memory_limit_error_max_depth is not positive integer',
+        self::MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER
+            => 'memory_limit_error_line is not integer',
+    ];
+}

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\MemoryProfilerSettings;
+
+use PhpCast\Cast;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+final class MemoryProfilerSettingsFromConsoleInput
+{
+    /** @codeCoverageIgnore */
+    public function setOptions(Command $command): void
+    {
+        $command->addOption(
+            'stop-process',
+            null,
+            InputOption::VALUE_NEGATABLE,
+            'stop the process while inspecting (default: on)',
+            true,
+        );
+        $command->addOption(
+            'pretty-print',
+            null,
+            InputOption::VALUE_NEGATABLE,
+            'pretty print the result (default: off)',
+            false,
+        );
+        $command->addOption(
+            'memory-limit-error-file',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'file path where memory_limit is exceeded'
+        );
+        $command->addOption(
+            'memory-limit-error-line',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'line number where memory_limit is exceeded'
+        );
+        $command->addOption(
+            'memory-limit-error-max-depth',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'max attempts to trace back the VM stack on memory_limit error',
+            512,
+        );
+    }
+
+    public function createSettings(InputInterface $input): MemoryProfilerSettings
+    {
+        $stop_process = Cast::toBool($input->getOption('stop-process'));
+        $pretty_print = Cast::toBool($input->getOption('pretty-print'));
+        $memory_exhaustion_error_details = null;
+        if (
+            $input->getOption('memory-limit-error-file') !== null
+            and $input->getOption('memory-limit-error-line') !== null
+        ) {
+            $memory_limit_error_max_depth = filter_var(
+                $input->getOption('memory-limit-error-max-depth'),
+                FILTER_VALIDATE_INT
+            );
+            if (
+                $memory_limit_error_max_depth === false
+                or $memory_limit_error_max_depth < 1
+            ) {
+                throw MemoryProfilerSettingsException::create(
+                    MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
+                );
+            }
+            $line = filter_var($input->getOption('memory-limit-error-line'), FILTER_VALIDATE_INT);
+            if ($line === false) {
+                throw MemoryProfilerSettingsException::create(
+                    MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER
+                );
+            }
+            $memory_exhaustion_error_details = new MemoryLimitErrorDetails(
+                Cast::toString($input->getOption('memory-limit-error-file')),
+                $line,
+                $memory_limit_error_max_depth,
+            );
+        }
+        return new MemoryProfilerSettings(
+            $stop_process,
+            $pretty_print,
+            $memory_exhaustion_error_details
+        );
+    }
+}

--- a/src/Lib/PhpInternals/Types/C/PointerArray.php
+++ b/src/Lib/PhpInternals/Types/C/PointerArray.php
@@ -8,6 +8,7 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Traversable;
 
 final class PointerArray implements Dereferencable
 {
@@ -125,5 +126,13 @@ final class PointerArray implements Dereferencable
             $address,
             8 * $len,
         );
+    }
+
+    /** @return \Traversable<int, int> */
+    public function getReverseIteratorAsInt(): Traversable
+    {
+        for ($i = $this->len - 1; $i >= 0; $i--) {
+            yield $i => Cast::toInt($this->casted_cdata->casted[$i]);
+        }
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -38,6 +38,9 @@ final class ZendExecutorGlobals implements Dereferencable
     /** @var Pointer<ZendVmStack>|null  */
     public ?Pointer $vm_stack;
 
+    /** @var Pointer<Zval>|null  */
+    public ?Pointer $vm_stack_top;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendArray $included_files;
 
@@ -64,6 +67,7 @@ final class ZendExecutorGlobals implements Dereferencable
         unset($this->zend_constants);
         unset($this->symbol_table);
         unset($this->vm_stack);
+        unset($this->vm_stack_top);
         unset($this->objects_store);
         unset($this->included_files);
     }
@@ -112,10 +116,17 @@ final class ZendExecutorGlobals implements Dereferencable
                     \FFI::sizeof($this->casted_cdata->casted->symbol_table),
                 ),
             ),
-            'vm_stack' => $this->casted_cdata->casted->vm_stack !== null
+            'vm_stack' => $this->vm_stack = $this->casted_cdata->casted->vm_stack !== null
                 ? Pointer::fromCData(
                     ZendVmStack::class,
                     $this->casted_cdata->casted->vm_stack,
+                )
+                : null
+            ,
+            'vm_stack_top' => $this->vm_stack_top = $this->casted_cdata->casted->vm_stack_top !== null
+                ? Pointer::fromCData(
+                    Zval::class,
+                    $this->casted_cdata->casted->vm_stack_top,
                 )
                 : null
             ,

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -23,6 +23,9 @@ use Reli\Lib\Process\Pointer\Pointer;
 /** @psalm-consistent-constructor */
 final class ZendFunction implements Dereferencable
 {
+    public const ZEND_INTERNAL_FUNCTION = 1;
+    public const ZEND_USER_FUNCTION = 2;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $type;
 
@@ -179,6 +182,11 @@ final class ZendFunction implements Dereferencable
 
     public function isUserFunction(): bool
     {
-        return $this->type === 2;
+        return $this->type === self::ZEND_USER_FUNCTION;
+    }
+
+    public function isInternalFunction(): bool
+    {
+        return $this->type === self::ZEND_INTERNAL_FUNCTION;
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\Types\C\PointerArray;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -120,5 +121,27 @@ class ZendVmStack implements Dereferencable
                 $stack = null;
             }
         }
+    }
+
+    public function getRootStack(Dereferencer $dereferencer): ZendVmStack
+    {
+        $stack = $this;
+        while ($stack->prev !== null) {
+            $stack = $dereferencer->deref($stack->prev);
+        }
+        return $stack;
+    }
+
+    public function materializeAsPointerArray(
+        Dereferencer $dereferencer,
+        int $end_address,
+    ): PointerArray {
+        assert($this->top !== null);
+        $pointer = new Pointer(
+            PointerArray::class,
+            $this->top->address,
+            $end_address - $this->top->address,
+        );
+        return $dereferencer->deref($pointer);
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendOpArrayHeaderMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendOpArrayHeaderMemoryLocation.php
@@ -16,13 +16,17 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
 use Reli\Lib\PhpInternals\Types\Zend\ZendFunction;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\MemoryLocation;
+use Reli\Lib\Process\Pointer\Dereferencer;
 
 class ZendOpArrayHeaderMemoryLocation extends MemoryLocation
 {
     public function __construct(
         int $address,
         int $size,
-        public string $function_name
+        public string $function_name,
+        public string $file,
+        public int $line_start,
+        public int $line_end,
     ) {
         parent::__construct($address, $size);
     }
@@ -30,12 +34,15 @@ class ZendOpArrayHeaderMemoryLocation extends MemoryLocation
     public static function fromZendFunction(
         ZendFunction $zend_function,
         ZendTypeReader $zend_type_reader,
-        string $function_name
+        Dereferencer $dereferencer,
     ): self {
         return new self(
             $zend_function->getPointer()->address,
             $zend_type_reader->sizeOf('zend_op_array'),
-            $function_name,
+            $zend_function->getFullyQualifiedFunctionName($dereferencer, $zend_type_reader),
+            $zend_function->op_array->getFileName($dereferencer) ?? '',
+            $zend_function->op_array->line_start,
+            $zend_function->op_array->line_end,
         );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayElementsContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayElementsContext.php
@@ -24,6 +24,16 @@ class ArrayElementsContext implements ReferenceContext
     ) {
     }
 
+    public function getCount(): int
+    {
+        return count($this->referencing_contexts);
+    }
+
+    public function getElementByKey(int|string $key): ?ReferenceContext
+    {
+        return $this->referencing_contexts[(string)$key] ?? null;
+    }
+
     public function getLocations(): iterable
     {
         return [$this->memory_location];
@@ -32,7 +42,7 @@ class ArrayElementsContext implements ReferenceContext
     public function getContexts(): iterable
     {
         return [
-            '#count' => count($this->referencing_contexts),
+            '#count' => $this->getCount(),
         ];
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayHeaderContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayHeaderContext.php
@@ -24,6 +24,17 @@ final class ArrayHeaderContext implements ReferenceContext
     ) {
     }
 
+    public function getElements(): ?ArrayElementsContext
+    {
+        /** @var ArrayElementsContext|null */
+        return $this->referencing_contexts['array_elements'] ?? null;
+    }
+
+    public function getElement(int|string $key): ?ReferenceContext
+    {
+        return $this->getElements()?->getElementByKey($key) ?? null;
+    }
+
     public function getLocations(): iterable
     {
         return [$this->memory_location];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
@@ -19,13 +19,26 @@ class CallFrameContext implements ReferenceContext
 
     public function __construct(
         public string $function_name,
+        public int $lineno,
     ) {
+    }
+
+    public function getLocalVariables(): ?CallFrameVariableTableContext
+    {
+        /** @var CallFrameVariableTableContext|null */
+        return $this->referencing_contexts['local_variables'] ?? null;
+    }
+
+    public function getLocalVariable(string $variable_name): ?ReferenceContext
+    {
+        return $this->getLocalVariables()?->getVariable($variable_name) ?? null;
     }
 
     public function getContexts(): iterable
     {
         return [
             'function_name' => $this->function_name,
+            'lineno' => $this->lineno,
         ];
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameVariableTableContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameVariableTableContext.php
@@ -17,6 +17,11 @@ final class CallFrameVariableTableContext implements ReferenceContext
 {
     use ReferenceContextDefault;
 
+    public function getVariable(string $variable_name): ?ReferenceContext
+    {
+        return $this->referencing_contexts[$variable_name] ?? null;
+    }
+
     public function getContexts(): iterable
     {
         return [

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFramesContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFramesContext.php
@@ -17,6 +17,17 @@ final class CallFramesContext implements ReferenceContext
 {
     use ReferenceContextDefault;
 
+    public function getFrameAt(int $frame_no): CallFrameContext
+    {
+        /** @var CallFrameContext */
+        return $this->referencing_contexts[(string)$frame_no];
+    }
+
+    public function getFrameCount(): int
+    {
+        return count($this->referencing_contexts);
+    }
+
     public function getContexts(): iterable
     {
         return [

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContext.php
@@ -22,6 +22,40 @@ class UserFunctionDefinitionContext extends FunctionDefinitionContext
     ) {
     }
 
+    public function getFunctionName(): string
+    {
+        return $this->memory_location->function_name;
+    }
+
+    public function getOpArrayAddress(): int
+    {
+        return $this->memory_location->address;
+    }
+
+    public function isClosureOf(UserFunctionDefinitionContext $context): bool
+    {
+        return $context->isThisContext(
+            $this->memory_location->file,
+            $this->memory_location->line_start,
+        );
+    }
+
+    public function isThisContext(
+        string $file,
+        int $line,
+    ): bool {
+        if ($this->memory_location->file !== $file) {
+            return false;
+        }
+        if ($this->memory_location->line_start > $line) {
+            return false;
+        }
+        if ($this->memory_location->line_end < $line) {
+            return false;
+        }
+        return true;
+    }
+
     public function getContexts(): iterable
     {
         return ['#is_internal' => false];

--- a/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\MemoryProfilerSettings;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Reli\BaseTestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
+{
+    public function testFromConsoleInput()
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('stop-process')->andReturns(true)->atLeast()->once();
+        $input->expects()->getOption('pretty-print')->andReturns(false)->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(512)->atLeast()->once();
+
+        $settings = (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertTrue($settings->stop_process);
+        $this->assertFalse($settings->pretty_print);
+        $this->assertSame('abc.php', $settings->memory_exhaustion_error_details->file);
+        $this->assertSame(20, $settings->memory_exhaustion_error_details->line);
+        $this->assertSame(512, $settings->memory_exhaustion_error_details->max_challenge_depth);
+    }
+
+    public function testFromConsoleInputDepthNotInteger()
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
+        $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
+        $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-max-depth')->andReturns('abc');
+        $this->expectException(MemoryProfilerSettingsException::class);
+        $this->expectExceptionCode(
+            MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
+        );
+        (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputDepthNotPositive()
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
+        $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
+        $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(-1);
+        $this->expectException(MemoryProfilerSettingsException::class);
+        $this->expectExceptionCode(
+            MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
+        );
+        (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputLineNotInteger()
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
+        $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
+        $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-line')->andReturns('abc')->atLeast()->once();
+        $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(512)->zeroOrMoreTimes();
+        $this->expectException(MemoryProfilerSettingsException::class);
+        $this->expectExceptionCode(
+            MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER
+        );
+        (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
+    }
+}

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -24,6 +24,7 @@ class zend_executor_globals extends CData
     public ?CPointer $zend_constants;
     public zend_array $symbol_table;
     public ?CPointer $vm_stack;
+    public ?CPointer $vm_stack_top;
     public zend_array $included_files;
     public ?CPointer $ini_directives;
     public ?CPointer $modified_ini_directives;


### PR DESCRIPTION
A `memory_limit` violation is a fatal error. It cannot be catched as an exception from user scripts.

As the shutdown handlers are invoked even on fatal errors, we often use the combination of `register_shutdown_function()` and `error_get_last()` to handle fatal errors in some ways. For example, if we detect the occurrence of `memory_limit` violation in a shutdown handler, we can kick Reli from there and analyze the memory usage of the dying process itself.

Like [`debug_backtrace()` in shutdown handlers](https://3v4l.org/YlHMA), normally Reli can only capture the call stack with the shutdown handler as the root. It's because of the `EG(current_execute_data)` [points into nirvana](https://github.com/php/php-src/blob/ba204a2e3aee1639471dbbc3423004887275a59c/main/main.c#L1817-L1820) before the shutdown handlers are invoked. We cannot get the real stack trace at the time of the `memory_limit` violation occurred, without a hack.

So, this PR implements the hack.

If you specify the file name and line number of the violation with `--memory-limit-error-file` and `--memory-limit-error-line` options, Reli first finds the corresponding op_array (the compiled VM codes) in the process memory, and then searches the call frame referencing the op_array by a linear scanning to the VM stack in reverse order. And by assuming it is the actual call frame lastly executed before the `memory_limit` violation and challenging whether it could be able to reach the root of the VM stack by tracing back from there, Reli can get the real stack trace including local variables.

The idea was born in [a convesation](https://phpc.social/@sji/111417260427019137) with @Jean85 at php.social .