### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Lib/Elf/Structure/Elf64/Elf64GnuHashTable.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64GnuHashTable.php
@@ -71,7 +71,7 @@ final class Elf64GnuHashTable
 
     public function checkBloomFilter(int $hash): bool
     {
-        $bloom = $this->bloom[($hash / self::ELFCLASS_BITS) % $this->bloom_size];
+        $bloom = $this->bloom[(int)($hash / self::ELFCLASS_BITS) % $this->bloom_size];
         $bloom_hash1 = $hash % self::ELFCLASS_BITS;
         $bloom_hash2 = ($hash >> $this->bloom_shift) % self::ELFCLASS_BITS;
         return $bloom->checkBitSet($bloom_hash1) and $bloom->checkBitSet($bloom_hash2);


### PR DESCRIPTION
This line causes deprecation warnings like this.

```
PHP Deprecated:  Implicit conversion from float 54839476.546875 to int loses precision in /home/sji/work/reli-prof/src/Lib/Elf/Structure/Elf64/Elf64GnuHashTable.php on line 74
```