### PR TITLE
Fix the target PHP version detection on some cases

### DIFF
--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -77,8 +77,14 @@ final class MemoryCommand extends Command
             defer($scope_guard, fn () => $this->process_stopper->resume($process_specifier->pid));
         }
 
-        $eg_address = $this->php_globals_finder->findExecutorGlobals($process_specifier, $target_php_settings);
-        $cg_address = $this->php_globals_finder->findCompilerGlobals($process_specifier, $target_php_settings);
+        $eg_address = $this->php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings_version_decided
+        );
+        $cg_address = $this->php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings_version_decided
+        );
 
         $collected_memories = $this->memory_locations_collector->collectAll(
             $process_specifier,

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -76,6 +76,7 @@ class PhpGlobalsFinder
     }
 
     /**
+     * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
      * @throws ElfParserException
      * @throws MemoryReaderException
      * @throws ProcessSymbolReaderException
@@ -93,6 +94,7 @@ class PhpGlobalsFinder
     }
 
     /**
+     * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
      * @throws ElfParserException
      * @throws MemoryReaderException
      * @throws ProcessSymbolReaderException


### PR DESCRIPTION
The automatically detected PHP version isn't actually used to get the address of EG and CG on `i:m` and `i:eg`