### PR TITLE
Test mutiple target PHP versions via docker and fixes some bugs

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run test suite
         run: |
           mkdir -p build/logs
-          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+          composer test-for-ci
 
       - name: Send to coveralls
         env:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,6 +51,9 @@ jobs:
           mkdir -p build/logs
           composer test-for-ci
 
+      - name: Fix absolute paths in the coverage report
+        run: sed -i "s|<file name=\"/app/|<file name=\"`pwd`/|g" build/logs/clover.xml
+
       - name: Send to coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,31 @@
+FROM php:8.1-cli
+
+RUN apt-get update && apt-get install -y \
+      libffi-dev \
+      libzip-dev \
+    && docker-php-ext-install ffi \
+    && docker-php-ext-install pcntl \
+    && docker-php-ext-install zip \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y \
+    && apt-get install -y ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update -y \
+    && apt-get install -y docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY . .
+
+RUN composer install
+
+CMD ["php", "vendor/bin/phpunit", "--colors=always", "--testdox", "--coverage-text", "--coverage-clover=coverage.xml", "--coverage-html=coverage"]

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Reli\\": "tests"
+      "Reli\\": "tests",
+      "Reli\\Command\\": "tests/Command/CommandEnumeratorTestData"
     }
   },
   "bin": [
@@ -56,7 +57,13 @@
   ],
   "scripts": {
     "test": [
-      "phpunit"
+      "docker-compose run reli-test"
+    ],
+    "test-with-coverage": [
+      "docker-compose run reli-test-with-coverage"
+    ],
+    "test-for-ci": [
+      "docker-compose run reli-test-for-ci"
     ],
     "psalm": [
       "psalm.phar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.9'
+services:
+  reli-test:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    pid: "host"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - .:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/reli-test:/tmp/reli-test
+    container_name: reli-test
+    command: ["vendor/bin/phpunit" , "--colors=always", "--testdox"]
+  reli-test-with-coverage:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    pid: "host"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - .:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/reli-test:/tmp/reli-test
+      - ./build:/app/build
+    container_name: reli-test
+    command: ["vendor/bin/phpunit" , "--colors=always", "--testdox", "--coverage-clover", "build/logs/clover.xml"]
+  reli-test-for-ci:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    pid: "host"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - .:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp/reli-test:/tmp/reli-test
+      - ./build:/app/build
+    container_name: reli-test
+    command: ["vendor/bin/phpunit" , "--coverage-clover", "build/logs/clover.xml"]

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -167,6 +167,17 @@ struct _zend_resource {
 	void             *ptr;
 };
 
+// zend_compile.h
+typedef struct _zend_property_info {
+	uint32_t offset; /* property offset for object properties or
+	                      property index for static properties */
+	uint32_t flags;
+	zend_string *name;
+	zend_string *doc_comment;
+	zend_class_entry *ce;
+} zend_property_info;
+
+// zend_types.h
 struct _zend_reference {
 	zend_refcounted_h              gc;
 	zval                           val;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -169,6 +169,17 @@ struct _zend_resource {
 	void             *ptr;
 };
 
+// zend_compile.h
+typedef struct _zend_property_info {
+	uint32_t offset; /* property offset for object properties or
+	                      property index for static properties */
+	uint32_t flags;
+	zend_string *name;
+	zend_string *doc_comment;
+	zend_class_entry *ce;
+} zend_property_info;
+
+// zend_types.h
 struct _zend_reference {
 	zend_refcounted_h              gc;
 	zval                           val;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -171,6 +171,17 @@ struct _zend_resource {
 
 typedef uintptr_t zend_type;
 
+// zend_compile.h
+typedef struct _zend_property_info {
+	uint32_t offset; /* property offset for object properties or
+	                      property index for static properties */
+	uint32_t flags;
+	zend_string *name;
+	zend_string *doc_comment;
+	zend_class_entry *ce;
+} zend_property_info;
+
+// zend_types.h
 struct _zend_reference {
 	zend_refcounted_h              gc;
 	zval                           val;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -168,6 +168,17 @@ struct _zend_resource {
 
 typedef uintptr_t zend_type;
 
+// zend_compile.h
+typedef struct _zend_property_info {
+	uint32_t offset; /* property offset for object properties or
+	                      property index for static properties */
+	uint32_t flags;
+	zend_string *name;
+	zend_string *doc_comment;
+	zend_class_entry *ce;
+} zend_property_info;
+
+// zend_types.h
 struct _zend_reference {
 	zend_refcounted_h              gc;
 	zval                           val;

--- a/src/Lib/PhpInternals/Types/Zend/V74/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/V74/ZendArray.php
@@ -33,6 +33,37 @@ final class ZendArray extends BaseZendArray implements Dereferencable
         };
     }
 
+    public function dumpFlags(): string
+    {
+        $flags = $this->flags;
+        $flag_names = [];
+        if ($flags & ((1 << 0) | (1 << 1))) {
+            $flag_names[] = 'HASH_FLAG_CONSISTENCY';
+        }
+        if ($flags & (1 << 2)) {
+            $flag_names[] = 'HASH_FLAG_PACKED';
+        }
+        if ($flags & (1 << 3)) {
+            $flag_names[] = 'HASH_FLAG_UNINITIALIZED';
+        }
+        if ($flags & (1 << 4)) {
+            $flag_names[] = 'HASH_FLAG_STATIC_KEYS';
+        }
+        if ($flags & (1 << 5)) {
+            $flag_names[] = 'HASH_FLAG_HAS_EMPTY_IND';
+        }
+        if ($flags & (1 << 6)) {
+            $flag_names[] = 'HASH_FLAG_ALLOW_COW_VIOLATION';
+        }
+
+        return implode(' | ', $flag_names);
+    }
+
+    public function isUninitialized(): bool
+    {
+        return (bool)($this->flags & (1 << 3));
+    }
+
     public function getDataSize(): int
     {
         return $this->nTableSize * self::BUCKET_SIZE_IN_BYTES;

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -351,6 +351,7 @@ class ZendArray implements Dereferencable
         return new static($casted_cdata, $pointer);
     }
 
+    /** @return Pointer<ZendArray> */
     public function getPointer(): Pointer
     {
         return $this->pointer;

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -198,7 +198,8 @@ final class ZendClassEntry implements Dereferencable
         Dereferencer $dereferencer,
         ZendTypeReader $type_reader,
     ): iterable {
-        foreach ($this->properties_info->getItemIterator($dereferencer) as $name => $item) {
+        $property_info = $dereferencer->deref($this->properties_info->getPointer());
+        foreach ($property_info->getItemIterator($dereferencer) as $name => $item) {
             $property_info_pointer = $item->value->getAsPointer(
                 ZendPropertyInfo::class,
                 $type_reader->sizeOf(ZendPropertyInfo::getCTypeName()),

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -259,7 +259,9 @@ final class ZendExecuteData implements Dereferencable
 
     public function getVariableTableAddress(): int
     {
-        return $this->pointer->indexedAt(1)->address;
+        return (int)($this->pointer->address
+            + (int)((($this->pointer->size) + 16 - 1) / 16) * 16
+        );
     }
 
     public function getTotalVariablesNum(Dereferencer $dereferencer): int

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -39,7 +39,10 @@ class ZendObjectMemoryLocation extends RefcountedMemoryLocation
         $class_name = $ce->getClassName($dereferencer);
         if ($class_name === \Fiber::class) {
             $size = $zend_type_reader->sizeOf('zend_fiber');
-        } elseif ($class_name === \Closure::class) {
+        } elseif (
+            $class_name === \Closure::class
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V71)
+        ) {
             $size = $zend_type_reader->sizeOf('zend_closure');
         } else {
             $size = $zend_object->getMemorySize($dereferencer);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1639,7 +1639,7 @@ final class MemoryLocationsCollector
         }
 
         $methods_context = $this->collectFunctionTable(
-            $class_entry->function_table,
+            $dereferencer->deref($class_entry->function_table->getPointer()),
             $map_ptr_base,
             $dereferencer,
             $zend_type_reader,
@@ -1650,7 +1650,7 @@ final class MemoryLocationsCollector
         $class_definition_context->add('methods', $methods_context);
 
         $class_constants_context = $this->collectClassConstantsTable(
-            $class_entry->constants_table,
+            $dereferencer->deref($class_entry->constants_table->getPointer()),
             $map_ptr_base,
             $dereferencer,
             $zend_type_reader,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1055,7 +1055,10 @@ final class MemoryLocationsCollector
 
         assert(!is_null($object->ce));
         $class_entry = $dereferencer->deref($object->ce);
-        if ($class_entry->getClassName($dereferencer) === 'Closure') {
+        if (
+            $class_entry->getClassName($dereferencer) === 'Closure'
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V71)
+        ) {
             $closure_context = $this->collectClosure(
                 $dereferencer->deref(
                     ZendClosure::getPointerFromZendObjectPointer(

--- a/tests/Command/CommandEnumeratorTestData/Test1Directory/Test1Command.php
+++ b/tests/Command/CommandEnumeratorTestData/Test1Directory/Test1Command.php
@@ -11,8 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Reli\Command\CommandEnumeratorTestData\Test1Directory;
+namespace Reli\Command\Test1Directory;
 
-final class Test1Command
+use Symfony\Component\Console\Command\Command;
+
+final class Test1Command extends Command
 {
 }

--- a/tests/Command/CommandEnumeratorTestData/Test1Directory/Test2Command.php
+++ b/tests/Command/CommandEnumeratorTestData/Test1Directory/Test2Command.php
@@ -11,8 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Reli\Command\CommandEnumeratorTestData\Test1Directory;
+namespace Reli\Command\Test1Directory;
 
-final class Test2Command
+use Symfony\Component\Console\Command\Command;
+
+final class Test2Command extends Command
 {
 }

--- a/tests/Command/CommandEnumeratorTestData/Test2Directory/Test3Command.php
+++ b/tests/Command/CommandEnumeratorTestData/Test2Directory/Test3Command.php
@@ -11,8 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Reli\Command\CommandEnumeratorTestData\Test2Directory;
+namespace Reli\Command\Test2Directory;
 
-final class Test3Command
+use Symfony\Component\Console\Command\Command;
+
+final class Test3Command extends Command
 {
 }

--- a/tests/Command/CommandEnumeratorTestData/Test2Directory/Test4Command.php
+++ b/tests/Command/CommandEnumeratorTestData/Test2Directory/Test4Command.php
@@ -11,8 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Reli\Command\CommandEnumeratorTestData\Test2Directory;
+namespace Reli\Command\Test2Directory;
 
-final class Test4Command
+use Symfony\Component\Console\Command\Command;
+
+final class Test4Command extends Command
 {
 }

--- a/tests/Lib/Process/MemoryMap/ProcessMemoryMapReaderTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessMemoryMapReaderTest.php
@@ -22,7 +22,8 @@ class ProcessMemoryMapReaderTest extends BaseTestCase
         $result = (new ProcessMemoryMapReader())->read(getmypid());
         $first_line = strtok($result, "\n");
         $this->assertMatchesRegularExpression(
-            '/[0-9a-f]+-[0-9a-f]+ [r\-][w\-][x\-][sp\-] [0-9a-f]+ [0-9][0-9][0-9]?:[0-9][0-9][0-9]? [0-9]+ +[^ ].*/',
+            // phpcs:ignore Generic.Files.LineLength.TooLong
+            '/[0-9a-f]+-[0-9a-f]+ [r\-][w\-][x\-][sp\-] [0-9a-f]+ [0-9a-z][0-9a-z][0-9a-z]?:[0-9a-z][0-9a-z][0-9a-z]? [0-9]+ +[^ ].*/',
             $first_line
         );
     }

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli;
+
+use Reli\Lib\PhpInternals\ZendTypeReader;
+
+class TargetPhpVmProvider
+{
+    public static function from(string $php_version)
+    {
+        $versions = [
+            ZendTypeReader::V70,
+            ZendTypeReader::V71,
+            ZendTypeReader::V72,
+            ZendTypeReader::V73,
+            ZendTypeReader::V74,
+            ZendTypeReader::V80,
+            ZendTypeReader::V81,
+            ZendTypeReader::V82,
+            ZendTypeReader::V83,
+        ];
+        foreach ($versions as $v) {
+            if ($php_version <= $v) {
+                yield $v => [$v, self::dockerImageNameFromPhpVersion($v)];
+            }
+        }
+    }
+
+    public static function allSupported()
+    {
+        $versions = [
+            ZendTypeReader::V70,
+            ZendTypeReader::V71,
+            ZendTypeReader::V72,
+            ZendTypeReader::V73,
+            ZendTypeReader::V74,
+            ZendTypeReader::V80,
+            ZendTypeReader::V81,
+            ZendTypeReader::V82,
+            ZendTypeReader::V83,
+        ];
+        foreach ($versions as $version) {
+            yield $version => [$version, self::dockerImageNameFromPhpVersion($version)];
+        }
+    }
+
+    public static function dockerImageNameFromPhpVersion(string $php_version): string
+    {
+        return match ($php_version) {
+            ZendTypeReader::V70 => 'php:7.0-cli',
+            ZendTypeReader::V71 => 'php:7.1-cli',
+            ZendTypeReader::V72 => 'php:7.2-cli',
+            ZendTypeReader::V73 => 'php:7.3-cli',
+            ZendTypeReader::V74 => 'php:7.4-cli',
+            ZendTypeReader::V80 => 'php:8.0-cli',
+            ZendTypeReader::V81 => 'php:8.1-cli',
+            ZendTypeReader::V82 => 'php:8.2-cli',
+            ZendTypeReader::V83 => 'php:8.3-cli',
+            default => throw new \InvalidArgumentException("unsupported php version: $php_version"),
+        };
+    }
+
+    public static function runScriptViaContainer(
+        string $docker_image_name,
+        string $script,
+        array &$pipes,
+    ) {
+        $tmp_file = tempnam('/tmp/reli-test', 'reli-prof-test');
+        $pid_writer = tempnam('/tmp/reli-test', 'reli-prof-test-pid-writer');
+        $pid_file = tempnam('/tmp/reli-test', 'reli-prof-test-pid');
+
+        chmod($tmp_file, 0777);
+        chmod($pid_writer, 0777);
+        chmod($pid_file, 0777);
+
+        file_put_contents(
+            $pid_writer,
+            <<<CODE
+            <?php
+            file_put_contents('/target-pid', getmypid());
+            fputs(STDOUT, "pid written\n");
+            CODE
+        );
+        file_put_contents(
+            $tmp_file,
+            $script
+        );
+
+        $proc_handle = self::procOpenViaDocker(
+            $docker_image_name,
+            'php -dauto_prepend_file=/pid-writer /source',
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w']
+            ],
+            $pipes,
+            [
+                $tmp_file => '/source',
+                $pid_writer => '/pid-writer',
+                $pid_file => '/target-pid',
+                '/tmp/reli-test' => '/tmp/reli-test',
+            ],
+        );
+        $pid_written_message = fgets($pipes[1]);
+        assert($pid_written_message === "pid written\n");
+        $pid = (int)file_get_contents($pid_file);
+        return [$proc_handle, $pid];
+    }
+
+    public static function procOpenViaDocker(
+        string $docker_image_name,
+        string $command,
+        array $descriptorspec,
+        array &$pipes,
+        array $mount_points = [],
+    ) {
+        $mount_options = array_map(
+            fn ($source, $target) => "-v$source:$target:rw",
+            array_keys($mount_points),
+            array_values($mount_points)
+        );
+        $uid = posix_getuid();
+        $gid = posix_getgid();
+
+        $docker_command = [
+            'docker',
+            'run',
+            '--rm',
+            '-u',
+            "$uid:$gid",
+            '--pid',
+            'host',
+            '-i',
+            '--entrypoint',
+            'sh',
+            ...$mount_options,
+            $docker_image_name,
+            '-c',
+            $command,
+        ];
+        return proc_open(
+            $docker_command,
+            $descriptorspec,
+            $pipes
+        );
+    }
+}


### PR DESCRIPTION
Also fixes several bugs found on this way.
Because target VMs in docker containers are not children of the invoker process, we cannot simply attach them from the PHPUnit process.
So I have moved the PHPUnit process itself to a docker container too and given it CAP_SYS_PTRACE.

Maybe we should cache images for speeding up testing in CI.