### PR TITLE
Improve support of non-executable ZTS binaries (support frankenphp)

### DIFF
--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
@@ -23,12 +23,14 @@ final class TargetPhpSettings
 {
     public const PHP_REGEX_DEFAULT = '.*/((php|php-fpm)(7\.?[01234]|8\.?[0123])?|libphp[78]?.*\.so)$';
     public const LIBPTHREAD_REGEX_DEFAULT = '.*/libpthread.*\.so';
+    public const ZTS_GLOBALS_REGEX_DEFAULT = self::PHP_REGEX_DEFAULT;
     public const TARGET_PHP_VERSION_DEFAULT = 'auto';
 
     /** @param TVersion $php_version */
     public function __construct(
         public string $php_regex = self::PHP_REGEX_DEFAULT,
         public string $libpthread_regex = self::LIBPTHREAD_REGEX_DEFAULT,
+        public string $zts_globals_regex = self::ZTS_GLOBALS_REGEX_DEFAULT,
         public string $php_version = self::TARGET_PHP_VERSION_DEFAULT,
         public ?string $php_path = null,
         public ?string $libpthread_path = null

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsException.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsException.php
@@ -19,13 +19,15 @@ final class TargetPhpSettingsException extends InspectorSettingsException
 {
     public const PHP_REGEX_IS_NOT_STRING = 3;
     public const LIBPTHREAD_REGEX_IS_NOT_STRING = 4;
-    public const PHP_PATH_IS_NOT_STRING = 5;
-    public const LIBPTHREAD_PATH_IS_NOT_STRING = 6;
-    public const TARGET_PHP_VERSION_INVALID = 7;
+    public const ZTS_GLOBALS_REGEX_IS_NOT_STRING = 5;
+    public const PHP_PATH_IS_NOT_STRING = 6;
+    public const LIBPTHREAD_PATH_IS_NOT_STRING = 7;
+    public const TARGET_PHP_VERSION_INVALID = 8;
 
     protected const ERRORS = [
         self::PHP_REGEX_IS_NOT_STRING => 'php-regex must be a string',
         self::LIBPTHREAD_REGEX_IS_NOT_STRING => 'libpthread-regex must be a string',
+        self::ZTS_GLOBALS_REGEX_IS_NOT_STRING => 'zts-globals-regex must be a string',
         self::PHP_PATH_IS_NOT_STRING => 'php-path must be a string',
         self::LIBPTHREAD_PATH_IS_NOT_STRING => 'libpthread-path must be a string',
         self::TARGET_PHP_VERSION_INVALID => 'php-version must be valid version string (eg: v80)',

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
@@ -41,6 +41,12 @@ final class TargetPhpSettingsFromConsoleInput
                 'regex to find the libpthread.so loaded in the target process'
             )
             ->addOption(
+                'zts-globals-regex',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'regex to find the binary containing globals symbols for ZTS loaded in the target process'
+            )
+            ->addOption(
                 'php-version',
                 null,
                 InputOption::VALUE_OPTIONAL,
@@ -77,6 +83,13 @@ final class TargetPhpSettingsFromConsoleInput
             );
         }
 
+        $zts_globals_regex = $input->getOption('zts-globals-regex') ?? $php_regex;
+        if (!is_string($zts_globals_regex)) {
+            throw TargetPhpSettingsException::create(
+                TargetPhpSettingsException::ZTS_GLOBALS_REGEX_IS_NOT_STRING
+            );
+        }
+
         $php_version = $input->getOption('php-version') ?? TargetPhpSettings::TARGET_PHP_VERSION_DEFAULT;
         if ($php_version !== 'auto' and !in_array($php_version, ZendTypeReader::ALL_SUPPORTED_VERSIONS, true)) {
             throw TargetPhpSettingsException::create(
@@ -98,6 +111,13 @@ final class TargetPhpSettingsFromConsoleInput
             );
         }
 
-        return new TargetPhpSettings($php_regex, $libpthread_regex, $php_version, $php_path, $libpthread_path);
+        return new TargetPhpSettings(
+            $php_regex,
+            $libpthread_regex,
+            $zts_globals_regex,
+            $php_version,
+            $php_path,
+            $libpthread_path
+        );
     }
 }

--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -17,6 +17,7 @@ use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\SymbolResolverCreatorInterface;
+use Reli\Lib\Integer\UInt64;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 
@@ -56,5 +57,21 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
             $this->resolver_cache = $this->loadResolver();
         }
         return $this->resolver_cache->resolve($symbol_name);
+    }
+
+    public function getDtDebugAddress(): ?int
+    {
+        if (!isset($this->resolver_cache)) {
+            $this->resolver_cache = $this->loadResolver();
+        }
+        return $this->resolver_cache->getDtDebugAddress();
+    }
+
+    public function getBaseAddress(): UInt64
+    {
+        if (!isset($this->resolver_cache)) {
+            $this->resolver_cache = $this->loadResolver();
+        }
+        return $this->resolver_cache->getBaseAddress();
     }
 }

--- a/src/Lib/Elf/Process/LinkMap.php
+++ b/src/Lib/Elf/Process/LinkMap.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+final class LinkMap
+{
+    public function __construct(
+        public int $this_address,
+        public int $l_addr,
+        public string $l_name,
+        public int $l_ld,
+        public int $l_next_address,
+        public int $l_prev_address,
+    ) {
+    }
+}

--- a/src/Lib/Elf/Process/LinkMapLoader.php
+++ b/src/Lib/Elf/Process/LinkMapLoader.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use Reli\Lib\ByteStream\CDataByteReader;
+use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+
+class LinkMapLoader
+{
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+        private IntegerByteSequenceReader $integer_reader,
+    ) {
+    }
+
+    public function loadFromAddress(int $pid, int $address): LinkMap
+    {
+        $bytes = new CDataByteReader($this->memory_reader->read($pid, $address, $this->getSize()));
+        $l_addr = $this->integer_reader->read64($bytes, 0);
+        $l_name_address = $this->integer_reader->read64($bytes, 8);
+        $l_ld = $this->integer_reader->read64($bytes, 16);
+        $l_next_address = $this->integer_reader->read64($bytes, 24);
+        $l_prev_address = $this->integer_reader->read64($bytes, 32);
+
+        return new LinkMap(
+            $address,
+            $l_addr->toInt(),
+            $this->readCString($pid, $l_name_address->toInt()),
+            $l_ld->toInt(),
+            $l_next_address->toInt(),
+            $l_prev_address->toInt()
+        );
+    }
+
+    public function searchByName(string $name, int $pid, int $root_address): ?LinkMap
+    {
+        $address = $root_address;
+        do {
+            $link_map = $this->loadFromAddress($pid, $address);
+            if ($link_map->l_name === $name) {
+                return $link_map;
+            }
+            $address = $link_map->l_next_address;
+        } while ($address !== 0);
+        return null;
+    }
+
+    private function getSize(): int
+    {
+        return 8 // l_addr
+            + 8 // l_name
+            + 8 // l_ld
+            + 8 // l_next
+            + 8 // l_prev
+        ;
+    }
+
+    private function readCString(int $pid, int $address): string
+    {
+        $bytes = $this->memory_reader->read($pid, $address, 1);
+        $str = '';
+        while (true) {
+            /** @var int $c */
+            $c = $bytes[0];
+            if ($c === 0) {
+                break;
+            }
+            $str .= chr($c);
+            $address += 1;
+            $bytes = $this->memory_reader->read($pid, $address, 1);
+        }
+        return $str;
+    }
+}

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
+use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\SymbolResolver\Elf64CachedSymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\SymbolResolverCreatorInterface;
+use Reli\Lib\Elf\Tls\LibThreadDbTlsFinder;
+use Reli\Lib\Elf\Tls\TlsFinderException;
+use Reli\Lib\Elf\Tls\X64LinuxThreadPointerRetriever;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -26,6 +30,8 @@ final class ProcessModuleSymbolReaderCreator
         private SymbolResolverCreatorInterface $symbol_resolver_creator,
         private MemoryReaderInterface $memory_reader,
         private PerBinarySymbolCacheRetriever $per_binary_symbol_cache_retriever,
+        private IntegerByteSequenceReader $integer_reader,
+        private LinkMapLoader $link_map_loader,
     ) {
     }
 
@@ -34,7 +40,8 @@ final class ProcessModuleSymbolReaderCreator
         ProcessMemoryMap $process_memory_map,
         string $regex,
         ?string $binary_path,
-        ?int $tls_block_address = null
+        ?ProcessModuleSymbolReader $libpthread_symbol_reader = null,
+        ?int $root_link_map_address = null,
     ): ?ProcessModuleSymbolReader {
         $memory_areas = $process_memory_map->findByNameRegex($regex);
         if ($memory_areas === []) {
@@ -57,11 +64,32 @@ final class ProcessModuleSymbolReaderCreator
                 BinaryFingerprint::fromProcessModuleMemoryMap($module_memory_map)
             ),
         );
+
+        $tls_block_address = null;
+        if (!is_null($libpthread_symbol_reader) and !is_null($root_link_map_address)) {
+            try {
+                $tls_finder = new LibThreadDbTlsFinder(
+                    $libpthread_symbol_reader,
+                    X64LinuxThreadPointerRetriever::createDefault(),
+                    $this->memory_reader,
+                    $this->integer_reader
+                );
+                $link_map = $this->link_map_loader->searchByName(
+                    $module_name,
+                    $pid,
+                    $root_link_map_address,
+                );
+                $tls_block_address = $tls_finder->findTlsBlock($pid, $link_map?->this_address);
+            } catch (TlsFinderException $e) {
+            }
+        }
+
         return new ProcessModuleSymbolReader(
             $pid,
             $symbol_resolver,
             $module_memory_map,
             $this->memory_reader,
+            $this->integer_reader,
             $tls_block_address
         );
     }

--- a/src/Lib/Elf/Process/ProcessSymbolReaderInterface.php
+++ b/src/Lib/Elf/Process/ProcessSymbolReaderInterface.php
@@ -27,4 +27,6 @@ interface ProcessSymbolReaderInterface
      * @throws ProcessSymbolReaderException
      */
     public function resolveAddress(string $symbol_name): ?int;
+
+    public function getLinkMapAddress(): ?int;
 }

--- a/src/Lib/Elf/Structure/Elf64/Elf64DynamicStructure.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64DynamicStructure.php
@@ -68,6 +68,8 @@ final class Elf64DynamicStructure
     public const DF_BIND_NOW = 8;
 
     public function __construct(
+        public int $offset,
+        public int $v_addr,
         public UInt64 $d_tag,
         public UInt64 $d_un
     ) {
@@ -76,6 +78,11 @@ final class Elf64DynamicStructure
     public function isEnd(): bool
     {
         return $this->d_tag->hi === 0 and $this->d_tag->lo === self::DT_NULL;
+    }
+
+    public function isPltGot(): bool
+    {
+        return $this->d_tag->hi === 0 and $this->d_tag->lo === self::DT_PLTGOT;
     }
 
     public function isHashTable(): bool

--- a/src/Lib/Elf/Structure/Elf64/Elf64ProgramHeaderTable.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64ProgramHeaderTable.php
@@ -41,7 +41,7 @@ final class Elf64ProgramHeaderTable
 
     public function findBaseAddress(): UInt64
     {
-        $base_address = new UInt64(0, 0);
+        $base_address = new UInt64(0xffff_ffff, 0xffff_ffff);
         foreach ($this->findLoad() as $pt_load) {
             if ($pt_load->p_vaddr->hi < $base_address->hi) {
                 $base_address = $pt_load->p_vaddr;
@@ -50,6 +50,9 @@ final class Elf64ProgramHeaderTable
                     $base_address = $pt_load->p_vaddr;
                 }
             }
+        }
+        if ($base_address->hi === 0xffff_ffff and $base_address->lo === 0xffff_ffff) {
+            $base_address = new UInt64(0, 0);
         }
         return $base_address;
     }

--- a/src/Lib/Elf/Structure/Elf64/Elf64SectionHeaderEntry.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64SectionHeaderEntry.php
@@ -64,4 +64,9 @@ final class Elf64SectionHeaderEntry
     {
         return $this->sh_type === self::SHT_STRTAB;
     }
+
+    public function isDynamic(): bool
+    {
+        return $this->sh_type === self::SHT_DYNAMIC;
+    }
 }

--- a/src/Lib/Elf/Structure/Elf64/Elf64SectionHeaderTable.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64SectionHeaderTable.php
@@ -44,4 +44,14 @@ final class Elf64SectionHeaderTable
         }
         return null;
     }
+
+    public function findDynamicEntry(): ?Elf64SectionHeaderEntry
+    {
+        foreach ($this->entries as $entry) {
+            if ($entry->isDynamic()) {
+                return $entry;
+            }
+        }
+        return null;
+    }
 }

--- a/src/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Elf\SymbolResolver;
 
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
+use Reli\Lib\Integer\UInt64;
 
 final class Elf64CachedSymbolResolver implements Elf64SymbolResolver
 {
@@ -32,5 +33,15 @@ final class Elf64CachedSymbolResolver implements Elf64SymbolResolver
             );
         }
         return $this->symbol_cache->get($symbol_name);
+    }
+
+    public function getDtDebugAddress(): ?int
+    {
+        return $this->resolver->getDtDebugAddress();
+    }
+
+    public function getBaseAddress(): UInt64
+    {
+        return $this->resolver->getBaseAddress();
     }
 }

--- a/src/Lib/Elf/SymbolResolver/Elf64DynamicSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64DynamicSymbolResolver.php
@@ -20,6 +20,7 @@ use Reli\Lib\Elf\Structure\Elf64\Elf64GnuHashTable;
 use Reli\Lib\Elf\Structure\Elf64\Elf64StringTable;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTable;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
+use Reli\Lib\Integer\UInt64;
 
 final class Elf64DynamicSymbolResolver implements Elf64SymbolResolver
 {
@@ -30,21 +31,37 @@ final class Elf64DynamicSymbolResolver implements Elf64SymbolResolver
     {
         $elf_header = $parser->parseElfHeader($php_binary);
         $elf_program_header = $parser->parseProgramHeader($php_binary, $elf_header);
-        $elf_dynamic_array = $parser->parseDynamicStructureArray($php_binary, $elf_program_header->findDynamic()[0]);
-        $elf_string_table = $parser->parseStringTable($php_binary, $elf_dynamic_array);
-        $elf_gnu_hash_table = $parser->parseGnuHashTable($php_binary, $elf_dynamic_array);
+        $base_address = $elf_program_header->findBaseAddress();
+        $dynamic_entry = $elf_program_header->findDynamic()[0];
+        $elf_dynamic_array = $parser->parseDynamicStructureArray(
+            $php_binary,
+            $dynamic_entry->p_offset,
+            $dynamic_entry->p_vaddr,
+        );
+        $elf_string_table = $parser->parseStringTable($php_binary, $base_address, $elf_dynamic_array);
+        $elf_gnu_hash_table = $parser->parseGnuHashTable($php_binary, $base_address, $elf_dynamic_array);
         if (is_null($elf_gnu_hash_table)) {
             throw new ElfParserException('cannot find gnu hash table');
         }
         $elf_symbol_table = $parser->parseSymbolTableFromDynamic(
             $php_binary,
+            $base_address,
             $elf_dynamic_array,
             $elf_gnu_hash_table->getNumberOfSymbols()
         );
+
+        $dt_debug_address = null;
+        $debug_entry = $elf_dynamic_array->findDebugEntry();
+        if (!is_null($debug_entry)) {
+            $dt_debug_address = $debug_entry->v_addr;
+        }
+
         return new self(
             $elf_symbol_table,
             $elf_gnu_hash_table,
-            $elf_string_table
+            $elf_string_table,
+            $base_address,
+            $dt_debug_address
         );
     }
 
@@ -52,6 +69,8 @@ final class Elf64DynamicSymbolResolver implements Elf64SymbolResolver
         private Elf64SymbolTable $symbol_table,
         private Elf64GnuHashTable $hash_table,
         private Elf64StringTable $string_table,
+        private UInt64 $base_address,
+        private ?int $dt_debug_address = null,
     ) {
     }
 
@@ -62,5 +81,15 @@ final class Elf64DynamicSymbolResolver implements Elf64SymbolResolver
             return $name === $this->string_table->lookup($symbol->st_name);
         });
         return $this->symbol_table->lookup($index);
+    }
+
+    public function getDtDebugAddress(): ?int
+    {
+        return $this->dt_debug_address;
+    }
+
+    public function getBaseAddress(): UInt64
+    {
+        return $this->base_address;
     }
 }

--- a/src/Lib/Elf/SymbolResolver/Elf64LinearScanSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64LinearScanSymbolResolver.php
@@ -16,12 +16,15 @@ namespace Reli\Lib\Elf\SymbolResolver;
 use Reli\Lib\Elf\Structure\Elf64\Elf64StringTable;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTable;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
+use Reli\Lib\Integer\UInt64;
 
 final class Elf64LinearScanSymbolResolver implements Elf64AllSymbolResolver
 {
     public function __construct(
         private Elf64SymbolTable $symbol_table,
         private Elf64StringTable $string_table,
+        private UInt64 $base_address,
+        private ?int $dt_debug_address,
     ) {
     }
 
@@ -35,5 +38,15 @@ final class Elf64LinearScanSymbolResolver implements Elf64AllSymbolResolver
             }
         }
         return $all_symbols[Elf64SymbolTable::STN_UNDEF];
+    }
+
+    public function getDtDebugAddress(): ?int
+    {
+        return $this->dt_debug_address;
+    }
+
+    public function getBaseAddress(): UInt64
+    {
+        return $this->base_address;
     }
 }

--- a/src/Lib/Elf/SymbolResolver/Elf64SymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64SymbolResolver.php
@@ -14,8 +14,13 @@ declare(strict_types=1);
 namespace Reli\Lib\Elf\SymbolResolver;
 
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
+use Reli\Lib\Integer\UInt64;
 
 interface Elf64SymbolResolver
 {
     public function resolve(string $symbol_name): Elf64SymbolTableEntry;
+
+    public function getDtDebugAddress(): ?int;
+
+    public function getBaseAddress(): UInt64;
 }

--- a/src/Lib/Elf/SymbolResolver/Elf64SymbolResolverCreator.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64SymbolResolverCreator.php
@@ -41,6 +41,8 @@ final class Elf64SymbolResolverCreator implements SymbolResolverCreatorInterface
         }
         $binary = new StringByteReader($binary_raw);
         $elf_header = $this->elf_parser->parseElfHeader($binary);
+        $program_header = $this->elf_parser->parseProgramHeader($binary, $elf_header);
+        $base_address = $program_header->findBaseAddress();
         $section_header = $this->elf_parser->parseSectionHeader($binary, $elf_header);
         $symbol_table_section_header_entry = $section_header->findSymbolTableEntry();
         $string_table_section_header_entry = $section_header->findStringTableEntry();
@@ -58,7 +60,27 @@ final class Elf64SymbolResolverCreator implements SymbolResolverCreatorInterface
             $binary,
             $string_table_section_header_entry
         );
-        return new Elf64LinearScanSymbolResolver($symbol_table, $string_table);
+
+        $dt_debug_address = null;
+        $dynamic_entry = $section_header->findDynamicEntry();
+        if (!is_null($dynamic_entry)) {
+            $dynamic_array = $this->elf_parser->parseDynamicStructureArray(
+                $binary,
+                $dynamic_entry->sh_offset,
+                $dynamic_entry->sh_addr
+            );
+            $debug_entry = $dynamic_array->findDebugEntry();
+            if (!is_null($debug_entry)) {
+                $dt_debug_address = $debug_entry->v_addr;
+            }
+        }
+
+        return new Elf64LinearScanSymbolResolver(
+            $symbol_table,
+            $string_table,
+            $base_address,
+            $dt_debug_address,
+        );
     }
 
     /**
@@ -83,29 +105,43 @@ final class Elf64SymbolResolverCreator implements SymbolResolverCreatorInterface
         ProcessModuleMemoryMapInterface $module_memory_map
     ): Elf64DynamicSymbolResolver {
         $php_binary = new ProcessMemoryByteReader($memory_reader, $pid, $module_memory_map);
-        $unrelocated_php_binary = new UnrelocatedProcessMemoryByteReader($php_binary, $module_memory_map);
+
+        $unrelocated_php_binary = $php_binary;
 
         $elf_header = $this->elf_parser->parseElfHeader($unrelocated_php_binary);
         $elf_program_header = $this->elf_parser->parseProgramHeader($unrelocated_php_binary, $elf_header);
+        $dynamic_entry = $elf_program_header->findDynamic()[0];
         $elf_dynamic_array = $this->elf_parser->parseDynamicStructureArray(
             $unrelocated_php_binary,
-            $elf_program_header->findDynamic()[0]
+            $dynamic_entry->p_offset,
+            $dynamic_entry->p_vaddr
         );
 
-        $elf_string_table = $this->elf_parser->parseStringTable($php_binary, $elf_dynamic_array);
-        $elf_gnu_hash_table = $this->elf_parser->parseGnuHashTable($php_binary, $elf_dynamic_array);
+        $base_address = $elf_program_header->findBaseAddress();
+        $elf_string_table = $this->elf_parser->parseStringTable($php_binary, $base_address, $elf_dynamic_array);
+        $elf_gnu_hash_table = $this->elf_parser->parseGnuHashTable($php_binary, $base_address, $elf_dynamic_array);
         if (is_null($elf_gnu_hash_table)) {
             throw new ElfParserException('cannot find gnu hash table');
         }
         $elf_symbol_table = $this->elf_parser->parseSymbolTableFromDynamic(
             $php_binary,
+            $base_address,
             $elf_dynamic_array,
             $elf_gnu_hash_table->getNumberOfSymbols()
         );
+
+        $link_map_pointer_address = null;
+        $debug_entry = $elf_dynamic_array->findDebugEntry();
+        if (!is_null($debug_entry)) {
+            $link_map_pointer_address = $debug_entry->d_un->toInt() + 4;
+        }
+
         return new Elf64DynamicSymbolResolver(
             $elf_symbol_table,
             $elf_gnu_hash_table,
-            $elf_string_table
+            $elf_string_table,
+            $base_address,
+            $link_map_pointer_address
         );
     }
 }

--- a/src/Lib/Elf/Tls/TlsFinderInterface.php
+++ b/src/Lib/Elf/Tls/TlsFinderInterface.php
@@ -15,5 +15,5 @@ namespace Reli\Lib\Elf\Tls;
 
 interface TlsFinderInterface
 {
-    public function findTlsBlock(int $pid, int $module_index): int;
+    public function findTlsBlock(int $pid, int $link_map_address): int;
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -196,11 +196,13 @@ final class MemoryLocationsCollector
     private function getMainChunkAddress(
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings,
+        int $eg_address,
         Dereferencer $dereferencer,
     ): int {
         $chunk_address = $this->chunk_finder->findAddress(
             $process_specifier,
             $target_php_settings,
+            $eg_address,
             $dereferencer,
         );
         if (is_null($chunk_address)) {
@@ -227,6 +229,7 @@ final class MemoryLocationsCollector
             $this->getMainChunkAddress(
                 $process_specifier,
                 $target_php_settings,
+                $eg_address,
                 $dereferencer,
             ),
             $zend_type_reader->sizeOf('zend_mm_chunk'),
@@ -446,7 +449,9 @@ final class MemoryLocationsCollector
                 $memory_limit_error_details,
             );
         } elseif ($zval->isObject()) {
-            assert(!is_null($zval->value->obj));
+            if ($zval->value->obj === null) {
+                return null;
+            }
             return $this->collectZendObjectPointer(
                 $zval->value->obj,
                 $map_ptr_base,

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -89,6 +89,7 @@ class PhpVersionDetector
         return new TargetPhpSettings(
             php_regex: $target_php_settings->php_regex,
             libpthread_regex: $target_php_settings->libpthread_regex,
+            zts_globals_regex: $target_php_settings->zts_globals_regex,
             php_version: $version,
             php_path: $target_php_settings->php_path,
             libpthread_path: $target_php_settings->libpthread_path,

--- a/src/Lib/PhpProcessReader/PhpZendMemoryManagerChunkFinder.php
+++ b/src/Lib/PhpProcessReader/PhpZendMemoryManagerChunkFinder.php
@@ -17,7 +17,6 @@ class PhpZendMemoryManagerChunkFinder
     public function __construct(
         private ProcessMemoryMapCreator $process_memory_map_creator,
         private ZendTypeReaderCreator $zend_type_reader_creator,
-        private PhpGlobalsFinder $php_globals_finder,
     ) {
     }
 
@@ -25,26 +24,19 @@ class PhpZendMemoryManagerChunkFinder
     public function findAddress(
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings,
+        int $eg_address,
         Dereferencer $dereferencer,
     ): ?int {
         $zend_type_reader = $this->zend_type_reader_creator->create($target_php_settings->php_version);
         $memory_map = $this->process_memory_map_creator->getProcessMemoryMap($process_specifier->pid);
-        $process_memory_area = $memory_map->findByNameRegex('\[anon:zend_alloc\]');
-        $execute_data_address = null;
-        if (!count($process_memory_area)) {
-            $eg_address = $this->php_globals_finder->findExecutorGlobals(
-                $process_specifier,
-                $target_php_settings
-            );
-            $eg_pointer = new Pointer(
-                ZendExecutorGlobals::class,
-                $eg_address,
-                $zend_type_reader->sizeOf('zend_executor_globals'),
-            );
-            $eg = $dereferencer->deref($eg_pointer);
-            $execute_data_address = $eg->current_execute_data?->address ?? 0;
-            $process_memory_area = $memory_map->findByAddress($execute_data_address);
-        }
+        $eg_pointer = new Pointer(
+            ZendExecutorGlobals::class,
+            $eg_address,
+            $zend_type_reader->sizeOf('zend_executor_globals'),
+        );
+        $eg = $dereferencer->deref($eg_pointer);
+        $execute_data_address = $eg->current_execute_data?->address ?? 0;
+        $process_memory_area = $memory_map->findByAddress($execute_data_address);
         foreach ($process_memory_area as $area) {
             $begin = hexdec($area->begin);
             $end = hexdec($area->end);
@@ -56,16 +48,8 @@ class PhpZendMemoryManagerChunkFinder
                     $zend_type_reader->sizeOf('zend_mm_chunk'),
                 );
                 $zend_mm_chunk = $dereferencer->deref($pointer);
-                $heap_address = $zend_mm_chunk->heap?->address;
                 if (
-                    $heap_address === $zend_mm_chunk->heap_slot->getPointer()->address
-                    and $zend_mm_chunk->num === 0
-                    and $zend_mm_chunk->heap_slot->size > 0
-                ) {
-                    return $p;
-                } elseif (
-                    isset($execute_data_address)
-                    and $zend_mm_chunk->isInRange($execute_data_address)
+                    $zend_mm_chunk->isInRange($execute_data_address)
                     and !is_null($zend_mm_chunk->heap)
                 ) {
                     $heap = $dereferencer->deref($zend_mm_chunk->heap);

--- a/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInputTest.php
@@ -27,6 +27,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('php-version')->andReturns('v74');
         $input->expects()->getOption('php-path')->andReturns('ghi');
         $input->expects()->getOption('libpthread-path')->andReturns('jkl');
+        $input->expects()->getOption('zts-globals-regex')->andReturns('mno');
 
         $settings = (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
 
@@ -35,6 +36,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertSame('v74', $settings->php_version);
         $this->assertSame('ghi', $settings->php_path);
         $this->assertSame('jkl', $settings->libpthread_path);
+        $this->assertSame('mno', $settings->zts_globals_regex);
     }
 
     public function testFromConsoleInputDefault(): void
@@ -45,6 +47,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('php-version')->andReturns(null);
         $input->expects()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(null);
+        $input->expects()->getOption('zts-globals-regex')->andReturns(null);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
 
@@ -56,6 +59,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('php-version')->andReturns('v56');
         $input->allows()->getOption('php-path')->andReturns(null);
         $input->allows()->getOption('libpthread-path')->andReturns(null);
+        $input->allows()->getOption('zts-globals-regex')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
@@ -68,6 +72,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('php-version')->andReturns(null);
         $input->allows()->getOption('php-path')->andReturns(null);
         $input->allows()->getOption('libpthread-path')->andReturns(null);
+        $input->allows()->getOption('zts-globals-regex')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
@@ -80,6 +85,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('php-version')->andReturns(null);
         $input->allows()->getOption('php-path')->andReturns(null);
         $input->allows()->getOption('libpthread-path')->andReturns(null);
+        $input->allows()->getOption('zts-globals-regex')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
@@ -92,6 +98,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('php-version')->andReturns(null);
         $input->expects()->getOption('php-path')->andReturns(1);
         $input->allows()->getOption('libpthread-path')->andReturns(null);
+        $input->allows()->getOption('zts-globals-regex')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }
@@ -104,6 +111,7 @@ class TargetPhpSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('php-version')->andReturns(null);
         $input->allows()->getOption('php-path')->andReturns(null);
         $input->expects()->getOption('libpthread-path')->andReturns(1);
+        $input->allows()->getOption('zts-globals-regex')->andReturns(null);
         $this->expectException(TargetPhpSettingsException::class);
         (new TargetPhpSettingsFromConsoleInput())->createSettings($input);
     }

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
@@ -15,6 +15,7 @@ namespace Reli\Lib\Elf\Process;
 
 use Mockery;
 use Reli\BaseTestCase;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
@@ -52,11 +53,20 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
                 )
             )
         ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
         $symbol_reader_creator = new ProcessModuleSymbolReaderCreator(
             $symbol_resolver_creator,
             $memory_reader,
             new PerBinarySymbolCacheRetriever(),
+            new LittleEndianReader(),
+            new LinkMapLoader(
+                $memory_reader,
+                new LittleEndianReader(),
+            ),
         );
         $process_memory_map = new ProcessMemoryMap([
             new ProcessMemoryArea(
@@ -112,6 +122,11 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
             ->andReturns($symbol_resolver = Mockery::mock(Elf64SymbolResolver::class))
         ;
         $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
+
+        $symbol_resolver->expects()
             ->resolve('test')
             ->andReturns(
                 new Elf64SymbolTableEntry(
@@ -129,6 +144,11 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
             $symbol_resolver_creator,
             $memory_reader,
             new PerBinarySymbolCacheRetriever(),
+            new LittleEndianReader(),
+            new LinkMapLoader(
+                $memory_reader,
+                new LittleEndianReader(),
+            ),
         );
         $process_memory_map = new ProcessMemoryMap([
             new ProcessMemoryArea(
@@ -164,6 +184,11 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
             $symbol_resolver_creator,
             $memory_reader,
             new PerBinarySymbolCacheRetriever(),
+            new LittleEndianReader(),
+            new LinkMapLoader(
+                $memory_reader,
+                new LittleEndianReader(),
+            ),
         );
         $process_memory_map = new ProcessMemoryMap([]);
 

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
@@ -16,6 +16,7 @@ namespace Reli\Lib\Elf\Process;
 use FFI;
 use Mockery;
 use Reli\BaseTestCase;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
@@ -57,7 +58,12 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
                 1,
                 new UInt64(0, 0x1000),
                 new UInt64(0, 8),
-            ));
+            ))
+        ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $return = FFI::new('unsigned char[8]');
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
         $memory_reader->expects()->read(1, 0x10001000, 8)->andReturns($return);
@@ -67,6 +73,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             $symbol_resolver,
             new ProcessModuleMemoryMap($memory_areas),
             $memory_reader,
+            new LittleEndianReader(),
             null
         );
         $this->assertSame(
@@ -109,6 +116,10 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             ))
             ->twice()
         ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         $process_symbol_reader = new ProcessModuleSymbolReader(
@@ -116,6 +127,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             $symbol_resolver,
             new ProcessModuleMemoryMap($memory_areas),
             $memory_reader,
+            new LittleEndianReader(),
             null
         );
 
@@ -159,7 +171,12 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
                 1,
                 new UInt64(0, 0x1000),
                 new UInt64(0, 8),
-            ));
+            ))
+        ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         $process_symbol_reader = new ProcessModuleSymbolReader(
@@ -167,6 +184,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             $symbol_resolver,
             new ProcessModuleMemoryMap($memory_areas),
             $memory_reader,
+            new LittleEndianReader(),
             null
         );
         $address = $process_symbol_reader->resolveAddress('test_symbol');
@@ -204,7 +222,12 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
                 1,
                 new UInt64(0, 0x1000),
                 new UInt64(0, 8),
-            ));
+            ))
+        ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         $process_symbol_reader = new ProcessModuleSymbolReader(
@@ -212,6 +235,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             $symbol_resolver,
             new ProcessModuleMemoryMap($memory_areas),
             $memory_reader,
+            new LittleEndianReader(),
             0x10000
         );
         $this->assertSame(
@@ -251,7 +275,12 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
                 1,
                 new UInt64(0, 0x1000),
                 new UInt64(0, 8),
-            ));
+            ))
+        ;
+        $symbol_resolver->expects()
+            ->getBaseAddress()
+            ->andReturns(new UInt64(0, 0))
+        ;
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         $process_symbol_reader = new ProcessModuleSymbolReader(
@@ -259,6 +288,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             $symbol_resolver,
             new ProcessModuleMemoryMap($memory_areas),
             $memory_reader,
+            new LittleEndianReader(),
             null
         );
         $this->expectException(ProcessSymbolReaderException::class);

--- a/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
+++ b/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
@@ -28,14 +28,21 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
         $_thread_db_pthread_dtvp = \FFI::new('unsigned char[12]');
         $_thread_db_dtv_dtv = \FFI::new('unsigned char[12]');
         $_thread_db_dtv_t_pointer_val = \FFI::new('unsigned char[12]');
+        $_thread_db_link_map_l_tls_modid = \FFI::new('unsigned char[12]');
         \FFI::memset($_thread_db_pthread_dtvp, 0, 12);
         \FFI::memset($_thread_db_dtv_dtv, 0, 12);
         \FFI::memset($_thread_db_dtv_t_pointer_val, 0, 12);
+        \FFI::memset($_thread_db_link_map_l_tls_modid, 0, 12);
         $_thread_db_pthread_dtvp[8] = 8;
         $_thread_db_dtv_dtv[0] = 64;
+        $_thread_db_link_map_l_tls_modid[8] = 128;
         $symbol_reader->expects()->read('_thread_db_pthread_dtvp')->andReturns($_thread_db_pthread_dtvp);
         $symbol_reader->expects()->read('_thread_db_dtv_dtv')->andReturns($_thread_db_dtv_dtv);
         $symbol_reader->expects()->read('_thread_db_dtv_t_pointer_val')->andReturns($_thread_db_dtv_t_pointer_val);
+        $symbol_reader->expects()
+            ->read('_thread_db_link_map_l_tls_modid')
+            ->andReturns($_thread_db_link_map_l_tls_modid)
+        ;
 
         $thread_pointer_retriever = Mockery::mock(ThreadPointerRetrieverInterface::class);
         $thread_pointer_retriever->expects()->getThreadPointer(1)->andReturns(0x10000);
@@ -46,10 +53,14 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
         $tls_block_address = \FFI::new('unsigned char[8]');
         \FFI::memset($tls_block_address, 0, 8);
         $tls_block_address[2] = 3;
+        $module_id = \FFI::new('unsigned char[4]');
+        \FFI::memset($module_id, 0, 4);
+        $module_id[0] = 1;
 
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
         $memory_reader->expects()->read(1, 0x10008, 8)->andReturns($dtv_address);
         $memory_reader->expects()->read(1, 0x20008, 8)->andReturns($tls_block_address);
+        $memory_reader->expects()->read(1, 0x40080, 4)->andReturns($module_id);
 
         $finder = new LibThreadDbTlsFinder(
             $symbol_reader,
@@ -60,7 +71,7 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
 
         $this->assertSame(
             0x30000,
-            $finder->findTlsBlock(1, 1)
+            $finder->findTlsBlock(1, 0x40000)
         );
     }
 

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -17,6 +17,7 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -78,7 +79,6 @@ class ZendArrayTest extends BaseTestCase
         fgets($pipes[1]);
         $child_status = proc_get_status($this->child);
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -88,9 +88,13 @@ class ZendArrayTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                )
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -18,6 +18,7 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -82,7 +83,6 @@ class CallTraceReaderTest extends BaseTestCase
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -92,9 +92,13 @@ class CallTraceReaderTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -17,6 +17,7 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -47,7 +48,6 @@ class PhpGlobalsFinderTest extends BaseTestCase
         fgets($pipes[1]);
         $child_status = proc_get_status($this->child);
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -57,9 +57,13 @@ class PhpGlobalsFinderTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader(),
+                ),
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -20,6 +20,7 @@ use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryLimitErrorDetails;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -114,7 +115,6 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertSame("a\n", $s);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -124,9 +124,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                )
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -355,7 +359,6 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -365,9 +368,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -503,7 +510,6 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -513,9 +519,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -665,7 +675,6 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -675,9 +684,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -17,6 +17,7 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -48,7 +49,6 @@ class PhpVersionDetectorTest extends BaseTestCase
         fgets($pipes[1]);
         $child_status = proc_get_status($this->child);
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
-            $memory_reader,
             new ProcessModuleSymbolReaderCreator(
                 new Elf64SymbolResolverCreator(
                     new CatFileReader(),
@@ -58,9 +58,13 @@ class PhpVersionDetectorTest extends BaseTestCase
                 ),
                 $memory_reader,
                 new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                )
             ),
             ProcessMemoryMapCreator::create(),
-            new LittleEndianReader()
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,


### PR DESCRIPTION
This resolves #402

For example, we can now analyze threads from debug builds of frankenphp with commands like this.

```
sudo ./reli i:tr --libpthread=libc.so --php-regex=libphp.so --zts-globals-regex=/frankenphp -p <pid_of_target_frankenphp_thread>
```

Note: The current support is limited to unstripped ZTS binaries only. During this work, I also got an idea to support analyzing stripped ZTS binaries.  See #450 and #451.