### PR TITLE
Replace mock objects with real implementations in tests

### DIFF
--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -62,7 +62,11 @@ class PhpGlobalsFinder
             return $tsrm_ls_cache_address;
         }
         assert($target_php_settings->isDecided());
-        return $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
+        try {
+            return $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -62,11 +62,7 @@ class PhpGlobalsFinder
             return $tsrm_ls_cache_address;
         }
         assert($target_php_settings->isDecided());
-        try {
-            return $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
-        } catch (\Throwable) {
-            return null;
-        }
+        return $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -46,11 +46,11 @@ class PhpTsrmLsCacheFinder
     ) {
     }
 
-    /** @return array{int, int} */
+    /** @return array{int, int}|null */
     public function resolveTlsBlock(
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
-    ): array {
+    ): ?array {
         $php_symbol_reader = $this->php_symbol_reader_creator->create(
             $process_specifier->pid,
             $target_php_settings->php_regex,
@@ -61,7 +61,7 @@ class PhpTsrmLsCacheFinder
 
         $tls_block_address = $php_symbol_reader->getTlsBlockAddress();
         if (is_null($tls_block_address)) {
-            throw new \RuntimeException('TLS block address not found');
+            return null;
         }
 
         $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap($process_specifier->pid);
@@ -87,10 +87,14 @@ class PhpTsrmLsCacheFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): ?int {
-        [$tls_block_address, $tls_block_size] = $this->resolveTlsBlock(
+        $tls_block = $this->resolveTlsBlock(
             $process_specifier,
             $target_php_settings,
         );
+        if (is_null($tls_block)) {
+            return null;
+        }
+        [$tls_block_address, $tls_block_size] = $tls_block;
         for ($current = $tls_block_address; $current < $tls_block_address + $tls_block_size; $current += 8) {
             $tsrm_ls_cache_candidate = $this->memory_reader->read(
                 $process_specifier->pid,

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -100,14 +100,13 @@ class ZendArrayTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -100,14 +100,30 @@ class ZendArrayTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -104,7 +104,10 @@ class ZendArrayTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -104,14 +104,13 @@ class CallTraceReaderTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -108,7 +108,10 @@ class CallTraceReaderTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -104,14 +104,30 @@ class CallTraceReaderTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -23,6 +23,7 @@ use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -74,7 +75,17 @@ class PhpGlobalsFinderTest extends BaseTestCase
             $integer_reader,
             $memory_reader_for_finder,
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             $integer_reader,

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -136,14 +136,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -386,14 +385,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -543,14 +541,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -714,14 +711,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -140,7 +140,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -387,7 +390,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -541,7 +547,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 
@@ -709,7 +718,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             new MemoryReader(),
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             \Mockery::mock(TsrmGlobalsResolver::class),
         );
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -136,14 +136,30 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -385,14 +401,30 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -541,14 +573,30 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -711,14 +759,30 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ),
             ProcessMemoryMapCreator::create(),
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
-            new MemoryReader(),
+            $integer_reader,
+            $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
-            \Mockery::mock(TsrmGlobalsResolver::class),
+            $tsrm_globals_resolver,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -74,14 +74,13 @@ class PhpVersionDetectorTest extends BaseTestCase
             new LittleEndianReader(),
             $memory_reader,
         );
+        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
+        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             $memory_reader,
-            \Mockery::mock(PhpTsrmLsCacheFinder::class)
-                ->shouldReceive('findByBruteForcing')
-                ->andReturnNull()
-                ->getMock(),
+            $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
         );
         $module_registry_address = $php_globals_finder->findModuleRegistry(

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -78,7 +78,10 @@ class PhpVersionDetectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             $memory_reader,
-            \Mockery::mock(PhpTsrmLsCacheFinder::class),
+            \Mockery::mock(PhpTsrmLsCacheFinder::class)
+                ->shouldReceive('findByBruteForcing')
+                ->andReturnNull()
+                ->getMock(),
             $tsrm_globals_resolver,
         );
         $module_registry_address = $php_globals_finder->findModuleRegistry(

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -74,11 +74,21 @@ class PhpVersionDetectorTest extends BaseTestCase
             new LittleEndianReader(),
             $memory_reader,
         );
-        $tsrm_ls_cache_finder = \Mockery::mock(PhpTsrmLsCacheFinder::class);
-        $tsrm_ls_cache_finder->shouldReceive('findByBruteForcing')->andReturnNull();
+        $integer_reader = new LittleEndianReader();
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+        );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
-            new LittleEndianReader(),
+            $integer_reader,
             $memory_reader,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,

--- a/tests/Lib/Process/MemoryMap/ProcessMemoryMapReaderTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessMemoryMapReaderTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Reli\Lib\Process\MemoryMap;
 
 use Reli\BaseTestCase;
+use Reli\Lib\File\CatFileReader;
 
 class ProcessMemoryMapReaderTest extends BaseTestCase
 {
     public function testRead()
     {
-        $result = (new ProcessMemoryMapReader())->read(getmypid());
+        $result = (new ProcessMemoryMapReader(new CatFileReader()))->read(getmypid());
         $first_line = strtok($result, "\n");
         $this->assertMatchesRegularExpression(
             // phpcs:ignore Generic.Files.LineLength.TooLong


### PR DESCRIPTION
## Summary
This PR replaces mock objects with real implementations in multiple test files and updates the `PhpTsrmLsCacheFinder` class to handle cases where TLS block resolution fails gracefully.

## Key Changes

### Test Updates
- Replaced `\Mockery::mock(PhpTsrmLsCacheFinder::class)` and `\Mockery::mock(TsrmGlobalsResolver::class)` with actual instantiated objects across multiple test files:
  - `MemoryLocationsCollectorTest.php` (4 test methods)
  - `ZendArrayTest.php`
  - `CallTraceReaderTest.php`
  - `PhpVersionDetectorTest.php`
  - `PhpGlobalsFinderTest.php`

- Added proper dependency injection for `PhpTsrmLsCacheFinder` initialization with all required dependencies:
  - `PhpSymbolReaderCreator`
  - `TsrmGlobalsResolver`
  - `MemoryReader`
  - `LittleEndianReader`
  - `Elf64Parser`
  - `CatFileReader`
  - `ProcessMemoryMapCreator`
  - `ContainerAwarePathResolver`
  - `ZendTypeReaderCreator`

- Updated `ProcessMemoryMapReaderTest` to inject `CatFileReader` dependency into `ProcessMemoryMapReader` constructor

### Source Code Changes
- Modified `PhpTsrmLsCacheFinder::resolveTlsBlock()` to return `?array` instead of `array`, allowing it to return `null` when TLS block address is not found
- Changed exception throwing to graceful `null` return when TLS block address cannot be resolved
- Updated `findByBruteForcing()` method to handle the nullable return value from `resolveTlsBlock()`

## Implementation Details
The changes improve test reliability by using real object instances instead of mocks, which better reflects actual runtime behavior and catches integration issues earlier. The `PhpTsrmLsCacheFinder` changes make the code more resilient by allowing callers to handle missing TLS block scenarios without exceptions.

https://claude.ai/code/session_01CxJdxPecWfnJ4bd41axBam