### PR TITLE
Fix resolveTlsBlock for binaries without PT_TLS and fix ZendArrayTest php_version

### DIFF
--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -77,9 +77,12 @@ class PhpTsrmLsCacheFinder
         $byte_reader = new StringByteReader($this->file_reader->readAll($php_path));
         $php_elf_header = $this->elf64_parser->parseElfHeader($byte_reader);
         $program_headers = $this->elf64_parser->parseProgramHeader($byte_reader, $php_elf_header);
-        $pt_tls = $program_headers->findTls()[0];
+        $tls_entries = $program_headers->findTls();
+        if ($tls_entries === []) {
+            return null;
+        }
 
-        return [$tls_block_address, $pt_tls->p_memsz->toInt()];
+        return [$tls_block_address, $tls_entries[0]->p_memsz->toInt()];
     }
 
     /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -129,7 +129,7 @@ class ZendArrayTest extends BaseTestCase
         /** @var int $child_status['pid'] */
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
             new ProcessSpecifier($child_status['pid']),
-            new TargetPhpSettings()
+            new TargetPhpSettings(php_version: ZendTypeReader::V81)
         );
 
         $zend_type_reader = $type_reader_creator->create(ZendTypeReader::V81);


### PR DESCRIPTION
Handle case where getTlsBlockAddress returns non-null but the ELF binary has no PT_TLS program header (e.g. NTS PHP in Docker). Also pass explicit php_version in ZendArrayTest to satisfy the isDecided() assertion in findTsrmLsCache.

https://claude.ai/code/session_01CxJdxPecWfnJ4bd41axBam