### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Options:
   -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
       --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)
+      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
   -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
@@ -147,7 +147,7 @@ Options:
   -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
       --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)
+      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
   -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
@@ -178,7 +178,7 @@ Options:
   -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
       --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)
+      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
   -h, --help                                 Display help for the given command. When no command is given display help for the list command
@@ -206,7 +206,7 @@ Options:
   -p, --pid=PID                              process id
       --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)
+      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
   -h, --help                                 Display help for the given command. When no command is given display help for the list command
@@ -239,7 +239,7 @@ Options:
   -p, --pid=PID                                                      process id
       --php-regex[=PHP-REGEX]                                        regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]                          regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)
+      --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                                          path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]                            path to the libpthread.so (only needed in tracing chrooted ZTS target)
   -h, --help                                                         Display help for the given command. When no command is given display help for the list command

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
@@ -22,7 +22,7 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
  */
 final class TargetPhpSettings
 {
-    public const PHP_REGEX_DEFAULT = '.*/((php|php-fpm)(7\.?[01234]|8\.?[0123])?|libphp[78]?.*\.so)$';
+    public const PHP_REGEX_DEFAULT = '.*/((php|php-fpm)(7\.?[01234]|8\.?[01234])?|libphp[78]?.*\.so)$';
     public const LIBPTHREAD_REGEX_DEFAULT = '.*/libpthread.*\.so';
     public const ZTS_GLOBALS_REGEX_DEFAULT = self::PHP_REGEX_DEFAULT;
     public const TARGET_PHP_VERSION_DEFAULT = 'auto';

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsFromConsoleInput.php
@@ -50,7 +50,7 @@ final class TargetPhpSettingsFromConsoleInput
                 'php-version',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'php version (auto|v7[0-4]|v8[0123]) of the target (default: auto)'
+                'php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)'
             )
             ->addOption(
                 'php-path',

--- a/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
+++ b/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
@@ -91,6 +91,7 @@ class TsrmGlobalsResolver
             case ZendTypeReader::V81:
             case ZendTypeReader::V82:
             case ZendTypeReader::V83:
+            case ZendTypeReader::V84:
                 $offset = $symbol_name . '_offset';
                 $globals_offset_cdata = $this->getZtsGlobalsSymbolReader(
                     $process_specifier,


### PR DESCRIPTION
#474 has a few missing parts. This PR completes the support for targeting PHP 8.4 by updating version detection patterns and TSRM globals resolution logic. 

## Summary
Updated the tool to recognize and properly handle PHP 8.4 in addition to previously supported versions (PHP 7.0-7.4 and PHP 8.0-8.3).

## Key Changes
- Updated PHP version regex pattern from `v8[0123]` to `v8[01234]` in documentation and help text to include PHP 8.4
- Modified `PHP_REGEX_DEFAULT` constant to match PHP 8.4 binaries: changed from `8\.?[0123]` to `8\.?[01234]`
- Added `ZendTypeReader::V84` case to the TSRM globals resolver switch statement to handle PHP 8.4's memory layout for thread-safe mode

## Implementation Details
The changes ensure that:
1. PHP 8.4 binaries are correctly identified during process inspection
2. The tool can properly resolve TSRM (Thread Safe Resource Manager) globals addresses for PHP 8.4 processes
3. All user-facing documentation reflects the expanded version support

https://claude.ai/code/session_01CtDnpAHzrpfrFu8zfpBx9J