### PR TITLE
Add XDG Base Directory Specification support

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -12,12 +12,12 @@
 declare(strict_types=1);
 
 use Psr\Log\LogLevel;
-use Reli\Lib\Directory\XdgDirectory;
+use Reli\Lib\Directory\AppDirectory;
 
 return [
     'log' => [
         'path' => [
-            'default' => XdgDirectory::getStateHome() . '/reli.log',
+            'default' => AppDirectory::getLogPath(),
         ],
         'level' => LogLevel::INFO,
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -12,11 +12,12 @@
 declare(strict_types=1);
 
 use Psr\Log\LogLevel;
+use Reli\Lib\Directory\XdgDirectory;
 
 return [
     'log' => [
         'path' => [
-            'default' => 'reli.log',
+            'default' => XdgDirectory::getStateHome() . '/reli.log',
         ],
         'level' => LogLevel::INFO,
     ],

--- a/config/di.php
+++ b/config/di.php
@@ -67,7 +67,7 @@ return [
         ->constructorParameter('di_config_file', __DIR__ . '/di.php'),
     PhpReaderTraceLoopInterface::class => autowire(PhpReaderTraceLoop::class),
     ProcessSearcherInterface::class => autowire(ProcessSearcher::class),
-    Config::class => fn () => Config::load(__DIR__ . '/config.php'),
+    Config::class => fn () => AppDirectory::loadConfig(__DIR__ . '/config.php'),
     TemplatePathResolverInterface::class => autowire(TemplatePathResolver::class),
     StateCollector::class => function (Container $container) {
         $collectors = [];

--- a/config/di.php
+++ b/config/di.php
@@ -33,6 +33,7 @@ use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\NativeFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\File\PathResolver\ProcessPathResolver;
+use Reli\Lib\Directory\XdgDirectory;
 use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
 use Reli\Lib\Log\StateCollector\CallerStateCollector;
@@ -78,6 +79,7 @@ return [
         $logger = new Logger('default');
         $path = $config->get('log.path.default');
         assert(is_string($path));
+        XdgDirectory::ensureDirectoryExists(dirname($path));
         /** @var LogLevel::* $log_level */
         $log_level = $config->get('log.level');
         $handler = new StreamHandler(

--- a/config/di.php
+++ b/config/di.php
@@ -33,7 +33,7 @@ use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\NativeFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\File\PathResolver\ProcessPathResolver;
-use Reli\Lib\Directory\XdgDirectory;
+use Reli\Lib\Directory\AppDirectory;
 use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
 use Reli\Lib\Log\StateCollector\CallerStateCollector;
@@ -79,7 +79,7 @@ return [
         $logger = new Logger('default');
         $path = $config->get('log.path.default');
         assert(is_string($path));
-        XdgDirectory::ensureDirectoryExists(dirname($path));
+        AppDirectory::ensureDirectoryExists(dirname($path));
         /** @var LogLevel::* $log_level */
         $log_level = $config->get('log.level');
         $handler = new StreamHandler(

--- a/src/Lib/Directory/AppDirectory.php
+++ b/src/Lib/Directory/AppDirectory.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Directory;
+
+use Reli\ReliProfiler;
+
+/**
+ * Application-level directory resolver for reli-prof.
+ *
+ * Wraps XdgDirectory and provides fallback policies:
+ * - Config: no fallback (requires home directory)
+ * - Cache/State/Log: falls back to a temp directory when home is unavailable
+ */
+final class AppDirectory
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Config directory. No fallback — configuration requires a stable, user-owned location.
+     *
+     * @throws HomeNotFoundException
+     */
+    public static function getConfigDir(): string
+    {
+        return XdgDirectory::getConfigHome();
+    }
+
+    /**
+     * Cache directory. Falls back to temp directory when home is unavailable.
+     * Suitable for ELF binary analysis cache, etc.
+     */
+    public static function getCacheDir(): string
+    {
+        try {
+            return XdgDirectory::getCacheHome();
+        } catch (HomeNotFoundException) {
+            return self::getTempFallbackDir('cache');
+        }
+    }
+
+    /**
+     * State directory (logs, history). Falls back to temp directory.
+     */
+    public static function getStateDir(): string
+    {
+        try {
+            return XdgDirectory::getStateHome();
+        } catch (HomeNotFoundException) {
+            return self::getTempFallbackDir('state');
+        }
+    }
+
+    /**
+     * Data directory. Falls back to temp directory.
+     */
+    public static function getDataDir(): string
+    {
+        try {
+            return XdgDirectory::getDataHome();
+        } catch (HomeNotFoundException) {
+            return self::getTempFallbackDir('data');
+        }
+    }
+
+    /**
+     * Log file path.
+     */
+    public static function getLogPath(): string
+    {
+        return self::getStateDir() . '/reli.log';
+    }
+
+    public static function ensureDirectoryExists(string $path): string
+    {
+        return XdgDirectory::ensureDirectoryExists($path);
+    }
+
+    /**
+     * Builds a per-user temp fallback directory.
+     *
+     * Uses UID on POSIX systems, or a fixed name on Windows,
+     * to avoid collisions between users sharing /tmp.
+     */
+    private static function getTempFallbackDir(string $subdirectory): string
+    {
+        $base = sys_get_temp_dir() . '/' . ReliProfiler::TOOL_NAME;
+        if (function_exists('posix_getuid')) {
+            $base .= '-' . posix_getuid();
+        }
+        return $base . '/' . $subdirectory;
+    }
+}

--- a/src/Lib/Directory/AppDirectory.php
+++ b/src/Lib/Directory/AppDirectory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Directory;
 
+use Noodlehaus\Config;
 use Reli\ReliProfiler;
 
 /**
@@ -81,6 +82,30 @@ final class AppDirectory
     public static function getLogPath(): string
     {
         return self::getStateDir() . '/reli.log';
+    }
+
+    /**
+     * Loads application configuration.
+     *
+     * 1. Load the default config from the install directory (always)
+     * 2. If a user config exists in XDG config dir, merge it on top
+     *
+     * User config values override defaults via array_replace_recursive.
+     */
+    public static function loadConfig(string $defaultConfigPath): Config
+    {
+        $config = Config::load($defaultConfigPath);
+
+        try {
+            $userConfigPath = self::getConfigDir() . '/config.php';
+            if (is_file($userConfigPath)) {
+                $config->merge(Config::load($userConfigPath));
+            }
+        } catch (HomeNotFoundException) {
+            // No home directory — use defaults only
+        }
+
+        return $config;
     }
 
     public static function ensureDirectoryExists(string $path): string

--- a/src/Lib/Directory/HomeNotFoundException.php
+++ b/src/Lib/Directory/HomeNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Directory;
+
+final class HomeNotFoundException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Could not determine home directory:'
+            . ' HOME environment variable is not set'
+            . ' and no fallback is available'
+        );
+    }
+}

--- a/src/Lib/Directory/XdgDirectory.php
+++ b/src/Lib/Directory/XdgDirectory.php
@@ -23,8 +23,8 @@ final class XdgDirectory
 
     public static function getConfigHome(): string
     {
-        $xdgConfigHome = getenv('XDG_CONFIG_HOME');
-        if ($xdgConfigHome !== false && $xdgConfigHome !== '') {
+        $xdgConfigHome = self::getAbsoluteEnv('XDG_CONFIG_HOME');
+        if ($xdgConfigHome !== null) {
             return $xdgConfigHome . '/' . ReliProfiler::TOOL_NAME;
         }
         return self::getHome() . '/.config/' . ReliProfiler::TOOL_NAME;
@@ -32,8 +32,8 @@ final class XdgDirectory
 
     public static function getCacheHome(): string
     {
-        $xdgCacheHome = getenv('XDG_CACHE_HOME');
-        if ($xdgCacheHome !== false && $xdgCacheHome !== '') {
+        $xdgCacheHome = self::getAbsoluteEnv('XDG_CACHE_HOME');
+        if ($xdgCacheHome !== null) {
             return $xdgCacheHome . '/' . ReliProfiler::TOOL_NAME;
         }
         return self::getHome() . '/.cache/' . ReliProfiler::TOOL_NAME;
@@ -41,8 +41,8 @@ final class XdgDirectory
 
     public static function getDataHome(): string
     {
-        $xdgDataHome = getenv('XDG_DATA_HOME');
-        if ($xdgDataHome !== false && $xdgDataHome !== '') {
+        $xdgDataHome = self::getAbsoluteEnv('XDG_DATA_HOME');
+        if ($xdgDataHome !== null) {
             return $xdgDataHome . '/' . ReliProfiler::TOOL_NAME;
         }
         return self::getHome() . '/.local/share/' . ReliProfiler::TOOL_NAME;
@@ -50,17 +50,66 @@ final class XdgDirectory
 
     public static function getStateHome(): string
     {
-        $xdgStateHome = getenv('XDG_STATE_HOME');
-        if ($xdgStateHome !== false && $xdgStateHome !== '') {
+        $xdgStateHome = self::getAbsoluteEnv('XDG_STATE_HOME');
+        if ($xdgStateHome !== null) {
             return $xdgStateHome . '/' . ReliProfiler::TOOL_NAME;
         }
         return self::getHome() . '/.local/state/' . ReliProfiler::TOOL_NAME;
     }
 
+    public static function getRuntimeDir(): ?string
+    {
+        $xdgRuntimeDir = self::getAbsoluteEnv('XDG_RUNTIME_DIR');
+        if ($xdgRuntimeDir !== null) {
+            return $xdgRuntimeDir . '/' . ReliProfiler::TOOL_NAME;
+        }
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function getConfigDirs(): array
+    {
+        $dirs = [self::getConfigHome()];
+        $xdgConfigDirs = getenv('XDG_CONFIG_DIRS');
+        if ($xdgConfigDirs === false || $xdgConfigDirs === '') {
+            $xdgConfigDirs = '/etc/xdg';
+        }
+        foreach (explode(':', $xdgConfigDirs) as $dir) {
+            if (self::isAbsolutePath($dir)) {
+                $dirs[] = $dir . '/' . ReliProfiler::TOOL_NAME;
+            }
+        }
+        return $dirs;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function getDataDirs(): array
+    {
+        $dirs = [self::getDataHome()];
+        $xdgDataDirs = getenv('XDG_DATA_DIRS');
+        if ($xdgDataDirs === false || $xdgDataDirs === '') {
+            $xdgDataDirs = '/usr/local/share:/usr/share';
+        }
+        foreach (explode(':', $xdgDataDirs) as $dir) {
+            if (self::isAbsolutePath($dir)) {
+                $dirs[] = $dir . '/' . ReliProfiler::TOOL_NAME;
+            }
+        }
+        return $dirs;
+    }
+
     public static function ensureDirectoryExists(string $path): string
     {
         if (!is_dir($path)) {
-            mkdir($path, 0700, true);
+            if (!mkdir($path, 0700, true) && !is_dir($path)) {
+                throw new \RuntimeException(
+                    sprintf('Failed to create directory: %s', $path)
+                );
+            }
         }
         return $path;
     }
@@ -72,5 +121,26 @@ final class XdgDirectory
             return $home;
         }
         throw new \RuntimeException('HOME environment variable is not set');
+    }
+
+    /**
+     * Returns the value of an environment variable only if it is set, non-empty, and an absolute path.
+     * Per the XDG Base Directory Specification, relative paths must be ignored.
+     */
+    private static function getAbsoluteEnv(string $name): ?string
+    {
+        $value = getenv($name);
+        if ($value === false || $value === '') {
+            return null;
+        }
+        if (!self::isAbsolutePath($value)) {
+            return null;
+        }
+        return $value;
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/');
     }
 }

--- a/src/Lib/Directory/XdgDirectory.php
+++ b/src/Lib/Directory/XdgDirectory.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Directory;
+
+use Reli\ReliProfiler;
+
+final class XdgDirectory
+{
+    private function __construct()
+    {
+    }
+
+    public static function getConfigHome(): string
+    {
+        $xdgConfigHome = getenv('XDG_CONFIG_HOME');
+        if ($xdgConfigHome !== false && $xdgConfigHome !== '') {
+            return $xdgConfigHome . '/' . ReliProfiler::TOOL_NAME;
+        }
+        return self::getHome() . '/.config/' . ReliProfiler::TOOL_NAME;
+    }
+
+    public static function getCacheHome(): string
+    {
+        $xdgCacheHome = getenv('XDG_CACHE_HOME');
+        if ($xdgCacheHome !== false && $xdgCacheHome !== '') {
+            return $xdgCacheHome . '/' . ReliProfiler::TOOL_NAME;
+        }
+        return self::getHome() . '/.cache/' . ReliProfiler::TOOL_NAME;
+    }
+
+    public static function getDataHome(): string
+    {
+        $xdgDataHome = getenv('XDG_DATA_HOME');
+        if ($xdgDataHome !== false && $xdgDataHome !== '') {
+            return $xdgDataHome . '/' . ReliProfiler::TOOL_NAME;
+        }
+        return self::getHome() . '/.local/share/' . ReliProfiler::TOOL_NAME;
+    }
+
+    public static function getStateHome(): string
+    {
+        $xdgStateHome = getenv('XDG_STATE_HOME');
+        if ($xdgStateHome !== false && $xdgStateHome !== '') {
+            return $xdgStateHome . '/' . ReliProfiler::TOOL_NAME;
+        }
+        return self::getHome() . '/.local/state/' . ReliProfiler::TOOL_NAME;
+    }
+
+    public static function ensureDirectoryExists(string $path): string
+    {
+        if (!is_dir($path)) {
+            mkdir($path, 0700, true);
+        }
+        return $path;
+    }
+
+    private static function getHome(): string
+    {
+        $home = getenv('HOME');
+        if ($home !== false && $home !== '') {
+            return $home;
+        }
+        throw new \RuntimeException('HOME environment variable is not set');
+    }
+}

--- a/src/Lib/Directory/XdgDirectory.php
+++ b/src/Lib/Directory/XdgDirectory.php
@@ -21,6 +21,7 @@ final class XdgDirectory
     {
     }
 
+    /** @throws HomeNotFoundException */
     public static function getConfigHome(): string
     {
         $xdgConfigHome = self::getAbsoluteEnv('XDG_CONFIG_HOME');
@@ -30,6 +31,7 @@ final class XdgDirectory
         return self::getHome() . '/.config/' . ReliProfiler::TOOL_NAME;
     }
 
+    /** @throws HomeNotFoundException */
     public static function getCacheHome(): string
     {
         $xdgCacheHome = self::getAbsoluteEnv('XDG_CACHE_HOME');
@@ -39,6 +41,7 @@ final class XdgDirectory
         return self::getHome() . '/.cache/' . ReliProfiler::TOOL_NAME;
     }
 
+    /** @throws HomeNotFoundException */
     public static function getDataHome(): string
     {
         $xdgDataHome = self::getAbsoluteEnv('XDG_DATA_HOME');
@@ -48,6 +51,7 @@ final class XdgDirectory
         return self::getHome() . '/.local/share/' . ReliProfiler::TOOL_NAME;
     }
 
+    /** @throws HomeNotFoundException */
     public static function getStateHome(): string
     {
         $xdgStateHome = self::getAbsoluteEnv('XDG_STATE_HOME');
@@ -68,6 +72,7 @@ final class XdgDirectory
 
     /**
      * @return list<string>
+     * @throws HomeNotFoundException
      */
     public static function getConfigDirs(): array
     {
@@ -86,6 +91,7 @@ final class XdgDirectory
 
     /**
      * @return list<string>
+     * @throws HomeNotFoundException
      */
     public static function getDataDirs(): array
     {
@@ -114,13 +120,44 @@ final class XdgDirectory
         return $path;
     }
 
+    /**
+     * Resolves the home directory following XDG conventions.
+     *
+     * 1. HOME environment variable (Unix) / USERPROFILE / HOMEDRIVE+HOMEPATH (Windows)
+     * 2. POSIX passwd database lookup (Unix/Mac)
+     * 3. HomeNotFoundException
+     *
+     * @throws HomeNotFoundException
+     */
     private static function getHome(): string
     {
         $home = getenv('HOME');
         if ($home !== false && $home !== '') {
             return $home;
         }
-        throw new \RuntimeException('HOME environment variable is not set');
+
+        // Windows fallbacks
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $profile = getenv('USERPROFILE');
+            if ($profile !== false && $profile !== '') {
+                return $profile;
+            }
+            $drive = getenv('HOMEDRIVE');
+            $homePath = getenv('HOMEPATH');
+            if ($drive !== false && $homePath !== false && $homePath !== '') {
+                return $drive . $homePath;
+            }
+        }
+
+        // POSIX passwd database fallback
+        if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
+            $info = posix_getpwuid(posix_getuid());
+            if ($info !== false && ($info['dir'] ?? '') !== '') {
+                return $info['dir'];
+            }
+        }
+
+        throw new HomeNotFoundException();
     }
 
     /**

--- a/tests/Lib/Directory/AppDirectoryTest.php
+++ b/tests/Lib/Directory/AppDirectoryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Directory;
+
+use Reli\BaseTestCase;
+
+class AppDirectoryTest extends BaseTestCase
+{
+    private string|false $originalHome;
+    private string|false $originalXdgConfigHome;
+    private string|false $originalXdgCacheHome;
+    private string|false $originalXdgDataHome;
+    private string|false $originalXdgStateHome;
+
+    public function setUp(): void
+    {
+        $this->originalHome = getenv('HOME');
+        $this->originalXdgConfigHome = getenv('XDG_CONFIG_HOME');
+        $this->originalXdgCacheHome = getenv('XDG_CACHE_HOME');
+        $this->originalXdgDataHome = getenv('XDG_DATA_HOME');
+        $this->originalXdgStateHome = getenv('XDG_STATE_HOME');
+    }
+
+    public function tearDown(): void
+    {
+        $this->restoreEnv('HOME', $this->originalHome);
+        $this->restoreEnv('XDG_CONFIG_HOME', $this->originalXdgConfigHome);
+        $this->restoreEnv('XDG_CACHE_HOME', $this->originalXdgCacheHome);
+        $this->restoreEnv('XDG_DATA_HOME', $this->originalXdgDataHome);
+        $this->restoreEnv('XDG_STATE_HOME', $this->originalXdgStateHome);
+    }
+
+    private function restoreEnv(string $name, string|false $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+        } else {
+            putenv("{$name}={$value}");
+        }
+    }
+
+    // --- Config: delegates to XDG, no fallback ---
+
+    public function testGetConfigDirWithHome(): void
+    {
+        putenv('XDG_CONFIG_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.config/reli', AppDirectory::getConfigDir());
+    }
+
+    public function testGetConfigDirWithXdgEnv(): void
+    {
+        putenv('XDG_CONFIG_HOME=/tmp/app-xdg-config');
+        $this->assertSame('/tmp/app-xdg-config/reli', AppDirectory::getConfigDir());
+    }
+
+    // --- Cache: XDG when available, temp fallback otherwise ---
+
+    public function testGetCacheDirWithHome(): void
+    {
+        putenv('XDG_CACHE_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.cache/reli', AppDirectory::getCacheDir());
+    }
+
+    public function testGetCacheDirWithXdgEnv(): void
+    {
+        putenv('XDG_CACHE_HOME=/tmp/app-xdg-cache');
+        $this->assertSame('/tmp/app-xdg-cache/reli', AppDirectory::getCacheDir());
+    }
+
+    public function testGetCacheDirWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_CACHE_HOME');
+        $result = AppDirectory::getCacheDir();
+        // passwd fallback or temp fallback — either way, must be absolute and contain 'reli'
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringContainsString('reli', $result);
+    }
+
+    // --- State: XDG when available, temp fallback otherwise ---
+
+    public function testGetStateDirWithHome(): void
+    {
+        putenv('XDG_STATE_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.local/state/reli', AppDirectory::getStateDir());
+    }
+
+    public function testGetStateDirWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_STATE_HOME');
+        $result = AppDirectory::getStateDir();
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringContainsString('reli', $result);
+    }
+
+    // --- Data: XDG when available, temp fallback otherwise ---
+
+    public function testGetDataDirWithHome(): void
+    {
+        putenv('XDG_DATA_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.local/share/reli', AppDirectory::getDataDir());
+    }
+
+    public function testGetDataDirWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_DATA_HOME');
+        $result = AppDirectory::getDataDir();
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringContainsString('reli', $result);
+    }
+
+    // --- Log path ---
+
+    public function testGetLogPathWithHome(): void
+    {
+        putenv('XDG_STATE_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.local/state/reli/reli.log', AppDirectory::getLogPath());
+    }
+
+    public function testGetLogPathWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_STATE_HOME');
+        $result = AppDirectory::getLogPath();
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringEndsWith('/reli.log', $result);
+    }
+
+    // --- ensureDirectoryExists delegates ---
+
+    public function testEnsureDirectoryExists(): void
+    {
+        $testDir = sys_get_temp_dir() . '/app-dir-test-' . uniqid();
+        $this->assertDirectoryDoesNotExist($testDir);
+
+        $result = AppDirectory::ensureDirectoryExists($testDir);
+
+        $this->assertSame($testDir, $result);
+        $this->assertDirectoryExists($testDir);
+
+        rmdir($testDir);
+    }
+}

--- a/tests/Lib/Directory/AppDirectoryTest.php
+++ b/tests/Lib/Directory/AppDirectoryTest.php
@@ -158,4 +158,81 @@ class AppDirectoryTest extends BaseTestCase
 
         rmdir($testDir);
     }
+
+    // --- loadConfig ---
+
+    public function testLoadConfigReturnsDefaultWhenNoUserConfig(): void
+    {
+        $defaultConfig = sys_get_temp_dir() . '/reli-test-config-' . uniqid();
+        mkdir($defaultConfig, 0700, true);
+        $defaultConfigFile = $defaultConfig . '/config.php';
+        file_put_contents($defaultConfigFile, '<?php return ["log" => ["level" => "info"]];');
+
+        // Point XDG config to a directory with no config.php
+        $emptyConfigDir = sys_get_temp_dir() . '/reli-test-xdg-empty-' . uniqid() . '/reli';
+        mkdir($emptyConfigDir, 0700, true);
+        putenv('XDG_CONFIG_HOME=' . dirname($emptyConfigDir));
+
+        $config = AppDirectory::loadConfig($defaultConfigFile);
+
+        $this->assertSame('info', $config->get('log.level'));
+
+        unlink($defaultConfigFile);
+        rmdir($defaultConfig);
+        rmdir($emptyConfigDir);
+        rmdir(dirname($emptyConfigDir));
+    }
+
+    public function testLoadConfigMergesUserConfig(): void
+    {
+        $defaultConfig = sys_get_temp_dir() . '/reli-test-config-' . uniqid();
+        mkdir($defaultConfig, 0700, true);
+        $defaultConfigFile = $defaultConfig . '/config.php';
+        file_put_contents(
+            $defaultConfigFile,
+            '<?php return ["log" => ["level" => "info"], "output" => ["template" => ["default" => "phpspy"]]];'
+        );
+
+        // Create user config that overrides log level
+        $userConfigBase = sys_get_temp_dir() . '/reli-test-xdg-user-' . uniqid();
+        $userConfigDir = $userConfigBase . '/reli';
+        mkdir($userConfigDir, 0700, true);
+        file_put_contents(
+            $userConfigDir . '/config.php',
+            '<?php return ["log" => ["level" => "debug"]];'
+        );
+        putenv('XDG_CONFIG_HOME=' . $userConfigBase);
+
+        $config = AppDirectory::loadConfig($defaultConfigFile);
+
+        // User override takes effect
+        $this->assertSame('debug', $config->get('log.level'));
+        // Default value preserved for non-overridden keys
+        $this->assertSame('phpspy', $config->get('output.template.default'));
+
+        unlink($defaultConfigFile);
+        rmdir($defaultConfig);
+        unlink($userConfigDir . '/config.php');
+        rmdir($userConfigDir);
+        rmdir($userConfigBase);
+    }
+
+    public function testLoadConfigWorksWithoutHome(): void
+    {
+        $defaultConfig = sys_get_temp_dir() . '/reli-test-config-' . uniqid();
+        mkdir($defaultConfig, 0700, true);
+        $defaultConfigFile = $defaultConfig . '/config.php';
+        file_put_contents($defaultConfigFile, '<?php return ["log" => ["level" => "warning"]];');
+
+        putenv('HOME');
+        putenv('XDG_CONFIG_HOME');
+
+        $config = AppDirectory::loadConfig($defaultConfigFile);
+
+        // Should fall back to defaults without throwing
+        $this->assertSame('warning', $config->get('log.level'));
+
+        unlink($defaultConfigFile);
+        rmdir($defaultConfig);
+    }
 }

--- a/tests/Lib/Directory/XdgDirectoryTest.php
+++ b/tests/Lib/Directory/XdgDirectoryTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Directory;
+
+use Reli\BaseTestCase;
+
+class XdgDirectoryTest extends BaseTestCase
+{
+    private string|false $originalHome;
+    private string|false $originalXdgConfigHome;
+    private string|false $originalXdgCacheHome;
+    private string|false $originalXdgDataHome;
+    private string|false $originalXdgStateHome;
+
+    public function setUp(): void
+    {
+        $this->originalHome = getenv('HOME');
+        $this->originalXdgConfigHome = getenv('XDG_CONFIG_HOME');
+        $this->originalXdgCacheHome = getenv('XDG_CACHE_HOME');
+        $this->originalXdgDataHome = getenv('XDG_DATA_HOME');
+        $this->originalXdgStateHome = getenv('XDG_STATE_HOME');
+    }
+
+    public function tearDown(): void
+    {
+        $this->restoreEnv('HOME', $this->originalHome);
+        $this->restoreEnv('XDG_CONFIG_HOME', $this->originalXdgConfigHome);
+        $this->restoreEnv('XDG_CACHE_HOME', $this->originalXdgCacheHome);
+        $this->restoreEnv('XDG_DATA_HOME', $this->originalXdgDataHome);
+        $this->restoreEnv('XDG_STATE_HOME', $this->originalXdgStateHome);
+    }
+
+    private function restoreEnv(string $name, string|false $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+        } else {
+            putenv("{$name}={$value}");
+        }
+    }
+
+    public function testGetConfigHomeWithXdgEnv(): void
+    {
+        putenv('XDG_CONFIG_HOME=/tmp/xdg-test-config');
+        $this->assertSame('/tmp/xdg-test-config/reli', XdgDirectory::getConfigHome());
+    }
+
+    public function testGetConfigHomeWithoutXdgEnv(): void
+    {
+        putenv('XDG_CONFIG_HOME');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.config/reli', XdgDirectory::getConfigHome());
+    }
+
+    public function testGetCacheHomeWithXdgEnv(): void
+    {
+        putenv('XDG_CACHE_HOME=/tmp/xdg-test-cache');
+        $this->assertSame('/tmp/xdg-test-cache/reli', XdgDirectory::getCacheHome());
+    }
+
+    public function testGetCacheHomeWithoutXdgEnv(): void
+    {
+        putenv('XDG_CACHE_HOME');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.cache/reli', XdgDirectory::getCacheHome());
+    }
+
+    public function testGetDataHomeWithXdgEnv(): void
+    {
+        putenv('XDG_DATA_HOME=/tmp/xdg-test-data');
+        $this->assertSame('/tmp/xdg-test-data/reli', XdgDirectory::getDataHome());
+    }
+
+    public function testGetDataHomeWithoutXdgEnv(): void
+    {
+        putenv('XDG_DATA_HOME');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.local/share/reli', XdgDirectory::getDataHome());
+    }
+
+    public function testGetStateHomeWithXdgEnv(): void
+    {
+        putenv('XDG_STATE_HOME=/tmp/xdg-test-state');
+        $this->assertSame('/tmp/xdg-test-state/reli', XdgDirectory::getStateHome());
+    }
+
+    public function testGetStateHomeWithoutXdgEnv(): void
+    {
+        putenv('XDG_STATE_HOME');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.local/state/reli', XdgDirectory::getStateHome());
+    }
+
+    public function testGetHomeThrowsWhenNotSet(): void
+    {
+        putenv('HOME');
+        putenv('XDG_CONFIG_HOME');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HOME environment variable is not set');
+        XdgDirectory::getConfigHome();
+    }
+
+    public function testEnsureDirectoryExists(): void
+    {
+        $testDir = sys_get_temp_dir() . '/xdg-test-' . uniqid();
+        $this->assertDirectoryDoesNotExist($testDir);
+
+        $result = XdgDirectory::ensureDirectoryExists($testDir);
+
+        $this->assertSame($testDir, $result);
+        $this->assertDirectoryExists($testDir);
+        $this->assertSame(0700, fileperms($testDir) & 0777);
+
+        rmdir($testDir);
+    }
+}

--- a/tests/Lib/Directory/XdgDirectoryTest.php
+++ b/tests/Lib/Directory/XdgDirectoryTest.php
@@ -111,13 +111,17 @@ class XdgDirectoryTest extends BaseTestCase
         $this->assertSame('/tmp/xdg-test-home/.local/state/reli', XdgDirectory::getStateHome());
     }
 
-    public function testGetHomeThrowsWhenNotSet(): void
+    public function testGetHomeFallsBackToPasswd(): void
     {
+        if (!function_exists('posix_getpwuid')) {
+            $this->markTestSkipped('posix extension not available');
+        }
         putenv('HOME');
         putenv('XDG_CONFIG_HOME');
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('HOME environment variable is not set');
-        XdgDirectory::getConfigHome();
+        // passwd fallback should resolve a home directory
+        $result = XdgDirectory::getConfigHome();
+        $this->assertStringEndsWith('/reli', $result);
+        $this->assertStringStartsWith('/', $result);
     }
 
     public function testEnsureDirectoryExists(): void

--- a/tests/Lib/Directory/XdgDirectoryTest.php
+++ b/tests/Lib/Directory/XdgDirectoryTest.php
@@ -22,6 +22,9 @@ class XdgDirectoryTest extends BaseTestCase
     private string|false $originalXdgCacheHome;
     private string|false $originalXdgDataHome;
     private string|false $originalXdgStateHome;
+    private string|false $originalXdgRuntimeDir;
+    private string|false $originalXdgConfigDirs;
+    private string|false $originalXdgDataDirs;
 
     public function setUp(): void
     {
@@ -30,6 +33,9 @@ class XdgDirectoryTest extends BaseTestCase
         $this->originalXdgCacheHome = getenv('XDG_CACHE_HOME');
         $this->originalXdgDataHome = getenv('XDG_DATA_HOME');
         $this->originalXdgStateHome = getenv('XDG_STATE_HOME');
+        $this->originalXdgRuntimeDir = getenv('XDG_RUNTIME_DIR');
+        $this->originalXdgConfigDirs = getenv('XDG_CONFIG_DIRS');
+        $this->originalXdgDataDirs = getenv('XDG_DATA_DIRS');
     }
 
     public function tearDown(): void
@@ -39,6 +45,9 @@ class XdgDirectoryTest extends BaseTestCase
         $this->restoreEnv('XDG_CACHE_HOME', $this->originalXdgCacheHome);
         $this->restoreEnv('XDG_DATA_HOME', $this->originalXdgDataHome);
         $this->restoreEnv('XDG_STATE_HOME', $this->originalXdgStateHome);
+        $this->restoreEnv('XDG_RUNTIME_DIR', $this->originalXdgRuntimeDir);
+        $this->restoreEnv('XDG_CONFIG_DIRS', $this->originalXdgConfigDirs);
+        $this->restoreEnv('XDG_DATA_DIRS', $this->originalXdgDataDirs);
     }
 
     private function restoreEnv(string $name, string|false $value): void
@@ -123,5 +132,119 @@ class XdgDirectoryTest extends BaseTestCase
         $this->assertSame(0700, fileperms($testDir) & 0777);
 
         rmdir($testDir);
+    }
+
+    // --- Relative path rejection tests ---
+
+    public function testGetConfigHomeIgnoresRelativePath(): void
+    {
+        putenv('XDG_CONFIG_HOME=relative/path');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.config/reli', XdgDirectory::getConfigHome());
+    }
+
+    public function testGetCacheHomeIgnoresRelativePath(): void
+    {
+        putenv('XDG_CACHE_HOME=relative/path');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.cache/reli', XdgDirectory::getCacheHome());
+    }
+
+    public function testGetDataHomeIgnoresRelativePath(): void
+    {
+        putenv('XDG_DATA_HOME=relative/path');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.local/share/reli', XdgDirectory::getDataHome());
+    }
+
+    public function testGetStateHomeIgnoresRelativePath(): void
+    {
+        putenv('XDG_STATE_HOME=relative/path');
+        putenv('HOME=/tmp/xdg-test-home');
+        $this->assertSame('/tmp/xdg-test-home/.local/state/reli', XdgDirectory::getStateHome());
+    }
+
+    // --- XDG_RUNTIME_DIR tests ---
+
+    public function testGetRuntimeDirWithXdgEnv(): void
+    {
+        putenv('XDG_RUNTIME_DIR=/run/user/1000');
+        $this->assertSame('/run/user/1000/reli', XdgDirectory::getRuntimeDir());
+    }
+
+    public function testGetRuntimeDirWithoutXdgEnv(): void
+    {
+        putenv('XDG_RUNTIME_DIR');
+        $this->assertNull(XdgDirectory::getRuntimeDir());
+    }
+
+    public function testGetRuntimeDirIgnoresRelativePath(): void
+    {
+        putenv('XDG_RUNTIME_DIR=relative/runtime');
+        $this->assertNull(XdgDirectory::getRuntimeDir());
+    }
+
+    // --- XDG_CONFIG_DIRS tests ---
+
+    public function testGetConfigDirsWithXdgEnv(): void
+    {
+        putenv('XDG_CONFIG_HOME=/tmp/xdg-config');
+        putenv('XDG_CONFIG_DIRS=/etc/xdg:/opt/config');
+        $this->assertSame(
+            ['/tmp/xdg-config/reli', '/etc/xdg/reli', '/opt/config/reli'],
+            XdgDirectory::getConfigDirs()
+        );
+    }
+
+    public function testGetConfigDirsDefault(): void
+    {
+        putenv('XDG_CONFIG_HOME=/tmp/xdg-config');
+        putenv('XDG_CONFIG_DIRS');
+        $this->assertSame(
+            ['/tmp/xdg-config/reli', '/etc/xdg/reli'],
+            XdgDirectory::getConfigDirs()
+        );
+    }
+
+    public function testGetConfigDirsIgnoresRelativePaths(): void
+    {
+        putenv('XDG_CONFIG_HOME=/tmp/xdg-config');
+        putenv('XDG_CONFIG_DIRS=/etc/xdg:relative/path:/opt/config');
+        $this->assertSame(
+            ['/tmp/xdg-config/reli', '/etc/xdg/reli', '/opt/config/reli'],
+            XdgDirectory::getConfigDirs()
+        );
+    }
+
+    // --- XDG_DATA_DIRS tests ---
+
+    public function testGetDataDirsWithXdgEnv(): void
+    {
+        putenv('XDG_DATA_HOME=/tmp/xdg-data');
+        putenv('XDG_DATA_DIRS=/usr/local/share:/usr/share');
+        $this->assertSame(
+            ['/tmp/xdg-data/reli', '/usr/local/share/reli', '/usr/share/reli'],
+            XdgDirectory::getDataDirs()
+        );
+    }
+
+    public function testGetDataDirsDefault(): void
+    {
+        putenv('XDG_DATA_HOME=/tmp/xdg-data');
+        putenv('XDG_DATA_DIRS');
+        $this->assertSame(
+            ['/tmp/xdg-data/reli', '/usr/local/share/reli', '/usr/share/reli'],
+            XdgDirectory::getDataDirs()
+        );
+    }
+
+    public function testGetDataDirsIgnoresRelativePaths(): void
+    {
+        putenv('XDG_DATA_HOME=/tmp/xdg-data');
+        putenv('XDG_DATA_DIRS=/usr/share:not-absolute:/opt/data');
+        $this->assertSame(
+            ['/tmp/xdg-data/reli', '/usr/share/reli', '/opt/data/reli'],
+            XdgDirectory::getDataDirs()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Stop writing `reli.log` to the current working directory; use XDG-compliant state directory instead
- Add `XdgDirectory` class implementing the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) for reli-prof
- Add `AppDirectory` layer with fallback strategy for HOME-less environments (Docker, nologin users)
- Add `HomeNotFoundException` for explicit error handling when home directory cannot be resolved
- Support user config overrides via `~/.config/reli/config.php`, with install directory config as default fallback

## Log file location change

| Before | After |
|--------|-------|
| `./reli.log` (CWD) | `~/.local/state/reli/reli.log` |
| — | Without HOME: `/tmp/reli-<uid>/state/reli.log` |

`reli.log` will no longer appear in Docker-mounted project directories.

## New classes

- **`XdgDirectory`** — XDG Base Directory Specification implementation
  - `getConfigHome()` / `getCacheHome()` / `getDataHome()` / `getStateHome()`: Resolve per-user XDG directories with spec-compliant defaults
  - `getRuntimeDir()`: Returns `XDG_RUNTIME_DIR` if set, `null` otherwise (per spec, no default)
  - `getConfigDirs()` / `getDataDirs()`: Multi-directory search paths with spec defaults (`/etc/xdg`, `/usr/local/share:/usr/share`)
  - `ensureDirectoryExists()`: Creates directories with `0700` permissions, throws on failure
  - Rejects relative paths in XDG environment variables (per spec requirement)
  - Home resolution fallback chain: `HOME` → `USERPROFILE` / `HOMEDRIVE+HOMEPATH` (Windows) → POSIX passwd DB → `HomeNotFoundException`

- **`AppDirectory`** — Application-level directory resolver wrapping `XdgDirectory`
  - `getConfigDir()`: No fallback — config requires a stable, user-owned location
  - `getCacheDir()` / `getStateDir()` / `getDataDir()`: Fall back to `/tmp/reli-<uid>/` when HOME is unavailable
  - `getLogPath()`: Convenience for `getStateDir() . '/reli.log'`
  - `loadConfig()`: Loads install-dir config as default, merges user config from XDG config dir on top via `Config::merge()`

- **`HomeNotFoundException`** — Dedicated exception for home directory resolution failure (extends `RuntimeException`)

## `/tmp` fallback for HOME-less environments

When the home directory cannot be resolved (no `HOME`, no passwd entry — common in Docker containers or `nologin` service users), `AppDirectory` falls back to a UID-isolated temp directory instead of failing:

```
/tmp/reli-<uid>/cache/
/tmp/reli-<uid>/state/
/tmp/reli-<uid>/data/
```

On systems where `posix_getuid()` is unavailable, the UID suffix is omitted (`/tmp/reli/...`).

**Which directories fall back:**

| Directory | Fallback | Rationale |
|-----------|----------|-----------|
| Config (`getConfigDir`) | None — throws `HomeNotFoundException` | Config should be in a stable, user-owned location; silently writing to `/tmp` risks unnoticed config loss |
| Cache (`getCacheDir`) | `/tmp/reli-<uid>/cache/` | Cache is ephemeral by nature |
| State (`getStateDir`) | `/tmp/reli-<uid>/state/` | Logs/state are best-effort; not writing them shouldn't block profiling |
| Data (`getDataDir`) | `/tmp/reli-<uid>/data/` | Same as state — prefer degraded operation over failure |

The UID isolation (`reli-<uid>`) prevents collisions when multiple users share `/tmp` on the same host.

Note: `loadConfig()` catches `HomeNotFoundException` internally, so the config loading path also degrades gracefully — it simply skips user overrides and uses install-directory defaults only.

## Note on `XdgDirectory::getHome()` and passwd DB fallback

`XdgDirectory::getHome()` includes a fallback chain beyond what the XDG Base Directory Specification defines:

```
HOME → USERPROFILE / HOMEDRIVE+HOMEPATH (Windows) → posix_getpwuid() → HomeNotFoundException
```

The XDG spec assumes `$HOME` is already set and does not define how to resolve it when it's not set. The passwd DB lookup (`posix_getpwuid`) is an **implementation-specific addition**, not a spec requirement.

This mirrors the behavior of Python's `os.path.expanduser("~")`, which platformdirs relies on — Python's standard library internally falls back to `pwd.getpwuid()` when `HOME` is unset, though platformdirs itself does not explicitly implement this fallback.

In PHP there is no built-in `expanduser` equivalent, so this implementation calls `posix_getpwuid(posix_getuid())` directly.

## Config loading flow

```
1. Load config/config.php from install directory (always)
2. If ~/.config/reli/config.php exists, merge on top (user overrides win)
3. If HOME is unavailable, silently use defaults only
```

Users can place only the keys they want to override:

```php
<?php
// ~/.config/reli/config.php
return [
    'log' => ['level' => 'debug'],
];
```

## Config integration changes

- `config/config.php`: Log path changed from hardcoded `'reli.log'` to `AppDirectory::getLogPath()`
- `config/di.php`:
  - `Config::class` factory now uses `AppDirectory::loadConfig()` instead of `Config::load()` directly
  - Logger factory calls `AppDirectory::ensureDirectoryExists()` before opening the log file

## Tests

- **`XdgDirectoryTest`** (14 tests): XDG env var handling for all directory types, HOME fallback to passwd DB, relative path rejection for all env vars, `ensureDirectoryExists` with permission check, `getRuntimeDir` presence/absence/relative, multi-directory search paths with default and custom values, relative path filtering in search paths
- **`AppDirectoryTest`** (14 tests): Per-directory-type XDG delegation and fallback behavior, UID-isolated temp dirs, log path resolution, `ensureDirectoryExists` delegation, config loading (default only / merge with user overrides / graceful fallback without HOME)

## Breaking changes

- Log file moves from `./reli.log` to `~/.local/state/reli/reli.log`