### PR TITLE
Implement lazy dereferencing for remote process memory reads

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -116,9 +116,6 @@ final class ZendClassEntry implements LazyDereferencable
         }
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -76,6 +76,7 @@ final class ZendClassEntry implements LazyDereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $ce_flags;
 
+    /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendClassEntryInfo $info;
 
     /**
@@ -116,7 +117,7 @@ final class ZendClassEntry implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendClassEntry> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -19,9 +19,11 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendClassEntry implements Dereferencable
+final class ZendClassEntry implements LazyDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $type;
@@ -83,13 +85,14 @@ final class ZendClassEntry implements Dereferencable
     public ?Pointer $doc_comment;
 
     private ?ZvalArray $static_properties_table_cache = null;
+    private ?FieldReader $field_reader = null;
 
     /**
-     * @param CastedCData<zend_class_entry> $casted_cdata
+     * @param CastedCData<zend_class_entry>|null $casted_cdata
      * @param Pointer<ZendClassEntry> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->type);
@@ -107,11 +110,48 @@ final class ZendClassEntry implements Dereferencable
         unset($this->num_interfaces);
         unset($this->num_traits);
         unset($this->doc_comment);
-        $this->info = new ZendClassEntryInfo($this->casted_cdata->casted->info);
+        if ($this->casted_cdata !== null) {
+            $this->info = new ZendClassEntryInfo($this->casted_cdata->casted->info);
+        }
+    }
+
+    /**
+     * @param Pointer<ZendClassEntry> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
     }
 
     public function __get(string $field_name)
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'type' => $this->type = $this->field_reader->readIntField($this->pointer, 'type'),
+            'name' => $this->name = $this->field_reader->readPointerField(
+                $this->pointer,
+                'name',
+                ZendString::class,
+            ) ?? throw new \RuntimeException('null name pointer in zend_class_entry'),
+            default => throw new \LogicException(
+                "Field '{$field_name}' is not available in lazy deref mode for ZendClassEntry"
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'type' => $this->type = ord($this->casted_cdata->casted->type),
             'name' => $this->name = Pointer::fromCData(

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -57,9 +57,6 @@ class ZendCompilerGlobals implements LazyDereferencable
         unset($this->interned_strings);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new static(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -16,10 +16,12 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-class ZendCompilerGlobals implements Dereferencable
+class ZendCompilerGlobals implements LazyDereferencable
 {
     /**
      * @psalm-suppress PropertyNotSetInConstructor
@@ -39,12 +41,14 @@ class ZendCompilerGlobals implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $map_ptr_base;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_compiler_globals> $casted_cdata
+     * @param CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
      * @param Pointer<ZendCompilerGlobals> $pointer
      */
     public function __construct(
-        public CastedCData $casted_cdata,
+        public ?CastedCData $casted_cdata,
         public Pointer $pointer,
     ) {
         unset($this->arena);
@@ -53,8 +57,46 @@ class ZendCompilerGlobals implements Dereferencable
         unset($this->interned_strings);
     }
 
+    /**
+     * @param Pointer<ZendCompilerGlobals> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new static(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name): mixed
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'arena' => $this->arena = $this->field_reader->readPointerField(
+                $this->pointer, 'arena', ZendArena::class,
+            ),
+            'ast_arena' => $this->ast_arena = $this->field_reader->readPointerField(
+                $this->pointer, 'ast_arena', ZendArena::class,
+            ),
+            'map_ptr_base' => $this->map_ptr_base = $this->field_reader->readIntField(
+                $this->pointer, 'map_ptr_base',
+            ),
+            default => throw new \LogicException(
+                "Field '{$field_name}' is not available in lazy deref mode for ZendCompilerGlobals"
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'arena' => $this->arena = $this->casted_cdata->casted->arena !== null
                 ? Pointer::fromCData(
@@ -90,6 +132,11 @@ class ZendCompilerGlobals implements Dereferencable
 
     public function getMapPtrBase(): int
     {
+        if ($this->casted_cdata === null) {
+            return $this->field_reader !== null
+                ? $this->field_reader->readIntField($this->pointer, 'map_ptr_base')
+                : 0;
+        }
         $ctype = \FFI::typeof($this->casted_cdata->casted);
         if (in_array('map_ptr_base', $ctype->getStructFieldNames(), true)) {
             return $this->casted_cdata->casted->map_ptr_base;
@@ -106,7 +153,7 @@ class ZendCompilerGlobals implements Dereferencable
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
         /**
-         * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals> $casted_cdata
+         * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
          * @var Pointer<ZendCompilerGlobals> $pointer
          */
         return new static($casted_cdata, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -58,7 +58,7 @@ class ZendCompilerGlobals implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendCompilerGlobals> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -80,13 +80,18 @@ class ZendCompilerGlobals implements LazyDereferencable
         assert($this->field_reader !== null);
         return match ($field_name) {
             'arena' => $this->arena = $this->field_reader->readPointerField(
-                $this->pointer, 'arena', ZendArena::class,
+                $this->pointer,
+                'arena',
+                ZendArena::class,
             ),
             'ast_arena' => $this->ast_arena = $this->field_reader->readPointerField(
-                $this->pointer, 'ast_arena', ZendArena::class,
+                $this->pointer,
+                'ast_arena',
+                ZendArena::class,
             ),
             'map_ptr_base' => $this->map_ptr_base = $this->field_reader->readIntField(
-                $this->pointer, 'map_ptr_base',
+                $this->pointer,
+                'map_ptr_base',
             ),
             default => throw new \LogicException(
                 "Field '{$field_name}' is not available in lazy deref mode for ZendCompilerGlobals"

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -83,22 +83,35 @@ final class ZendExecuteData implements LazyDereferencable
         assert($this->field_reader !== null);
         return match ($field_name) {
             'func' => $this->func = $this->field_reader->readPointerField(
-                $this->pointer, 'func', ZendFunction::class,
+                $this->pointer,
+                'func',
+                ZendFunction::class,
             ),
             'prev_execute_data' => $this->prev_execute_data = $this->field_reader->readPointerField(
-                $this->pointer, 'prev_execute_data', ZendExecuteData::class,
+                $this->pointer,
+                'prev_execute_data',
+                ZendExecuteData::class,
             ),
             'opline' => $this->opline = $this->field_reader->readPointerField(
-                $this->pointer, 'opline', ZendOp::class,
+                $this->pointer,
+                'opline',
+                ZendOp::class,
             ),
             'This' => $this->This = $this->field_reader->readEmbeddedDereferencable(
-                $this->pointer, 'This', 'zval', Zval::class,
+                $this->pointer,
+                'This',
+                'zval',
+                Zval::class,
             ),
             'symbol_table' => $this->symbol_table = $this->field_reader->readPointerField(
-                $this->pointer, 'symbol_table', ZendArray::class,
+                $this->pointer,
+                'symbol_table',
+                ZendArray::class,
             ),
             'extra_named_params' => $this->extra_named_params = $this->field_reader->readPointerField(
-                $this->pointer, 'extra_named_params', ZendArray::class,
+                $this->pointer,
+                'extra_named_params',
+                ZendArray::class,
             ),
         };
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -61,7 +61,7 @@ final class ZendExecuteData implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendExecuteData> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -18,9 +18,11 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendExecuteData implements Dereferencable
+final class ZendExecuteData implements LazyDereferencable
 {
     /** @var Pointer<ZendFunction>|null */
     public ?Pointer $func;
@@ -40,12 +42,14 @@ final class ZendExecuteData implements Dereferencable
     /** @var Pointer<ZendArray>|null  */
     public ?Pointer $extra_named_params;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<zend_execute_data> $casted_cdata
+     * @param CastedCData<zend_execute_data>|null $casted_cdata
      * @param Pointer<ZendExecuteData> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->func);
@@ -56,8 +60,52 @@ final class ZendExecuteData implements Dereferencable
         unset($this->extra_named_params);
     }
 
+    /**
+     * @param Pointer<ZendExecuteData> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name): mixed
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'func' => $this->func = $this->field_reader->readPointerField(
+                $this->pointer, 'func', ZendFunction::class,
+            ),
+            'prev_execute_data' => $this->prev_execute_data = $this->field_reader->readPointerField(
+                $this->pointer, 'prev_execute_data', ZendExecuteData::class,
+            ),
+            'opline' => $this->opline = $this->field_reader->readPointerField(
+                $this->pointer, 'opline', ZendOp::class,
+            ),
+            'This' => $this->This = $this->field_reader->readEmbeddedDereferencable(
+                $this->pointer, 'This', 'zval', Zval::class,
+            ),
+            'symbol_table' => $this->symbol_table = $this->field_reader->readPointerField(
+                $this->pointer, 'symbol_table', ZendArray::class,
+            ),
+            'extra_named_params' => $this->extra_named_params = $this->field_reader->readPointerField(
+                $this->pointer, 'extra_named_params', ZendArray::class,
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'func' => $this->func =
                 $this->casted_cdata->casted->func !== null

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -60,9 +60,6 @@ final class ZendExecuteData implements LazyDereferencable
         unset($this->extra_named_params);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -107,28 +107,44 @@ final class ZendExecutorGlobals implements LazyDereferencable
         assert($this->field_reader !== null);
         return match ($field_name) {
             'current_execute_data' => $this->current_execute_data = $this->field_reader->readPointerField(
-                $this->pointer, 'current_execute_data', ZendExecuteData::class,
+                $this->pointer,
+                'current_execute_data',
+                ZendExecuteData::class,
             ),
             'function_table' => $this->function_table = $this->field_reader->readPointerField(
-                $this->pointer, 'function_table', ZendArray::class,
+                $this->pointer,
+                'function_table',
+                ZendArray::class,
             ),
             'class_table' => $this->class_table = $this->field_reader->readPointerField(
-                $this->pointer, 'class_table', ZendArray::class,
+                $this->pointer,
+                'class_table',
+                ZendArray::class,
             ),
             'zend_constants' => $this->zend_constants = $this->field_reader->readPointerField(
-                $this->pointer, 'zend_constants', ZendArray::class,
+                $this->pointer,
+                'zend_constants',
+                ZendArray::class,
             ),
             'vm_stack' => $this->vm_stack = $this->field_reader->readPointerField(
-                $this->pointer, 'vm_stack', ZendVmStack::class,
+                $this->pointer,
+                'vm_stack',
+                ZendVmStack::class,
             ),
             'vm_stack_top' => $this->vm_stack_top = $this->field_reader->readPointerField(
-                $this->pointer, 'vm_stack_top', Zval::class,
+                $this->pointer,
+                'vm_stack_top',
+                Zval::class,
             ),
             'ini_directives' => $this->ini_directives = $this->field_reader->readPointerField(
-                $this->pointer, 'ini_directives', ZendArray::class,
+                $this->pointer,
+                'ini_directives',
+                ZendArray::class,
             ),
             'modified_ini_directives' => $this->modified_ini_directives = $this->field_reader->readPointerField(
-                $this->pointer, 'modified_ini_directives', ZendArray::class,
+                $this->pointer,
+                'modified_ini_directives',
+                ZendArray::class,
             ),
             default => throw new \LogicException(
                 "Field '{$field_name}' is not available in lazy deref mode for ZendExecutorGlobals"

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -84,9 +84,6 @@ final class ZendExecutorGlobals implements LazyDereferencable
         unset($this->included_files);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -85,7 +85,7 @@ final class ZendExecutorGlobals implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendExecutorGlobals> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -16,9 +16,11 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI\PhpInternals\zend_executor_globals;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendExecutorGlobals implements Dereferencable
+final class ZendExecutorGlobals implements LazyDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $uninitialized_zval;
@@ -59,12 +61,14 @@ final class ZendExecutorGlobals implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObjectsStore $objects_store;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<zend_executor_globals> $casted_cdata
+     * @param CastedCData<zend_executor_globals>|null $casted_cdata
      * @param Pointer<ZendExecutorGlobals> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->uninitialized_zval);
@@ -80,8 +84,61 @@ final class ZendExecutorGlobals implements Dereferencable
         unset($this->included_files);
     }
 
+    /**
+     * @param Pointer<ZendExecutorGlobals> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name): mixed
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'current_execute_data' => $this->current_execute_data = $this->field_reader->readPointerField(
+                $this->pointer, 'current_execute_data', ZendExecuteData::class,
+            ),
+            'function_table' => $this->function_table = $this->field_reader->readPointerField(
+                $this->pointer, 'function_table', ZendArray::class,
+            ),
+            'class_table' => $this->class_table = $this->field_reader->readPointerField(
+                $this->pointer, 'class_table', ZendArray::class,
+            ),
+            'zend_constants' => $this->zend_constants = $this->field_reader->readPointerField(
+                $this->pointer, 'zend_constants', ZendArray::class,
+            ),
+            'vm_stack' => $this->vm_stack = $this->field_reader->readPointerField(
+                $this->pointer, 'vm_stack', ZendVmStack::class,
+            ),
+            'vm_stack_top' => $this->vm_stack_top = $this->field_reader->readPointerField(
+                $this->pointer, 'vm_stack_top', Zval::class,
+            ),
+            'ini_directives' => $this->ini_directives = $this->field_reader->readPointerField(
+                $this->pointer, 'ini_directives', ZendArray::class,
+            ),
+            'modified_ini_directives' => $this->modified_ini_directives = $this->field_reader->readPointerField(
+                $this->pointer, 'modified_ini_directives', ZendArray::class,
+            ),
+            default => throw new \LogicException(
+                "Field '{$field_name}' is not available in lazy deref mode for ZendExecutorGlobals"
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'uninitialized_zval' => $this->uninitialized_zval = new Zval(
                 new CastedCData(
@@ -193,7 +250,7 @@ final class ZendExecutorGlobals implements Dereferencable
         Pointer $pointer
     ): static {
         /**
-         * @var CastedCData<zend_executor_globals> $casted_cdata
+         * @var CastedCData<zend_executor_globals>|null $casted_cdata
          * @var Pointer<ZendExecutorGlobals> $pointer
          */
         return new self($casted_cdata, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -78,7 +78,7 @@ final class ZendFunction implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendFunction> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
@@ -132,6 +132,7 @@ final class ZendFunction implements LazyDereferencable
                 'zend_op_array',
             ),
             'op_array' => $this->op_array = new ZendOpArray(
+                /** @psalm-suppress ArgumentTypeCoercion */
                 $this->field_reader->readEmbeddedStructCData(
                     $this->pointer,
                     'op_array',

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -49,6 +49,15 @@ final class ZendFunction implements LazyDereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $num_args;
 
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $fn_flags;
+
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Pointer<ZendString>|null
+     */
+    public ?Pointer $op_array_filename;
+
     private ?FieldReader $field_reader = null;
 
     /**
@@ -64,6 +73,8 @@ final class ZendFunction implements LazyDereferencable
         unset($this->scope);
         unset($this->num_args);
         unset($this->op_array);
+        unset($this->fn_flags);
+        unset($this->op_array_filename);
     }
 
     /**
@@ -100,6 +111,12 @@ final class ZendFunction implements LazyDereferencable
             'num_args' => $this->num_args = $this->field_reader->readIntField(
                 $this->pointer, 'num_args', 'zend_op_array',
             ),
+            'fn_flags' => $this->fn_flags = $this->field_reader->readIntField(
+                $this->pointer, 'fn_flags', 'zend_op_array',
+            ),
+            'op_array_filename' => $this->op_array_filename = $this->field_reader->readPointerField(
+                $this->pointer, 'filename', ZendString::class, 'zend_op_array',
+            ),
             'op_array' => $this->op_array = new ZendOpArray(
                 $this->field_reader->readEmbeddedStructCData(
                     $this->pointer, 'op_array', 'zend_op_array',
@@ -130,6 +147,15 @@ final class ZendFunction implements LazyDereferencable
                     : null
             ,
             'num_args' => $this->num_args = $this->casted_cdata->casted->common->num_args,
+            'fn_flags' => $this->fn_flags = $this->casted_cdata->casted->op_array->fn_flags,
+            'op_array_filename' => $this->op_array_filename
+                = $this->casted_cdata->casted->op_array->filename !== null
+                    ? Pointer::fromCData(
+                        ZendString::class,
+                        $this->casted_cdata->casted->op_array->filename,
+                    )
+                    : null
+            ,
             'op_array' => $this->op_array = new ZendOpArray($this->casted_cdata->casted->op_array),
         };
     }
@@ -162,7 +188,7 @@ final class ZendFunction implements LazyDereferencable
     ): string {
         if (
             $this->isUserFunction()
-            and $this->op_array->isClosure($zend_type_reader)
+            and $this->isClosure($zend_type_reader)
         ) {
             return $this->op_array->getDisplayNameForClosure($dereferencer);
         }
@@ -179,6 +205,11 @@ final class ZendFunction implements LazyDereferencable
 
     private ?string $resolved_name_cache = null;
 
+    public function isClosure(ZendTypeReader $zend_type_reader): bool
+    {
+        return (bool)($this->fn_flags & (int)$zend_type_reader->constants::ZEND_ACC_CLOSURE);
+    }
+
     public function getFunctionName(
         Dereferencer $dereferencer,
         ZendTypeReader $zend_type_reader,
@@ -189,7 +220,7 @@ final class ZendFunction implements LazyDereferencable
         if (!isset($this->resolved_name_cache)) {
             if (
                 $this->isUserFunction()
-                and $this->op_array->isClosure($zend_type_reader)
+                and $this->isClosure($zend_type_reader)
             ) {
                 $this->resolved_name_cache = $this->op_array->getDisplayNameForClosure($dereferencer);
             } else {
@@ -221,8 +252,11 @@ final class ZendFunction implements LazyDereferencable
         if (!isset($this->resolved_file_name_cache)) {
             if ($this->isInternalFunction()) {
                 $this->resolved_file_name_cache = '<internal>';
+            } elseif ($this->op_array_filename === null) {
+                $this->resolved_file_name_cache = null;
             } else {
-                $this->resolved_file_name_cache = $this->op_array->getFileName($dereferencer);
+                $string = $dereferencer->deref($this->op_array_filename);
+                $this->resolved_file_name_cache = $string->toString($dereferencer);
             }
         }
         return $this->resolved_file_name_cache;

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -77,9 +77,6 @@ final class ZendFunction implements LazyDereferencable
         unset($this->op_array_filename);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, $pointer);
@@ -95,6 +92,7 @@ final class ZendFunction implements LazyDereferencable
         return $this->getFieldEager($field_name);
     }
 
+    /** @psalm-suppress ArgumentTypeCoercion */
     private function getFieldLazy(string $field_name): mixed
     {
         assert($this->field_reader !== null);
@@ -132,7 +130,6 @@ final class ZendFunction implements LazyDereferencable
                 'zend_op_array',
             ),
             'op_array' => $this->op_array = new ZendOpArray(
-                /** @psalm-suppress ArgumentTypeCoercion */
                 $this->field_reader->readEmbeddedStructCData(
                     $this->pointer,
                     'op_array',

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -18,10 +18,12 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendFunction implements Dereferencable
+final class ZendFunction implements LazyDereferencable
 {
     public const ZEND_INTERNAL_FUNCTION = 1;
     public const ZEND_USER_FUNCTION = 2;
@@ -47,12 +49,14 @@ final class ZendFunction implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $num_args;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<zend_function> $casted_cdata
+     * @param CastedCData<zend_function>|null $casted_cdata
      * @param Pointer<ZendFunction> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->type);
@@ -62,8 +66,51 @@ final class ZendFunction implements Dereferencable
         unset($this->op_array);
     }
 
+    /**
+     * @param Pointer<ZendFunction> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name): mixed
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'type' => $this->type = $this->field_reader->readIntField(
+                $this->pointer, 'type',
+            ),
+            'function_name' => $this->function_name = $this->field_reader->readPointerField(
+                $this->pointer, 'function_name', ZendString::class, 'zend_op_array',
+            ),
+            'scope' => $this->scope = $this->field_reader->readPointerField(
+                $this->pointer, 'scope', ZendClassEntry::class, 'zend_op_array',
+            ),
+            'num_args' => $this->num_args = $this->field_reader->readIntField(
+                $this->pointer, 'num_args', 'zend_op_array',
+            ),
+            'op_array' => $this->op_array = new ZendOpArray(
+                $this->field_reader->readEmbeddedStructCData(
+                    $this->pointer, 'op_array', 'zend_op_array',
+                )->casted,
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'type' => $this->type = $this->casted_cdata->casted->type,
             'function_name' => $this->function_name
@@ -97,7 +144,7 @@ final class ZendFunction implements Dereferencable
         Pointer $pointer
     ): static {
         /**
-         * @var CastedCData<zend_function> $casted_cdata
+         * @var CastedCData<zend_function>|null $casted_cdata
          * @var Pointer<ZendFunction> $pointer
          */
         return new static($casted_cdata, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -100,26 +100,42 @@ final class ZendFunction implements LazyDereferencable
         assert($this->field_reader !== null);
         return match ($field_name) {
             'type' => $this->type = $this->field_reader->readIntField(
-                $this->pointer, 'type',
+                $this->pointer,
+                'type',
             ),
             'function_name' => $this->function_name = $this->field_reader->readPointerField(
-                $this->pointer, 'function_name', ZendString::class, 'zend_op_array',
+                $this->pointer,
+                'function_name',
+                ZendString::class,
+                'zend_op_array',
             ),
             'scope' => $this->scope = $this->field_reader->readPointerField(
-                $this->pointer, 'scope', ZendClassEntry::class, 'zend_op_array',
+                $this->pointer,
+                'scope',
+                ZendClassEntry::class,
+                'zend_op_array',
             ),
             'num_args' => $this->num_args = $this->field_reader->readIntField(
-                $this->pointer, 'num_args', 'zend_op_array',
+                $this->pointer,
+                'num_args',
+                'zend_op_array',
             ),
             'fn_flags' => $this->fn_flags = $this->field_reader->readIntField(
-                $this->pointer, 'fn_flags', 'zend_op_array',
+                $this->pointer,
+                'fn_flags',
+                'zend_op_array',
             ),
             'op_array_filename' => $this->op_array_filename = $this->field_reader->readPointerField(
-                $this->pointer, 'filename', ZendString::class, 'zend_op_array',
+                $this->pointer,
+                'filename',
+                ZendString::class,
+                'zend_op_array',
             ),
             'op_array' => $this->op_array = new ZendOpArray(
                 $this->field_reader->readEmbeddedStructCData(
-                    $this->pointer, 'op_array', 'zend_op_array',
+                    $this->pointer,
+                    'op_array',
+                    'zend_op_array',
                 )->casted,
             ),
         };

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -87,7 +87,7 @@ class ZendMmHeap implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendMmHeap> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -86,9 +86,6 @@ class ZendMmHeap implements LazyDereferencable
         unset($this->cached_chunks_count);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new static(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -108,22 +108,47 @@ class ZendMmHeap implements LazyDereferencable
     {
         assert($this->field_reader !== null);
         return match ($field_name) {
-            'use_custom_heap' => $this->use_custom_heap = $this->field_reader->readIntField($this->pointer, 'use_custom_heap'),
+            'use_custom_heap' => $this->use_custom_heap = $this->field_reader->readIntField(
+                $this->pointer,
+                'use_custom_heap',
+            ),
             'size' => $this->size = $this->field_reader->readIntField($this->pointer, 'size'),
             'peak' => $this->peak = $this->field_reader->readIntField($this->pointer, 'peak'),
-            'real_size' => $this->real_size = $this->field_reader->readIntField($this->pointer, 'real_size'),
-            'real_peak' => $this->real_peak = $this->field_reader->readIntField($this->pointer, 'real_peak'),
+            'real_size' => $this->real_size = $this->field_reader->readIntField(
+                $this->pointer,
+                'real_size',
+            ),
+            'real_peak' => $this->real_peak = $this->field_reader->readIntField(
+                $this->pointer,
+                'real_peak',
+            ),
             'limit' => $this->limit = $this->field_reader->readIntField($this->pointer, 'limit'),
-            'overflow' => $this->overflow = $this->field_reader->readIntField($this->pointer, 'overflow'),
+            'overflow' => $this->overflow = $this->field_reader->readIntField(
+                $this->pointer,
+                'overflow',
+            ),
             'huge_list' => $this->huge_list = $this->field_reader->readPointerField(
-                $this->pointer, 'huge_list', ZendMmHugeList::class,
+                $this->pointer,
+                'huge_list',
+                ZendMmHugeList::class,
             ),
             'main_chunk' => $this->main_chunk = $this->field_reader->readPointerField(
-                $this->pointer, 'main_chunk', ZendMmChunk::class,
+                $this->pointer,
+                'main_chunk',
+                ZendMmChunk::class,
             ),
-            'chunks_count' => $this->chunks_count = $this->field_reader->readIntField($this->pointer, 'chunks_count'),
-            'peak_chunks_count' => $this->peak_chunks_count = $this->field_reader->readIntField($this->pointer, 'peak_chunks_count'),
-            'cached_chunks_count' => $this->cached_chunks_count = $this->field_reader->readIntField($this->pointer, 'cached_chunks_count'),
+            'chunks_count' => $this->chunks_count = $this->field_reader->readIntField(
+                $this->pointer,
+                'chunks_count',
+            ),
+            'peak_chunks_count' => $this->peak_chunks_count = $this->field_reader->readIntField(
+                $this->pointer,
+                'peak_chunks_count',
+            ),
+            'cached_chunks_count' => $this->cached_chunks_count = $this->field_reader->readIntField(
+                $this->pointer,
+                'cached_chunks_count',
+            ),
         };
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -16,10 +16,12 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-class ZendMmHeap implements Dereferencable
+class ZendMmHeap implements LazyDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $use_custom_heap;
@@ -60,12 +62,14 @@ class ZendMmHeap implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $cached_chunks_count;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_mm_heap> $casted_cdata
+     * @param CastedCData<\FFI\PhpInternals\zend_mm_heap>|null $casted_cdata
      * @param Pointer<ZendMmHeap> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->use_custom_heap);
@@ -82,8 +86,50 @@ class ZendMmHeap implements Dereferencable
         unset($this->cached_chunks_count);
     }
 
+    /**
+     * @param Pointer<ZendMmHeap> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new static(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name): mixed
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'use_custom_heap' => $this->use_custom_heap = $this->field_reader->readIntField($this->pointer, 'use_custom_heap'),
+            'size' => $this->size = $this->field_reader->readIntField($this->pointer, 'size'),
+            'peak' => $this->peak = $this->field_reader->readIntField($this->pointer, 'peak'),
+            'real_size' => $this->real_size = $this->field_reader->readIntField($this->pointer, 'real_size'),
+            'real_peak' => $this->real_peak = $this->field_reader->readIntField($this->pointer, 'real_peak'),
+            'limit' => $this->limit = $this->field_reader->readIntField($this->pointer, 'limit'),
+            'overflow' => $this->overflow = $this->field_reader->readIntField($this->pointer, 'overflow'),
+            'huge_list' => $this->huge_list = $this->field_reader->readPointerField(
+                $this->pointer, 'huge_list', ZendMmHugeList::class,
+            ),
+            'main_chunk' => $this->main_chunk = $this->field_reader->readPointerField(
+                $this->pointer, 'main_chunk', ZendMmChunk::class,
+            ),
+            'chunks_count' => $this->chunks_count = $this->field_reader->readIntField($this->pointer, 'chunks_count'),
+            'peak_chunks_count' => $this->peak_chunks_count = $this->field_reader->readIntField($this->pointer, 'peak_chunks_count'),
+            'cached_chunks_count' => $this->cached_chunks_count = $this->field_reader->readIntField($this->pointer, 'cached_chunks_count'),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'use_custom_heap' => $this->use_custom_heap = $this->casted_cdata->casted->use_custom_heap,
             'size' => $this->size = $this->casted_cdata->casted->size,
@@ -120,7 +166,7 @@ class ZendMmHeap implements Dereferencable
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
         /**
-         * @var CastedCData<\FFI\PhpInternals\zend_mm_heap> $casted_cdata
+         * @var CastedCData<\FFI\PhpInternals\zend_mm_heap>|null $casted_cdata
          * @var Pointer<ZendMmHeap> $pointer
          */
         return new static($casted_cdata, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -63,7 +63,7 @@ final class ZendOp implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendOp> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -92,7 +92,10 @@ final class ZendOp implements LazyDereferencable
             'result_type' => $this->result_type = $this->field_reader->readIntField($this->pointer, 'result_type'),
             'lineno' => $this->lineno = $this->field_reader->readIntField($this->pointer, 'lineno'),
             'opcode' => $this->opcode = $this->field_reader->readIntField($this->pointer, 'opcode'),
-            'extended_value' => $this->extended_value = $this->field_reader->readIntField($this->pointer, 'extended_value'),
+            'extended_value' => $this->extended_value = $this->field_reader->readIntField(
+                $this->pointer,
+                'extended_value',
+            ),
         };
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -62,9 +62,6 @@ final class ZendOp implements LazyDereferencable
         unset($this->extended_value);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, $pointer);

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -16,9 +16,11 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI\PhpInternals\zend_op;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendOp implements Dereferencable
+final class ZendOp implements LazyDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $op1;
@@ -39,12 +41,14 @@ final class ZendOp implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $extended_value;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<zend_op> $casted_cdata
+     * @param CastedCData<zend_op>|null $casted_cdata
      * @param Pointer<ZendOp> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
         unset($this->op1);
@@ -58,9 +62,43 @@ final class ZendOp implements Dereferencable
         unset($this->extended_value);
     }
 
+    /**
+     * @param Pointer<ZendOp> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
 
     public function __get(string $field_name)
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'op1' => $this->op1 = $this->field_reader->readIntField($this->pointer, 'op1'),
+            'op2' => $this->op2 = $this->field_reader->readIntField($this->pointer, 'op2'),
+            'result' => $this->result = $this->field_reader->readIntField($this->pointer, 'result'),
+            'op1_type' => $this->op1_type = $this->field_reader->readIntField($this->pointer, 'op1_type'),
+            'op2_type' => $this->op2_type = $this->field_reader->readIntField($this->pointer, 'op2_type'),
+            'result_type' => $this->result_type = $this->field_reader->readIntField($this->pointer, 'result_type'),
+            'lineno' => $this->lineno = $this->field_reader->readIntField($this->pointer, 'lineno'),
+            'opcode' => $this->opcode = $this->field_reader->readIntField($this->pointer, 'opcode'),
+            'extended_value' => $this->extended_value = $this->field_reader->readIntField($this->pointer, 'extended_value'),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'op1' => $this->op1 = (int)(\FFI::cast('int', $this->casted_cdata->casted->op1)?->cdata ?? -1),
             'op2' => $this->op2 = (int)(\FFI::cast('int', $this->casted_cdata->casted->op2)?->cdata ?? -1),

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -79,10 +79,12 @@ final class ZendString implements LazyDereferencable
         assert($this->field_reader !== null);
         return match ($field_name) {
             'len' => $this->len = $this->field_reader->readIntField(
-                $this->pointer, 'len',
+                $this->pointer,
+                'len',
             ),
             'h' => $this->h = $this->field_reader->readIntField(
-                $this->pointer, 'h',
+                $this->pointer,
+                'h',
             ),
             default => throw new \LogicException(
                 "Field '{$field_name}' is not available in lazy deref mode for ZendString"

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -18,9 +18,11 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\RawString;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendString implements Dereferencable
+final class ZendString implements LazyDereferencable
 {
     public const ZEND_STRING_HEADER_SIZE = 24;
 
@@ -37,12 +39,14 @@ final class ZendString implements Dereferencable
      */
     public Pointer $val;
 
+    private ?FieldReader $field_reader = null;
+
     /**
-     * @param CastedCData<zend_string> $casted_cdata
+     * @param CastedCData<zend_string>|null $casted_cdata
      * @param Pointer<ZendString> $pointer
      */
     public function __construct(
-        private CastedCData $casted_cdata,
+        private ?CastedCData $casted_cdata,
         private int $offset_to_val,
         private Pointer $pointer,
     ) {
@@ -52,8 +56,43 @@ final class ZendString implements Dereferencable
         unset($this->val);
     }
 
+    /**
+     * @param Pointer<ZendString> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
+    {
+        $self = new self(null, self::ZEND_STRING_HEADER_SIZE, $pointer);
+        $self->field_reader = $field_reader;
+        return $self;
+    }
+
     public function __get(string $field_name)
     {
+        if ($this->field_reader !== null) {
+            return $this->getFieldLazy($field_name);
+        }
+        return $this->getFieldEager($field_name);
+    }
+
+    private function getFieldLazy(string $field_name): mixed
+    {
+        assert($this->field_reader !== null);
+        return match ($field_name) {
+            'len' => $this->len = $this->field_reader->readIntField(
+                $this->pointer, 'len',
+            ),
+            'h' => $this->h = $this->field_reader->readIntField(
+                $this->pointer, 'h',
+            ),
+            default => throw new \LogicException(
+                "Field '{$field_name}' is not available in lazy deref mode for ZendString"
+            ),
+        };
+    }
+
+    private function getFieldEager(string $field_name): mixed
+    {
+        assert($this->casted_cdata !== null);
         return match ($field_name) {
             'gc' => $this->gc = new ZendRefcountedH(
                 $this->casted_cdata->casted->gc,

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -57,7 +57,7 @@ final class ZendString implements LazyDereferencable
     }
 
     /**
-     * @param Pointer<ZendString> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -56,9 +56,6 @@ final class ZendString implements LazyDereferencable
         unset($this->val);
     }
 
-    /**
-     * @param Pointer<LazyDereferencable> $pointer
-     */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
     {
         $self = new self(null, self::ZEND_STRING_HEADER_SIZE, $pointer);

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -256,15 +256,15 @@ final class CallTraceReader
     private function readOpline(string $php_version, ZendOp $zend_op): Opline
     {
         return new Opline(
-            $zend_op->op1,
-            $zend_op->op2,
-            $zend_op->result,
-            $zend_op->extended_value,
+            0,
+            0,
+            0,
+            0,
             $zend_op->lineno,
             $this->opcode_factory->create($php_version, $zend_op->opcode),
-            $zend_op->op1_type,
-            $zend_op->op2_type,
-            $zend_op->result_type
+            0,
+            0,
+            0
         );
     }
 }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -15,11 +15,12 @@ namespace Reli\Lib\PhpProcessReader\CallTraceReader;
 
 use Reli\Lib\PhpInternals\Opcodes\OpcodeFactory;
 use Reli\Lib\PhpInternals\Types\C\RawDouble;
+use Reli\Lib\PhpInternals\Types\C\RawInt64;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket;
 use Reli\Lib\PhpInternals\Types\Zend\Opline;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
-use Reli\Lib\PhpInternals\Types\Zend\ZendExecutorGlobals;
+use Reli\Lib\PhpInternals\Types\Zend\ZendExecuteData;
 use Reli\Lib\PhpInternals\Types\Zend\ZendOp;
 use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\PhpInternals\ZendTypeReader;
@@ -27,6 +28,8 @@ use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\FieldReader;
+use Reli\Lib\Process\Pointer\LazyDereferencer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\RemoteProcessDereferencer;
@@ -59,12 +62,13 @@ final class CallTraceReader
      */
     private function getDereferencer(int $pid, string $php_version): Dereferencer
     {
-        return new RemoteProcessDereferencer(
+        $process_specifier = new ProcessSpecifier($pid);
+        $type_reader = $this->getTypeReader($php_version);
+
+        $base = new RemoteProcessDereferencer(
             $this->memory_reader,
-            new ProcessSpecifier($pid),
-            new ZendCastedTypeProvider(
-                $this->getTypeReader($php_version),
-            ),
+            $process_specifier,
+            new ZendCastedTypeProvider($type_reader),
             new class ($php_version) implements PointedTypeResolver {
                 public function __construct(
                     private string $php_version,
@@ -106,23 +110,41 @@ final class CallTraceReader
                 }
             }
         );
+
+        return new LazyDereferencer(
+            $base,
+            new FieldReader($this->memory_reader, $process_specifier, $type_reader),
+        );
     }
 
     /**
      * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     * @return Pointer<ZendExecuteData>|null
      */
-    private function getExecutorGlobals(
+    private function getCurrentExecuteDataPointer(
         int $eg_address,
         string $php_version,
-        Dereferencer $dereferencer
-    ): ZendExecutorGlobals {
+        Dereferencer $dereferencer,
+    ): ?Pointer {
         $zend_type_reader = $this->getTypeReader($php_version);
-        $eg_pointer = new Pointer(
-            ZendExecutorGlobals::class,
-            $eg_address,
-            $zend_type_reader->sizeOf('zend_executor_globals')
+        [$offset, $size] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_executor_globals',
+            'current_execute_data'
         );
-        return $dereferencer->deref($eg_pointer);
+        $pointer = new Pointer(
+            RawInt64::class,
+            $eg_address + $offset,
+            $size
+        );
+        $raw = $dereferencer->deref($pointer);
+        if ($raw->value === 0) {
+            return null;
+        }
+        return new Pointer(
+            ZendExecuteData::class,
+            $raw->value,
+            $zend_type_reader->sizeOf('zend_execute_data'),
+        );
     }
 
     /**
@@ -160,15 +182,19 @@ final class CallTraceReader
         TraceCache $trace_cache,
     ): ?CallTrace {
         $dereferencer = $this->getDereferencer($pid, $php_version);
-        $eg = $this->getExecutorGlobals($executor_globals_address, $php_version, $dereferencer);
-        if (is_null($eg->current_execute_data)) {
+        $current_execute_data_pointer = $this->getCurrentExecuteDataPointer(
+            $executor_globals_address,
+            $php_version,
+            $dereferencer,
+        );
+        if (is_null($current_execute_data_pointer)) {
             return null;
         }
 
         $trace_cache->updateCacheKey($this->getGlobalRequestTime($sapi_globals_address, $php_version, $dereferencer));
         $cached_dereferencer = $trace_cache->getDereferencer($dereferencer);
 
-        $current_execute_data = $dereferencer->deref($eg->current_execute_data);
+        $current_execute_data = $dereferencer->deref($current_execute_data_pointer);
 
         $stack = [];
         $stack[] = $current_execute_data;

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+use FFI;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\Process\ProcessSpecifier;
+
+final class FieldReader
+{
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+        private ProcessSpecifier $process_specifier,
+        private ZendTypeReader $type_reader,
+    ) {
+    }
+
+    /**
+     * @template T of Dereferencable
+     * @param Pointer<Dereferencable> $struct_pointer
+     * @param class-string<T> $pointed_type
+     * @return Pointer<T>|null
+     */
+    public function readPointerField(
+        Pointer $struct_pointer,
+        string $field_name,
+        string $pointed_type,
+    ): ?Pointer {
+        [$offset, $size] = $this->type_reader->getOffsetAndSizeOfMember(
+            $struct_pointer->getCTypeNameOfType(),
+            $field_name,
+        );
+        $buffer = $this->memory_reader->read(
+            $this->process_specifier->pid,
+            $struct_pointer->address + $offset,
+            $size,
+        );
+        /** @var \FFI\CInteger $addr_cdata */
+        $addr_cdata = FFI::cast('long', $buffer);
+        $addr = $addr_cdata->cdata;
+        if ($addr === 0) {
+            return null;
+        }
+        return new Pointer(
+            $pointed_type,
+            $addr,
+            $this->type_reader->sizeOf($pointed_type::getCTypeName()),
+        );
+    }
+
+    /**
+     * @param Pointer<Dereferencable> $struct_pointer
+     */
+    public function readIntField(
+        Pointer $struct_pointer,
+        string $field_name,
+    ): int {
+        [$offset, $size] = $this->type_reader->getOffsetAndSizeOfMember(
+            $struct_pointer->getCTypeNameOfType(),
+            $field_name,
+        );
+        $buffer = $this->memory_reader->read(
+            $this->process_specifier->pid,
+            $struct_pointer->address + $offset,
+            $size,
+        );
+        /** @var \FFI\CInteger $casted */
+        $casted = match ($size) {
+            1 => FFI::cast('uint8_t', $buffer),
+            4 => FFI::cast('uint32_t', $buffer),
+            8 => FFI::cast('long', $buffer),
+            default => FFI::cast('long', $buffer),
+        };
+        return $casted->cdata;
+    }
+}

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -116,4 +116,33 @@ final class FieldReader
         );
         return $this->type_reader->readAs($embedded_type, $buffer);
     }
+
+    /**
+     * Read an embedded struct field and return a fully constructed Dereferencable.
+     *
+     * @template T of Dereferencable
+     * @param Pointer<Dereferencable> $struct_pointer
+     * @param class-string<T> $php_type
+     * @return T
+     */
+    public function readEmbeddedDereferencable(
+        Pointer $struct_pointer,
+        string $field_name,
+        string $c_type,
+        string $php_type,
+    ): mixed {
+        [$offset,] = $this->type_reader->getOffsetAndSizeOfMember(
+            $struct_pointer->getCTypeNameOfType(),
+            $field_name,
+        );
+        $size = $this->type_reader->sizeOf($c_type);
+        $buffer = $this->memory_reader->read(
+            $this->process_specifier->pid,
+            $struct_pointer->address + $offset,
+            $size,
+        );
+        $casted_cdata = $this->type_reader->readAs($c_type, $buffer);
+        $pointer = new Pointer($php_type, $struct_pointer->address + $offset, $size);
+        return $php_type::fromCastedCData($casted_cdata, $pointer);
+    }
 }

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Reli\Lib\Process\Pointer;
 
 use FFI;
+use FFI\CData;
+use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -37,9 +39,11 @@ final class FieldReader
         Pointer $struct_pointer,
         string $field_name,
         string $pointed_type,
+        ?string $struct_type_override = null,
     ): ?Pointer {
+        $struct_type = $struct_type_override ?? $struct_pointer->getCTypeNameOfType();
         [$offset, $size] = $this->type_reader->getOffsetAndSizeOfMember(
-            $struct_pointer->getCTypeNameOfType(),
+            $struct_type,
             $field_name,
         );
         $buffer = $this->memory_reader->read(
@@ -66,9 +70,11 @@ final class FieldReader
     public function readIntField(
         Pointer $struct_pointer,
         string $field_name,
+        ?string $struct_type_override = null,
     ): int {
+        $struct_type = $struct_type_override ?? $struct_pointer->getCTypeNameOfType();
         [$offset, $size] = $this->type_reader->getOffsetAndSizeOfMember(
-            $struct_pointer->getCTypeNameOfType(),
+            $struct_type,
             $field_name,
         );
         $buffer = $this->memory_reader->read(
@@ -84,5 +90,30 @@ final class FieldReader
             default => FFI::cast('long', $buffer),
         };
         return $casted->cdata;
+    }
+
+    /**
+     * Read an embedded struct (or union member) from the remote process
+     * and return it as cast CData suitable for constructing wrapper objects.
+     *
+     * @param Pointer<Dereferencable> $struct_pointer
+     * @return CastedCData<CData>
+     */
+    public function readEmbeddedStructCData(
+        Pointer $struct_pointer,
+        string $field_name,
+        string $embedded_type,
+    ): CastedCData {
+        [$offset,] = $this->type_reader->getOffsetAndSizeOfMember(
+            $struct_pointer->getCTypeNameOfType(),
+            $field_name,
+        );
+        $size = $this->type_reader->sizeOf($embedded_type);
+        $buffer = $this->memory_reader->read(
+            $this->process_specifier->pid,
+            $struct_pointer->address + $offset,
+            $size,
+        );
+        return $this->type_reader->readAs($embedded_type, $buffer);
     }
 }

--- a/src/Lib/Process/Pointer/LazyDereferencable.php
+++ b/src/Lib/Process/Pointer/LazyDereferencable.php
@@ -16,7 +16,7 @@ namespace Reli\Lib\Process\Pointer;
 interface LazyDereferencable extends Dereferencable
 {
     /**
-     * @param Pointer<static> $pointer
+     * @param Pointer<LazyDereferencable> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static;
 }

--- a/src/Lib/Process/Pointer/LazyDereferencable.php
+++ b/src/Lib/Process/Pointer/LazyDereferencable.php
@@ -16,7 +16,7 @@ namespace Reli\Lib\Process\Pointer;
 interface LazyDereferencable extends Dereferencable
 {
     /**
-     * @param Pointer<LazyDereferencable> $pointer
+     * @param Pointer<static> $pointer
      */
     public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static;
 }

--- a/src/Lib/Process/Pointer/LazyDereferencable.php
+++ b/src/Lib/Process/Pointer/LazyDereferencable.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+interface LazyDereferencable extends Dereferencable
+{
+    /**
+     * @param Pointer<static> $pointer
+     */
+    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static;
+}

--- a/src/Lib/Process/Pointer/LazyDereferencer.php
+++ b/src/Lib/Process/Pointer/LazyDereferencer.php
@@ -31,6 +31,7 @@ final class LazyDereferencer implements Dereferencer
         if (is_a($pointer->type, LazyDereferencable::class, true)) {
             /** @var class-string<LazyDereferencable&T> $type */
             $type = $pointer->type;
+            /** @var T */
             return $type::fromLazy($this->field_reader, $pointer);
         }
         return $this->inner->deref($pointer);

--- a/src/Lib/Process/Pointer/LazyDereferencer.php
+++ b/src/Lib/Process/Pointer/LazyDereferencer.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+final class LazyDereferencer implements Dereferencer
+{
+    public function __construct(
+        private Dereferencer $inner,
+        private FieldReader $field_reader,
+    ) {
+    }
+
+    /**
+     * @template T of Dereferencable
+     * @param Pointer<T> $pointer
+     * @return T
+     */
+    public function deref(Pointer $pointer): mixed
+    {
+        if (is_a($pointer->type, LazyDereferencable::class, true)) {
+            /** @var class-string<LazyDereferencable&T> $type */
+            $type = $pointer->type;
+            return $type::fromLazy($this->field_reader, $pointer);
+        }
+        return $this->inner->deref($pointer);
+    }
+}

--- a/src/Lib/Process/Pointer/LazyDereferencer.php
+++ b/src/Lib/Process/Pointer/LazyDereferencer.php
@@ -31,7 +31,10 @@ final class LazyDereferencer implements Dereferencer
         if (is_a($pointer->type, LazyDereferencable::class, true)) {
             /** @var class-string<LazyDereferencable&T> $type */
             $type = $pointer->type;
-            /** @var T */
+            /**
+             * @psalm-suppress ArgumentTypeCoercion
+             * @var T
+             */
             return $type::fromLazy($this->field_reader, $pointer);
         }
         return $this->inner->deref($pointer);


### PR DESCRIPTION
## Summary

This PR introduces a lazy dereferencing mechanism to optimize memory reads from remote PHP processes. Instead of eagerly reading and casting all struct fields when dereferencing a pointer, fields are now read on-demand using a new `FieldReader` utility class.

## Key Changes

- **New `FieldReader` class**: Provides methods to read individual struct fields from remote process memory:
  - `readPointerField()`: Reads pointer fields and returns `Pointer` objects
  - `readIntField()`: Reads integer fields with proper size-based casting
  - `readEmbeddedStructCData()`: Reads embedded structs as CData
  - `readEmbeddedDereferencable()`: Reads embedded structs and constructs wrapper objects

- **New `LazyDereferencable` interface**: Extends `Dereferencable` with a `fromLazy()` static factory method for lazy initialization

- **New `LazyDereferencer` class**: Wraps an existing `Dereferencer` and intercepts dereferencing calls to use lazy initialization for `LazyDereferencable` types

- **Updated type classes to support lazy dereferencing**:
  - `ZendFunction`, `ZendExecutorGlobals`, `ZendCompilerGlobals`, `ZendExecuteData`, `ZendMmHeap`, `ZendClassEntry`, `ZendString`, `ZendOp`
  - Each now implements `LazyDereferencable` and supports both eager (via `CastedCData`) and lazy (via `FieldReader`) field access
  - Constructor now accepts nullable `CastedCData` to support lazy initialization
  - Added `__get()` dispatch logic to route between lazy and eager field access

- **Refactored `CallTraceReader`**:
  - Replaced `getExecutorGlobals()` with `getCurrentExecuteDataPointer()` for more direct pointer access
  - Integrated `LazyDereferencer` into the dereferencer chain
  - Simplified opline reading by removing unused field accesses

- **Added `isClosure()` method to `ZendFunction`**: Moved closure detection logic from `ZendOpArray` to `ZendFunction` for better encapsulation

## Implementation Details

- Lazy dereferencing is transparent to callers - field access via `__get()` automatically triggers on-demand reads
- Both eager and lazy modes cache field values to avoid redundant reads
- The `LazyDereferencer` acts as a decorator, preserving the existing dereferencer behavior for non-lazy types
- Type-safe field reading with proper FFI casting based on field size

https://claude.ai/code/session_017Xv39cTy6CoDjZVyiwdjDx