### PR TITLE
Refactor type resolution and lazy dereference for PHP version-specific Zend types

### DIFF
--- a/src/Lib/PhpInternals/Types/C/Char.php
+++ b/src/Lib/PhpInternals/Types/C/Char.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\C;
 
 use FFI\CInteger;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class Char implements Dereferencable
+final class Char implements CDataDereferencable
 {
     public int $value;
 

--- a/src/Lib/PhpInternals/Types/C/PointerArray.php
+++ b/src/Lib/PhpInternals/Types/C/PointerArray.php
@@ -6,11 +6,12 @@ use FFI\CArray;
 use PhpCast\Cast;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 use Traversable;
 
-final class PointerArray implements Dereferencable
+final class PointerArray implements CDataDereferencable
 {
     /** @var array<int, Pointer> */
     private array $pointers_cache = [];

--- a/src/Lib/PhpInternals/Types/C/RawDouble.php
+++ b/src/Lib/PhpInternals/Types/C/RawDouble.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\C;
 
 use FFI\CInteger;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class RawDouble implements Dereferencable
+final class RawDouble implements CDataDereferencable
 {
     public float $value;
 

--- a/src/Lib/PhpInternals/Types/C/RawInt32.php
+++ b/src/Lib/PhpInternals/Types/C/RawInt32.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\C;
 
 use FFI\CInteger;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class RawInt32 implements Dereferencable
+final class RawInt32 implements CDataDereferencable
 {
     public int $value;
 

--- a/src/Lib/PhpInternals/Types/C/RawInt64.php
+++ b/src/Lib/PhpInternals/Types/C/RawInt64.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\C;
 
 use FFI\CInteger;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class RawInt64 implements Dereferencable
+final class RawInt64 implements CDataDereferencable
 {
     public int $value;
 

--- a/src/Lib/PhpInternals/Types/C/RawString.php
+++ b/src/Lib/PhpInternals/Types/C/RawString.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\C;
 
 use FFI\CData;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class RawString implements Dereferencable
+final class RawString implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public string $value;

--- a/src/Lib/PhpInternals/Types/Php/SapiGlobalsStruct.php
+++ b/src/Lib/PhpInternals/Types/Php/SapiGlobalsStruct.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\Php;
 
 use FFI\PhpInternals\sapi_globals_struct;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class SapiGlobalsStruct implements Dereferencable
+final class SapiGlobalsStruct implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public float $global_request_time;

--- a/src/Lib/PhpInternals/Types/Zend/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/Bucket.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-class Bucket implements Dereferencable
+class Bucket implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $val;

--- a/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
+++ b/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
@@ -24,17 +25,19 @@ trait InlineCDataCreatorTrait
     private PointedTypeResolver $pointed_type_resolver;
 
     /**
-     * @template T of Dereferencable
+     * @template T of CDataDereferencable
      * @param class-string<T> $target_class
      * @return T
      * @psalm-suppress RedundantConditionGivenDocblockType
+     * @psalm-suppress InvalidReturnType psalm cannot narrow T through resolve()
      */
-    private function createInlineDereferencable(string $field_name, string $target_class): Dereferencable
+    private function createInlineDereferencable(string $field_name, string $target_class): CDataDereferencable
     {
         assert($this->casted_cdata !== null);
         /** @var \FFI\CData $field_cdata */
         $field_cdata = $this->casted_cdata->casted->$field_name;
         $resolved_class = $this->pointed_type_resolver->resolve($target_class);
+        assert(is_a($resolved_class, CDataDereferencable::class, true));
         return $resolved_class::fromCastedCData(
             new CastedCData(
                 $field_cdata,

--- a/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
+++ b/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+
+trait InlineCDataCreatorTrait
+{
+    private ?PointedTypeResolver $pointed_type_resolver = null;
+
+    #[\Override]
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    /**
+     * @template T of Dereferencable
+     * @param class-string<T> $target_class
+     * @return T
+     * @psalm-suppress RedundantConditionGivenDocblockType
+     */
+    private function createInlineDereferencable(string $field_name, string $target_class): Dereferencable
+    {
+        assert($this->casted_cdata !== null);
+        /** @var \FFI\CData $field_cdata */
+        $field_cdata = $this->casted_cdata->casted->$field_name;
+        $resolved_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve($target_class)
+            : $target_class;
+        return $resolved_class::fromCastedCData(
+            new CastedCData(
+                $field_cdata,
+                $field_cdata,
+            ),
+            new Pointer(
+                $resolved_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
+                \FFI::sizeof($field_cdata),
+            ),
+        );
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
+++ b/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
@@ -20,7 +20,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 
 trait InlineCDataCreatorTrait
 {
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    /** @psalm-suppress PropertyNotSetInConstructor set via factory methods */
+    private PointedTypeResolver $pointed_type_resolver;
 
     /**
      * @template T of Dereferencable
@@ -33,9 +34,7 @@ trait InlineCDataCreatorTrait
         assert($this->casted_cdata !== null);
         /** @var \FFI\CData $field_cdata */
         $field_cdata = $this->casted_cdata->casted->$field_name;
-        $resolved_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve($target_class)
-            : $target_class;
+        $resolved_class = $this->pointed_type_resolver->resolve($target_class);
         return $resolved_class::fromCastedCData(
             new CastedCData(
                 $field_cdata,

--- a/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
+++ b/src/Lib/PhpInternals/Types/Zend/InlineCDataCreatorTrait.php
@@ -22,12 +22,6 @@ trait InlineCDataCreatorTrait
 {
     private ?PointedTypeResolver $pointed_type_resolver = null;
 
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
     /**
      * @template T of Dereferencable
      * @param class-string<T> $target_class

--- a/src/Lib/PhpInternals/Types/Zend/V70/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V70/Bucket.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V70;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class Bucket extends BaseBucket implements Dereferencable
+final class Bucket extends BaseBucket implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V70/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V70/Bucket.php
@@ -15,7 +15,6 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V70;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 

--- a/src/Lib/PhpInternals/Types/Zend/V70/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/V70/ZendArray.php
@@ -16,11 +16,11 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V70;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray as BaseZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
 use Reli\Lib\PhpInternals\Types\Zend\Zval;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendArray extends BaseZendArray implements Dereferencable
+final class ZendArray extends BaseZendArray implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V70/Zval.php
+++ b/src/Lib/PhpInternals/Types/Zend/V70/Zval.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend\V70;
 
 use Reli\Lib\PhpInternals\Types\Zend\Zval as BaseZval;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 
-final class Zval extends BaseZval implements Dereferencable
+final class Zval extends BaseZval implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V73/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V73/Bucket.php
@@ -15,7 +15,6 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V73;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 

--- a/src/Lib/PhpInternals/Types/Zend/V73/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V73/Bucket.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V73;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class Bucket extends BaseBucket implements Dereferencable
+final class Bucket extends BaseBucket implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V73/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/V73/ZendArray.php
@@ -16,11 +16,11 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V73;
 use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray as BaseZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
-class ZendArray extends BaseZendArray implements Dereferencable
+class ZendArray extends BaseZendArray implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V73/Zval.php
+++ b/src/Lib/PhpInternals/Types/Zend/V73/Zval.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend\V73;
 
 use Reli\Lib\PhpInternals\Types\Zend\Zval as BaseZval;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 
-final class Zval extends BaseZval implements Dereferencable
+final class Zval extends BaseZval implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V74/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V74/Bucket.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V74;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class Bucket extends BaseBucket implements Dereferencable
+final class Bucket extends BaseBucket implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V74/Bucket.php
+++ b/src/Lib/PhpInternals/Types/Zend/V74/Bucket.php
@@ -15,7 +15,6 @@ namespace Reli\Lib\PhpInternals\Types\Zend\V74;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\Zend\Bucket as BaseBucket;
-use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 

--- a/src/Lib/PhpInternals/Types/Zend/V74/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/V74/ZendArray.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend\V74;
 
 use Reli\Lib\PhpInternals\Types\Zend\V73\ZendArray as BaseZendArray;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendArray extends BaseZendArray implements Dereferencable
+final class ZendArray extends BaseZendArray implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V74/Zval.php
+++ b/src/Lib/PhpInternals/Types/Zend/V74/Zval.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend\V74;
 
 use Reli\Lib\PhpInternals\Types\Zend\Zval as BaseZval;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 
-final class Zval extends BaseZval implements Dereferencable
+final class Zval extends BaseZval implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/V80/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/V80/ZendArray.php
@@ -17,11 +17,11 @@ use Reli\Lib\PhpInternals\Types\Zend\Bucket;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray as BaseZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
 use Reli\Lib\PhpInternals\Types\Zend\Zval;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendArray extends BaseZendArray implements Dereferencable
+final class ZendArray extends BaseZendArray implements CDataDereferencable
 {
     #[\Override]
     public function __get(string $field_name): mixed

--- a/src/Lib/PhpInternals/Types/Zend/ZendArena.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArena.php
@@ -15,12 +15,12 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\FFI\Cast;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendArena implements Dereferencable
+final class ZendArena implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $ptr;

--- a/src/Lib/PhpInternals/Types/Zend/ZendArgInfo.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArgInfo.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor  */
-final class ZendArgInfo implements Dereferencable
+final class ZendArgInfo implements CDataDereferencable
 {
     /** @var Pointer<ZendString>|null */
     public ?Pointer $name;

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -17,7 +17,7 @@ use FFI\PhpInternals\zend_array;
 use FFI\PhpInternals\zend_hash_func_ffi;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\RawInt32;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
@@ -43,7 +43,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 * dtor_func_t       pDestructor;
 * }; */
 /** @psalm-consistent-constructor */
-class ZendArray implements Dereferencable
+class ZendArray implements CDataDereferencable
 {
     public const BUCKET_SIZE_IN_BYTES = 32;
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -31,7 +31,7 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     /** @var Pointer<ZendString>|null */
     public ?Pointer $doc_comment;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    use InlineCDataCreatorTrait;
 
     /** @var Pointer<ZendArray>|null */
     public ?Pointer $attributes;
@@ -60,7 +60,7 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'value' => $this->value = $this->createInlineZval(),
+            'value' => $this->value = $this->createInlineDereferencable('value', Zval::class),
             'doc_comment' => $this->doc_comment = $this->casted_cdata->casted->doc_comment !== null
                 ? Pointer::fromCData(
                     ZendString::class,
@@ -88,32 +88,6 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
         };
     }
 
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZval(): Zval
-    {
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->value,
-                $this->casted_cdata->casted->value,
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('value'),
-                \FFI::sizeof($this->casted_cdata->casted->value),
-            ),
-        );
-    }
 
     #[\Override]
     public static function getCTypeName(): string

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -19,7 +19,10 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-consistent-constructor */
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
@@ -86,6 +89,7 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     }
 
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
@@ -23,7 +22,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
  */
-class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
+class ZendClassConstant implements PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
 
@@ -96,24 +95,16 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_class_constant> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_class_constant> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -106,6 +106,7 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
          * @var Pointer<self> $pointer
          */
         $self = new static($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -25,13 +25,13 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
  */
 class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $value;
 
     /** @var Pointer<ZendString>|null */
     public ?Pointer $doc_comment;
-
-    use InlineCDataCreatorTrait;
 
     /** @var Pointer<ZendArray>|null */
     public ?Pointer $attributes;

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -16,15 +16,19 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 /** @psalm-consistent-constructor */
-final class ZendClassConstant implements Dereferencable
+class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $value;
 
     /** @var Pointer<ZendString>|null */
     public ?Pointer $doc_comment;
+
+    private ?PointedTypeResolver $pointed_type_resolver = null;
 
     /** @var Pointer<ZendArray>|null */
     public ?Pointer $attributes;
@@ -53,19 +57,7 @@ final class ZendClassConstant implements Dereferencable
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'value' => $this->value = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->value,
-                    $this->casted_cdata->casted->value,
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('value'),
-                    \FFI::sizeof($this->casted_cdata->casted->value),
-                ),
-            ),
+            'value' => $this->value = $this->createInlineZval(),
             'doc_comment' => $this->doc_comment = $this->casted_cdata->casted->doc_comment !== null
                 ? Pointer::fromCData(
                     ZendString::class,
@@ -93,6 +85,31 @@ final class ZendClassConstant implements Dereferencable
         };
     }
 
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZval(): Zval
+    {
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->value,
+                $this->casted_cdata->casted->value,
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('value'),
+                \FFI::sizeof($this->casted_cdata->casted->value),
+            ),
+        );
+    }
 
     #[\Override]
     public static function getCTypeName(): string

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -22,7 +22,6 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
- * @psalm-suppress MethodSignatureMismatch
  */
 class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
 {
@@ -100,13 +99,21 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_class_constant> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        $self = new static($casted_cdata, $pointer);
+        return new static($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -98,13 +98,16 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
-        Pointer $pointer
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_class_constant> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        return new static($casted_cdata, $pointer);
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendClassConstant> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassConstant.php
@@ -22,6 +22,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
+ * @psalm-suppress MethodSignatureMismatch
  */
 class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
 {
@@ -99,14 +100,13 @@ class ZendClassConstant implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_class_constant> $casted_cdata
          * @var Pointer<self> $pointer
          */
         $self = new static($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -298,24 +298,16 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<zend_class_entry> $casted_cdata
-         * @var Pointer<ZendClassEntry> $pointer
-         */
-        return new self($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<zend_class_entry> $casted_cdata
+         * @var Pointer<ZendClassEntry> $pointer
+         */
+        $self = new self($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -122,10 +122,14 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -88,7 +88,8 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     public ?Pointer $doc_comment;
 
     private ?ZvalArray $static_properties_table_cache = null;
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    use InlineCDataCreatorTrait;
+
     private ?FieldReader $field_reader = null;
 
     /**
@@ -171,10 +172,10 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
                 )
                 : null
             ,
-            'function_table' => $this->function_table = $this->createInlineZendArray('function_table'),
-            'constants_table' => $this->constants_table = $this->createInlineZendArray('constants_table'),
+            'function_table' => $this->function_table = $this->createInlineDereferencable('function_table', ZendArray::class),
+            'constants_table' => $this->constants_table = $this->createInlineDereferencable('constants_table', ZendArray::class),
             'ce_flags' => $this->ce_flags = $this->casted_cdata->casted->ce_flags,
-            'properties_info' => $this->properties_info = $this->createInlineZendArray('properties_info'),
+            'properties_info' => $this->properties_info = $this->createInlineDereferencable('properties_info', ZendArray::class),
             'info' => $this->info = new ZendClassEntryInfo($this->casted_cdata->casted->info),
             'default_properties_count' => $this->default_properties_count =
                 $this->casted_cdata->casted->default_properties_count
@@ -273,35 +274,6 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
             $real_offset = $property_info->offset;
             yield $name => $this->static_properties_table_cache[$real_offset];
         }
-    }
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZendArray(string $field_name): ZendArray
-    {
-        assert($this->casted_cdata !== null);
-        /** @var \FFI\CData $field_cdata */
-        $field_cdata = $this->casted_cdata->casted->$field_name;
-        $zend_array_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(ZendArray::class)
-            : ZendArray::class;
-        return $zend_array_class::fromCastedCData(
-            new CastedCData(
-                $field_cdata,
-                $field_cdata,
-            ),
-            new Pointer(
-                $zend_array_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($field_cdata),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -129,6 +129,7 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -307,6 +308,7 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
          * @var Pointer<ZendClassEntry> $pointer
          */
         $self = new self($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -285,13 +285,16 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
-        Pointer $pointer
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
     ): static {
         /**
          * @var CastedCData<zend_class_entry> $casted_cdata
          * @var Pointer<ZendClassEntry> $pointer
          */
-        return new self($casted_cdata, $pointer);
+        $self = new self($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -22,8 +22,10 @@ use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-final class ZendClassEntry implements LazyDereferencable
+final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $type;
@@ -86,6 +88,7 @@ final class ZendClassEntry implements LazyDereferencable
     public ?Pointer $doc_comment;
 
     private ?ZvalArray $static_properties_table_cache = null;
+    private ?PointedTypeResolver $pointed_type_resolver = null;
     private ?FieldReader $field_reader = null;
 
     /**
@@ -168,46 +171,10 @@ final class ZendClassEntry implements LazyDereferencable
                 )
                 : null
             ,
-            'function_table' => $this->function_table = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->function_table,
-                    $this->casted_cdata->casted->function_table,
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('function_table'),
-                    \FFI::sizeof($this->casted_cdata->casted->function_table),
-                ),
-            ),
-            'constants_table' => $this->constants_table = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->constants_table,
-                    $this->casted_cdata->casted->constants_table,
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('constants_table'),
-                    \FFI::sizeof($this->casted_cdata->casted->constants_table),
-                ),
-            ),
+            'function_table' => $this->function_table = $this->createInlineZendArray('function_table'),
+            'constants_table' => $this->constants_table = $this->createInlineZendArray('constants_table'),
             'ce_flags' => $this->ce_flags = $this->casted_cdata->casted->ce_flags,
-            'properties_info' => $this->properties_info = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->properties_info,
-                    $this->casted_cdata->casted->properties_info,
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('properties_info'),
-                    \FFI::sizeof($this->casted_cdata->casted->properties_info),
-                ),
-            ),
+            'properties_info' => $this->properties_info = $this->createInlineZendArray('properties_info'),
             'info' => $this->info = new ZendClassEntryInfo($this->casted_cdata->casted->info),
             'default_properties_count' => $this->default_properties_count =
                 $this->casted_cdata->casted->default_properties_count
@@ -306,6 +273,31 @@ final class ZendClassEntry implements LazyDereferencable
             $real_offset = $property_info->offset;
             yield $name => $this->static_properties_table_cache[$real_offset];
         }
+    }
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZendArray(string $field_name): ZendArray
+    {
+        $zend_array_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(ZendArray::class)
+            : ZendArray::class;
+        return $zend_array_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->$field_name,
+                $this->casted_cdata->casted->$field_name,
+            ),
+            new Pointer(
+                $zend_array_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
+                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -275,11 +275,18 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
         }
     }
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;
     }
 
+    /**
+     * @psalm-suppress MixedArgument
+     * @psalm-suppress MixedArgumentTypeCoercion
+     * @psalm-suppress PossiblyNullPropertyFetch
+     * @psalm-suppress PossiblyNullArgument
+     */
     private function createInlineZendArray(string $field_name): ZendArray
     {
         $zend_array_class = $this->pointed_type_resolver !== null

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -25,6 +25,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
+/** @psalm-suppress MethodSignatureMismatch */
 final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -301,14 +302,13 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_class_entry> $casted_cdata
          * @var Pointer<ZendClassEntry> $pointer
          */
         $self = new self($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -27,6 +27,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $type;
 
@@ -88,7 +90,6 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     public ?Pointer $doc_comment;
 
     private ?ZvalArray $static_properties_table_cache = null;
-    use InlineCDataCreatorTrait;
 
     private ?FieldReader $field_reader = null;
 
@@ -172,10 +173,19 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
                 )
                 : null
             ,
-            'function_table' => $this->function_table = $this->createInlineDereferencable('function_table', ZendArray::class),
-            'constants_table' => $this->constants_table = $this->createInlineDereferencable('constants_table', ZendArray::class),
+            'function_table' => $this->function_table = $this->createInlineDereferencable(
+                'function_table',
+                ZendArray::class,
+            ),
+            'constants_table' => $this->constants_table = $this->createInlineDereferencable(
+                'constants_table',
+                ZendArray::class,
+            ),
             'ce_flags' => $this->ce_flags = $this->casted_cdata->casted->ce_flags,
-            'properties_info' => $this->properties_info = $this->createInlineDereferencable('properties_info', ZendArray::class),
+            'properties_info' => $this->properties_info = $this->createInlineDereferencable(
+                'properties_info',
+                ZendArray::class,
+            ),
             'info' => $this->info = new ZendClassEntryInfo($this->casted_cdata->casted->info),
             'default_properties_count' => $this->default_properties_count =
                 $this->casted_cdata->casted->default_properties_count

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -25,7 +25,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-suppress MethodSignatureMismatch */
 final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -302,13 +301,21 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_class_entry> $casted_cdata
          * @var Pointer<ZendClassEntry> $pointer
          */
-        $self = new self($casted_cdata, $pointer);
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -281,27 +281,25 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
         $this->pointed_type_resolver = $resolver;
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     private function createInlineZendArray(string $field_name): ZendArray
     {
         assert($this->casted_cdata !== null);
+        /** @var \FFI\CData $field_cdata */
+        $field_cdata = $this->casted_cdata->casted->$field_name;
         $zend_array_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(ZendArray::class)
             : ZendArray::class;
         return $zend_array_class::fromCastedCData(
             new CastedCData(
-                $this->casted_cdata->casted->$field_name,
-                $this->casted_cdata->casted->$field_name,
+                $field_cdata,
+                $field_cdata,
             ),
             new Pointer(
                 $zend_array_class,
                 $this->pointer->address
                 +
                 \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+                \FFI::sizeof($field_cdata),
             ),
         );
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -284,11 +284,10 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
     /**
      * @psalm-suppress MixedArgument
      * @psalm-suppress MixedArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullPropertyFetch
-     * @psalm-suppress PossiblyNullArgument
      */
     private function createInlineZendArray(string $field_name): ZendArray
     {
+        assert($this->casted_cdata !== null);
         $zend_array_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(ZendArray::class)
             : ZendArray::class;

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -39,8 +39,7 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
     /** @var Pointer<ZendClassEntry>|null */
     public ?Pointer $called_scope;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
-
+    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
@@ -83,7 +82,7 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
                     FFI::typeof($this->casted_cdata->casted->func)->getSize(),
                 ),
             ),
-            'this_ptr' => $this->this_ptr = $this->createInlineZval(),
+            'this_ptr' => $this->this_ptr = $this->createInlineDereferencable('this_ptr', Zval::class),
             'called_scope' => $this->called_scope = $this->casted_cdata->casted->called_scope !== null
                 ? Pointer::fromCData(
                     ZendClassEntry::class,
@@ -92,32 +91,6 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
                 : null
             ,
         };
-    }
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZval(): Zval
-    {
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->this_ptr,
-                $this->casted_cdata->casted->this_ptr,
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('this_ptr'),
-                FFI::typeof($this->casted_cdata->casted->this_ptr)->getSize(),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -16,7 +16,6 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
-use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
@@ -25,7 +24,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
  */
-class ZendClosure implements Dereferencable, PointedTypeResolverAware
+class ZendClosure implements PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
 
@@ -100,24 +99,16 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
-         * @var Pointer<ZendClosure> $pointer
-         */
-        return new static($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
+         * @var Pointer<ZendClosure> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -24,6 +24,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
+ * @psalm-suppress MethodSignatureMismatch
  */
 class ZendClosure implements Dereferencable, PointedTypeResolverAware
 {
@@ -103,14 +104,13 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
          * @var Pointer<ZendClosure> $pointer
          */
         $self = new static($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -100,13 +100,18 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
-    {
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
          * @var Pointer<ZendClosure> $pointer
          */
-        return new static($casted_cdata, $pointer);
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendClosure> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -27,6 +27,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
  */
 class ZendClosure implements Dereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObject $std;
 
@@ -38,8 +40,6 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
 
     /** @var Pointer<ZendClassEntry>|null */
     public ?Pointer $called_scope;
-
-    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -18,9 +18,11 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 /** @psalm-consistent-constructor */
-final class ZendClosure implements Dereferencable
+class ZendClosure implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObject $std;
@@ -33,6 +35,8 @@ final class ZendClosure implements Dereferencable
 
     /** @var Pointer<ZendClassEntry>|null */
     public ?Pointer $called_scope;
+
+    private ?PointedTypeResolver $pointed_type_resolver = null;
 
 
     /**
@@ -76,19 +80,7 @@ final class ZendClosure implements Dereferencable
                     FFI::typeof($this->casted_cdata->casted->func)->getSize(),
                 ),
             ),
-            'this_ptr' => $this->this_ptr = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->this_ptr,
-                    $this->casted_cdata->casted->this_ptr,
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('this_ptr'),
-                    FFI::typeof($this->casted_cdata->casted->this_ptr)->getSize(),
-                ),
-            ),
+            'this_ptr' => $this->this_ptr = $this->createInlineZval(),
             'called_scope' => $this->called_scope = $this->casted_cdata->casted->called_scope !== null
                 ? Pointer::fromCData(
                     ZendClassEntry::class,
@@ -97,6 +89,31 @@ final class ZendClosure implements Dereferencable
                 : null
             ,
         };
+    }
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZval(): Zval
+    {
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->this_ptr,
+                $this->casted_cdata->casted->this_ptr,
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('this_ptr'),
+                FFI::typeof($this->casted_cdata->casted->this_ptr)->getSize(),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -110,6 +110,7 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
          * @var Pointer<ZendClosure> $pointer
          */
         $self = new static($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -21,7 +21,10 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-consistent-constructor */
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ZendClosure implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
@@ -91,6 +94,7 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
         };
     }
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;

--- a/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClosure.php
@@ -24,7 +24,6 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
- * @psalm-suppress MethodSignatureMismatch
  */
 class ZendClosure implements Dereferencable, PointedTypeResolverAware
 {
@@ -104,13 +103,21 @@ class ZendClosure implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_closure> $casted_cdata
          * @var Pointer<ZendClosure> $pointer
          */
-        $self = new static($casted_cdata, $pointer);
+        return new static($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -25,7 +25,6 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
- * @psalm-suppress MethodSignatureMismatch
  */
 class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
@@ -161,13 +160,21 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
          * @var Pointer<ZendCompilerGlobals> $pointer
          */
-        $self = new static($casted_cdata, $pointer);
+        return new static($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -28,6 +28,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
  */
 class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /**
      * @psalm-suppress PropertyNotSetInConstructor
      * @var Pointer<ZendArena>|null
@@ -45,8 +47,6 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
 
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $map_ptr_base;
-
-    use InlineCDataCreatorTrait;
 
     private ?FieldReader $field_reader = null;
 
@@ -123,7 +123,10 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
                 : null
             ,
             'map_ptr_base' => $this->getMapPtrBase(),
-            'interned_strings' => $this->interned_strings = $this->createInlineDereferencable('interned_strings', ZendArray::class),
+            'interned_strings' => $this->interned_strings = $this->createInlineDereferencable(
+                'interned_strings',
+                ZendArray::class,
+            ),
         };
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -157,24 +157,16 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
-         * @var Pointer<ZendCompilerGlobals> $pointer
-         */
-        return new static($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
+         * @var Pointer<ZendCompilerGlobals> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -19,9 +19,11 @@ use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 /** @psalm-consistent-constructor */
-final class ZendCompilerGlobals implements LazyDereferencable
+class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
     /**
      * @psalm-suppress PropertyNotSetInConstructor
@@ -41,6 +43,7 @@ final class ZendCompilerGlobals implements LazyDereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $map_ptr_base;
 
+    private ?PointedTypeResolver $pointed_type_resolver = null;
     private ?FieldReader $field_reader = null;
 
     /**
@@ -116,21 +119,34 @@ final class ZendCompilerGlobals implements LazyDereferencable
                 : null
             ,
             'map_ptr_base' => $this->getMapPtrBase(),
-            'interned_strings' => $this->interned_strings = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->interned_strings,
-                    $this->casted_cdata->casted->interned_strings,
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)
-                        ->getStructFieldOffset('interned_strings'),
-                    \FFI::sizeof($this->casted_cdata->casted->interned_strings),
-                ),
-            ),
+            'interned_strings' => $this->interned_strings = $this->createInlineZendArray(),
         };
+    }
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZendArray(): ZendArray
+    {
+        $zend_array_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(ZendArray::class)
+            : ZendArray::class;
+        return $zend_array_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->interned_strings,
+                $this->casted_cdata->casted->interned_strings,
+            ),
+            new Pointer(
+                $zend_array_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)
+                    ->getStructFieldOffset('interned_strings'),
+                \FFI::sizeof($this->casted_cdata->casted->interned_strings),
+            ),
+        );
     }
 
     public function getMapPtrBase(): int

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -72,6 +72,7 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     ): static {
         $self = new static(null, $pointer);
         $self->field_reader = $field_reader;
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -166,6 +167,7 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
          * @var Pointer<ZendCompilerGlobals> $pointer
          */
         $self = new static($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -132,10 +132,6 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
         $this->pointed_type_resolver = $resolver;
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     private function createInlineZendArray(): ZendArray
     {
         assert($this->casted_cdata !== null);

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -25,6 +25,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
+ * @psalm-suppress MethodSignatureMismatch
  */
 class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
@@ -160,14 +161,13 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
          * @var Pointer<ZendCompilerGlobals> $pointer
          */
         $self = new static($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -135,11 +135,10 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     /**
      * @psalm-suppress MixedArgument
      * @psalm-suppress MixedArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullPropertyFetch
-     * @psalm-suppress PossiblyNullArgument
      */
     private function createInlineZendArray(): ZendArray
     {
+        assert($this->casted_cdata !== null);
         $zend_array_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(ZendArray::class)
             : ZendArray::class;

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -22,7 +22,10 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-consistent-constructor */
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
     /**
@@ -123,11 +126,18 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
         };
     }
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;
     }
 
+    /**
+     * @psalm-suppress MixedArgument
+     * @psalm-suppress MixedArgumentTypeCoercion
+     * @psalm-suppress PossiblyNullPropertyFetch
+     * @psalm-suppress PossiblyNullArgument
+     */
     private function createInlineZendArray(): ZendArray
     {
         $zend_array_class = $this->pointed_type_resolver !== null

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -46,7 +46,8 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $map_ptr_base;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    use InlineCDataCreatorTrait;
+
     private ?FieldReader $field_reader = null;
 
     /**
@@ -122,36 +123,8 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
                 : null
             ,
             'map_ptr_base' => $this->getMapPtrBase(),
-            'interned_strings' => $this->interned_strings = $this->createInlineZendArray(),
+            'interned_strings' => $this->interned_strings = $this->createInlineDereferencable('interned_strings', ZendArray::class),
         };
-    }
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZendArray(): ZendArray
-    {
-        assert($this->casted_cdata !== null);
-        $zend_array_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(ZendArray::class)
-            : ZendArray::class;
-        return $zend_array_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->interned_strings,
-                $this->casted_cdata->casted->interned_strings,
-            ),
-            new Pointer(
-                $zend_array_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)
-                    ->getStructFieldOffset('interned_strings'),
-                \FFI::sizeof($this->casted_cdata->casted->interned_strings),
-            ),
-        );
     }
 
     public function getMapPtrBase(): int

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -65,10 +65,14 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new static(null, $pointer);
         $self->field_reader = $field_reader;
+        $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendCompilerGlobals.php
@@ -149,13 +149,18 @@ class ZendCompilerGlobals implements LazyDereferencable, PointedTypeResolverAwar
     }
 
     #[\Override]
-    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
-    {
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_compiler_globals>|null $casted_cdata
          * @var Pointer<ZendCompilerGlobals> $pointer
          */
-        return new static($casted_cdata, $pointer);
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendCompilerGlobals> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -55,6 +55,7 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
         };
     }
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -21,13 +21,13 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 final class ZendConstant implements Dereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $value;
 
     /** @var Pointer<ZendString>|null */
     public ?Pointer $name;
-
-    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -16,14 +16,18 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-final class ZendConstant implements Dereferencable
+final class ZendConstant implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $value;
 
     /** @var Pointer<ZendString>|null */
     public ?Pointer $name;
+
+    private ?PointedTypeResolver $pointed_type_resolver = null;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
@@ -40,19 +44,7 @@ final class ZendConstant implements Dereferencable
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'value' => $this->value = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->value,
-                    $this->casted_cdata->casted->value,
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted->value)->getStructFieldOffset('value'),
-                    \FFI::sizeof($this->casted_cdata->casted->value),
-                ),
-            ),
+            'value' => $this->value = $this->createInlineZval(),
             'name' => $this->name = $this->casted_cdata->casted->name !== null
                 ? Pointer::fromCData(
                     ZendString::class,
@@ -61,6 +53,31 @@ final class ZendConstant implements Dereferencable
                 : null
             ,
         };
+    }
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZval(): Zval
+    {
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->value,
+                $this->casted_cdata->casted->value,
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted->value)->getStructFieldOffset('value'),
+                \FFI::sizeof($this->casted_cdata->casted->value),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -62,13 +62,18 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
-    {
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
          * @var Pointer<ZendConstant> $pointer
          */
-        return new static($casted_cdata, $pointer);
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendConstant> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -14,12 +14,11 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-final class ZendConstant implements Dereferencable, PointedTypeResolverAware
+final class ZendConstant implements PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
 
@@ -62,24 +61,16 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
-         * @var Pointer<ZendConstant> $pointer
-         */
-        return new static($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
+         * @var Pointer<ZendConstant> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -27,7 +27,7 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     /** @var Pointer<ZendString>|null */
     public ?Pointer $name;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
@@ -44,7 +44,7 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'value' => $this->value = $this->createInlineZval(),
+            'value' => $this->value = $this->createInlineDereferencable('value', Zval::class),
             'name' => $this->name = $this->casted_cdata->casted->name !== null
                 ? Pointer::fromCData(
                     ZendString::class,
@@ -53,32 +53,6 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
                 : null
             ,
         };
-    }
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZval(): Zval
-    {
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->value,
-                $this->casted_cdata->casted->value,
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted->value)->getStructFieldOffset('value'),
-                \FFI::sizeof($this->casted_cdata->casted->value),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -19,6 +19,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
+/** @psalm-suppress MethodSignatureMismatch */
 final class ZendConstant implements Dereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -65,14 +66,13 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
          * @var Pointer<ZendConstant> $pointer
          */
         $self = new static($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -19,7 +19,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-suppress MethodSignatureMismatch */
 final class ZendConstant implements Dereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -66,13 +65,21 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_constants> $casted_cdata
          * @var Pointer<ZendConstant> $pointer
          */
-        $self = new static($casted_cdata, $pointer);
+        return new static($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendConstant.php
@@ -72,6 +72,7 @@ final class ZendConstant implements Dereferencable, PointedTypeResolverAware
          * @var Pointer<ZendConstant> $pointer
          */
         $self = new static($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -26,6 +26,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @var Pointer<ZendFunction>|null */
     public ?Pointer $func;
 
@@ -43,8 +45,6 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
 
     /** @var Pointer<ZendArray>|null  */
     public ?Pointer $extra_named_params;
-
-    use InlineCDataCreatorTrait;
 
     private ?FieldReader $field_reader = null;
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -24,6 +24,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
+/** @psalm-suppress MethodSignatureMismatch */
 final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -181,14 +182,13 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_execute_data> $casted_cdata
          * @var Pointer<ZendExecuteData> $pointer
          */
         $self = new self($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -21,8 +21,10 @@ use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-final class ZendExecuteData implements LazyDereferencable
+final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAware
 {
     /** @var Pointer<ZendFunction>|null */
     public ?Pointer $func;
@@ -42,6 +44,7 @@ final class ZendExecuteData implements LazyDereferencable
     /** @var Pointer<ZendArray>|null  */
     public ?Pointer $extra_named_params;
 
+    private ?PointedTypeResolver $pointed_type_resolver = null;
     private ?FieldReader $field_reader = null;
 
     /**
@@ -142,19 +145,7 @@ final class ZendExecuteData implements LazyDereferencable
                 )
                 : null
             ,
-            'This' => $this->This = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->This,
-                    $this->casted_cdata->casted->This,
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('This'),
-                    \FFI::sizeof($this->casted_cdata->casted->This),
-                ),
-            ),
+            'This' => $this->This = $this->createInlineZval(),
             'symbol_table' => $this->symbol_table =
                 $this->casted_cdata->casted->symbol_table !== null
                 ? Pointer::fromCData(
@@ -172,6 +163,31 @@ final class ZendExecuteData implements LazyDereferencable
                 : null
             ,
         };
+    }
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
+
+    private function createInlineZval(): Zval
+    {
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->This,
+                $this->casted_cdata->casted->This,
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('This'),
+                \FFI::sizeof($this->casted_cdata->casted->This),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -175,13 +175,16 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
-        Pointer $pointer
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
     ): static {
         /**
          * @var CastedCData<zend_execute_data> $casted_cdata
          * @var Pointer<ZendExecuteData> $pointer
          */
-        return new self($casted_cdata, $pointer);
+        $self = new self($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendExecuteData> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -44,7 +44,8 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     /** @var Pointer<ZendArray>|null  */
     public ?Pointer $extra_named_params;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
+    use InlineCDataCreatorTrait;
+
     private ?FieldReader $field_reader = null;
 
     /**
@@ -145,7 +146,7 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
                 )
                 : null
             ,
-            'This' => $this->This = $this->createInlineZval(),
+            'This' => $this->This = $this->createInlineDereferencable('This', Zval::class),
             'symbol_table' => $this->symbol_table =
                 $this->casted_cdata->casted->symbol_table !== null
                 ? Pointer::fromCData(
@@ -163,33 +164,6 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
                 : null
             ,
         };
-    }
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
-
-    private function createInlineZval(): Zval
-    {
-        assert($this->casted_cdata !== null);
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->This,
-                $this->casted_cdata->casted->This,
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('This'),
-                \FFI::sizeof($this->casted_cdata->casted->This),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -178,24 +178,16 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<zend_execute_data> $casted_cdata
-         * @var Pointer<ZendExecuteData> $pointer
-         */
-        return new self($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<zend_execute_data> $casted_cdata
+         * @var Pointer<ZendExecuteData> $pointer
+         */
+        $self = new self($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -165,11 +165,16 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         };
     }
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;
     }
 
+    /**
+     * @psalm-suppress PossiblyNullPropertyFetch
+     * @psalm-suppress PossiblyNullArgument
+     */
     private function createInlineZval(): Zval
     {
         $zval_class = $this->pointed_type_resolver !== null

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -171,12 +171,9 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         $this->pointed_type_resolver = $resolver;
     }
 
-    /**
-     * @psalm-suppress PossiblyNullPropertyFetch
-     * @psalm-suppress PossiblyNullArgument
-     */
     private function createInlineZval(): Zval
     {
+        assert($this->casted_cdata !== null);
         $zval_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(Zval::class)
             : Zval::class;

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -65,10 +65,14 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -24,7 +24,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-suppress MethodSignatureMismatch */
 final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -182,13 +181,21 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_execute_data> $casted_cdata
          * @var Pointer<ZendExecuteData> $pointer
          */
-        $self = new self($casted_cdata, $pointer);
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -72,6 +72,7 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -187,6 +188,7 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
          * @var Pointer<ZendExecuteData> $pointer
          */
         $self = new self($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -22,7 +22,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-/** @psalm-suppress MethodSignatureMismatch */
 final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -238,13 +237,21 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_executor_globals>|null $casted_cdata
          * @var Pointer<ZendExecutorGlobals> $pointer
          */
-        $self = new self($casted_cdata, $pointer);
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -66,6 +66,7 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     private ?PointedTypeResolver $pointed_type_resolver = null;
     private ?FieldReader $field_reader = null;
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;
@@ -214,6 +215,11 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
         };
     }
 
+    /**
+     * @psalm-suppress MixedArgument
+     * @psalm-suppress MixedArgumentTypeCoercion
+     * @psalm-suppress PossiblyNullPropertyFetch
+     */
     private function createInlineZval(string $field_name): Zval
     {
         assert($this->casted_cdata !== null);
@@ -235,6 +241,11 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
         );
     }
 
+    /**
+     * @psalm-suppress MixedArgument
+     * @psalm-suppress MixedArgumentTypeCoercion
+     * @psalm-suppress PossiblyNullPropertyFetch
+     */
     private function createInlineZendArray(string $field_name): ZendArray
     {
         assert($this->casted_cdata !== null);

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -19,8 +19,10 @@ use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
-final class ZendExecutorGlobals implements LazyDereferencable
+final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $uninitialized_zval;
@@ -61,7 +63,13 @@ final class ZendExecutorGlobals implements LazyDereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObjectsStore $objects_store;
 
+    private ?PointedTypeResolver $pointed_type_resolver = null;
     private ?FieldReader $field_reader = null;
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
 
     /**
      * @param CastedCData<zend_executor_globals>|null $casted_cdata
@@ -154,32 +162,8 @@ final class ZendExecutorGlobals implements LazyDereferencable
     {
         assert($this->casted_cdata !== null);
         return match ($field_name) {
-            'uninitialized_zval' => $this->uninitialized_zval = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->uninitialized_zval,
-                    $this->casted_cdata->casted->uninitialized_zval
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('uninitialized_zval'),
-                    \FFI::sizeof($this->casted_cdata->casted->uninitialized_zval),
-                ),
-            ),
-            'error_zval' => $this->error_zval = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->error_zval,
-                    $this->casted_cdata->casted->error_zval
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('error_zval'),
-                    \FFI::sizeof($this->casted_cdata->casted->error_zval),
-                ),
-            ),
+            'uninitialized_zval' => $this->uninitialized_zval = $this->createInlineZval('uninitialized_zval'),
+            'error_zval' => $this->error_zval = $this->createInlineZval('error_zval'),
             'current_execute_data' => $this->casted_cdata->casted->current_execute_data !== null
                 ? Pointer::fromCData(
                     ZendExecuteData::class,
@@ -208,19 +192,7 @@ final class ZendExecutorGlobals implements LazyDereferencable
                 )
                 : null
             ,
-            'symbol_table' => $this->symbol_table = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->symbol_table,
-                    $this->casted_cdata->casted->symbol_table
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('symbol_table'),
-                    \FFI::sizeof($this->casted_cdata->casted->symbol_table),
-                ),
-            ),
+            'symbol_table' => $this->symbol_table = $this->createInlineZendArray('symbol_table'),
             'vm_stack' => $this->vm_stack = $this->casted_cdata->casted->vm_stack !== null
                 ? Pointer::fromCData(
                     ZendVmStack::class,
@@ -238,20 +210,50 @@ final class ZendExecutorGlobals implements LazyDereferencable
             'objects_store' => $this->objects_store = new ZendObjectsStore(
                 $this->casted_cdata->casted->objects_store,
             ),
-            'included_files' => $this->included_files = new ZendArray(
-                new CastedCData(
-                    $this->casted_cdata->casted->included_files,
-                    $this->casted_cdata->casted->included_files
-                ),
-                new Pointer(
-                    ZendArray::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('included_files'),
-                    \FFI::sizeof($this->casted_cdata->casted->included_files),
-                ),
-            ),
+            'included_files' => $this->included_files = $this->createInlineZendArray('included_files'),
         };
+    }
+
+    private function createInlineZval(string $field_name): Zval
+    {
+        assert($this->casted_cdata !== null);
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->$field_name,
+                $this->casted_cdata->casted->$field_name
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
+                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+            ),
+        );
+    }
+
+    private function createInlineZendArray(string $field_name): ZendArray
+    {
+        assert($this->casted_cdata !== null);
+        $zend_array_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(ZendArray::class)
+            : ZendArray::class;
+        return $zend_array_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->$field_name,
+                $this->casted_cdata->casted->$field_name
+            ),
+            new Pointer(
+                $zend_array_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
+                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -22,6 +22,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
+/** @psalm-suppress MethodSignatureMismatch */
 final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -237,14 +238,13 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<zend_executor_globals>|null $casted_cdata
          * @var Pointer<ZendExecutorGlobals> $pointer
          */
         $self = new self($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -89,10 +89,14 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -215,52 +215,48 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
         };
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     private function createInlineZval(string $field_name): Zval
     {
         assert($this->casted_cdata !== null);
+        /** @var \FFI\CData $field_cdata */
+        $field_cdata = $this->casted_cdata->casted->$field_name;
         $zval_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(Zval::class)
             : Zval::class;
         return $zval_class::fromCastedCData(
             new CastedCData(
-                $this->casted_cdata->casted->$field_name,
-                $this->casted_cdata->casted->$field_name
+                $field_cdata,
+                $field_cdata
             ),
             new Pointer(
                 $zval_class,
                 $this->pointer->address
                 +
                 \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+                \FFI::sizeof($field_cdata),
             ),
         );
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     private function createInlineZendArray(string $field_name): ZendArray
     {
         assert($this->casted_cdata !== null);
+        /** @var \FFI\CData $field_cdata */
+        $field_cdata = $this->casted_cdata->casted->$field_name;
         $zend_array_class = $this->pointed_type_resolver !== null
             ? $this->pointed_type_resolver->resolve(ZendArray::class)
             : ZendArray::class;
         return $zend_array_class::fromCastedCData(
             new CastedCData(
-                $this->casted_cdata->casted->$field_name,
-                $this->casted_cdata->casted->$field_name
+                $field_cdata,
+                $field_cdata
             ),
             new Pointer(
                 $zend_array_class,
                 $this->pointer->address
                 +
                 \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($this->casted_cdata->casted->$field_name),
+                \FFI::sizeof($field_cdata),
             ),
         );
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -218,7 +218,6 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     /**
      * @psalm-suppress MixedArgument
      * @psalm-suppress MixedArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullPropertyFetch
      */
     private function createInlineZval(string $field_name): Zval
     {
@@ -244,7 +243,6 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     /**
      * @psalm-suppress MixedArgument
      * @psalm-suppress MixedArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullPropertyFetch
      */
     private function createInlineZendArray(string $field_name): ZendArray
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -24,6 +24,8 @@ use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $uninitialized_zval;
 
@@ -62,8 +64,6 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
 
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObjectsStore $objects_store;
-
-    use InlineCDataCreatorTrait;
 
     private ?FieldReader $field_reader = null;
 
@@ -158,8 +158,14 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     {
         assert($this->casted_cdata !== null);
         return match ($field_name) {
-            'uninitialized_zval' => $this->uninitialized_zval = $this->createInlineDereferencable('uninitialized_zval', Zval::class),
-            'error_zval' => $this->error_zval = $this->createInlineDereferencable('error_zval', Zval::class),
+            'uninitialized_zval' => $this->uninitialized_zval = $this->createInlineDereferencable(
+                'uninitialized_zval',
+                Zval::class,
+            ),
+            'error_zval' => $this->error_zval = $this->createInlineDereferencable(
+                'error_zval',
+                Zval::class,
+            ),
             'current_execute_data' => $this->casted_cdata->casted->current_execute_data !== null
                 ? Pointer::fromCData(
                     ZendExecuteData::class,
@@ -188,7 +194,10 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
                 )
                 : null
             ,
-            'symbol_table' => $this->symbol_table = $this->createInlineDereferencable('symbol_table', ZendArray::class),
+            'symbol_table' => $this->symbol_table = $this->createInlineDereferencable(
+                'symbol_table',
+                ZendArray::class,
+            ),
             'vm_stack' => $this->vm_stack = $this->casted_cdata->casted->vm_stack !== null
                 ? Pointer::fromCData(
                     ZendVmStack::class,
@@ -206,7 +215,10 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
             'objects_store' => $this->objects_store = new ZendObjectsStore(
                 $this->casted_cdata->casted->objects_store,
             ),
-            'included_files' => $this->included_files = $this->createInlineDereferencable('included_files', ZendArray::class),
+            'included_files' => $this->included_files = $this->createInlineDereferencable(
+                'included_files',
+                ZendArray::class,
+            ),
         };
     }
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -219,13 +219,16 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
-        Pointer $pointer
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
     ): static {
         /**
          * @var CastedCData<zend_executor_globals>|null $casted_cdata
          * @var Pointer<ZendExecutorGlobals> $pointer
          */
-        return new self($casted_cdata, $pointer);
+        $self = new self($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /** @return Pointer<ZendExecutorGlobals> */

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -234,24 +234,16 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<zend_executor_globals>|null $casted_cdata
-         * @var Pointer<ZendExecutorGlobals> $pointer
-         */
-        return new self($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<zend_executor_globals>|null $casted_cdata
+         * @var Pointer<ZendExecutorGlobals> $pointer
+         */
+        $self = new self($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -63,14 +63,9 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendObjectsStore $objects_store;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
-    private ?FieldReader $field_reader = null;
+    use InlineCDataCreatorTrait;
 
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
+    private ?FieldReader $field_reader = null;
 
     /**
      * @param CastedCData<zend_executor_globals>|null $casted_cdata
@@ -163,8 +158,8 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     {
         assert($this->casted_cdata !== null);
         return match ($field_name) {
-            'uninitialized_zval' => $this->uninitialized_zval = $this->createInlineZval('uninitialized_zval'),
-            'error_zval' => $this->error_zval = $this->createInlineZval('error_zval'),
+            'uninitialized_zval' => $this->uninitialized_zval = $this->createInlineDereferencable('uninitialized_zval', Zval::class),
+            'error_zval' => $this->error_zval = $this->createInlineDereferencable('error_zval', Zval::class),
             'current_execute_data' => $this->casted_cdata->casted->current_execute_data !== null
                 ? Pointer::fromCData(
                     ZendExecuteData::class,
@@ -193,7 +188,7 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
                 )
                 : null
             ,
-            'symbol_table' => $this->symbol_table = $this->createInlineZendArray('symbol_table'),
+            'symbol_table' => $this->symbol_table = $this->createInlineDereferencable('symbol_table', ZendArray::class),
             'vm_stack' => $this->vm_stack = $this->casted_cdata->casted->vm_stack !== null
                 ? Pointer::fromCData(
                     ZendVmStack::class,
@@ -211,54 +206,8 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
             'objects_store' => $this->objects_store = new ZendObjectsStore(
                 $this->casted_cdata->casted->objects_store,
             ),
-            'included_files' => $this->included_files = $this->createInlineZendArray('included_files'),
+            'included_files' => $this->included_files = $this->createInlineDereferencable('included_files', ZendArray::class),
         };
-    }
-
-    private function createInlineZval(string $field_name): Zval
-    {
-        assert($this->casted_cdata !== null);
-        /** @var \FFI\CData $field_cdata */
-        $field_cdata = $this->casted_cdata->casted->$field_name;
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $field_cdata,
-                $field_cdata
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($field_cdata),
-            ),
-        );
-    }
-
-    private function createInlineZendArray(string $field_name): ZendArray
-    {
-        assert($this->casted_cdata !== null);
-        /** @var \FFI\CData $field_cdata */
-        $field_cdata = $this->casted_cdata->casted->$field_name;
-        $zend_array_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(ZendArray::class)
-            : ZendArray::class;
-        return $zend_array_class::fromCastedCData(
-            new CastedCData(
-                $field_cdata,
-                $field_cdata
-            ),
-            new Pointer(
-                $zend_array_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset($field_name),
-                \FFI::sizeof($field_cdata),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -96,6 +96,7 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -243,6 +244,7 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
          * @var Pointer<ZendExecutorGlobals> $pointer
          */
         $self = new self($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -16,7 +16,7 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI\PhpInternals\zend_function;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
@@ -24,7 +24,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendFunction implements LazyDereferencable
+final class ZendFunction implements LazyDereferencable, CDataDereferencable
 {
     public const ZEND_INTERNAL_FUNCTION = 1;
     public const ZEND_USER_FUNCTION = 2;

--- a/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFunction.php
@@ -20,6 +20,7 @@ use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
@@ -78,8 +79,11 @@ final class ZendFunction implements LazyDereferencable
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
         return $self;

--- a/src/Lib/PhpInternals/Types/Zend/ZendLiveRange.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendLiveRange.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendLiveRange implements Dereferencable
+final class ZendLiveRange implements CDataDereferencable
 {
     public const ZEND_LIVE_TMPVAR = 0;
     public const ZEND_LIVE_LOOP = 1;

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmChunk.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmChunk.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendMmChunk implements Dereferencable
+final class ZendMmChunk implements CDataDereferencable
 {
     public const SIZE = (2 * 1024 * 1024);
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
@@ -22,7 +22,7 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
-final class ZendMmHeap implements LazyDereferencable
+final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $use_custom_heap;

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -18,6 +18,7 @@ use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @psalm-consistent-constructor */
@@ -87,8 +88,11 @@ final class ZendMmHeap implements LazyDereferencable
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new static(null, $pointer);
         $self->field_reader = $field_reader;
         return $self;

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHugeList.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHugeList.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendMmHugeList implements Dereferencable
+final class ZendMmHugeList implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $ptr;

--- a/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendModuleEntry.php
@@ -17,11 +17,11 @@ use FFI\PhpInternals\zend_module_entry;
 use Reli\Lib\FFI\Cast;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\RawString;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendModuleEntry implements Dereferencable
+final class ZendModuleEntry implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public bool $zts;

--- a/src/Lib/PhpInternals/Types/Zend/ZendObject.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendObject.php
@@ -17,14 +17,14 @@ use FFI\CInteger;
 use Reli\Lib\FFI\Cast;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-final class ZendObject implements Dereferencable
+final class ZendObject implements CDataDereferencable
 {
     public ZendRefcountedH $zend_refcounted_h;
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -18,6 +18,7 @@ use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 final class ZendOp implements LazyDereferencable
@@ -63,8 +64,11 @@ final class ZendOp implements LazyDereferencable
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, $pointer);
         $self->field_reader = $field_reader;
         return $self;

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -15,13 +15,13 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use FFI\PhpInternals\zend_op;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendOp implements LazyDereferencable
+final class ZendOp implements LazyDereferencable, CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $op1;

--- a/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-final class ZendPropertyInfo implements Dereferencable
+final class ZendPropertyInfo implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $offset;

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -22,7 +22,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
- * @psalm-suppress MethodSignatureMismatch
  */
 class ZendReference implements Dereferencable, PointedTypeResolverAware
 {
@@ -64,13 +63,21 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        $self = new static($casted_cdata, $pointer);
+        return new static($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -21,6 +21,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
  */
 class ZendReference implements Dereferencable, PointedTypeResolverAware
 {
@@ -32,6 +33,7 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
 
     private ?PointedTypeResolver $pointed_type_resolver = null;
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -31,13 +31,7 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $val;
 
-    private ?PointedTypeResolver $pointed_type_resolver = null;
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
+    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
@@ -55,28 +49,8 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     {
         return match ($field_name) {
             'gc' => $this->gc = new ZendRefcountedH($this->casted_cdata->casted->gc),
-            'val' => $this->val = $this->createInlineZval(),
+            'val' => $this->val = $this->createInlineDereferencable('val', Zval::class),
         };
-    }
-
-    private function createInlineZval(): Zval
-    {
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
-        return $zval_class::fromCastedCData(
-            new CastedCData(
-                $this->casted_cdata->casted->val,
-                $this->casted_cdata->casted->val,
-            ),
-            new Pointer(
-                $zval_class,
-                $this->pointer->address
-                +
-                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('val'),
-                \FFI::sizeof($this->casted_cdata->casted->val),
-            ),
-        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -22,6 +22,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 /**
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
+ * @psalm-suppress MethodSignatureMismatch
  */
 class ZendReference implements Dereferencable, PointedTypeResolverAware
 {
@@ -63,14 +64,13 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
          * @var Pointer<self> $pointer
          */
         $self = new static($casted_cdata, $pointer);
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -25,13 +25,13 @@ use Reli\Lib\Process\Pointer\Pointer;
  */
 class ZendReference implements Dereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendRefcountedH $gc;
 
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $val;
-
-    use InlineCDataCreatorTrait;
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -15,12 +15,14 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-final class ZendReference implements Dereferencable
+class ZendReference implements Dereferencable, PointedTypeResolverAware
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendRefcountedH $gc;
@@ -28,6 +30,12 @@ final class ZendReference implements Dereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public Zval $val;
 
+    private ?PointedTypeResolver $pointed_type_resolver = null;
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
@@ -45,20 +53,28 @@ final class ZendReference implements Dereferencable
     {
         return match ($field_name) {
             'gc' => $this->gc = new ZendRefcountedH($this->casted_cdata->casted->gc),
-            'val' => $this->val = new Zval(
-                new CastedCData(
-                    $this->casted_cdata->casted->val,
-                    $this->casted_cdata->casted->val,
-                ),
-                new Pointer(
-                    Zval::class,
-                    $this->pointer->address
-                    +
-                    \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('val'),
-                    \FFI::sizeof($this->casted_cdata->casted->val),
-                ),
-            ),
+            'val' => $this->val = $this->createInlineZval(),
         };
+    }
+
+    private function createInlineZval(): Zval
+    {
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
+            new CastedCData(
+                $this->casted_cdata->casted->val,
+                $this->casted_cdata->casted->val,
+            ),
+            new Pointer(
+                $zval_class,
+                $this->pointer->address
+                +
+                \FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('val'),
+                \FFI::sizeof($this->casted_cdata->casted->val),
+            ),
+        );
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -60,13 +60,18 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
-    {
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        return new static($casted_cdata, $pointer);
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -23,7 +22,7 @@ use Reli\Lib\Process\Pointer\Pointer;
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
  */
-class ZendReference implements Dereferencable, PointedTypeResolverAware
+class ZendReference implements PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
 
@@ -60,24 +59,16 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
     }
 
     #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
-    }
-
-    #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_reference> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendReference.php
@@ -70,6 +70,7 @@ class ZendReference implements Dereferencable, PointedTypeResolverAware
          * @var Pointer<self> $pointer
          */
         $self = new static($casted_cdata, $pointer);
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZendResource.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendResource.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-final class ZendResource implements Dereferencable
+final class ZendResource implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendRefcountedH $gc;

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -20,6 +20,7 @@ use Reli\Lib\Process\Pointer\Dereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
 final class ZendString implements LazyDereferencable
@@ -57,8 +58,11 @@ final class ZendString implements LazyDereferencable
     }
 
     #[\Override]
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static
-    {
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static {
         $self = new self(null, self::ZEND_STRING_HEADER_SIZE, $pointer);
         $self->field_reader = $field_reader;
         return $self;

--- a/src/Lib/PhpInternals/Types/Zend/ZendString.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendString.php
@@ -16,14 +16,14 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI\PhpInternals\zend_string;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\RawString;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencable;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 
-final class ZendString implements LazyDereferencable
+final class ZendString implements LazyDereferencable, CDataDereferencable
 {
     public const ZEND_STRING_HEADER_SIZE = 24;
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
@@ -15,14 +15,14 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\PointerArray;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-final class ZendVmStack implements Dereferencable
+final class ZendVmStack implements CDataDereferencable
 {
     /**
      * @psalm-suppress PropertyNotSetInConstructor

--- a/src/Lib/PhpInternals/Types/Zend/Zval.php
+++ b/src/Lib/PhpInternals/Types/Zend/Zval.php
@@ -15,13 +15,13 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use FFI\CData;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @psalm-consistent-constructor
  */
-class Zval implements Dereferencable
+class Zval implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendValue $value;

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -64,6 +64,7 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
             (int)($pointer->size / 16),
             $pointer
         );
+        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -106,9 +107,7 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
 
     private function getZval(int $offset): Zval
     {
-        $zval_class = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve(Zval::class)
-            : Zval::class;
+        $zval_class = $this->pointed_type_resolver->resolve(Zval::class);
         return $zval_class::fromCastedCData(
             new CastedCData(
                 $this->casted_cdata->casted[$offset],

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -28,6 +28,7 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
 
     private ?PointedTypeResolver $pointed_type_resolver = null;
 
+    #[\Override]
     public function setPointedTypeResolver(PointedTypeResolver $resolver): void
     {
         $this->pointed_type_resolver = $resolver;

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -20,7 +20,10 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 use Reli\Lib\Process\Pointer\Pointer;
 
-/** @implements \ArrayAccess<int, Zval> */
+/**
+ * @implements \ArrayAccess<int, Zval>
+ * @psalm-suppress MethodSignatureMismatch
+ */
 final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
@@ -53,7 +56,7 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
@@ -64,7 +67,6 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
             (int)($pointer->size / 16),
             $pointer
         );
-        assert($pointed_type_resolver !== null);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -52,17 +52,20 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
-        Pointer $pointer
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        return new static(
+        $self = new static(
             $casted_cdata,
             (int)($pointer->size / 16),
             $pointer
         );
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
     }
 
     /**

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -22,7 +22,6 @@ use Reli\Lib\Process\Pointer\Pointer;
 
 /**
  * @implements \ArrayAccess<int, Zval>
- * @psalm-suppress MethodSignatureMismatch
  */
 final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolverAware
 {
@@ -56,17 +55,25 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        PointedTypeResolver $pointed_type_resolver,
     ): static {
         /**
          * @var CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
          * @var Pointer<self> $pointer
          */
-        $self = new static(
+        return new static(
             $casted_cdata,
             (int)($pointer->size / 16),
             $pointer
         );
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        $self = static::fromCastedCData($casted_cdata, $pointer);
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -15,7 +15,7 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 
 use FFI\CData;
 use Reli\Lib\PhpInternals\CastedCData;
-use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -23,7 +23,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 /**
  * @implements \ArrayAccess<int, Zval>
  */
-final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolverAware
+final class ZvalArray implements \ArrayAccess, PointedTypeResolverAware
 {
     use InlineCDataCreatorTrait;
 
@@ -47,33 +47,21 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
         return 'zval[0]';
     }
 
-    /**
-     * @param CastedCData<CData> $casted_cdata
-     * @param Pointer<Dereferencable> $pointer
-     */
-    #[\Override]
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer,
-    ): static {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static(
-            $casted_cdata,
-            (int)($pointer->size / 16),
-            $pointer
-        );
-    }
-
     #[\Override]
     public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,
     ): static {
-        $self = static::fromCastedCData($casted_cdata, $pointer);
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        $self = new static(
+            $casted_cdata,
+            (int)($pointer->size / 16),
+            $pointer
+        );
         $self->pointed_type_resolver = $pointed_type_resolver;
         return $self;
     }
@@ -117,6 +105,7 @@ final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolv
     private function getZval(int $offset): Zval
     {
         $zval_class = $this->pointed_type_resolver->resolve(Zval::class);
+        assert(is_a($zval_class, CDataDereferencable::class, true));
         return $zval_class::fromCastedCData(
             new CastedCData(
                 $this->casted_cdata->casted[$offset],

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -16,13 +16,22 @@ namespace Reli\Lib\PhpInternals\Types\Zend;
 use FFI\CData;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\Dereferencable;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /** @implements \ArrayAccess<int, Zval> */
-final class ZvalArray implements \ArrayAccess, Dereferencable
+final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolverAware
 {
     /** @var array<int, Zval> */
     private array $zvals_cache = [];
+
+    private ?PointedTypeResolver $pointed_type_resolver = null;
+
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
+    {
+        $this->pointed_type_resolver = $resolver;
+    }
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata
@@ -99,13 +108,16 @@ final class ZvalArray implements \ArrayAccess, Dereferencable
 
     private function getZval(int $offset): Zval
     {
-        return new Zval(
+        $zval_class = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve(Zval::class)
+            : Zval::class;
+        return $zval_class::fromCastedCData(
             new CastedCData(
                 $this->casted_cdata->casted[$offset],
                 $this->casted_cdata->casted[$offset],
             ),
             new Pointer(
-                Zval::class,
+                $zval_class,
                 $this->pointer->address + 16 * $offset,
                 16,
             ),

--- a/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZvalArray.php
@@ -23,16 +23,10 @@ use Reli\Lib\Process\Pointer\Pointer;
 /** @implements \ArrayAccess<int, Zval> */
 final class ZvalArray implements \ArrayAccess, Dereferencable, PointedTypeResolverAware
 {
+    use InlineCDataCreatorTrait;
+
     /** @var array<int, Zval> */
     private array $zvals_cache = [];
-
-    private ?PointedTypeResolver $pointed_type_resolver = null;
-
-    #[\Override]
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void
-    {
-        $this->pointed_type_resolver = $resolver;
-    }
 
     /**
      * @param CastedCData<\FFI\PhpInternals\zval_array> $casted_cdata

--- a/src/Lib/PhpInternals/VersionedPointedTypeResolver.php
+++ b/src/Lib/PhpInternals/VersionedPointedTypeResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals;
+
+use Reli\Lib\PhpInternals\Types\Zend\Bucket;
+use Reli\Lib\PhpInternals\Types\Zend\Zval;
+use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+
+final class VersionedPointedTypeResolver implements PointedTypeResolver
+{
+    /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */
+    public function __construct(
+        private string $php_version,
+    ) {
+    }
+
+    #[\Override]
+    public function resolve(string $type_name): string
+    {
+        return match ($this->php_version) {
+            ZendTypeReader::V70,
+            ZendTypeReader::V71,
+            ZendTypeReader::V72 => match ($type_name) {
+                Bucket::class => Types\Zend\V70\Bucket::class,
+                ZendArray::class => Types\Zend\V70\ZendArray::class,
+                Zval::class => Types\Zend\V70\Zval::class,
+                default => $type_name,
+            },
+            ZendTypeReader::V73 => match ($type_name) {
+                Bucket::class => Types\Zend\V73\Bucket::class,
+                ZendArray::class => Types\Zend\V73\ZendArray::class,
+                Zval::class => Types\Zend\V73\Zval::class,
+                default => $type_name,
+            },
+            ZendTypeReader::V74 => match ($type_name) {
+                Bucket::class => Types\Zend\V74\Bucket::class,
+                ZendArray::class => Types\Zend\V74\ZendArray::class,
+                Zval::class => Types\Zend\V74\Zval::class,
+                default => $type_name,
+            },
+            ZendTypeReader::V80,
+            ZendTypeReader::V81 => match ($type_name) {
+                ZendArray::class => Types\Zend\V80\ZendArray::class,
+                default => $type_name,
+            },
+            default => $type_name,
+        };
+    }
+}

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -65,54 +65,57 @@ final class CallTraceReader
         $process_specifier = new ProcessSpecifier($pid);
         $type_reader = $this->getTypeReader($php_version);
 
+        $pointed_type_resolver = new class ($php_version) implements PointedTypeResolver {
+            public function __construct(
+                private string $php_version,
+            ) {
+            }
+
+            #[\Override]
+            public function resolve(string $type_name): string
+            {
+                return match ($this->php_version) {
+                    ZendTypeReader::V70,
+                    ZendTypeReader::V71,
+                    ZendTypeReader::V72 => match ($type_name) {
+                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Bucket::class,
+                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V70\ZendArray::class,
+                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Zval::class,
+                        default => $type_name,
+                    },
+                    ZendTypeReader::V73 => match ($type_name) {
+                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Bucket::class,
+                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V73\ZendArray::class,
+                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Zval::class,
+                        default => $type_name,
+                    },
+                    ZendTypeReader::V74 => match ($type_name) {
+                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Bucket::class,
+                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V74\ZendArray::class,
+                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Zval::class,
+                        default => $type_name,
+                    },
+                    ZendTypeReader::V80,
+                    ZendTypeReader::V81 => match ($type_name) {
+                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
+                        default => $type_name,
+                    },
+                    default => $type_name,
+                };
+            }
+        };
+
         $base = new RemoteProcessDereferencer(
             $this->memory_reader,
             $process_specifier,
             new ZendCastedTypeProvider($type_reader),
-            new class ($php_version) implements PointedTypeResolver {
-                public function __construct(
-                    private string $php_version,
-                ) {
-                }
-
-                #[\Override]
-                public function resolve(string $type_name): string
-                {
-                    return match ($this->php_version) {
-                        ZendTypeReader::V70,
-                        ZendTypeReader::V71,
-                        ZendTypeReader::V72 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V70\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V73 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V73\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V74 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V74\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V80,
-                        ZendTypeReader::V81 => match ($type_name) {
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
-                            default => $type_name,
-                        },
-                        default => $type_name,
-                    };
-                }
-            }
+            $pointed_type_resolver,
         );
 
         return new LazyDereferencer(
             $base,
-            new FieldReader($this->memory_reader, $process_specifier, $type_reader),
+            new FieldReader($this->memory_reader, $process_specifier, $type_reader, $pointed_type_resolver),
+            $pointed_type_resolver,
         );
     }
 

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -104,9 +104,7 @@ final class CallTraceReader
                             ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
                             default => $type_name,
                         },
-                        ZendTypeReader::V82,
-                        ZendTypeReader::V83,
-                        ZendTypeReader::V84 => $type_name,
+                        default => $type_name,
                     };
                 }
             }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -16,13 +16,11 @@ namespace Reli\Lib\PhpProcessReader\CallTraceReader;
 use Reli\Lib\PhpInternals\Opcodes\OpcodeFactory;
 use Reli\Lib\PhpInternals\Types\C\RawDouble;
 use Reli\Lib\PhpInternals\Types\C\RawInt64;
-use Reli\Lib\PhpInternals\Types\Zend\Bucket;
 use Reli\Lib\PhpInternals\Types\Zend\Opline;
-use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecuteData;
 use Reli\Lib\PhpInternals\Types\Zend\ZendOp;
-use Reli\Lib\PhpInternals\Types\Zend\Zval;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -30,7 +28,6 @@ use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\FieldReader;
 use Reli\Lib\Process\Pointer\LazyDereferencer;
-use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\RemoteProcessDereferencer;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -65,45 +62,7 @@ final class CallTraceReader
         $process_specifier = new ProcessSpecifier($pid);
         $type_reader = $this->getTypeReader($php_version);
 
-        $pointed_type_resolver = new class ($php_version) implements PointedTypeResolver {
-            public function __construct(
-                private string $php_version,
-            ) {
-            }
-
-            #[\Override]
-            public function resolve(string $type_name): string
-            {
-                return match ($this->php_version) {
-                    ZendTypeReader::V70,
-                    ZendTypeReader::V71,
-                    ZendTypeReader::V72 => match ($type_name) {
-                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Bucket::class,
-                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V70\ZendArray::class,
-                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Zval::class,
-                        default => $type_name,
-                    },
-                    ZendTypeReader::V73 => match ($type_name) {
-                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Bucket::class,
-                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V73\ZendArray::class,
-                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Zval::class,
-                        default => $type_name,
-                    },
-                    ZendTypeReader::V74 => match ($type_name) {
-                        Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Bucket::class,
-                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V74\ZendArray::class,
-                        Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Zval::class,
-                        default => $type_name,
-                    },
-                    ZendTypeReader::V80,
-                    ZendTypeReader::V81 => match ($type_name) {
-                        ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
-                        default => $type_name,
-                    },
-                    default => $type_name,
-                };
-            }
-        };
+        $pointed_type_resolver = new VersionedPointedTypeResolver($php_version);
 
         $base = new RemoteProcessDereferencer(
             $this->memory_reader,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -185,9 +185,7 @@ final class MemoryLocationsCollector
                             ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
                             default => $type_name,
                         },
-                        ZendTypeReader::V82,
-                        ZendTypeReader::V83,
-                        ZendTypeReader::V84 => $type_name,
+                        default => $type_name,
                     };
                 }
             }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -16,7 +16,7 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryLimitErrorDetails;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\Log\Log;
-use Reli\Lib\PhpInternals\Types\Zend\Bucket;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendClassConstant;
@@ -110,7 +110,6 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefin
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
-use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\Pointer;
 use Reli\Lib\Process\Pointer\RemoteProcessDereferencer;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -150,45 +149,7 @@ final class MemoryLocationsCollector
             new ZendCastedTypeProvider(
                 $this->getTypeReader($php_version),
             ),
-            new class ($php_version) implements PointedTypeResolver {
-                public function __construct(
-                    private string $php_version,
-                ) {
-                }
-
-                #[\Override]
-                public function resolve(string $type_name): string
-                {
-                    return match ($this->php_version) {
-                        ZendTypeReader::V70,
-                        ZendTypeReader::V71,
-                        ZendTypeReader::V72 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V70\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V70\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V73 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V73\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V73\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V74 => match ($type_name) {
-                            Bucket::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Bucket::class,
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V74\ZendArray::class,
-                            Zval::class => \Reli\Lib\PhpInternals\Types\Zend\V74\Zval::class,
-                            default => $type_name,
-                        },
-                        ZendTypeReader::V80,
-                        ZendTypeReader::V81 => match ($type_name) {
-                            ZendArray::class => \Reli\Lib\PhpInternals\Types\Zend\V80\ZendArray::class,
-                            default => $type_name,
-                        },
-                        default => $type_name,
-                    };
-                }
-            }
+            new VersionedPointedTypeResolver($php_version)
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -22,6 +22,7 @@ use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecutorGlobals;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
@@ -145,6 +146,7 @@ final class PhpTsrmLsCacheFinder
                 $this->memory_reader,
                 $process_specifier,
                 new ZendCastedTypeProvider($zend_type_reader),
+                new VersionedPointedTypeResolver($target_php_settings->php_version),
             );
             $eg = $dereferencer->deref($eg_pointer);
             if (!$eg->uninitialized_zval->isNull()) {

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendModuleEntry;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -59,7 +60,8 @@ class PhpVersionDetector
             new ProcessSpecifier($pid),
             new ZendCastedTypeProvider(
                 $this->getTypeReader($php_version),
-            )
+            ),
+            new VersionedPointedTypeResolver($php_version),
         );
     }
 

--- a/src/Lib/Process/Pointer/CDataDereferencable.php
+++ b/src/Lib/Process/Pointer/CDataDereferencable.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+use FFI\CData;
+use Reli\Lib\PhpInternals\CastedCData;
+
+interface CDataDereferencable extends Dereferencable
+{
+    /**
+     * @template T of CData
+     * @param CastedCData<T> $casted_cdata
+     * @param Pointer<self> $pointer
+     */
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer
+    ): static;
+}

--- a/src/Lib/Process/Pointer/Dereferencable.php
+++ b/src/Lib/Process/Pointer/Dereferencable.php
@@ -13,22 +13,9 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Process\Pointer;
 
-use FFI\CData;
-use Reli\Lib\PhpInternals\CastedCData;
-
 interface Dereferencable
 {
     public static function getCTypeName(): string;
-
-    /**
-     * @template T of CData
-     * @param CastedCData<T> $casted_cdata
-     * @param Pointer<self> $pointer
-     */
-    public static function fromCastedCData(
-        CastedCData $casted_cdata,
-        Pointer $pointer
-    ): static;
 
     public function getPointer(): Pointer;
 }

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -26,7 +26,7 @@ final class FieldReader
         private MemoryReaderInterface $memory_reader,
         private ProcessSpecifier $process_specifier,
         private ZendTypeReader $type_reader,
-        private ?PointedTypeResolver $pointed_type_resolver = null,
+        private PointedTypeResolver $pointed_type_resolver,
     ) {
     }
 
@@ -145,9 +145,7 @@ final class FieldReader
         );
         $casted_cdata = $this->type_reader->readAs($c_type, $buffer);
         $pointer = new Pointer($php_type, $struct_pointer->address + $offset, $size);
-        $resolved_type = $this->pointed_type_resolver !== null
-            ? $this->pointed_type_resolver->resolve($php_type)
-            : $php_type;
+        $resolved_type = $this->pointed_type_resolver->resolve($php_type);
         if (is_a($resolved_type, PointedTypeResolverAware::class, true)) {
             /**
              * @psalm-suppress TooManyArguments

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -153,7 +153,12 @@ final class FieldReader
              */
             return $resolved_type::fromCastedCDataWithResolver($casted_cdata, $pointer, $this->pointed_type_resolver);
         }
-        /** @psalm-suppress InvalidReturnStatement */
+        assert(is_a($resolved_type, CDataDereferencable::class, true));
+        /**
+         * @var class-string<CDataDereferencable&T> $resolved_type
+         * @psalm-suppress ArgumentTypeCoercion
+         * @psalm-suppress InvalidReturnStatement
+         */
         return $resolved_type::fromCastedCData($casted_cdata, $pointer);
     }
 }

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -26,6 +26,7 @@ final class FieldReader
         private MemoryReaderInterface $memory_reader,
         private ProcessSpecifier $process_specifier,
         private ZendTypeReader $type_reader,
+        private ?PointedTypeResolver $pointed_type_resolver = null,
     ) {
     }
 
@@ -124,6 +125,7 @@ final class FieldReader
      * @param Pointer<Dereferencable> $struct_pointer
      * @param class-string<T> $php_type
      * @return T
+     * @psalm-suppress InvalidReturnType psalm cannot narrow T through resolve()
      */
     public function readEmbeddedDereferencable(
         Pointer $struct_pointer,
@@ -143,6 +145,17 @@ final class FieldReader
         );
         $casted_cdata = $this->type_reader->readAs($c_type, $buffer);
         $pointer = new Pointer($php_type, $struct_pointer->address + $offset, $size);
-        return $php_type::fromCastedCData($casted_cdata, $pointer);
+        $resolved_type = $this->pointed_type_resolver !== null
+            ? $this->pointed_type_resolver->resolve($php_type)
+            : $php_type;
+        if (is_a($resolved_type, PointedTypeResolverAware::class, true)) {
+            /**
+             * @psalm-suppress TooManyArguments
+             * @psalm-suppress InvalidReturnStatement
+             */
+            return $resolved_type::fromCastedCData($casted_cdata, $pointer, $this->pointed_type_resolver);
+        }
+        /** @psalm-suppress InvalidReturnStatement */
+        return $resolved_type::fromCastedCData($casted_cdata, $pointer);
     }
 }

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -148,10 +148,10 @@ final class FieldReader
         $resolved_type = $this->pointed_type_resolver->resolve($php_type);
         if (is_a($resolved_type, PointedTypeResolverAware::class, true)) {
             /**
-             * @psalm-suppress TooManyArguments
+             * @psalm-suppress ArgumentTypeCoercion
              * @psalm-suppress InvalidReturnStatement
              */
-            return $resolved_type::fromCastedCData($casted_cdata, $pointer, $this->pointed_type_resolver);
+            return $resolved_type::fromCastedCDataWithResolver($casted_cdata, $pointer, $this->pointed_type_resolver);
         }
         /** @psalm-suppress InvalidReturnStatement */
         return $resolved_type::fromCastedCData($casted_cdata, $pointer);

--- a/src/Lib/Process/Pointer/LazyDereferencable.php
+++ b/src/Lib/Process/Pointer/LazyDereferencable.php
@@ -18,5 +18,9 @@ interface LazyDereferencable extends Dereferencable
     /**
      * @param Pointer<static> $pointer
      */
-    public static function fromLazy(FieldReader $field_reader, Pointer $pointer): static;
+    public static function fromLazy(
+        FieldReader $field_reader,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static;
 }

--- a/src/Lib/Process/Pointer/LazyDereferencer.php
+++ b/src/Lib/Process/Pointer/LazyDereferencer.php
@@ -18,6 +18,7 @@ final class LazyDereferencer implements Dereferencer
     public function __construct(
         private Dereferencer $inner,
         private FieldReader $field_reader,
+        private ?PointedTypeResolver $pointed_type_resolver = null,
     ) {
     }
 
@@ -36,7 +37,7 @@ final class LazyDereferencer implements Dereferencer
              * @psalm-suppress ArgumentTypeCoercion
              * @var T
              */
-            return $type::fromLazy($this->field_reader, $pointer);
+            return $type::fromLazy($this->field_reader, $pointer, $this->pointed_type_resolver);
         }
         return $this->inner->deref($pointer);
     }

--- a/src/Lib/Process/Pointer/LazyDereferencer.php
+++ b/src/Lib/Process/Pointer/LazyDereferencer.php
@@ -18,7 +18,7 @@ final class LazyDereferencer implements Dereferencer
     public function __construct(
         private Dereferencer $inner,
         private FieldReader $field_reader,
-        private ?PointedTypeResolver $pointed_type_resolver = null,
+        private PointedTypeResolver $pointed_type_resolver,
     ) {
     }
 

--- a/src/Lib/Process/Pointer/PointedTypeResolverAware.php
+++ b/src/Lib/Process/Pointer/PointedTypeResolverAware.php
@@ -15,12 +15,13 @@ namespace Reli\Lib\Process\Pointer;
 
 use Reli\Lib\PhpInternals\CastedCData;
 
+/** @psalm-suppress MethodSignatureMismatch intentionally requires resolver param */
 interface PointedTypeResolverAware extends Dereferencable
 {
     #[\Override]
     public static function fromCastedCData(
         CastedCData $casted_cdata,
         Pointer $pointer,
-        ?PointedTypeResolver $pointed_type_resolver = null,
+        PointedTypeResolver $pointed_type_resolver,
     ): static;
 }

--- a/src/Lib/Process/Pointer/PointedTypeResolverAware.php
+++ b/src/Lib/Process/Pointer/PointedTypeResolverAware.php
@@ -15,11 +15,14 @@ namespace Reli\Lib\Process\Pointer;
 
 use Reli\Lib\PhpInternals\CastedCData;
 
-/** @psalm-suppress MethodSignatureMismatch intentionally requires resolver param */
 interface PointedTypeResolverAware extends Dereferencable
 {
-    #[\Override]
-    public static function fromCastedCData(
+    /**
+     * @template T of \FFI\CData
+     * @param CastedCData<T> $casted_cdata
+     * @param Pointer<self> $pointer
+     */
+    public static function fromCastedCDataWithResolver(
         CastedCData $casted_cdata,
         Pointer $pointer,
         PointedTypeResolver $pointed_type_resolver,

--- a/src/Lib/Process/Pointer/PointedTypeResolverAware.php
+++ b/src/Lib/Process/Pointer/PointedTypeResolverAware.php
@@ -13,7 +13,14 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Process\Pointer;
 
-interface PointedTypeResolverAware
+use Reli\Lib\PhpInternals\CastedCData;
+
+interface PointedTypeResolverAware extends Dereferencable
 {
-    public function setPointedTypeResolver(PointedTypeResolver $resolver): void;
+    #[\Override]
+    public static function fromCastedCData(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        ?PointedTypeResolver $pointed_type_resolver = null,
+    ): static;
 }

--- a/src/Lib/Process/Pointer/PointedTypeResolverAware.php
+++ b/src/Lib/Process/Pointer/PointedTypeResolverAware.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+interface PointedTypeResolverAware
+{
+    public function setPointedTypeResolver(PointedTypeResolver $resolver): void;
+}

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -25,7 +25,7 @@ final class RemoteProcessDereferencer implements Dereferencer
         private MemoryReaderInterface $memory_reader,
         private ProcessSpecifier $process_specifier,
         private CastedTypeProvider $ctype_provider,
-        private ?PointedTypeResolver $pointed_type_resolver = null,
+        private PointedTypeResolver $pointed_type_resolver,
     ) {
     }
 
@@ -64,11 +64,7 @@ final class RemoteProcessDereferencer implements Dereferencer
         CastedCData $casted_cdata,
         Pointer $pointer
     ): mixed {
-        if (!is_null($this->pointed_type_resolver)) {
-            $type = $this->pointed_type_resolver->resolve($pointer->type);
-        } else {
-            $type = $pointer->type;
-        }
+        $type = $this->pointed_type_resolver->resolve($pointer->type);
         if (is_a($type, PointedTypeResolverAware::class, true)) {
             /**
              * @var class-string<PointedTypeResolverAware&T> $type

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -68,10 +68,10 @@ final class RemoteProcessDereferencer implements Dereferencer
         if (is_a($type, PointedTypeResolverAware::class, true)) {
             /**
              * @var class-string<PointedTypeResolverAware&T> $type
-             * @psalm-suppress TooManyArguments psalm sees Dereferencable::fromCastedCData(2 args)
+             * @psalm-suppress ArgumentTypeCoercion
              * @psalm-suppress InvalidReturnStatement
              */
-            return $type::fromCastedCData($casted_cdata, $pointer, $this->pointed_type_resolver);
+            return $type::fromCastedCDataWithResolver($casted_cdata, $pointer, $this->pointed_type_resolver);
         }
         return $type::fromCastedCData($casted_cdata, $pointer);
     }

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -68,6 +68,10 @@ final class RemoteProcessDereferencer implements Dereferencer
         } else {
             $type = $pointer->type;
         }
-        return $type::fromCastedCData($casted_cdata, $pointer);
+        $result = $type::fromCastedCData($casted_cdata, $pointer);
+        if ($result instanceof PointedTypeResolverAware && !is_null($this->pointed_type_resolver)) {
+            $result->setPointedTypeResolver($this->pointed_type_resolver);
+        }
+        return $result;
     }
 }

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -73,6 +73,12 @@ final class RemoteProcessDereferencer implements Dereferencer
              */
             return $type::fromCastedCDataWithResolver($casted_cdata, $pointer, $this->pointed_type_resolver);
         }
+        assert(is_a($type, CDataDereferencable::class, true));
+        /**
+         * @var class-string<CDataDereferencable&T> $type
+         * @psalm-suppress ArgumentTypeCoercion
+         * @psalm-suppress InvalidReturnStatement
+         */
         return $type::fromCastedCData($casted_cdata, $pointer);
     }
 }

--- a/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
+++ b/src/Lib/Process/Pointer/RemoteProcessDereferencer.php
@@ -58,6 +58,7 @@ final class RemoteProcessDereferencer implements Dereferencer
      * @param CastedCData<CData> $casted_cdata
      * @param Pointer<T> $pointer
      * @return T
+     * @psalm-suppress InvalidReturnType psalm cannot narrow T through is_a for static calls
      */
     public function fromCastedCDataOfType(
         CastedCData $casted_cdata,
@@ -68,10 +69,14 @@ final class RemoteProcessDereferencer implements Dereferencer
         } else {
             $type = $pointer->type;
         }
-        $result = $type::fromCastedCData($casted_cdata, $pointer);
-        if ($result instanceof PointedTypeResolverAware && !is_null($this->pointed_type_resolver)) {
-            $result->setPointedTypeResolver($this->pointed_type_resolver);
+        if (is_a($type, PointedTypeResolverAware::class, true)) {
+            /**
+             * @var class-string<PointedTypeResolverAware&T> $type
+             * @psalm-suppress TooManyArguments psalm sees Dereferencable::fromCastedCData(2 args)
+             * @psalm-suppress InvalidReturnStatement
+             */
+            return $type::fromCastedCData($casted_cdata, $pointer, $this->pointed_type_resolver);
         }
-        return $result;
+        return $type::fromCastedCData($casted_cdata, $pointer);
     }
 }

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -23,6 +23,7 @@ use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
@@ -142,6 +143,7 @@ class ZendArrayTest extends BaseTestCase
             $memory_reader,
             new ProcessSpecifier($child_status['pid']),
             new ZendCastedTypeProvider($zend_type_reader),
+            new VersionedPointedTypeResolver(ZendTypeReader::V81),
         );
         $eg = $dereferencer->deref($eg_pointer);
         $server_array_bucket = $eg->symbol_table->findByKey($dereferencer, '_SERVER');


### PR DESCRIPTION
## Summary
This PR refactors PHP version-specific Zend type handling by introducing a layered dereference architecture. Type resolution is centralized, factory methods are split by responsibility, and a new lazy dereference path minimizes `process_vm_readv` copy volume on the trace hot path.

## Key Changes

### Dereferencable interface hierarchy
- Split the original `Dereferencable` into focused sub-interfaces:
  - **`CDataDereferencable`** — types constructed via `fromCastedCData()` (bulk CData copy)
  - **`LazyDereferencable`** — types constructed via `fromLazy(FieldReader, ...)` (per-field on-demand reads)
  - **`PointedTypeResolverAware`** — types that need a `PointedTypeResolver` injected via `fromCastedCDataWithResolver()`
- Base `Dereferencable` now only declares `getCTypeName()` and `getPointer()`

### Lazy dereference for hot-path types
- Added **`FieldReader`** — reads individual struct fields (pointer, int, embedded struct) from remote process memory without copying the entire struct
- Added **`LazyDereferencer`** — a `Dereferencer` decorator that routes `LazyDereferencable` types through `fromLazy()` instead of full CData copy
- Applied `LazyDereferencable` to **`ZendFunction`**, **`ZendExecutorGlobals`**, **`ZendMmHeap`**, **`ZendCompilerGlobals`**, **`ZendExecuteData`**, **`ZendOp`**, **`ZendString`**
- This significantly reduces `process_vm_readv` copy volume on the trace collection hot path

### Centralized version-specific type resolution
- Added **`VersionedPointedTypeResolver`** — maps base types (`Zval`, `ZendArray`, `Bucket`) to version-specific subclasses based on PHP version
- Added **`InlineCDataCreatorTrait`** — shared helper for creating inline (embedded struct) dereferencables with proper type resolution
- `PointedTypeResolverAware` types (`ZendClassEntry`, `ZendExecuteData`, `ZendReference`, `ZendClassConstant`, `ZendConstant`, `ZvalArray`, `ZendClosure`, etc.) receive the resolver via their factory method
- Replaced inline version-matching logic in `CallTraceReader` and `MemoryLocationsCollector` with `VersionedPointedTypeResolver`

### Psalm v6 upgrade and CI updates
- Upgraded Psalm from v5 to v6, bumped CI PHP version to 8.2
- Updated Docker images to PHP 8.2
- Added `#[Override]` attributes throughout
- Removed `final` from classes that need Mockery mocking in tests

## Implementation Details

The dereference pipeline now works as:

1. `RemoteProcessDereferencer` wraps itself with `LazyDereferencer`
2. For `LazyDereferencable` types → `fromLazy(FieldReader)` is called; the type reads only the fields it actually uses
3. For `PointedTypeResolverAware` types → `fromCastedCDataWithResolver()` injects the resolver for nested type creation
4. For plain `CDataDereferencable` types → `fromCastedCData()` as before
5. `VersionedPointedTypeResolver` handles all base-to-versioned type mapping centrally

This reduces both code duplication and memory copy overhead, while making it straightforward to add new PHP version support.

https://claude.ai/code/session_011z8zaim2DMpQhbSertQuVZ