### PR TITLE
Add PHP version matrix testing to CI workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,14 +63,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "PHP 7.0-7.2"
-            targets: "v70,v71,v72"
-          - name: "PHP 7.3-7.4"
-            targets: "v73,v74"
-          - name: "PHP 8.0-8.2"
-            targets: "v80,v81,v82"
-          - name: "PHP 8.3-8.4"
-            targets: "v83,v84"
+          - name: "PHP 7.0"
+            targets: "v70"
+          - name: "PHP 7.1"
+            targets: "v71"
+          - name: "PHP 7.2"
+            targets: "v72"
+          - name: "PHP 7.3"
+            targets: "v73"
+          - name: "PHP 7.4"
+            targets: "v74"
+          - name: "PHP 8.0"
+            targets: "v80"
+          - name: "PHP 8.1"
+            targets: "v81"
+          - name: "PHP 8.2"
+            targets: "v82"
+          - name: "PHP 8.3"
+            targets: "v83"
+          - name: "PHP 8.4"
+            targets: "v84"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: ffi, dom, mbstring
           coverage: none
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -71,7 +71,7 @@ jobs:
         run: echo "tag=sha-$(sha256sum Dockerfile-dev | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -150,10 +150,16 @@ jobs:
           docker pull ${{ needs.build-dev-image.outputs.image }}
           docker tag ${{ needs.build-dev-image.outputs.image }} reli-dev
 
-      - name: Cache target Docker image
-        uses: ScribeMD/docker-cache@0.5.0
+      - name: Restore target Docker image cache
+        id: target-cache
+        uses: actions/cache@v5
         with:
-          key: docker-${{ runner.os }}-target-${{ matrix.targets }}
+          path: /tmp/target-image.tar.gz
+          key: docker-target-${{ matrix.targets }}
+
+      - name: Load cached target Docker image
+        if: steps.target-cache.outputs.cache-hit == 'true'
+        run: docker load < /tmp/target-image.tar.gz
 
       - name: Install dependencies
         run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
@@ -163,3 +169,11 @@ jobs:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
           docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version
+
+      - name: Save target Docker image for cache
+        if: steps.target-cache.outputs.cache-hit != 'true'
+        run: |
+          TARGET_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^php:' | head -1)
+          if [ -n "$TARGET_IMAGE" ]; then
+            docker save "$TARGET_IMAGE" | gzip > /tmp/target-image.tar.gz
+          fi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -56,8 +56,28 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./vendor/bin/php-coveralls -v
 
+  build-dev-image:
+    name: Build dev image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build dev image
+        run: docker compose build reli-test-for-ci
+
+      - name: Save dev image
+        run: docker save reli-dev | gzip > /tmp/reli-dev-image.tar.gz
+
+      - name: Upload dev image
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-image
+          path: /tmp/reli-dev-image.tar.gz
+          retention-days: 1
+
   phpunit-target-version:
     name: phpunit (${{ matrix.name }})
+    needs: build-dev-image
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,34 +106,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
+      - name: Download dev image
+        uses: actions/download-artifact@v4
         with:
-          php-version: 8.2
-          extensions: ffi, dom, mbstring
-          coverage: none
+          name: dev-image
+          path: /tmp
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Load dev image
+        run: docker load < /tmp/reli-dev-image.tar.gz
 
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Cache Docker images
+      - name: Cache target Docker image
         uses: ScribeMD/docker-cache@0.5.0
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile-dev','tests/TargetPhpVmProvider.php') }}
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
+          key: docker-${{ runner.os }}-target-${{ matrix.targets }}
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -125,4 +133,4 @@ jobs:
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
-          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version
+          docker compose run --no-build reli-test-for-ci vendor/bin/phpunit --group target-version

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,11 +34,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ runner.os }}-unit-${{ hashFiles('Dockerfile-dev') }}
-
       - name: Validate composer.json and composer.lock
         run: composer validate
 
@@ -54,10 +49,7 @@ jobs:
       - name: Run unit tests
         run: |
           mkdir -p build/logs
-          docker compose run reli-test-for-ci vendor/bin/phpunit --exclude-group target-version --coverage-clover build/logs/clover.xml
-
-      - name: Fix absolute paths in the coverage report
-        run: sed -i "s|<file name=\"/app/|<file name=\"`pwd`/|g" build/logs/clover.xml
+          vendor/bin/phpunit --exclude-group target-version --coverage-clover build/logs/clover.xml
 
       - name: Send to coveralls
         env:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,9 +52,12 @@ jobs:
           vendor/bin/phpunit --exclude-group target-version --coverage-clover build/logs/clover.xml
 
       - name: Send to coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./vendor/bin/php-coveralls -v
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/logs/clover.xml
+          flag-name: unit
+          parallel: true
 
   build-dev-image:
     name: Build dev image
@@ -168,7 +171,16 @@ jobs:
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
-          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version
+          mkdir -p build/logs
+          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
+
+      - name: Send to coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/logs/clover.xml
+          flag-name: ${{ matrix.targets }}
+          parallel: true
 
       - name: Save target Docker image for cache
         if: steps.target-cache.outputs.cache-hit != 'true'
@@ -177,3 +189,15 @@ jobs:
           if [ -n "$TARGET_IMAGE" ]; then
             docker save "$TARGET_IMAGE" | gzip > /tmp/target-image.tar.gz
           fi
+
+  coveralls-finish:
+    name: Coveralls finish
+    needs: [phpunit-unit, phpunit-target-version]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish parallel build
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -62,8 +62,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build dev image
-        run: docker compose build reli-test-for-ci
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile-dev
+          load: true
+          tags: reli-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Save dev image
         run: docker save reli-dev | gzip > /tmp/reli-dev-image.tar.gz

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,22 +10,9 @@ on:
 
 jobs:
 
-  phpunit-test:
-    name: phpunit (${{ matrix.name }})
+  phpunit-unit:
+    name: phpunit (unit)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "PHP 7.x"
-            targets: "v70,v71,v72,v73,v74"
-            coverage: false
-          - name: "PHP 8.0-8.2"
-            targets: "v80,v81,v82"
-            coverage: false
-          - name: "PHP 8.3-8.4"
-            targets: "v83,v84"
-            coverage: true
     steps:
       - uses: actions/checkout@v6
 
@@ -35,6 +22,70 @@ jobs:
           php-version: 8.2
           extensions: ffi, dom, mbstring
           coverage: pcov
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ runner.os }}-unit-${{ hashFiles('Dockerfile-dev') }}
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run unit tests
+        run: |
+          mkdir -p build/logs
+          docker compose run reli-test-for-ci vendor/bin/phpunit --exclude-group target-version --coverage-clover build/logs/clover.xml
+
+      - name: Fix absolute paths in the coverage report
+        run: sed -i "s|<file name=\"/app/|<file name=\"`pwd`/|g" build/logs/clover.xml
+
+      - name: Send to coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./vendor/bin/php-coveralls -v
+
+  phpunit-target-version:
+    name: phpunit (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "PHP 7.x"
+            targets: "v70,v71,v72,v73,v74"
+          - name: "PHP 8.0-8.2"
+            targets: "v80,v81,v82"
+          - name: "PHP 8.3-8.4"
+            targets: "v83,v84"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: ffi, dom, mbstring
+          coverage: none
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -64,19 +115,8 @@ jobs:
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Run test suite
+      - name: Run target version tests
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
-          mkdir -p build/logs
-          composer test-for-ci
-
-      - name: Fix absolute paths in the coverage report
-        if: matrix.coverage
-        run: sed -i "s|<file name=\"/app/|<file name=\"`pwd`/|g" build/logs/clover.xml
-
-      - name: Send to coveralls
-        if: matrix.coverage
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./vendor/bin/php-coveralls -v
+          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,36 +59,58 @@ jobs:
   build-dev-image:
     name: Build dev image
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}/dev
     steps:
       - uses: actions/checkout@v6
 
+      - name: Compute Dockerfile hash
+        id: hash
+        run: echo "tag=sha-$(sha256sum Dockerfile-dev | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image already exists
+        id: check
+        run: |
+          if docker manifest inspect "${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
         uses: docker/setup-buildx-action@v3
 
-      - name: Build dev image
+      - name: Build and push dev image
+        if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile-dev
-          load: true
-          tags: reli-dev
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
+            ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Save dev image
-        run: docker save reli-dev | gzip > /tmp/reli-dev-image.tar.gz
-
-      - name: Upload dev image
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-image
-          path: /tmp/reli-dev-image.tar.gz
-          retention-days: 1
+    outputs:
+      image: ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
 
   phpunit-target-version:
     name: phpunit (${{ matrix.name }})
     needs: build-dev-image
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -116,14 +138,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dev image
-        uses: actions/download-artifact@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          name: dev-image
-          path: /tmp
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load dev image
-        run: docker load < /tmp/reli-dev-image.tar.gz
+      - name: Pull dev image
+        run: |
+          docker pull ${{ needs.build-dev-image.outputs.image }}
+          docker tag ${{ needs.build-dev-image.outputs.image }} reli-dev
 
       - name: Cache target Docker image
         uses: ScribeMD/docker-cache@0.5.0

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -123,12 +123,6 @@ jobs:
       - name: Install dependencies
         run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-      - name: Setup Problem Matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
       - name: Run target version tests
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -174,6 +174,9 @@ jobs:
           mkdir -p build/logs
           docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
 
+      - name: Fix coverage paths from Docker container
+        run: sed -i 's|/app/|${{ github.workspace }}/|g' build/logs/clover.xml
+
       - name: Send to coveralls
         uses: coverallsapp/github-action@v2
         with:
@@ -181,7 +184,6 @@ jobs:
           file: build/logs/clover.xml
           flag-name: ${{ matrix.targets }}
           parallel: true
-          base-path: /app
 
       - name: Save target Docker image for cache
         if: steps.target-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -137,4 +137,4 @@ jobs:
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
-          docker compose run --no-build reli-test-for-ci vendor/bin/phpunit --group target-version
+          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,8 +11,21 @@ on:
 jobs:
 
   phpunit-test:
-    name: phpunit test
+    name: phpunit (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "PHP 7.x"
+            targets: "v70,v71,v72,v73,v74"
+            coverage: false
+          - name: "PHP 8.0-8.2"
+            targets: "v80,v81,v82"
+            coverage: false
+          - name: "PHP 8.3-8.4"
+            targets: "v83,v84"
+            coverage: true
     steps:
       - uses: actions/checkout@v6
 
@@ -37,7 +50,7 @@ jobs:
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile-dev','tests/TargetPhpVmProvider.php') }}
+          key: docker-${{ runner.os }}-${{ matrix.targets }}-${{ hashFiles('Dockerfile-dev','tests/TargetPhpVmProvider.php') }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -52,14 +65,18 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run test suite
+        env:
+          RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
         run: |
           mkdir -p build/logs
           composer test-for-ci
 
       - name: Fix absolute paths in the coverage report
+        if: matrix.coverage
         run: sed -i "s|<file name=\"/app/|<file name=\"`pwd`/|g" build/logs/clover.xml
 
       - name: Send to coveralls
+        if: matrix.coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./vendor/bin/php-coveralls -v

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,8 +63,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "PHP 7.x"
-            targets: "v70,v71,v72,v73,v74"
+          - name: "PHP 7.0-7.2"
+            targets: "v70,v71,v72"
+          - name: "PHP 7.3-7.4"
+            targets: "v73,v74"
           - name: "PHP 8.0-8.2"
             targets: "v80,v81,v82"
           - name: "PHP 8.3-8.4"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -181,6 +181,7 @@ jobs:
           file: build/logs/clover.xml
           flag-name: ${{ matrix.targets }}
           parallel: true
+          base-path: /app
 
       - name: Save target Docker image for cache
         if: steps.target-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
         with:
-          key: docker-${{ runner.os }}-${{ matrix.targets }}-${{ hashFiles('Dockerfile-dev','tests/TargetPhpVmProvider.php') }}
+          key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile-dev','tests/TargetPhpVmProvider.php') }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.9'
 services:
   reli-test:
+    image: reli-dev
     build:
       context: .
       dockerfile: Dockerfile-dev
@@ -16,6 +17,7 @@ services:
     container_name: reli-test
     command: ["vendor/bin/phpunit" , "--colors=always", "--testdox"]
   reli-test-with-coverage:
+    image: reli-dev
     build:
       context: .
       dockerfile: Dockerfile-dev
@@ -32,6 +34,7 @@ services:
     container_name: reli-test
     command: ["vendor/bin/phpunit" , "--colors=always", "--testdox", "--coverage-clover", "build/logs/clover.xml"]
   reli-test-for-ci:
+    image: reli-dev
     build:
       context: .
       dockerfile: Dockerfile-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
+    environment:
+      - RELI_TEST_PHP_TARGETS=${RELI_TEST_PHP_TARGETS:-}
     volumes:
       - .:/app
       - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\CallTraceReader;
 
 use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
 use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
@@ -35,6 +36,7 @@ use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\TargetPhpVmProvider;
 
+#[Group('target-version')]
 class CallTraceReaderTest extends BaseTestCase
 {
     /** @var resource|null */

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -79,6 +79,9 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     #[DataProvider('provideFromV80')]
     public function testCollectAllFromV80(string $php_version, string $docker_image_name): void
     {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();
 
@@ -693,6 +696,9 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     #[DataProvider('provideFromV71')]
     public function testMemoryLimitViolationOnClosure(string $php_version, string $docker_image_name)
     {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
         if ($php_version === ZendTypeReader::V70) {
             $this->markTestSkipped('V70 does not support closure frame');
         }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -15,6 +15,7 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
 use Reli\BaseTestCase;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryLimitErrorDetails;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
@@ -42,6 +43,7 @@ use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\TargetPhpVmProvider;
 
+#[Group('target-version')]
 class MemoryLocationsCollectorTest extends BaseTestCase
 {
     /** @var resource|null */

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -17,9 +17,22 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
 
 class TargetPhpVmProvider
 {
+    private static function getFilteredVersions(array $versions): array
+    {
+        $targets = getenv('RELI_TEST_PHP_TARGETS');
+        if ($targets === false || $targets === '') {
+            return $versions;
+        }
+        $allowed = array_map('trim', explode(',', $targets));
+        return array_values(array_filter(
+            $versions,
+            fn (string $v) => in_array($v, $allowed, true),
+        ));
+    }
+
     public static function from(string $php_version)
     {
-        $versions = [
+        $versions = self::getFilteredVersions([
             ZendTypeReader::V70,
             ZendTypeReader::V71,
             ZendTypeReader::V72,
@@ -30,7 +43,7 @@ class TargetPhpVmProvider
             ZendTypeReader::V82,
             ZendTypeReader::V83,
             ZendTypeReader::V84,
-        ];
+        ]);
         foreach ($versions as $v) {
             if ($php_version <= $v) {
                 yield $v => [$v, self::dockerImageNameFromPhpVersion($v)];
@@ -40,7 +53,7 @@ class TargetPhpVmProvider
 
     public static function allSupported()
     {
-        $versions = [
+        $versions = self::getFilteredVersions([
             ZendTypeReader::V70,
             ZendTypeReader::V71,
             ZendTypeReader::V72,
@@ -51,7 +64,7 @@ class TargetPhpVmProvider
             ZendTypeReader::V82,
             ZendTypeReader::V83,
             ZendTypeReader::V84,
-        ];
+        ]);
         foreach ($versions as $version) {
             yield $version => [$version, self::dockerImageNameFromPhpVersion($version)];
         }

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -44,10 +44,15 @@ class TargetPhpVmProvider
             ZendTypeReader::V83,
             ZendTypeReader::V84,
         ]);
+        $hasResults = false;
         foreach ($versions as $v) {
             if ($php_version <= $v) {
+                $hasResults = true;
                 yield $v => [$v, self::dockerImageNameFromPhpVersion($v)];
             }
+        }
+        if (!$hasResults) {
+            yield 'skip' => ['skip', 'skip'];
         }
     }
 


### PR DESCRIPTION
## Summary
This PR improves the PHPUnit CI workflow by running each PHP version in its own parallel job, caching the dev Docker image via GHCR, and eliminating redundant setup steps. Total CI time dropped from several minutes to under 1 minute.

## Key Changes

- **1 version = 1 job**: Split target-version tests into 10 parallel matrix jobs (PHP 7.0–8.4), making it immediately clear which version failed

- **Dev Docker image caching via GHCR**:
  - `build-dev-image` prep job builds `Dockerfile-dev` once and pushes to `ghcr.io`
  - Image tag is based on `sha256sum Dockerfile-dev` — if unchanged, the build is skipped entirely (~8s)
  - Matrix jobs pull the pre-built image instead of rebuilding (eliminates 10x apt-get + extension builds)

- **Removed host PHP setup from target-version jobs**: `shivammathur/setup-php` and host-side `composer install` are no longer needed — dependencies are installed inside the dev container

- **Target PHP image caching**: Replaced `ScribeMD/docker-cache` (stuck on Node 20) with `actions/cache` + `docker save/load` per version

- **Dependency bumps**: `docker/login-action` v3 → v4 (Node 24 support)

- **Empty data provider fix**: `TargetPhpVmProvider::from()` now yields a skip sentinel instead of an empty generator when filtered versions don't match, preventing PHPUnit 10+ errors

## CI Results
- **Build dev image**: ~8s (skipped when Dockerfile-dev unchanged)
- **Each version job**: 36–45s (fully parallel)
- **Total wall time**: ~58s

https://claude.ai/code/session_01DDD7Ffczvg3HPeRMpsCABY