### PR TITLE
Add database output support for memory profiler

### DIFF
--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -59,6 +59,20 @@ All other options of `inspector:memory` work the same regardless of output forma
 
 ## Database Schema
 
+### Runs Table
+
+#### `runs`
+Each invocation of `inspector:memory` with a database output format creates a new run. This allows multiple snapshots to coexist in the same database for comparison.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `run_id` | INTEGER (PK) | Auto-incremented run identifier |
+| `created_at` | TEXT | ISO 8601 timestamp (UTC) of when the run was created |
+
+```sql
+SELECT * FROM runs;
+```
+
 ### Summary Tables
 
 #### `summary`
@@ -66,11 +80,12 @@ Key-value pairs containing metadata about the analysis snapshot.
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER (PK) | References `runs.run_id` |
 | `key` | TEXT (PK) | Metric name (e.g. `zend_mm_heap_total`, `php_version`) |
 | `value` | TEXT | Metric value |
 
 ```sql
-SELECT * FROM summary;
+SELECT * FROM summary WHERE run_id = 1;
 ```
 
 #### `location_types_summary`
@@ -78,12 +93,13 @@ Aggregated memory usage by location type, computed via `GROUP BY` from `context_
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER (PK) | References `runs.run_id` |
 | `type` | TEXT (PK) | Location type (e.g. `ZendStringMemoryLocation`, `ZendObjectMemoryLocation`) |
 | `count` | INTEGER | Number of locations of this type |
 | `memory_usage` | INTEGER | Total bytes consumed |
 
 ```sql
-SELECT * FROM location_types_summary ORDER BY memory_usage DESC;
+SELECT * FROM location_types_summary WHERE run_id = 1 ORDER BY memory_usage DESC;
 ```
 
 #### `class_objects_summary`
@@ -91,12 +107,13 @@ Aggregated memory usage by class, computed via `GROUP BY` from `context_node_loc
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER (PK) | References `runs.run_id` |
 | `class_name` | TEXT (PK) | Fully qualified class name |
 | `count` | INTEGER | Number of instances |
 | `memory_usage` | INTEGER | Total bytes consumed |
 
 ```sql
-SELECT * FROM class_objects_summary ORDER BY memory_usage DESC;
+SELECT * FROM class_objects_summary WHERE run_id = 1 ORDER BY memory_usage DESC;
 ```
 
 ### Context Graph Tables
@@ -108,7 +125,8 @@ Each node represents a unique context (object, array, string, etc.) in the memor
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `node_id` | INTEGER (PK) | Unique node identifier (same as `#node_id` in JSON) |
+| `run_id` | INTEGER (PK) | References `runs.run_id` |
+| `node_id` | INTEGER (PK) | Unique node identifier within this run (same as `#node_id` in JSON) |
 | `type` | TEXT | Context type (e.g. `ObjectContext`, `ArrayHeaderContext`) |
 
 #### `context_edges`
@@ -116,6 +134,7 @@ Edges represent parent-child relationships in the reference graph. A node may ha
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER | References `runs.run_id` |
 | `parent_node_id` | INTEGER | Parent node (NULL for root nodes) |
 | `child_node_id` | INTEGER | Child node (references `context_nodes.node_id`) |
 | `link_name` | TEXT | Name of the link (e.g. property name, variable name, array key) |
@@ -126,10 +145,10 @@ The `is_tree` flag distinguishes the DFS spanning tree from back-references:
 - `is_tree = 0` edges represent additional references to already-visited nodes — these capture shared and circular references
 
 ```sql
--- Find all places that reference node 42
+-- Find all places that reference node 42 in run 1
 SELECT parent_node_id, link_name, is_tree
 FROM context_edges
-WHERE child_node_id = 42;
+WHERE run_id = 1 AND child_node_id = 42;
 ```
 
 #### `context_node_locations`
@@ -138,6 +157,7 @@ Physical memory locations associated with nodes. A node may have multiple locati
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | INTEGER (PK) | Auto-incremented row ID |
+| `run_id` | INTEGER | References `runs.run_id` |
 | `node_id` | INTEGER (FK) | References `context_nodes.node_id` |
 | `address` | INTEGER | Memory address in the target process |
 | `size` | INTEGER | Size in bytes |
@@ -154,6 +174,7 @@ Key-value metadata attached to nodes (e.g. `#count` for array element counts).
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | INTEGER (PK) | Auto-incremented row ID |
+| `run_id` | INTEGER | References `runs.run_id` |
 | `node_id` | INTEGER (FK) | References `context_nodes.node_id` |
 | `key` | TEXT | Attribute name |
 | `value` | TEXT | Attribute value |
@@ -162,29 +183,30 @@ Key-value metadata attached to nodes (e.g. `#count` for array element counts).
 
 The following indexes are created after bulk insertion for query performance:
 
-- `idx_context_edges_parent_tree` on `context_edges(parent_node_id, is_tree)` -- essential for recursive CTE path queries
-- `idx_context_edges_child` on `context_edges(child_node_id)` -- essential for "find all references to node X"
-- `idx_context_node_locations_node` on `context_node_locations(node_id)` -- essential for joining locations to nodes
-- `idx_context_node_locations_class` on `context_node_locations(class_name)` -- speeds up class-based queries
-- `idx_context_node_attributes_node` on `context_node_attributes(node_id)` -- for attribute lookups
+- `idx_context_edges_run_parent_tree` on `context_edges(run_id, parent_node_id, is_tree)` -- essential for recursive CTE path queries
+- `idx_context_edges_run_child` on `context_edges(run_id, child_node_id)` -- essential for "find all references to node X"
+- `idx_context_node_locations_run_node` on `context_node_locations(run_id, node_id)` -- essential for joining locations to nodes
+- `idx_context_node_locations_run_class` on `context_node_locations(run_id, class_name)` -- speeds up class-based queries
+- `idx_context_node_attributes_run_node` on `context_node_attributes(run_id, node_id)` -- for attribute lookups
 
 ### Views
 
 #### `v_node_paths`
-Computes the canonical path from root to each node using a recursive CTE that follows only `is_tree = 1` edges. Each node has exactly one path. This view is convenient but can be slow on large databases.
+Computes the canonical path from root to each node using a recursive CTE that follows only `is_tree = 1` edges. Each node has exactly one path per run. This view is convenient but can be slow on large databases.
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER | Run identifier |
 | `node_id` | INTEGER | Node identifier |
 | `path` | TEXT | Full path (e.g. `call_frames -> 0 -> local_variables -> myVar -> object_properties -> items`) |
 | `depth` | INTEGER | Depth in the tree (0 = root) |
 
 ```sql
--- Find where a specific class is referenced
+-- Find where a specific class is referenced in run 1
 SELECT np.path, loc.size, loc.refcount
 FROM v_node_paths np
-JOIN context_node_locations loc ON loc.node_id = np.node_id
-WHERE loc.class_name = 'App\\MyClass'
+JOIN context_node_locations loc ON loc.run_id = np.run_id AND loc.node_id = np.node_id
+WHERE np.run_id = 1 AND loc.class_name = 'App\\MyClass'
 ORDER BY loc.size DESC;
 ```
 
@@ -195,6 +217,7 @@ Provides a convenient view of PHP array memory usage by joining array headers wi
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER | Run identifier |
 | `node_id` | INTEGER | Node identifier of the array header |
 | `address` | INTEGER | Memory address |
 | `header_size` | INTEGER | Size of the `zend_array` header |
@@ -208,10 +231,14 @@ Provides a convenient view of PHP array memory usage by joining array headers wi
 For large databases, the `v_node_paths` view (recursive CTE) can be slow. The `inspector:optimize-memory-db` command materializes all node paths into a physical `node_paths` table for much faster queries.
 
 ```bash
+# Materialize all runs
 ./reli inspector:optimize-memory-db memory.db
+
+# Materialize a specific run only
+./reli inspector:optimize-memory-db memory.db --run-id=1
 ```
 
-This creates a `node_paths` table with the same schema as the `v_node_paths` view, plus an index on `depth`. After materialization, you can query `node_paths` directly instead of `v_node_paths`.
+This creates a `node_paths` table with the same schema as the `v_node_paths` view, plus an index on `(run_id, depth)`. After materialization, you can query `node_paths` directly instead of `v_node_paths`.
 
 > **Note**: This command currently supports SQLite databases only. For MySQL/PostgreSQL, you can run the equivalent `INSERT INTO ... WITH RECURSIVE` SQL manually.
 
@@ -221,20 +248,24 @@ This creates a `node_paths` table with the same schema as the `v_node_paths` vie
 
 | Column | Type | Description |
 |--------|------|-------------|
+| `run_id` | INTEGER (PK) | Run identifier |
 | `node_id` | INTEGER (PK) | Node identifier |
 | `path` | TEXT | Full path from root |
 | `depth` | INTEGER | Depth in the tree |
 
-Index: `idx_node_paths_depth` on `node_paths(depth)`
+Index: `idx_node_paths_run_depth` on `node_paths(run_id, depth)`
 
 ## Example Queries
+
+All example queries below use `WHERE run_id = 1` to target a specific run. Replace `1` with the desired run ID, or omit the condition to query across all runs.
 
 ### Top memory consumers by location type
 
 ```sql
 SELECT type, count, memory_usage,
-       printf('%.1f%%', memory_usage * 100.0 / (SELECT SUM(memory_usage) FROM location_types_summary)) AS pct
+       printf('%.1f%%', memory_usage * 100.0 / (SELECT SUM(memory_usage) FROM location_types_summary WHERE run_id = 1)) AS pct
 FROM location_types_summary
+WHERE run_id = 1
 ORDER BY memory_usage DESC;
 ```
 
@@ -244,6 +275,7 @@ ORDER BY memory_usage DESC;
 SELECT class_name, count, memory_usage,
        CAST(memory_usage / count AS INTEGER) AS avg_size
 FROM class_objects_summary
+WHERE run_id = 1
 ORDER BY memory_usage DESC
 LIMIT 20;
 ```
@@ -256,7 +288,8 @@ SELECT string_value,
        SUM(size) AS total_bytes,
        size AS per_copy_bytes
 FROM context_node_locations
-WHERE location_type = 'ZendStringMemoryLocation'
+WHERE run_id = 1
+  AND location_type = 'ZendStringMemoryLocation'
   AND string_value IS NOT NULL
 GROUP BY string_value, size
 HAVING COUNT(*) > 1
@@ -270,7 +303,7 @@ LIMIT 20;
 SELECT location_type, class_name, printf('0x%x', address) AS hex_addr,
        size, refcount
 FROM context_node_locations
-WHERE refcount IS NOT NULL
+WHERE run_id = 1 AND refcount IS NOT NULL
 ORDER BY refcount DESC
 LIMIT 20;
 ```
@@ -280,19 +313,19 @@ LIMIT 20;
 ```sql
 WITH RECURSIVE node_depth(node_id, depth) AS (
     SELECT child_node_id, 0
-    FROM context_edges WHERE parent_node_id IS NULL AND is_tree = 1
+    FROM context_edges WHERE run_id = 1 AND parent_node_id IS NULL AND is_tree = 1
     UNION ALL
     SELECT e.child_node_id, nd.depth + 1
     FROM context_edges e
     JOIN node_depth nd ON e.parent_node_id = nd.node_id
-    WHERE e.is_tree = 1
+    WHERE e.run_id = 1 AND e.is_tree = 1
 )
 SELECT depth,
        COUNT(DISTINCT nd.node_id) AS nodes,
        SUM(loc.size) AS total_bytes,
-       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations)) AS pct
+       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations WHERE run_id = 1)) AS pct
 FROM node_depth nd
-JOIN context_node_locations loc ON loc.node_id = nd.node_id
+JOIN context_node_locations loc ON loc.run_id = 1 AND loc.node_id = nd.node_id
 GROUP BY depth
 ORDER BY depth
 LIMIT 30;
@@ -304,8 +337,8 @@ LIMIT 30;
 SELECT va.node_id, va.total_size, va.element_count, va.refcount,
        np.path
 FROM v_arrays va
-JOIN v_node_paths np ON np.node_id = va.node_id
-WHERE va.element_count = 0
+JOIN v_node_paths np ON np.run_id = va.run_id AND np.node_id = va.node_id
+WHERE va.run_id = 1 AND va.element_count = 0
 ORDER BY va.total_size DESC
 LIMIT 20;
 ```
@@ -315,10 +348,10 @@ LIMIT 20;
 Edges with `is_tree = 0` are back-references to already-visited nodes in the DFS traversal. This includes both truly circular references (A -> B -> A) and shared references (A -> C, B -> C).
 
 ```sql
--- All back-references (shared + circular)
+-- All back-references (shared + circular) in run 1
 SELECT parent_node_id, child_node_id, link_name
 FROM context_edges
-WHERE is_tree = 0
+WHERE run_id = 1 AND is_tree = 0
 LIMIT 20;
 ```
 
@@ -327,14 +360,14 @@ LIMIT 20;
 ```sql
 WITH RECURSIVE subtree(node_id, root_path) AS (
     SELECT e.child_node_id, e.link_name
-    FROM context_edges e WHERE e.parent_node_id IS NULL AND e.is_tree = 1
+    FROM context_edges e WHERE e.run_id = 1 AND e.parent_node_id IS NULL AND e.is_tree = 1
     UNION ALL
     SELECT e.child_node_id,
            CASE WHEN st.root_path = '' THEN e.link_name
                 ELSE st.root_path || ' -> ' || e.link_name END
     FROM context_edges e
     JOIN subtree st ON e.parent_node_id = st.node_id
-    WHERE e.is_tree = 1
+    WHERE e.run_id = 1 AND e.is_tree = 1
 ),
 root_two AS (
     SELECT node_id,
@@ -351,9 +384,9 @@ root_two AS (
 SELECT root_prefix,
        COUNT(DISTINCT rt.node_id) AS nodes,
        SUM(loc.size) AS total_bytes,
-       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations)) AS pct
+       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations WHERE run_id = 1)) AS pct
 FROM root_two rt
-JOIN context_node_locations loc ON loc.node_id = rt.node_id
+JOIN context_node_locations loc ON loc.run_id = 1 AND loc.node_id = rt.node_id
 GROUP BY root_prefix
 ORDER BY total_bytes DESC
 LIMIT 15;
@@ -366,7 +399,7 @@ SELECT size, refcount,
        printf('0x%x', address) AS hex_addr,
        substr(string_value, 1, 80) AS preview
 FROM context_node_locations
-WHERE location_type = 'ZendStringMemoryLocation'
+WHERE run_id = 1 AND location_type = 'ZendStringMemoryLocation'
 ORDER BY size DESC
 LIMIT 10;
 ```
@@ -377,7 +410,7 @@ LIMIT 10;
 SELECT va.node_id, va.element_count, va.header_size, va.table_size, va.total_size,
        CASE WHEN va.element_count > 0 THEN va.table_size / va.element_count ELSE NULL END AS bytes_per_elem
 FROM v_arrays va
-WHERE va.element_count > 0 AND va.table_size > 0
+WHERE va.run_id = 1 AND va.element_count > 0 AND va.table_size > 0
 ORDER BY (CAST(va.table_size AS REAL) / va.element_count) DESC
 LIMIT 15;
 ```
@@ -389,7 +422,7 @@ SELECT region, location_type,
        COUNT(*) AS count,
        SUM(size) AS total_bytes
 FROM context_node_locations
-WHERE region IS NOT NULL
+WHERE run_id = 1 AND region IS NOT NULL
 GROUP BY region, location_type
 ORDER BY total_bytes DESC
 LIMIT 20;
@@ -398,19 +431,19 @@ LIMIT 20;
 ### Find all references to a specific node (equivalent to JSON `#reference_node_id` lookup)
 
 ```sql
--- Find all edges pointing to node 42 (both tree and back-references)
+-- Find all edges pointing to node 42 in run 1 (both tree and back-references)
 SELECT e.parent_node_id, e.link_name, e.is_tree
 FROM context_edges e
-WHERE e.child_node_id = 42;
+WHERE e.run_id = 1 AND e.child_node_id = 42;
 ```
 
 ### All non-circular paths to a specific node
 
 ```sql
--- All paths from root to node 42, avoiding cycles
+-- All paths from root to node 42 in run 1, avoiding cycles
 WITH RECURSIVE cte(node_id, path, depth, visited) AS (
     SELECT child_node_id, link_name, 0, ',' || child_node_id || ','
-    FROM context_edges WHERE parent_node_id IS NULL
+    FROM context_edges WHERE run_id = 1 AND parent_node_id IS NULL
   UNION ALL
     SELECT e.child_node_id,
            cte.path || ' -> ' || e.link_name,
@@ -418,11 +451,39 @@ WITH RECURSIVE cte(node_id, path, depth, visited) AS (
            cte.visited || e.child_node_id || ','
     FROM context_edges e
     JOIN cte ON e.parent_node_id = cte.node_id
-    WHERE cte.visited NOT LIKE '%,' || e.child_node_id || ',%'
+    WHERE e.run_id = 1 AND cte.visited NOT LIKE '%,' || e.child_node_id || ',%'
 )
 SELECT path, depth FROM cte
 WHERE node_id = 42
 LIMIT 100;
+```
+
+### Comparing runs: memory growth by class
+
+```sql
+SELECT
+    r1.class_name,
+    r1.count AS count_run1,
+    r2.count AS count_run2,
+    r2.count - r1.count AS count_diff,
+    r1.memory_usage AS mem_run1,
+    r2.memory_usage AS mem_run2,
+    r2.memory_usage - r1.memory_usage AS mem_diff
+FROM class_objects_summary r1
+JOIN class_objects_summary r2 ON r1.class_name = r2.class_name
+WHERE r1.run_id = 1 AND r2.run_id = 2
+ORDER BY mem_diff DESC
+LIMIT 20;
+```
+
+### Comparing runs: new classes in later run
+
+```sql
+SELECT r2.class_name, r2.count, r2.memory_usage
+FROM class_objects_summary r2
+LEFT JOIN class_objects_summary r1 ON r1.class_name = r2.class_name AND r1.run_id = 1
+WHERE r2.run_id = 2 AND r1.class_name IS NULL
+ORDER BY r2.memory_usage DESC;
 ```
 
 ## Choosing an Output Format
@@ -437,6 +498,7 @@ LIMIT 100;
 | Streaming | Pipe to stdout | Requires `-o` file path | Writes to remote server |
 | Remote use | Must copy file | Must copy file | Direct write, no file transfer |
 | Team sharing | Share file | Share file | Connect to shared server |
+| Multi-run comparison | Separate files | Same DB, compare via `run_id` | Same DB, compare via `run_id` |
 | Path queries | `jq path(...)` | `v_node_paths` / `node_paths` | `v_node_paths` / manual CTE |
 | Reference lookup | `jq` + `#reference_node_id` | `context_edges WHERE child_node_id = ?` | Same |
 | Large snapshots | May exceed `jq` depth limit | Handles well | Handles well |

--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -188,7 +188,7 @@ WHERE loc.class_name = 'App\\MyClass'
 ORDER BY loc.size DESC;
 ```
 
-> **Performance note**: For large databases (100K+ nodes), queries against `v_node_paths` can be slow because the recursive CTE is recomputed on every query. Use `inspector:memory:optimize-db` to materialize paths into a real table for faster queries.
+> **Performance note**: For large databases (100K+ nodes), queries against `v_node_paths` can be slow because the recursive CTE is recomputed on every query. Use `inspector:optimize-memory-db` to materialize paths into a real table for faster queries.
 
 #### `v_arrays`
 Provides a convenient view of PHP array memory usage by joining array headers with their table allocations.
@@ -203,12 +203,12 @@ Provides a convenient view of PHP array memory usage by joining array headers wi
 | `element_count` | INTEGER | Number of elements in the array |
 | `refcount` | INTEGER | Reference count |
 
-## Optimizing the Database: `inspector:memory:optimize-db`
+## Optimizing the Database: `inspector:optimize-memory-db`
 
-For large databases, the `v_node_paths` view (recursive CTE) can be slow. The `inspector:memory:optimize-db` command materializes all node paths into a physical `node_paths` table for much faster queries.
+For large databases, the `v_node_paths` view (recursive CTE) can be slow. The `inspector:optimize-memory-db` command materializes all node paths into a physical `node_paths` table for much faster queries.
 
 ```bash
-./reli inspector:memory:optimize-db memory.db
+./reli inspector:optimize-memory-db memory.db
 ```
 
 This creates a `node_paths` table with the same schema as the `v_node_paths` view, plus an index on `depth`. After materialization, you can query `node_paths` directly instead of `v_node_paths`.

--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -1,25 +1,59 @@
-# SQLite Output for Memory Profiler
+# Database Output for Memory Profiler
 
-The memory profiler supports outputting analysis results to a SQLite database instead of JSON. This is useful for analyzing large memory snapshots where the JSON output would be too large to handle with tools like `jq`, and enables powerful ad-hoc querying with SQL.
+The memory profiler supports outputting analysis results to a relational database instead of JSON. This is useful for analyzing large memory snapshots where the JSON output would be too large to handle with tools like `jq`, and enables powerful ad-hoc querying with SQL.
+
+Supported databases:
+- **SQLite** (`-f sqlite3`) — local file, no server needed
+- **MySQL** (`-f mysql`) — connect to an existing MySQL/MariaDB server
+- **PostgreSQL** (`-f postgresql`) — connect to an existing PostgreSQL server
 
 ## Quick Start
 
-```bash
-# Capture memory snapshot to SQLite
-sudo ./reli inspector:memory -p <pid> -f sqlite3 -o memory.db
+### SQLite (local file)
 
-# Query the results
+```bash
+sudo ./reli inspector:memory -p <pid> -f sqlite3 -o memory.db
 sqlite3 memory.db "SELECT * FROM location_types_summary ORDER BY memory_usage DESC"
+```
+
+### MySQL
+
+```bash
+# Create the database first
+mysql -u root -e "CREATE DATABASE reli_memory"
+
+sudo ./reli inspector:memory -p <pid> -f mysql --db-name reli_memory --db-user root
+mysql -u root reli_memory -e "SELECT * FROM location_types_summary ORDER BY memory_usage DESC"
+```
+
+### PostgreSQL
+
+```bash
+# Create the database first
+createdb reli_memory
+
+sudo ./reli inspector:memory -p <pid> -f postgresql --db-name reli_memory --db-user postgres
+psql reli_memory -c "SELECT * FROM location_types_summary ORDER BY memory_usage DESC"
 ```
 
 ## Command Options
 
-The following options control SQLite output:
+### Output format
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--output-format` | `-f` | Set to `sqlite3` to enable SQLite output (default: `json`) |
-| `--output` | `-o` | Output file path (required when using `sqlite3` format) |
+| `--output-format` | `-f` | Output format: `json` (default), `sqlite3`, `mysql`, `postgresql` |
+| `--output` | `-o` | Output file path (required for `sqlite3`) |
+
+### Database connection (for `mysql` / `postgresql`)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--db-host` | `127.0.0.1` | Database server host |
+| `--db-port` | `3306` / `5432` | Database server port (auto-detected from format) |
+| `--db-name` | (required) | Database name |
+| `--db-user` | (required) | Database user |
+| `--db-password` | (empty) | Database password |
 
 All other options of `inspector:memory` work the same regardless of output format.
 
@@ -179,7 +213,9 @@ For large databases, the `v_node_paths` view (recursive CTE) can be slow. The `i
 
 This creates a `node_paths` table with the same schema as the `v_node_paths` view, plus an index on `depth`. After materialization, you can query `node_paths` directly instead of `v_node_paths`.
 
-> **Note**: Materialization can significantly increase the database file size. For databases with deep reference trees, path strings can average several KB each, so the `node_paths` table may be much larger than the rest of the database combined.
+> **Note**: This command currently supports SQLite databases only. For MySQL/PostgreSQL, you can run the equivalent `INSERT INTO ... WITH RECURSIVE` SQL manually.
+
+> **Note**: Materialization can significantly increase the database size. For databases with deep reference trees, path strings can average several KB each, so the `node_paths` table may be much larger than the rest of the data combined.
 
 ### The `node_paths` table (after optimization)
 
@@ -389,18 +425,39 @@ WHERE node_id = 42
 LIMIT 100;
 ```
 
-## JSON vs SQLite: When to Use Which
+## Choosing an Output Format
 
-| Aspect | JSON (`-f json`) | SQLite (`-f sqlite3`) |
-|--------|------|---------|
-| Output speed | Baseline | Faster (deferred summary computation) |
-| File size | Can be very large for deep trees | More compact (normalized schema) |
-| Queryability | `jq` (limited by depth, memory) | Full SQL with indexes |
-| Tooling | `jq`, `gojq`, `jj` | `sqlite3` CLI, any SQLite client |
-| Streaming | Pipe to stdout | Requires `-o` file path |
-| Path queries | `jq path(...)` | `v_node_paths` view or `node_paths` table |
-| Reference lookup | `jq` with `#reference_node_id` | `context_edges WHERE child_node_id = ?` |
-| All paths to a node | Manual | Recursive CTE with cycle avoidance |
-| Large snapshots | May exceed `jq` depth limit | Handles well with proper indexes |
+| Aspect | JSON | SQLite | MySQL / PostgreSQL |
+|--------|------|--------|-------------------|
+| Setup | None | None | Requires a running server |
+| Output speed | Baseline | Faster (deferred summaries) | Faster (deferred summaries) |
+| File size | Large for deep trees | Compact (normalized) | N/A (server-side) |
+| Queryability | `jq` (limited by depth) | Full SQL | Full SQL |
+| Tooling | `jq`, `gojq`, `jj` | `sqlite3` CLI | `mysql` / `psql` CLI, any SQL client |
+| Streaming | Pipe to stdout | Requires `-o` file path | Writes to remote server |
+| Remote use | Must copy file | Must copy file | Direct write, no file transfer |
+| Team sharing | Share file | Share file | Connect to shared server |
+| Path queries | `jq path(...)` | `v_node_paths` / `node_paths` | `v_node_paths` / manual CTE |
+| Reference lookup | `jq` + `#reference_node_id` | `context_edges WHERE child_node_id = ?` | Same |
+| Large snapshots | May exceed `jq` depth limit | Handles well | Handles well |
 
-For snapshots with more than ~100K nodes, the SQLite format is strongly recommended.
+**Recommendations**:
+- **Local analysis**: SQLite is the simplest — no setup, single file, portable
+- **Remote servers**: MySQL/PostgreSQL avoids copying large files off the server
+- **Team collaboration**: MySQL/PostgreSQL lets multiple people query the same results
+- **Small snapshots**: JSON + `jq` is fine for quick one-off checks
+
+For snapshots with more than ~100K nodes, any database format is recommended over JSON.
+
+## Database Compatibility Notes
+
+The schema and views are designed to work across all three databases. Key dialect differences are handled automatically:
+
+| Feature | SQLite | MySQL | PostgreSQL |
+|---------|--------|-------|------------|
+| Duplicate-safe insert | `INSERT OR IGNORE` | `INSERT IGNORE` | `INSERT ... ON CONFLICT DO NOTHING` |
+| String concatenation | `\|\|` | `CONCAT()` | `\|\|` |
+| Auto-increment PK | `INTEGER PRIMARY KEY` | `INTEGER PRIMARY KEY AUTO_INCREMENT` | `SERIAL PRIMARY KEY` |
+| Bulk insert tuning | `PRAGMA journal_mode=OFF`, etc. | `SET unique_checks=0`, etc. | `SET synchronous_commit=off` |
+
+> **Note**: The example queries in this document use SQLite syntax (`printf()`, `||`). When using MySQL, replace `||` with `CONCAT()` and `printf()` with `FORMAT()` or `CONCAT()` as appropriate. PostgreSQL uses `||` like SQLite but uses `format()` or `to_char()` instead of `printf()`.

--- a/docs/memory-profiler-sqlite.md
+++ b/docs/memory-profiler-sqlite.md
@@ -1,0 +1,361 @@
+# SQLite Output for Memory Profiler
+
+The memory profiler supports outputting analysis results to a SQLite database instead of JSON. This is useful for analyzing large memory snapshots where the JSON output would be too large to handle with tools like `jq`, and enables powerful ad-hoc querying with SQL.
+
+## Quick Start
+
+```bash
+# Capture memory snapshot to SQLite
+sudo ./reli inspector:memory -p <pid> -f sqlite3 -o memory.db
+
+# Query the results
+sqlite3 memory.db "SELECT * FROM location_types_summary ORDER BY memory_usage DESC"
+```
+
+## Command Options
+
+The following options control SQLite output:
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--output-format` | `-f` | Set to `sqlite3` to enable SQLite output (default: `json`) |
+| `--output` | `-o` | Output file path (required when using `sqlite3` format) |
+
+All other options of `inspector:memory` work the same regardless of output format.
+
+## Database Schema
+
+### Summary Tables
+
+#### `summary`
+Key-value pairs containing metadata about the analysis snapshot.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | TEXT (PK) | Metric name (e.g. `zend_mm_heap_total`, `php_version`) |
+| `value` | TEXT | Metric value |
+
+```sql
+SELECT * FROM summary;
+```
+
+#### `location_types_summary`
+Aggregated memory usage by location type, computed via `GROUP BY` from `context_node_locations`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `type` | TEXT (PK) | Location type (e.g. `ZendStringMemoryLocation`, `ZendObjectMemoryLocation`) |
+| `count` | INTEGER | Number of locations of this type |
+| `memory_usage` | INTEGER | Total bytes consumed |
+
+```sql
+SELECT * FROM location_types_summary ORDER BY memory_usage DESC;
+```
+
+#### `class_objects_summary`
+Aggregated memory usage by class, computed via `GROUP BY` from `context_node_locations`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `class_name` | TEXT (PK) | Fully qualified class name |
+| `count` | INTEGER | Number of instances |
+| `memory_usage` | INTEGER | Total bytes consumed |
+
+```sql
+SELECT * FROM class_objects_summary ORDER BY memory_usage DESC;
+```
+
+### Context Tree Tables
+
+The context tree (reference graph) is stored in a normalized relational schema across three tables. This is equivalent to the `"context"` field in the JSON output.
+
+#### `context_nodes`
+The tree structure representing the memory reference hierarchy. Each node corresponds to a context in the JSON output's `"context"` field.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_id` | INTEGER (PK) | Unique node identifier (same as `#node_id` in JSON) |
+| `parent_node_id` | INTEGER | Parent node (NULL for root nodes) |
+| `link_name` | TEXT | Name of the link from parent (e.g. property name, variable name, array key) |
+| `type` | TEXT | Context type (e.g. `ObjectContext`, `ArrayHeaderContext`) |
+| `reference_node_id` | INTEGER | If set, this node is a back-reference to another node (same as `#reference_node_id` in JSON) |
+
+#### `context_node_locations`
+Physical memory locations associated with nodes. A node may have multiple locations (e.g. an array has both a header and a table location).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER (PK) | Auto-incremented row ID |
+| `node_id` | INTEGER (FK) | References `context_nodes.node_id` |
+| `address` | INTEGER | Memory address in the target process |
+| `size` | INTEGER | Size in bytes |
+| `location_type` | TEXT | Type of memory location (e.g. `ZendStringMemoryLocation`) |
+| `class_name` | TEXT | Class name (for object locations) |
+| `string_value` | TEXT | String value (for string locations) |
+| `refcount` | INTEGER | Reference count |
+| `type_info` | INTEGER | Zval type info flags |
+| `region` | TEXT | Memory region (`zend_mm_heap`, `zend_mm_huge`, `vm_stack`, `compiler_arena`, or NULL) |
+
+#### `context_node_attributes`
+Key-value metadata attached to nodes (e.g. `#count` for array element counts).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER (PK) | Auto-incremented row ID |
+| `node_id` | INTEGER (FK) | References `context_nodes.node_id` |
+| `key` | TEXT | Attribute name |
+| `value` | TEXT | Attribute value |
+
+### Indexes
+
+The following indexes are created after bulk insertion for query performance:
+
+- `idx_context_nodes_parent` on `context_nodes(parent_node_id)` -- essential for recursive CTE path queries and joins
+- `idx_context_node_locations_node` on `context_node_locations(node_id)` -- essential for joining locations to nodes
+- `idx_context_node_locations_class` on `context_node_locations(class_name)` -- speeds up class-based queries
+- `idx_context_node_attributes_node` on `context_node_attributes(node_id)` -- for attribute lookups
+
+### Views
+
+#### `v_node_paths`
+Computes the full reference path from root to each node using a recursive CTE. This view is convenient but can be slow on large databases.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_id` | INTEGER | Node identifier |
+| `path` | TEXT | Full path (e.g. `call_frames -> 0 -> local_variables -> myVar -> object_properties -> items`) |
+| `depth` | INTEGER | Depth in the tree (0 = root) |
+
+```sql
+-- Find where a specific class is referenced
+SELECT np.path, loc.size, loc.refcount
+FROM v_node_paths np
+JOIN context_node_locations loc ON loc.node_id = np.node_id
+WHERE loc.class_name = 'App\\MyClass'
+ORDER BY loc.size DESC;
+```
+
+> **Performance note**: For large databases (100K+ nodes), queries against `v_node_paths` can be slow because the recursive CTE is recomputed on every query. Use `inspector:memory:optimize-db` to materialize paths into a real table for faster queries.
+
+#### `v_arrays`
+Provides a convenient view of PHP array memory usage by joining array headers with their table allocations.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_id` | INTEGER | Node identifier of the array header |
+| `address` | INTEGER | Memory address |
+| `header_size` | INTEGER | Size of the `zend_array` header |
+| `table_size` | INTEGER | Size of the hash table allocation |
+| `total_size` | INTEGER | `header_size + table_size` |
+| `element_count` | INTEGER | Number of elements in the array |
+| `refcount` | INTEGER | Reference count |
+
+## Optimizing the Database: `inspector:memory:optimize-db`
+
+For large databases, the `v_node_paths` view (recursive CTE) can be slow. The `inspector:memory:optimize-db` command materializes all node paths into a physical `node_paths` table for much faster queries.
+
+```bash
+./reli inspector:memory:optimize-db memory.db
+```
+
+This creates a `node_paths` table with the same schema as the `v_node_paths` view, plus an index on `depth`. After materialization, you can query `node_paths` directly instead of `v_node_paths`.
+
+> **Note**: Materialization can significantly increase the database file size. For databases with deep reference trees, path strings can average several KB each, so the `node_paths` table may be much larger than the rest of the database combined.
+
+### The `node_paths` table (after optimization)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_id` | INTEGER (PK) | Node identifier |
+| `path` | TEXT | Full path from root |
+| `depth` | INTEGER | Depth in the tree |
+
+Index: `idx_node_paths_depth` on `node_paths(depth)`
+
+## Example Queries
+
+### Top memory consumers by location type
+
+```sql
+SELECT type, count, memory_usage,
+       printf('%.1f%%', memory_usage * 100.0 / (SELECT SUM(memory_usage) FROM location_types_summary)) AS pct
+FROM location_types_summary
+ORDER BY memory_usage DESC;
+```
+
+### Top memory-consuming classes
+
+```sql
+SELECT class_name, count, memory_usage,
+       CAST(memory_usage / count AS INTEGER) AS avg_size
+FROM class_objects_summary
+ORDER BY memory_usage DESC
+LIMIT 20;
+```
+
+### Duplicate strings (candidates for interning)
+
+```sql
+SELECT string_value,
+       COUNT(*) AS copies,
+       SUM(size) AS total_bytes,
+       size AS per_copy_bytes
+FROM context_node_locations
+WHERE location_type = 'ZendStringMemoryLocation'
+  AND string_value IS NOT NULL
+GROUP BY string_value, size
+HAVING COUNT(*) > 1
+ORDER BY total_bytes DESC
+LIMIT 20;
+```
+
+### High refcount values (widely shared structures)
+
+```sql
+SELECT location_type, class_name, printf('0x%x', address) AS hex_addr,
+       size, refcount
+FROM context_node_locations
+WHERE refcount IS NOT NULL
+ORDER BY refcount DESC
+LIMIT 20;
+```
+
+### Memory distribution by tree depth
+
+```sql
+WITH RECURSIVE node_depth(node_id, depth) AS (
+    SELECT node_id, 0
+    FROM context_nodes WHERE parent_node_id IS NULL
+    UNION ALL
+    SELECT cn.node_id, nd.depth + 1
+    FROM context_nodes cn
+    JOIN node_depth nd ON cn.parent_node_id = nd.node_id
+)
+SELECT depth,
+       COUNT(DISTINCT nd.node_id) AS nodes,
+       SUM(loc.size) AS total_bytes,
+       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations)) AS pct
+FROM node_depth nd
+JOIN context_node_locations loc ON loc.node_id = nd.node_id
+GROUP BY depth
+ORDER BY depth
+LIMIT 30;
+```
+
+### Empty arrays (allocated but unused)
+
+```sql
+SELECT va.node_id, va.total_size, va.element_count, va.refcount,
+       np.path
+FROM v_arrays va
+JOIN v_node_paths np ON np.node_id = va.node_id
+WHERE va.element_count = 0
+ORDER BY va.total_size DESC
+LIMIT 20;
+```
+
+### Circular references (potential GC targets)
+
+```sql
+SELECT cn.node_id, cn.parent_node_id, cn.link_name,
+       cn.reference_node_id
+FROM context_nodes cn
+WHERE cn.reference_node_id IS NOT NULL
+LIMIT 20;
+```
+
+### Top root paths by memory consumption (depth <= 2)
+
+```sql
+WITH RECURSIVE subtree(node_id, root_path) AS (
+    SELECT cn.node_id, cn.link_name
+    FROM context_nodes cn WHERE parent_node_id IS NULL
+    UNION ALL
+    SELECT cn.node_id,
+           CASE WHEN st.root_path = '' THEN cn.link_name
+                ELSE st.root_path || ' -> ' || cn.link_name END
+    FROM context_nodes cn
+    JOIN subtree st ON cn.parent_node_id = st.node_id
+),
+root_two AS (
+    SELECT node_id,
+           CASE
+             WHEN instr(root_path, ' -> ') > 0
+               THEN substr(root_path, 1,
+                    CASE WHEN instr(substr(root_path, instr(root_path, ' -> ') + 4), ' -> ') > 0
+                         THEN instr(root_path, ' -> ') + 3 + instr(substr(root_path, instr(root_path, ' -> ') + 4), ' -> ') - 1
+                         ELSE length(root_path) END)
+             ELSE root_path
+           END AS root_prefix
+    FROM subtree
+)
+SELECT root_prefix,
+       COUNT(DISTINCT rt.node_id) AS nodes,
+       SUM(loc.size) AS total_bytes,
+       printf('%.1f%%', SUM(loc.size) * 100.0 / (SELECT SUM(size) FROM context_node_locations)) AS pct
+FROM root_two rt
+JOIN context_node_locations loc ON loc.node_id = rt.node_id
+GROUP BY root_prefix
+ORDER BY total_bytes DESC
+LIMIT 15;
+```
+
+### Largest strings (log buffers, serialized data)
+
+```sql
+SELECT size, refcount,
+       printf('0x%x', address) AS hex_addr,
+       substr(string_value, 1, 80) AS preview
+FROM context_node_locations
+WHERE location_type = 'ZendStringMemoryLocation'
+ORDER BY size DESC
+LIMIT 10;
+```
+
+### Array table waste (over-allocated hash tables)
+
+```sql
+SELECT va.node_id, va.element_count, va.header_size, va.table_size, va.total_size,
+       CASE WHEN va.element_count > 0 THEN va.table_size / va.element_count ELSE NULL END AS bytes_per_elem
+FROM v_arrays va
+WHERE va.element_count > 0 AND va.table_size > 0
+ORDER BY (CAST(va.table_size AS REAL) / va.element_count) DESC
+LIMIT 15;
+```
+
+### Region x location type matrix
+
+```sql
+SELECT region, location_type,
+       COUNT(*) AS count,
+       SUM(size) AS total_bytes
+FROM context_node_locations
+WHERE region IS NOT NULL
+GROUP BY region, location_type
+ORDER BY total_bytes DESC
+LIMIT 20;
+```
+
+### Find all references to a specific node (equivalent to JSON `#reference_node_id` lookup)
+
+```sql
+-- Find all references to node 42
+SELECT cn.node_id, cn.parent_node_id, cn.link_name, cn.type
+FROM context_nodes cn
+WHERE cn.reference_node_id = 42 OR cn.node_id = 42;
+```
+
+## JSON vs SQLite: When to Use Which
+
+| Aspect | JSON (`-f json`) | SQLite (`-f sqlite3`) |
+|--------|------|---------|
+| Output speed | Baseline | Faster (deferred summary computation) |
+| File size | Can be very large for deep trees | More compact (normalized schema) |
+| Queryability | `jq` (limited by depth, memory) | Full SQL with indexes |
+| Tooling | `jq`, `gojq`, `jj` | `sqlite3` CLI, any SQLite client |
+| Streaming | Pipe to stdout | Requires `-o` file path |
+| Path queries | `jq path(...)` | `v_node_paths` view or `node_paths` table |
+| Reference lookup | `jq` with `#reference_node_id` | `WHERE reference_node_id = ?` |
+| Large snapshots | May exceed `jq` depth limit | Handles well with proper indexes |
+
+For snapshots with more than ~100K nodes, the SQLite format is strongly recommended.

--- a/docs/memory-profiler-sqlite.md
+++ b/docs/memory-profiler-sqlite.md
@@ -254,9 +254,12 @@ ORDER BY va.total_size DESC
 LIMIT 20;
 ```
 
-### Circular references (potential GC targets)
+### Back-references (shared or circular references)
+
+Nodes with `reference_node_id` are back-references to already-visited nodes in the DFS traversal. This includes both truly circular references (A -> B -> A) and shared references (A -> C, B -> C). To distinguish between them, check whether `reference_node_id` points to an ancestor of the current node.
 
 ```sql
+-- All back-references (shared + circular)
 SELECT cn.node_id, cn.parent_node_id, cn.link_name,
        cn.reference_node_id
 FROM context_nodes cn

--- a/docs/memory-profiler-sqlite.md
+++ b/docs/memory-profiler-sqlite.md
@@ -65,20 +65,38 @@ Aggregated memory usage by class, computed via `GROUP BY` from `context_node_loc
 SELECT * FROM class_objects_summary ORDER BY memory_usage DESC;
 ```
 
-### Context Tree Tables
+### Context Graph Tables
 
-The context tree (reference graph) is stored in a normalized relational schema across three tables. This is equivalent to the `"context"` field in the JSON output.
+The context graph (reference graph) is stored as separate nodes and edges, enabling natural representation of shared references. This is equivalent to the `"context"` field in the JSON output.
 
 #### `context_nodes`
-The tree structure representing the memory reference hierarchy. Each node corresponds to a context in the JSON output's `"context"` field.
+Each node represents a unique context (object, array, string, etc.) in the memory graph.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `node_id` | INTEGER (PK) | Unique node identifier (same as `#node_id` in JSON) |
-| `parent_node_id` | INTEGER | Parent node (NULL for root nodes) |
-| `link_name` | TEXT | Name of the link from parent (e.g. property name, variable name, array key) |
 | `type` | TEXT | Context type (e.g. `ObjectContext`, `ArrayHeaderContext`) |
-| `reference_node_id` | INTEGER | If set, this node is a back-reference to another node (same as `#reference_node_id` in JSON) |
+
+#### `context_edges`
+Edges represent parent-child relationships in the reference graph. A node may have multiple incoming edges (shared references).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `parent_node_id` | INTEGER | Parent node (NULL for root nodes) |
+| `child_node_id` | INTEGER | Child node (references `context_nodes.node_id`) |
+| `link_name` | TEXT | Name of the link (e.g. property name, variable name, array key) |
+| `is_tree` | INTEGER | `1` = DFS first-visit (spanning tree edge), `0` = back-reference (shared/circular) |
+
+The `is_tree` flag distinguishes the DFS spanning tree from back-references:
+- `is_tree = 1` edges form a tree where each node has exactly one parent — use these for canonical path queries
+- `is_tree = 0` edges represent additional references to already-visited nodes — these capture shared and circular references
+
+```sql
+-- Find all places that reference node 42
+SELECT parent_node_id, link_name, is_tree
+FROM context_edges
+WHERE child_node_id = 42;
+```
 
 #### `context_node_locations`
 Physical memory locations associated with nodes. A node may have multiple locations (e.g. an array has both a header and a table location).
@@ -110,7 +128,8 @@ Key-value metadata attached to nodes (e.g. `#count` for array element counts).
 
 The following indexes are created after bulk insertion for query performance:
 
-- `idx_context_nodes_parent` on `context_nodes(parent_node_id)` -- essential for recursive CTE path queries and joins
+- `idx_context_edges_parent_tree` on `context_edges(parent_node_id, is_tree)` -- essential for recursive CTE path queries
+- `idx_context_edges_child` on `context_edges(child_node_id)` -- essential for "find all references to node X"
 - `idx_context_node_locations_node` on `context_node_locations(node_id)` -- essential for joining locations to nodes
 - `idx_context_node_locations_class` on `context_node_locations(class_name)` -- speeds up class-based queries
 - `idx_context_node_attributes_node` on `context_node_attributes(node_id)` -- for attribute lookups
@@ -118,7 +137,7 @@ The following indexes are created after bulk insertion for query performance:
 ### Views
 
 #### `v_node_paths`
-Computes the full reference path from root to each node using a recursive CTE. This view is convenient but can be slow on large databases.
+Computes the canonical path from root to each node using a recursive CTE that follows only `is_tree = 1` edges. Each node has exactly one path. This view is convenient but can be slow on large databases.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -224,12 +243,13 @@ LIMIT 20;
 
 ```sql
 WITH RECURSIVE node_depth(node_id, depth) AS (
-    SELECT node_id, 0
-    FROM context_nodes WHERE parent_node_id IS NULL
+    SELECT child_node_id, 0
+    FROM context_edges WHERE parent_node_id IS NULL AND is_tree = 1
     UNION ALL
-    SELECT cn.node_id, nd.depth + 1
-    FROM context_nodes cn
-    JOIN node_depth nd ON cn.parent_node_id = nd.node_id
+    SELECT e.child_node_id, nd.depth + 1
+    FROM context_edges e
+    JOIN node_depth nd ON e.parent_node_id = nd.node_id
+    WHERE e.is_tree = 1
 )
 SELECT depth,
        COUNT(DISTINCT nd.node_id) AS nodes,
@@ -256,14 +276,13 @@ LIMIT 20;
 
 ### Back-references (shared or circular references)
 
-Nodes with `reference_node_id` are back-references to already-visited nodes in the DFS traversal. This includes both truly circular references (A -> B -> A) and shared references (A -> C, B -> C). To distinguish between them, check whether `reference_node_id` points to an ancestor of the current node.
+Edges with `is_tree = 0` are back-references to already-visited nodes in the DFS traversal. This includes both truly circular references (A -> B -> A) and shared references (A -> C, B -> C).
 
 ```sql
 -- All back-references (shared + circular)
-SELECT cn.node_id, cn.parent_node_id, cn.link_name,
-       cn.reference_node_id
-FROM context_nodes cn
-WHERE cn.reference_node_id IS NOT NULL
+SELECT parent_node_id, child_node_id, link_name
+FROM context_edges
+WHERE is_tree = 0
 LIMIT 20;
 ```
 
@@ -271,14 +290,15 @@ LIMIT 20;
 
 ```sql
 WITH RECURSIVE subtree(node_id, root_path) AS (
-    SELECT cn.node_id, cn.link_name
-    FROM context_nodes cn WHERE parent_node_id IS NULL
+    SELECT e.child_node_id, e.link_name
+    FROM context_edges e WHERE e.parent_node_id IS NULL AND e.is_tree = 1
     UNION ALL
-    SELECT cn.node_id,
-           CASE WHEN st.root_path = '' THEN cn.link_name
-                ELSE st.root_path || ' -> ' || cn.link_name END
-    FROM context_nodes cn
-    JOIN subtree st ON cn.parent_node_id = st.node_id
+    SELECT e.child_node_id,
+           CASE WHEN st.root_path = '' THEN e.link_name
+                ELSE st.root_path || ' -> ' || e.link_name END
+    FROM context_edges e
+    JOIN subtree st ON e.parent_node_id = st.node_id
+    WHERE e.is_tree = 1
 ),
 root_two AS (
     SELECT node_id,
@@ -342,10 +362,31 @@ LIMIT 20;
 ### Find all references to a specific node (equivalent to JSON `#reference_node_id` lookup)
 
 ```sql
--- Find all references to node 42
-SELECT cn.node_id, cn.parent_node_id, cn.link_name, cn.type
-FROM context_nodes cn
-WHERE cn.reference_node_id = 42 OR cn.node_id = 42;
+-- Find all edges pointing to node 42 (both tree and back-references)
+SELECT e.parent_node_id, e.link_name, e.is_tree
+FROM context_edges e
+WHERE e.child_node_id = 42;
+```
+
+### All non-circular paths to a specific node
+
+```sql
+-- All paths from root to node 42, avoiding cycles
+WITH RECURSIVE cte(node_id, path, depth, visited) AS (
+    SELECT child_node_id, link_name, 0, ',' || child_node_id || ','
+    FROM context_edges WHERE parent_node_id IS NULL
+  UNION ALL
+    SELECT e.child_node_id,
+           cte.path || ' -> ' || e.link_name,
+           cte.depth + 1,
+           cte.visited || e.child_node_id || ','
+    FROM context_edges e
+    JOIN cte ON e.parent_node_id = cte.node_id
+    WHERE cte.visited NOT LIKE '%,' || e.child_node_id || ',%'
+)
+SELECT path, depth FROM cte
+WHERE node_id = 42
+LIMIT 100;
 ```
 
 ## JSON vs SQLite: When to Use Which
@@ -358,7 +399,8 @@ WHERE cn.reference_node_id = 42 OR cn.node_id = 42;
 | Tooling | `jq`, `gojq`, `jj` | `sqlite3` CLI, any SQLite client |
 | Streaming | Pipe to stdout | Requires `-o` file path |
 | Path queries | `jq path(...)` | `v_node_paths` view or `node_paths` table |
-| Reference lookup | `jq` with `#reference_node_id` | `WHERE reference_node_id = ?` |
+| Reference lookup | `jq` with `#reference_node_id` | `context_edges WHERE child_node_id = ?` |
+| All paths to a node | Manual | Recursive CTE with cycle avoidance |
 | Large snapshots | May exceed `jq` depth limit | Handles well with proper indexes |
 
 For snapshots with more than ~100K nodes, the SQLite format is strongly recommended.

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -737,6 +737,9 @@ If you hit the memory_limit during the analysis, then you can increase the memor
 $ docker run --entrypoint=php -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof -dmemory_limit=2G reli i:m -p <pid_of_target_process> >memory_analyzed.json
 ```
 
+# Database output
+The memory profiler can also output analysis results to a relational database (SQLite, MySQL, PostgreSQL) for interactive querying with SQL. See [Database Output](./memory-profiler-database.md) for details.
+
 # See also
 - [PHP Internals Book](https://www.phpinternalsbook.com/)
 - [PHP's new hashtable implementation ](https://www.npopov.com/2014/12/22/PHPs-new-hashtable-implementation.html)

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -20,7 +20,7 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -20,7 +20,6 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Command\Inspector;
 
+use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
+use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
@@ -141,23 +143,20 @@ final class MemoryCommand extends Command
             $collected_memories->top_reference_context,
         );
 
-        $flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
-        if ($memory_profiler_settings->pretty_print) {
-            $flags |= JSON_PRETTY_PRINT;
-        }
-        echo json_encode(
-            [
-                'summary' => $summary,
-                "location_types_summary" => $heap_location_type_summary->per_type_usage,
-                'class_objects_summary' => $object_class_summary->per_class_usage,
-                'context' => $analyzed_context,
-            ],
-            $flags,
-            2147483647
+        $result = new MemoryAnalysisResult(
+            $summary,
+            $heap_location_type_summary->per_type_usage,
+            $object_class_summary->per_class_usage,
+            $analyzed_context,
         );
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException(json_last_error_msg());
-        }
+
+        $output_factory = new MemoryOutputFactory();
+        $memory_output = $output_factory->create(
+            $memory_profiler_settings->output_format,
+            $memory_profiler_settings->pretty_print,
+            $memory_profiler_settings->output_path,
+        );
+        $memory_output->output($result);
 
         Log::info('end memory command');
         return 0;

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -129,13 +129,13 @@ final class MemoryCommand extends Command
             ]
         ];
 
-        $is_sqlite = $memory_profiler_settings->output_format === 'sqlite3';
+        $is_db = in_array($memory_profiler_settings->output_format, ['sqlite3', 'mysql', 'postgresql'], true);
 
-        // For SQLite: type/class summaries are computed from DB via GROUP BY.
+        // For DB formats: type/class summaries are computed from DB via GROUP BY.
         // For JSON: compute them in-memory as before.
         $location_types_summary = null;
         $class_objects_summary = null;
-        if (!$is_sqlite) {
+        if (!$is_db) {
             $location_type_analyzer = new LocationTypeAnalyzer();
             $location_types_summary = $location_type_analyzer->analyze(
                 $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -21,7 +21,7 @@ use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConso
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
@@ -138,16 +138,11 @@ final class MemoryCommand extends Command
             ]
         ];
 
-        $context_analyzer = new ContextAnalyzer();
-        $analyzed_context = $context_analyzer->analyze(
-            $collected_memories->top_reference_context,
-        );
-
         $result = new MemoryAnalysisResult(
             $summary,
             $heap_location_type_summary->per_type_usage,
             $object_class_summary->per_class_usage,
-            $analyzed_context,
+            $collected_memories->top_reference_context,
         );
 
         $output_factory = new MemoryOutputFactory();

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -169,9 +169,7 @@ final class MemoryCommand extends Command
 
         $output_factory = new MemoryOutputFactory();
         $memory_output = $output_factory->create(
-            $memory_profiler_settings->output_format,
-            $memory_profiler_settings->pretty_print,
-            $memory_profiler_settings->output_path,
+            $memory_profiler_settings,
             $region_boundaries,
         );
         $memory_output->output($result);

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -21,11 +21,11 @@ use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConso
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Reli\ReliProfiler;
@@ -108,15 +108,6 @@ final class MemoryCommand extends Command
         $analyzed_regions = $region_analyzer->analyze(
             $collected_memories->memory_locations,
         );
-        $location_type_analyzer = new LocationTypeAnalyzer();
-        $heap_location_type_summary = $location_type_analyzer->analyze(
-            $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-        );
-
-        $object_class_analyzer = new ObjectClassAnalyzer();
-        $object_class_summary = $object_class_analyzer->analyze(
-            $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-        );
 
         $summary = [
             $analyzed_regions->summary->toArray()
@@ -138,11 +129,42 @@ final class MemoryCommand extends Command
             ]
         ];
 
+        $is_sqlite = $memory_profiler_settings->output_format === 'sqlite3';
+
+        // For SQLite: type/class summaries are computed from DB via GROUP BY.
+        // For JSON: compute them in-memory as before.
+        $location_types_summary = null;
+        $class_objects_summary = null;
+        if (!$is_sqlite) {
+            $location_type_analyzer = new LocationTypeAnalyzer();
+            $location_types_summary = $location_type_analyzer->analyze(
+                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
+            )->per_type_usage;
+
+            $object_class_analyzer = new ObjectClassAnalyzer();
+            $class_objects_summary = $object_class_analyzer->analyze(
+                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
+            )->per_class_usage;
+        }
+
+        // Region boundaries are small (a few entries each) — keep for PdoContextTreeSink.
+        // Everything else can be released before the tree walk.
+        $region_boundaries = new RegionBoundaries(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+        $top_reference_context = $collected_memories->top_reference_context;
+
+        // Release the large flat location lists before the tree walk
+        unset($collected_memories, $analyzed_regions, $region_analyzer);
+
         $result = new MemoryAnalysisResult(
             $summary,
-            $heap_location_type_summary->per_type_usage,
-            $object_class_summary->per_class_usage,
-            $collected_memories->top_reference_context,
+            $top_reference_context,
+            $location_types_summary,
+            $class_objects_summary,
         );
 
         $output_factory = new MemoryOutputFactory();
@@ -150,6 +172,7 @@ final class MemoryCommand extends Command
             $memory_profiler_settings->output_format,
             $memory_profiler_settings->pretty_print,
             $memory_profiler_settings->output_path,
+            $region_boundaries,
         );
         $memory_output->output($result);
 

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -72,13 +72,14 @@ final class MemoryDbOptimizeCommand extends Command
         $db->exec("
             INSERT INTO node_paths (node_id, path, depth)
             WITH RECURSIVE cte(node_id, path, depth) AS (
-                SELECT node_id, link_name, 0
-                FROM context_nodes
-                WHERE parent_node_id IS NULL
+                SELECT child_node_id, link_name, 0
+                FROM context_edges
+                WHERE parent_node_id IS NULL AND is_tree = 1
               UNION ALL
-                SELECT cn.node_id, cte.path || ' -> ' || cn.link_name, cte.depth + 1
-                FROM context_nodes cn
-                JOIN cte ON cn.parent_node_id = cte.node_id
+                SELECT e.child_node_id, cte.path || ' -> ' || e.link_name, cte.depth + 1
+                FROM context_edges e
+                JOIN cte ON e.parent_node_id = cte.node_id
+                WHERE e.is_tree = 1
             )
             SELECT node_id, path, depth FROM cte
         ");

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Reli\Command\Inspector;
 
+use PhpCast\NullableCast;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class MemoryDbOptimizeCommand extends Command
@@ -29,6 +31,12 @@ final class MemoryDbOptimizeCommand extends Command
                 'db-path',
                 InputArgument::REQUIRED,
                 'path to the SQLite database file',
+            )
+            ->addOption(
+                'run-id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'run ID to materialize (default: all runs)',
             )
         ;
     }
@@ -44,6 +52,8 @@ final class MemoryDbOptimizeCommand extends Command
             return 1;
         }
 
+        $run_id = NullableCast::toInt($input->getOption('run-id'));
+
         $db = new \PDO('sqlite:' . $db_path);
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
@@ -56,34 +66,42 @@ final class MemoryDbOptimizeCommand extends Command
             $db->exec('DROP TABLE node_paths');
         }
 
-        $node_count = (int)$db->query('SELECT COUNT(*) FROM context_nodes')->fetchColumn();
-        $output->writeln("Materializing node_paths for {$node_count} nodes...");
+        $where = $run_id !== null ? ' AND run_id = ' . $run_id : '';
+        $node_count = (int)$db->query(
+            'SELECT COUNT(*) FROM context_nodes WHERE 1=1' . $where
+        )->fetchColumn();
+        $label = $run_id !== null ? " (run_id={$run_id})" : ' (all runs)';
+        $output->writeln("Materializing node_paths for {$node_count} nodes{$label}...");
         $output->writeln('<comment>Note: this may significantly increase the database file size</comment>');
 
         $start = hrtime(true);
 
         $db->exec('
             CREATE TABLE node_paths (
-                node_id INTEGER NOT NULL PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
                 path TEXT NOT NULL,
-                depth INTEGER NOT NULL
+                depth INTEGER NOT NULL,
+                PRIMARY KEY (run_id, node_id)
             )
         ');
+
+        $run_filter = $run_id !== null ? ' AND run_id = ' . $run_id : '';
         $db->exec("
-            INSERT INTO node_paths (node_id, path, depth)
-            WITH RECURSIVE cte(node_id, path, depth) AS (
-                SELECT child_node_id, link_name, 0
+            INSERT INTO node_paths (run_id, node_id, path, depth)
+            WITH RECURSIVE cte(run_id, node_id, path, depth) AS (
+                SELECT run_id, child_node_id, link_name, 0
                 FROM context_edges
-                WHERE parent_node_id IS NULL AND is_tree = 1
+                WHERE parent_node_id IS NULL AND is_tree = 1{$run_filter}
               UNION ALL
-                SELECT e.child_node_id, cte.path || ' -> ' || e.link_name, cte.depth + 1
+                SELECT cte.run_id, e.child_node_id, cte.path || ' -> ' || e.link_name, cte.depth + 1
                 FROM context_edges e
-                JOIN cte ON e.parent_node_id = cte.node_id
+                JOIN cte ON e.parent_node_id = cte.node_id AND e.run_id = cte.run_id
                 WHERE e.is_tree = 1
             )
-            SELECT node_id, path, depth FROM cte
+            SELECT run_id, node_id, path, depth FROM cte
         ");
-        $db->exec('CREATE INDEX idx_node_paths_depth ON node_paths(depth)');
+        $db->exec('CREATE INDEX idx_node_paths_run_depth ON node_paths(run_id, depth)');
 
         $output->writeln('Compacting database...');
         $db->exec('VACUUM');

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -48,6 +48,7 @@ final class MemoryDbOptimizeCommand extends Command
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
         // Check if already materialized
+        /** @var int $exists */
         $exists = $db->query(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='node_paths'"
         )->fetchColumn();
@@ -56,6 +57,7 @@ final class MemoryDbOptimizeCommand extends Command
             $db->exec('DROP TABLE node_paths');
         }
 
+        /** @var int $node_count */
         $node_count = $db->query('SELECT COUNT(*) FROM context_nodes')->fetchColumn();
         $output->writeln("Materializing node_paths for {$node_count} nodes...");
         $output->writeln('<comment>Note: this may significantly increase the database file size</comment>');
@@ -88,12 +90,13 @@ final class MemoryDbOptimizeCommand extends Command
         $output->writeln('Compacting database...');
         $db->exec('VACUUM');
 
-        $elapsed = (hrtime(true) - $start) / 1e9;
+        $elapsed = (float)(hrtime(true) - $start) / 1e9;
+        /** @var int $row_count */
         $row_count = $db->query('SELECT COUNT(*) FROM node_paths')->fetchColumn();
 
         $output->writeln(sprintf(
             'Done: %s rows materialized in %.1fs',
-            number_format((int)$row_count),
+            number_format($row_count),
             $elapsed,
         ));
 

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class MemoryDbOptimizeCommand extends Command
+{
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('inspector:memory:optimize-db')
+            ->setDescription('[experimental] materialize node_paths in a memory analysis SQLite database')
+            ->addArgument(
+                'db-path',
+                InputArgument::REQUIRED,
+                'path to the SQLite database file',
+            )
+        ;
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $db_path = $input->getArgument('db-path');
+        assert(is_string($db_path));
+
+        if (!file_exists($db_path)) {
+            $output->writeln("<error>File not found: {$db_path}</error>");
+            return 1;
+        }
+
+        $db = new \PDO('sqlite:' . $db_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        // Check if already materialized
+        $exists = $db->query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='node_paths'"
+        )->fetchColumn();
+        if ($exists) {
+            $output->writeln('node_paths table already exists, dropping and recreating...');
+            $db->exec('DROP TABLE node_paths');
+        }
+
+        $node_count = $db->query('SELECT COUNT(*) FROM context_nodes')->fetchColumn();
+        $output->writeln("Materializing node_paths for {$node_count} nodes...");
+        $output->writeln('<comment>Note: this may significantly increase the database file size</comment>');
+
+        $start = hrtime(true);
+
+        $db->exec('
+            CREATE TABLE node_paths (
+                node_id INTEGER NOT NULL PRIMARY KEY,
+                path TEXT NOT NULL,
+                depth INTEGER NOT NULL
+            )
+        ');
+        $db->exec("
+            INSERT INTO node_paths (node_id, path, depth)
+            WITH RECURSIVE cte(node_id, path, depth) AS (
+                SELECT node_id, link_name, 0
+                FROM context_nodes
+                WHERE parent_node_id IS NULL
+              UNION ALL
+                SELECT cn.node_id, cte.path || ' -> ' || cn.link_name, cte.depth + 1
+                FROM context_nodes cn
+                JOIN cte ON cn.parent_node_id = cte.node_id
+            )
+            SELECT node_id, path, depth FROM cte
+        ");
+        $db->exec('CREATE INDEX idx_node_paths_depth ON node_paths(depth)');
+
+        $output->writeln('Compacting database...');
+        $db->exec('VACUUM');
+
+        $elapsed = (hrtime(true) - $start) / 1e9;
+        $row_count = $db->query('SELECT COUNT(*) FROM node_paths')->fetchColumn();
+
+        $output->writeln(sprintf(
+            'Done: %s rows materialized in %.1fs',
+            number_format((int)$row_count),
+            $elapsed,
+        ));
+
+        return 0;
+    }
+}

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -23,7 +23,7 @@ final class MemoryDbOptimizeCommand extends Command
     #[\Override]
     public function configure(): void
     {
-        $this->setName('inspector:memory:optimize-db')
+        $this->setName('inspector:optimize-memory-db')
             ->setDescription('[experimental] materialize node_paths in a memory analysis SQLite database')
             ->addArgument(
                 'db-path',

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -48,8 +48,7 @@ final class MemoryDbOptimizeCommand extends Command
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
         // Check if already materialized
-        /** @var int $exists */
-        $exists = $db->query(
+        $exists = (int)$db->query(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='node_paths'"
         )->fetchColumn();
         if ($exists) {
@@ -57,8 +56,7 @@ final class MemoryDbOptimizeCommand extends Command
             $db->exec('DROP TABLE node_paths');
         }
 
-        /** @var int $node_count */
-        $node_count = $db->query('SELECT COUNT(*) FROM context_nodes')->fetchColumn();
+        $node_count = (int)$db->query('SELECT COUNT(*) FROM context_nodes')->fetchColumn();
         $output->writeln("Materializing node_paths for {$node_count} nodes...");
         $output->writeln('<comment>Note: this may significantly increase the database file size</comment>');
 
@@ -91,8 +89,7 @@ final class MemoryDbOptimizeCommand extends Command
         $db->exec('VACUUM');
 
         $elapsed = (float)(hrtime(true) - $start) / 1e9;
-        /** @var int $row_count */
-        $row_count = $db->query('SELECT COUNT(*) FROM node_paths')->fetchColumn();
+        $row_count = (int)$db->query('SELECT COUNT(*) FROM node_paths')->fetchColumn();
 
         $output->writeln(sprintf(
             'Done: %s rows materialized in %.1fs',

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -18,7 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
@@ -105,16 +105,11 @@ final class CoreDumpReader
             ]
         ];
 
-        $context_analyzer = new ContextAnalyzer();
-        $analyzed_context = $context_analyzer->analyze(
-            $collected_memories->top_reference_context,
-        );
-
         $result = new MemoryAnalysisResult(
             $summary,
             $heap_location_type_summary->per_type_usage,
             $object_class_summary->per_class_usage,
-            $analyzed_context,
+            $collected_memories->top_reference_context,
         );
 
         $output_factory = new MemoryOutputFactory();

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -96,11 +96,11 @@ final class CoreDumpReader
             ]
         ];
 
-        $is_sqlite = $memory_profiler_settings->output_format === 'sqlite3';
+        $is_db = in_array($memory_profiler_settings->output_format, ['sqlite3', 'mysql', 'postgresql'], true);
 
         $location_types_summary = null;
         $class_objects_summary = null;
-        if (!$is_sqlite) {
+        if (!$is_db) {
             $location_type_analyzer = new LocationTypeAnalyzer();
             $location_types_summary = $location_type_analyzer->analyze(
                 $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\CoreDumpReader;
 
+use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
+use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
@@ -108,22 +110,19 @@ final class CoreDumpReader
             $collected_memories->top_reference_context,
         );
 
-        $flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
-        if ($memory_profiler_settings->pretty_print) {
-            $flags |= JSON_PRETTY_PRINT;
-        }
-        echo json_encode(
-            [
-                'summary' => $summary,
-                "location_types_summary" => $heap_location_type_summary->per_type_usage,
-                'class_objects_summary' => $object_class_summary->per_class_usage,
-                'context' => $analyzed_context,
-            ],
-            $flags,
-            2147483647
+        $result = new MemoryAnalysisResult(
+            $summary,
+            $heap_location_type_summary->per_type_usage,
+            $object_class_summary->per_class_usage,
+            $analyzed_context,
         );
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException(json_last_error_msg());
-        }
+
+        $output_factory = new MemoryOutputFactory();
+        $memory_output = $output_factory->create(
+            $memory_profiler_settings->output_format,
+            $memory_profiler_settings->pretty_print,
+            $memory_profiler_settings->output_path,
+        );
+        $memory_output->output($result);
     }
 }

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -18,11 +18,11 @@ use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\ReliProfiler;
@@ -75,15 +75,6 @@ final class CoreDumpReader
         $analyzed_regions = $region_analyzer->analyze(
             $collected_memories->memory_locations,
         );
-        $location_type_analyzer = new LocationTypeAnalyzer();
-        $heap_location_type_summary = $location_type_analyzer->analyze(
-            $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-        );
-
-        $object_class_analyzer = new ObjectClassAnalyzer();
-        $object_class_summary = $object_class_analyzer->analyze(
-            $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-        );
 
         $summary = [
             $analyzed_regions->summary->toArray()
@@ -105,11 +96,37 @@ final class CoreDumpReader
             ]
         ];
 
+        $is_sqlite = $memory_profiler_settings->output_format === 'sqlite3';
+
+        $location_types_summary = null;
+        $class_objects_summary = null;
+        if (!$is_sqlite) {
+            $location_type_analyzer = new LocationTypeAnalyzer();
+            $location_types_summary = $location_type_analyzer->analyze(
+                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
+            )->per_type_usage;
+
+            $object_class_analyzer = new ObjectClassAnalyzer();
+            $class_objects_summary = $object_class_analyzer->analyze(
+                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
+            )->per_class_usage;
+        }
+
+        $region_boundaries = new RegionBoundaries(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+        $top_reference_context = $collected_memories->top_reference_context;
+
+        unset($collected_memories, $analyzed_regions, $region_analyzer);
+
         $result = new MemoryAnalysisResult(
             $summary,
-            $heap_location_type_summary->per_type_usage,
-            $object_class_summary->per_class_usage,
-            $collected_memories->top_reference_context,
+            $top_reference_context,
+            $location_types_summary,
+            $class_objects_summary,
         );
 
         $output_factory = new MemoryOutputFactory();
@@ -117,6 +134,7 @@ final class CoreDumpReader
             $memory_profiler_settings->output_format,
             $memory_profiler_settings->pretty_print,
             $memory_profiler_settings->output_path,
+            $region_boundaries,
         );
         $memory_output->output($result);
     }

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -131,9 +131,7 @@ final class CoreDumpReader
 
         $output_factory = new MemoryOutputFactory();
         $memory_output = $output_factory->create(
-            $memory_profiler_settings->output_format,
-            $memory_profiler_settings->pretty_print,
-            $memory_profiler_settings->output_path,
+            $memory_profiler_settings,
             $region_boundaries,
         );
         $memory_output->output($result);

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -37,8 +37,8 @@ final class JsonMemoryOutput implements MemoryOutputInterface
         $json = json_encode(
             [
                 'summary' => $result->summary,
-                'location_types_summary' => $result->location_types_summary,
-                'class_objects_summary' => $result->class_objects_summary,
+                'location_types_summary' => $result->location_types_summary ?? [],
+                'class_objects_summary' => $result->class_objects_summary ?? [],
                 'context' => $sink->getResult(),
             ],
             $flags,

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ArrayContextTreeSink;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+
 final class JsonMemoryOutput implements MemoryOutputInterface
 {
     public function __construct(
@@ -23,6 +26,10 @@ final class JsonMemoryOutput implements MemoryOutputInterface
 
     public function output(MemoryAnalysisResult $result): void
     {
+        $sink = new ArrayContextTreeSink();
+        $analyzer = new ContextAnalyzer();
+        $analyzer->analyze($result->context, $sink);
+
         $flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
         if ($this->pretty_print) {
             $flags |= JSON_PRETTY_PRINT;
@@ -32,7 +39,7 @@ final class JsonMemoryOutput implements MemoryOutputInterface
                 'summary' => $result->summary,
                 'location_types_summary' => $result->location_types_summary,
                 'class_objects_summary' => $result->class_objects_summary,
-                'context' => $result->context,
+                'context' => $sink->getResult(),
             ],
             $flags,
             2147483647

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+final class JsonMemoryOutput implements MemoryOutputInterface
+{
+    public function __construct(
+        private bool $pretty_print = false,
+        private ?string $output_path = null,
+    ) {
+    }
+
+    public function output(MemoryAnalysisResult $result): void
+    {
+        $flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
+        if ($this->pretty_print) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+        $json = json_encode(
+            [
+                'summary' => $result->summary,
+                'location_types_summary' => $result->location_types_summary,
+                'class_objects_summary' => $result->class_objects_summary,
+                'context' => $result->context,
+            ],
+            $flags,
+            2147483647
+        );
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException(json_last_error_msg());
+        }
+
+        if ($this->output_path !== null) {
+            file_put_contents($this->output_path, $json);
+        } else {
+            echo $json;
+        }
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -24,6 +24,7 @@ final class JsonMemoryOutput implements MemoryOutputInterface
     ) {
     }
 
+    #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
         $sink = new ArrayContextTreeSink();
@@ -48,9 +49,9 @@ final class JsonMemoryOutput implements MemoryOutputInterface
             throw new \RuntimeException(json_last_error_msg());
         }
 
-        if ($this->output_path !== null) {
+        if ($this->output_path !== null && $json !== false) {
             file_put_contents($this->output_path, $json);
-        } else {
+        } elseif ($json !== false) {
             echo $json;
         }
     }

--- a/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+final class MemoryAnalysisResult
+{
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
+     * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        public readonly array $summary,
+        public readonly array $location_types_summary,
+        public readonly array $class_objects_summary,
+        public readonly array $context,
+    ) {
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
@@ -13,19 +13,20 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
+
 final class MemoryAnalysisResult
 {
     /**
      * @param array<int, array<string, mixed>> $summary
      * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
      * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
-     * @param array<string, mixed> $context
      */
     public function __construct(
         public readonly array $summary,
         public readonly array $location_types_summary,
         public readonly array $class_objects_summary,
-        public readonly array $context,
+        public readonly ReferenceContext $context,
     ) {
     }
 }

--- a/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
@@ -19,14 +19,14 @@ final class MemoryAnalysisResult
 {
     /**
      * @param array<int, array<string, mixed>> $summary
-     * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
-     * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
+     * @param array<string, array{count: int, memory_usage: int}>|null $location_types_summary
+     * @param array<string, array{count: int, memory_usage: int}>|null $class_objects_summary
      */
     public function __construct(
         public readonly array $summary,
-        public readonly array $location_types_summary,
-        public readonly array $class_objects_summary,
         public readonly ReferenceContext $context,
+        public readonly ?array $location_types_summary = null,
+        public readonly ?array $class_objects_summary = null,
     ) {
     }
 }

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
@@ -13,26 +13,58 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\MySqlDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\PostgreSqlDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 
 final class MemoryOutputFactory
 {
     public function create(
-        string $format,
-        bool $pretty_print,
-        ?string $output_path,
+        MemoryProfilerSettings $settings,
         ?RegionBoundaries $region_boundaries = null,
     ): MemoryOutputInterface {
-        return match ($format) {
-            'json' => new JsonMemoryOutput($pretty_print, $output_path),
-            'sqlite3' => new SqliteMemoryOutput(
-                $output_path ?? throw new \RuntimeException(
-                    '--output is required when using sqlite3 format'
+        return match ($settings->output_format) {
+            'json' => new JsonMemoryOutput($settings->pretty_print, $settings->output_path),
+            'sqlite3' => new PdoMemoryOutput(
+                new SqliteDriver(
+                    $settings->output_path ?? throw new \RuntimeException(
+                        '--output is required when using sqlite3 format'
+                    ),
+                ),
+                $region_boundaries,
+            ),
+            'mysql' => new PdoMemoryOutput(
+                new MySqlDriver(
+                    $settings->db_host,
+                    $settings->db_port ?? 3306,
+                    $settings->db_name ?? throw new \RuntimeException(
+                        '--db-name is required when using mysql format'
+                    ),
+                    $settings->db_user ?? throw new \RuntimeException(
+                        '--db-user is required when using mysql format'
+                    ),
+                    $settings->db_password ?? '',
+                ),
+                $region_boundaries,
+            ),
+            'postgresql' => new PdoMemoryOutput(
+                new PostgreSqlDriver(
+                    $settings->db_host,
+                    $settings->db_port ?? 5432,
+                    $settings->db_name ?? throw new \RuntimeException(
+                        '--db-name is required when using postgresql format'
+                    ),
+                    $settings->db_user ?? throw new \RuntimeException(
+                        '--db-user is required when using postgresql format'
+                    ),
+                    $settings->db_password ?? '',
                 ),
                 $region_boundaries,
             ),
             default => throw new \RuntimeException(
-                "unsupported output format: {$format} (supported: json, sqlite3)"
+                "unsupported output format: {$settings->output_format} (supported: json, sqlite3, mysql, postgresql)"
             ),
         };
     }

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
@@ -13,19 +13,23 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+
 final class MemoryOutputFactory
 {
     public function create(
         string $format,
         bool $pretty_print,
         ?string $output_path,
+        ?RegionBoundaries $region_boundaries = null,
     ): MemoryOutputInterface {
         return match ($format) {
             'json' => new JsonMemoryOutput($pretty_print, $output_path),
             'sqlite3' => new SqliteMemoryOutput(
                 $output_path ?? throw new \RuntimeException(
                     '--output is required when using sqlite3 format'
-                )
+                ),
+                $region_boundaries,
             ),
             default => throw new \RuntimeException(
                 "unsupported output format: {$format} (supported: json, sqlite3)"

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+final class MemoryOutputFactory
+{
+    public function create(
+        string $format,
+        bool $pretty_print,
+        ?string $output_path,
+    ): MemoryOutputInterface {
+        return match ($format) {
+            'json' => new JsonMemoryOutput($pretty_print, $output_path),
+            'sqlite3' => new SqliteMemoryOutput(
+                $output_path ?? throw new \RuntimeException(
+                    '--output is required when using sqlite3 format'
+                )
+            ),
+            default => throw new \RuntimeException(
+                "unsupported output format: {$format} (supported: json, sqlite3)"
+            ),
+        };
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputInterface.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+interface MemoryOutputInterface
+{
+    public function output(MemoryAnalysisResult $result): void;
+}

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
@@ -63,4 +63,19 @@ final class MySqlDriver implements PdoDriverInterface
     {
         return "CREATE OR REPLACE VIEW {$view_name} AS";
     }
+
+    public function quoteIdentifier(string $identifier): string
+    {
+        return '`' . $identifier . '`';
+    }
+
+    public function primaryKeyTextType(): string
+    {
+        return 'VARCHAR(255)';
+    }
+
+    public function castAsInteger(string $expr): string
+    {
+        return "CAST({$expr} AS SIGNED)";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+final class MySqlDriver implements PdoDriverInterface
+{
+    public function __construct(
+        private string $host,
+        private int $port,
+        private string $database,
+        private string $user,
+        private string $password,
+    ) {
+    }
+
+    public function createConnection(): \PDO
+    {
+        $dsn = "mysql:host={$this->host};port={$this->port};dbname={$this->database};charset=utf8mb4";
+        $db = new \PDO($dsn, $this->user, $this->password);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        return $db;
+    }
+
+    public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
+    {
+        return "INSERT IGNORE INTO {$table} ({$columns}) VALUES ({$placeholders})";
+    }
+
+    public function concatExpr(string $a, string $b): string
+    {
+        return "CONCAT({$a}, {$b})";
+    }
+
+    public function autoIncrementPrimaryKey(): string
+    {
+        return 'INTEGER PRIMARY KEY AUTO_INCREMENT';
+    }
+
+    public function tuneForBulkInsert(\PDO $db): void
+    {
+        $db->exec('SET unique_checks=0');
+        $db->exec('SET foreign_key_checks=0');
+    }
+
+    public function afterBulkInsert(\PDO $db): void
+    {
+        $db->exec('SET unique_checks=1');
+        $db->exec('SET foreign_key_checks=1');
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
@@ -24,6 +24,7 @@ final class MySqlDriver implements PdoDriverInterface
     ) {
     }
 
+    #[\Override]
     public function createConnection(): \PDO
     {
         $dsn = "mysql:host={$this->host};port={$this->port};dbname={$this->database};charset=utf8mb4";
@@ -32,48 +33,57 @@ final class MySqlDriver implements PdoDriverInterface
         return $db;
     }
 
+    #[\Override]
     public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
     {
         return "INSERT IGNORE INTO {$table} ({$columns}) VALUES ({$placeholders})";
     }
 
+    #[\Override]
     public function concatExpr(string $a, string $b): string
     {
         return "CONCAT({$a}, {$b})";
     }
 
+    #[\Override]
     public function autoIncrementPrimaryKey(): string
     {
         return 'INTEGER PRIMARY KEY AUTO_INCREMENT';
     }
 
+    #[\Override]
     public function tuneForBulkInsert(\PDO $db): void
     {
         $db->exec('SET unique_checks=0');
         $db->exec('SET foreign_key_checks=0');
     }
 
+    #[\Override]
     public function afterBulkInsert(\PDO $db): void
     {
         $db->exec('SET unique_checks=1');
         $db->exec('SET foreign_key_checks=1');
     }
 
+    #[\Override]
     public function createViewSql(string $view_name): string
     {
         return "CREATE OR REPLACE VIEW {$view_name} AS";
     }
 
+    #[\Override]
     public function quoteIdentifier(string $identifier): string
     {
         return '`' . $identifier . '`';
     }
 
+    #[\Override]
     public function primaryKeyTextType(): string
     {
         return 'VARCHAR(255)';
     }
 
+    #[\Override]
     public function castAsInteger(string $expr): string
     {
         return "CAST({$expr} AS SIGNED)";

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriver.php
@@ -58,4 +58,9 @@ final class MySqlDriver implements PdoDriverInterface
         $db->exec('SET unique_checks=1');
         $db->exec('SET foreign_key_checks=1');
     }
+
+    public function createViewSql(string $view_name): string
+    {
+        return "CREATE OR REPLACE VIEW {$view_name} AS";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
@@ -31,4 +31,7 @@ interface PdoDriverInterface
 
     /** Statements to execute after bulk insert completes */
     public function afterBulkInsert(\PDO $db): void;
+
+    /** SQL prefix for creating a view (handles dialect differences) */
+    public function createViewSql(string $view_name): string;
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
@@ -34,4 +34,13 @@ interface PdoDriverInterface
 
     /** SQL prefix for creating a view (handles dialect differences) */
     public function createViewSql(string $view_name): string;
+
+    /** Quote an identifier (table/column name) for this database */
+    public function quoteIdentifier(string $identifier): string;
+
+    /** Text column type suitable for use as a PRIMARY KEY */
+    public function primaryKeyTextType(): string;
+
+    /** SQL expression to cast a value to integer */
+    public function castAsInteger(string $expr): string;
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PdoDriverInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+interface PdoDriverInterface
+{
+    public function createConnection(): \PDO;
+
+    /** SQL for inserting a node, ignoring duplicates */
+    public function insertIgnoreSql(string $table, string $columns, string $placeholders): string;
+
+    /** SQL expression to concatenate two strings */
+    public function concatExpr(string $a, string $b): string;
+
+    /** Auto-increment column definition for surrogate PKs */
+    public function autoIncrementPrimaryKey(): string;
+
+    /** Statements to execute after creating tables and before bulk insert */
+    public function tuneForBulkInsert(\PDO $db): void;
+
+    /** Statements to execute after bulk insert completes */
+    public function afterBulkInsert(\PDO $db): void;
+}

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
@@ -24,6 +24,7 @@ final class PostgreSqlDriver implements PdoDriverInterface
     ) {
     }
 
+    #[\Override]
     public function createConnection(): \PDO
     {
         $dsn = "pgsql:host={$this->host};port={$this->port};dbname={$this->database}";
@@ -32,46 +33,55 @@ final class PostgreSqlDriver implements PdoDriverInterface
         return $db;
     }
 
+    #[\Override]
     public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
     {
         return "INSERT INTO {$table} ({$columns}) VALUES ({$placeholders}) ON CONFLICT DO NOTHING";
     }
 
+    #[\Override]
     public function concatExpr(string $a, string $b): string
     {
         return "{$a} || {$b}";
     }
 
+    #[\Override]
     public function autoIncrementPrimaryKey(): string
     {
         return 'SERIAL PRIMARY KEY';
     }
 
+    #[\Override]
     public function tuneForBulkInsert(\PDO $db): void
     {
         $db->exec('SET synchronous_commit=off');
     }
 
+    #[\Override]
     public function afterBulkInsert(\PDO $db): void
     {
         $db->exec('SET synchronous_commit=on');
     }
 
+    #[\Override]
     public function createViewSql(string $view_name): string
     {
         return "CREATE OR REPLACE VIEW {$view_name} AS";
     }
 
+    #[\Override]
     public function quoteIdentifier(string $identifier): string
     {
         return '"' . $identifier . '"';
     }
 
+    #[\Override]
     public function primaryKeyTextType(): string
     {
         return 'TEXT';
     }
 
+    #[\Override]
     public function castAsInteger(string $expr): string
     {
         return "CAST({$expr} AS INTEGER)";

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
@@ -56,4 +56,9 @@ final class PostgreSqlDriver implements PdoDriverInterface
     {
         $db->exec('SET synchronous_commit=on');
     }
+
+    public function createViewSql(string $view_name): string
+    {
+        return "CREATE OR REPLACE VIEW {$view_name} AS";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+final class PostgreSqlDriver implements PdoDriverInterface
+{
+    public function __construct(
+        private string $host,
+        private int $port,
+        private string $database,
+        private string $user,
+        private string $password,
+    ) {
+    }
+
+    public function createConnection(): \PDO
+    {
+        $dsn = "pgsql:host={$this->host};port={$this->port};dbname={$this->database}";
+        $db = new \PDO($dsn, $this->user, $this->password);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        return $db;
+    }
+
+    public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
+    {
+        return "INSERT INTO {$table} ({$columns}) VALUES ({$placeholders}) ON CONFLICT DO NOTHING";
+    }
+
+    public function concatExpr(string $a, string $b): string
+    {
+        return "{$a} || {$b}";
+    }
+
+    public function autoIncrementPrimaryKey(): string
+    {
+        return 'SERIAL PRIMARY KEY';
+    }
+
+    public function tuneForBulkInsert(\PDO $db): void
+    {
+        $db->exec('SET synchronous_commit=off');
+    }
+
+    public function afterBulkInsert(\PDO $db): void
+    {
+        $db->exec('SET synchronous_commit=on');
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriver.php
@@ -61,4 +61,19 @@ final class PostgreSqlDriver implements PdoDriverInterface
     {
         return "CREATE OR REPLACE VIEW {$view_name} AS";
     }
+
+    public function quoteIdentifier(string $identifier): string
+    {
+        return '"' . $identifier . '"';
+    }
+
+    public function primaryKeyTextType(): string
+    {
+        return 'TEXT';
+    }
+
+    public function castAsInteger(string $expr): string
+    {
+        return "CAST({$expr} AS INTEGER)";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
@@ -55,4 +55,9 @@ final class SqliteDriver implements PdoDriverInterface
     public function afterBulkInsert(\PDO $db): void
     {
     }
+
+    public function createViewSql(string $view_name): string
+    {
+        return "CREATE VIEW IF NOT EXISTS {$view_name} AS";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
@@ -60,4 +60,19 @@ final class SqliteDriver implements PdoDriverInterface
     {
         return "CREATE VIEW IF NOT EXISTS {$view_name} AS";
     }
+
+    public function quoteIdentifier(string $identifier): string
+    {
+        return '"' . $identifier . '"';
+    }
+
+    public function primaryKeyTextType(): string
+    {
+        return 'TEXT';
+    }
+
+    public function castAsInteger(string $expr): string
+    {
+        return "CAST({$expr} AS INTEGER)";
+    }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+final class SqliteDriver implements PdoDriverInterface
+{
+    public function __construct(
+        private string $path,
+    ) {
+    }
+
+    public function createConnection(): \PDO
+    {
+        $db = new \PDO('sqlite:' . $this->path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        return $db;
+    }
+
+    public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
+    {
+        return "INSERT OR IGNORE INTO {$table} ({$columns}) VALUES ({$placeholders})";
+    }
+
+    public function concatExpr(string $a, string $b): string
+    {
+        return "{$a} || {$b}";
+    }
+
+    public function autoIncrementPrimaryKey(): string
+    {
+        return 'INTEGER PRIMARY KEY';
+    }
+
+    public function tuneForBulkInsert(\PDO $db): void
+    {
+        $db->exec('PRAGMA journal_mode=OFF');
+        $db->exec('PRAGMA synchronous=OFF');
+        $db->exec('PRAGMA cache_size=-65536');
+        $db->exec('PRAGMA temp_store=MEMORY');
+        $db->exec('PRAGMA locking_mode=EXCLUSIVE');
+        $db->exec('PRAGMA mmap_size=268435456');
+    }
+
+    public function afterBulkInsert(\PDO $db): void
+    {
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
+++ b/src/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriver.php
@@ -20,6 +20,7 @@ final class SqliteDriver implements PdoDriverInterface
     ) {
     }
 
+    #[\Override]
     public function createConnection(): \PDO
     {
         $db = new \PDO('sqlite:' . $this->path);
@@ -27,21 +28,25 @@ final class SqliteDriver implements PdoDriverInterface
         return $db;
     }
 
+    #[\Override]
     public function insertIgnoreSql(string $table, string $columns, string $placeholders): string
     {
         return "INSERT OR IGNORE INTO {$table} ({$columns}) VALUES ({$placeholders})";
     }
 
+    #[\Override]
     public function concatExpr(string $a, string $b): string
     {
         return "{$a} || {$b}";
     }
 
+    #[\Override]
     public function autoIncrementPrimaryKey(): string
     {
         return 'INTEGER PRIMARY KEY';
     }
 
+    #[\Override]
     public function tuneForBulkInsert(\PDO $db): void
     {
         $db->exec('PRAGMA journal_mode=OFF');
@@ -52,25 +57,30 @@ final class SqliteDriver implements PdoDriverInterface
         $db->exec('PRAGMA mmap_size=268435456');
     }
 
+    #[\Override]
     public function afterBulkInsert(\PDO $db): void
     {
     }
 
+    #[\Override]
     public function createViewSql(string $view_name): string
     {
         return "CREATE VIEW IF NOT EXISTS {$view_name} AS";
     }
 
+    #[\Override]
     public function quoteIdentifier(string $identifier): string
     {
         return '"' . $identifier . '"';
     }
 
+    #[\Override]
     public function primaryKeyTextType(): string
     {
         return 'TEXT';
     }
 
+    #[\Override]
     public function castAsInteger(string $expr): string
     {
         return "CAST({$expr} AS INTEGER)";

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -13,28 +13,23 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 
-final class SqliteMemoryOutput implements MemoryOutputInterface
+final class PdoMemoryOutput implements MemoryOutputInterface
 {
     public function __construct(
-        private string $output_path,
+        private PdoDriverInterface $driver,
         private ?RegionBoundaries $region_boundaries = null,
     ) {
     }
 
     public function output(MemoryAnalysisResult $result): void
     {
-        $db = new \PDO('sqlite:' . $this->output_path);
-        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $db->exec('PRAGMA journal_mode=OFF');
-        $db->exec('PRAGMA synchronous=OFF');
-        $db->exec('PRAGMA cache_size=-65536'); // 64MB cache
-        $db->exec('PRAGMA temp_store=MEMORY');
-        $db->exec('PRAGMA locking_mode=EXCLUSIVE');
-        $db->exec('PRAGMA mmap_size=268435456'); // 256MB mmap
+        $db = $this->driver->createConnection();
+        $this->driver->tuneForBulkInsert($db);
 
         $this->createTables($db);
 
@@ -42,14 +37,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         try {
             $this->insertSummary($db, $result->summary);
 
-            // Emit context tree first — this writes all locations to DB
-            // and allows the ReferenceContext tree to be GC'd incrementally
-            $sink = new PdoContextTreeSink($db, $this->region_boundaries);
+            $sink = new PdoContextTreeSink($db, $this->driver, $this->region_boundaries);
             $analyzer = new ContextAnalyzer();
             $analyzer->analyze($result->context, $sink);
             $sink->flush();
 
-            // Compute type/class summaries from DB via GROUP BY
             $this->insertLocationTypesSummaryFromDb($db);
             $this->insertClassObjectsSummaryFromDb($db);
 
@@ -59,13 +51,15 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             throw $e;
         }
 
-        // Create indexes and views after bulk insert
+        $this->driver->afterBulkInsert($db);
         $this->createIndexes($db);
         $this->createViews($db);
     }
 
     private function createTables(\PDO $db): void
     {
+        $autoId = $this->driver->autoIncrementPrimaryKey();
+
         $db->exec('
             CREATE TABLE IF NOT EXISTS summary (
                 key TEXT NOT NULL,
@@ -109,51 +103,46 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             )
         ');
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS context_node_locations (
-                id INTEGER PRIMARY KEY,
+                id {$autoId},
                 node_id INTEGER NOT NULL,
-                address INTEGER,
+                address BIGINT,
                 size INTEGER,
                 location_type TEXT NOT NULL,
                 class_name TEXT,
                 string_value TEXT,
                 refcount INTEGER,
                 type_info INTEGER,
-                region TEXT,
-                FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
+                region TEXT
             )
-        ');
+        ");
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS context_node_attributes (
-                id INTEGER PRIMARY KEY,
+                id {$autoId},
                 node_id INTEGER NOT NULL,
                 key TEXT NOT NULL,
-                value TEXT,
-                FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
+                value TEXT
             )
-        ');
+        ");
     }
 
     private function createIndexes(\PDO $db): void
     {
-        // Essential for v_node_paths recursive CTE (follow tree edges from parent)
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_parent_tree ON context_edges(parent_node_id, is_tree)');
-        // Essential for "find all references to node X"
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_child ON context_edges(child_node_id)');
-        // Essential for JOIN context_node_locations ON node_id
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
-        // Frequently used in user queries
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
     }
 
     private function createViews(\PDO $db): void
     {
-        // Canonical path view via recursive CTE following tree edges only.
-        // Each node has exactly one path. For materialized version, use
-        // inspector:memory:optimize-db.
+        $concat = fn (string $a, string $b) => $this->driver->concatExpr($a, $b);
+
+        $pathExpr = $concat('np.path', $concat("' -> '", 'e.link_name'));
+
         $db->exec("
             CREATE VIEW IF NOT EXISTS v_node_paths AS
             WITH RECURSIVE node_paths(node_id, path, depth) AS (
@@ -161,7 +150,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 FROM context_edges
                 WHERE parent_node_id IS NULL AND is_tree = 1
               UNION ALL
-                SELECT e.child_node_id, np.path || ' -> ' || e.link_name, np.depth + 1
+                SELECT e.child_node_id, {$pathExpr}, np.depth + 1
                 FROM context_edges e
                 JOIN node_paths np ON e.parent_node_id = np.node_id
                 WHERE e.is_tree = 1

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -198,11 +198,12 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $stmt = $db->prepare("INSERT INTO summary ({$qi('key')}, {$qi('value')}) VALUES (:key, :value)");
         foreach ($summary as $entry) {
-            /** @var mixed $value */
             foreach ($entry as $key => $value) {
+                $string_value = is_scalar($value) ? (string)$value : json_encode($value);
+                assert(is_string($string_value));
                 $stmt->execute([
                     ':key' => $key,
-                    ':value' => is_scalar($value) ? (string)$value : json_encode($value),
+                    ':value' => $string_value,
                 ]);
             }
         }

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -26,6 +26,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     ) {
     }
 
+    #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
         $db = $this->driver->createConnection();
@@ -59,7 +60,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     private function createTables(\PDO $db): void
     {
         $autoId = $this->driver->autoIncrementPrimaryKey();
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $pkText = $this->driver->primaryKeyTextType();
 
         $db->exec("
@@ -141,9 +142,9 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function createViews(\PDO $db): void
     {
-        $concat = fn (string $a, string $b) => $this->driver->concatExpr($a, $b);
-        $createView = fn (string $name) => $this->driver->createViewSql($name);
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $concat = fn (string $a, string $b): string => $this->driver->concatExpr($a, $b);
+        $createView = fn (string $name): string => $this->driver->createViewSql($name);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
 
         $pathExpr = $concat('np.path', $concat("' -> '", 'e.link_name'));
 
@@ -194,9 +195,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      */
     private function insertSummary(\PDO $db, array $summary): void
     {
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $stmt = $db->prepare("INSERT INTO summary ({$qi('key')}, {$qi('value')}) VALUES (:key, :value)");
         foreach ($summary as $entry) {
+            /** @var mixed $value */
             foreach ($entry as $key => $value) {
                 $stmt->execute([
                     ':key' => $key,
@@ -208,7 +210,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertLocationTypesSummaryFromDb(\PDO $db): void
     {
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $db->exec("
             INSERT INTO location_types_summary ({$qi('type')}, {$qi('count')}, memory_usage)
             SELECT location_type, COUNT(*), SUM(size)
@@ -222,7 +224,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertClassObjectsSummaryFromDb(\PDO $db): void
     {
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $db->exec("
             INSERT INTO class_objects_summary (class_name, {$qi('count')}, memory_usage)
             SELECT class_name, COUNT(*), SUM(size)

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -198,6 +198,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         $stmt = $db->prepare("INSERT INTO summary ({$qi('key')}, {$qi('value')}) VALUES (:key, :value)");
         foreach ($summary as $entry) {
+            /** @psalm-suppress MixedAssignment -- $entry is array<string, mixed> */
             foreach ($entry as $key => $value) {
                 $string_value = is_scalar($value) ? (string)$value : json_encode($value);
                 assert(is_string($string_value));

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -36,15 +36,16 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
         $db->beginTransaction();
         try {
-            $this->insertSummary($db, $result->summary);
+            $run_id = $this->insertRun($db);
+            $this->insertSummary($db, $run_id, $result->summary);
 
-            $sink = new PdoContextTreeSink($db, $this->driver, $this->region_boundaries);
+            $sink = new PdoContextTreeSink($db, $this->driver, $run_id, $this->region_boundaries);
             $analyzer = new ContextAnalyzer();
             $analyzer->analyze($result->context, $sink);
             $sink->flush();
 
-            $this->insertLocationTypesSummaryFromDb($db);
-            $this->insertClassObjectsSummaryFromDb($db);
+            $this->insertLocationTypesSummaryFromDb($db, $run_id);
+            $this->insertClassObjectsSummaryFromDb($db, $run_id);
 
             $db->commit();
         } catch (\Throwable $e) {
@@ -64,41 +65,53 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $pkText = $this->driver->primaryKeyTextType();
 
         $db->exec("
+            CREATE TABLE IF NOT EXISTS runs (
+                run_id {$autoId},
+                created_at TEXT NOT NULL
+            )
+        ");
+
+        $db->exec("
             CREATE TABLE IF NOT EXISTS summary (
+                run_id INTEGER NOT NULL,
                 {$qi('key')} {$pkText} NOT NULL,
                 {$qi('value')} TEXT,
-                PRIMARY KEY ({$qi('key')})
+                PRIMARY KEY (run_id, {$qi('key')})
             )
         ");
 
         $db->exec("
             CREATE TABLE IF NOT EXISTS location_types_summary (
+                run_id INTEGER NOT NULL,
                 {$qi('type')} {$pkText} NOT NULL,
                 {$qi('count')} INTEGER NOT NULL,
                 memory_usage INTEGER NOT NULL,
-                PRIMARY KEY ({$qi('type')})
+                PRIMARY KEY (run_id, {$qi('type')})
             )
         ");
 
         $db->exec("
             CREATE TABLE IF NOT EXISTS class_objects_summary (
+                run_id INTEGER NOT NULL,
                 class_name {$pkText} NOT NULL,
                 {$qi('count')} INTEGER NOT NULL,
                 memory_usage INTEGER NOT NULL,
-                PRIMARY KEY (class_name)
+                PRIMARY KEY (run_id, class_name)
             )
         ");
 
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
                 node_id INTEGER NOT NULL,
                 type TEXT NOT NULL,
-                PRIMARY KEY (node_id)
+                PRIMARY KEY (run_id, node_id)
             )
         ');
 
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_edges (
+                run_id INTEGER NOT NULL,
                 parent_node_id INTEGER,
                 child_node_id INTEGER NOT NULL,
                 link_name TEXT NOT NULL,
@@ -109,6 +122,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $db->exec("
             CREATE TABLE IF NOT EXISTS context_node_locations (
                 id {$autoId},
+                run_id INTEGER NOT NULL,
                 node_id INTEGER NOT NULL,
                 address BIGINT,
                 size BIGINT,
@@ -124,6 +138,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $db->exec("
             CREATE TABLE IF NOT EXISTS context_node_attributes (
                 id {$autoId},
+                run_id INTEGER NOT NULL,
                 node_id INTEGER NOT NULL,
                 {$qi('key')} TEXT NOT NULL,
                 {$qi('value')} TEXT
@@ -133,11 +148,26 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function createIndexes(\PDO $db): void
     {
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_parent_tree ON context_edges(parent_node_id, is_tree)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_child ON context_edges(child_node_id)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_edges_run_parent_tree'
+            . ' ON context_edges(run_id, parent_node_id, is_tree)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_edges_run_child'
+            . ' ON context_edges(run_id, child_node_id)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_node_locations_run_node'
+            . ' ON context_node_locations(run_id, node_id)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_node_locations_run_class'
+            . ' ON context_node_locations(run_id, class_name)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_node_attributes_run_node'
+            . ' ON context_node_attributes(run_id, node_id)'
+        );
     }
 
     private function createViews(\PDO $db): void
@@ -150,22 +180,23 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
         $db->exec("
             {$createView('v_node_paths')}
-            WITH RECURSIVE node_paths(node_id, path, depth) AS (
-                SELECT child_node_id, link_name, 0
+            WITH RECURSIVE node_paths(run_id, node_id, path, depth) AS (
+                SELECT run_id, child_node_id, link_name, 0
                 FROM context_edges
                 WHERE parent_node_id IS NULL AND is_tree = 1
               UNION ALL
-                SELECT e.child_node_id, {$pathExpr}, np.depth + 1
+                SELECT np.run_id, e.child_node_id, {$pathExpr}, np.depth + 1
                 FROM context_edges e
-                JOIN node_paths np ON e.parent_node_id = np.node_id
+                JOIN node_paths np ON e.parent_node_id = np.node_id AND e.run_id = np.run_id
                 WHERE e.is_tree = 1
             )
-            SELECT node_id, path, depth FROM node_paths
+            SELECT run_id, node_id, path, depth FROM node_paths
         ");
 
         $db->exec("
             {$createView('v_arrays')}
             SELECT
+                header_cn.run_id,
                 header_cn.node_id,
                 header_loc.address,
                 header_loc.size AS header_size,
@@ -175,34 +206,47 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 header_loc.refcount
             FROM context_nodes header_cn
             JOIN context_node_locations header_loc
-                ON header_loc.node_id = header_cn.node_id
+                ON header_loc.run_id = header_cn.run_id
+                AND header_loc.node_id = header_cn.node_id
                 AND header_loc.location_type = 'ZendArrayMemoryLocation'
             LEFT JOIN context_edges elements_edge
-                ON elements_edge.parent_node_id = header_cn.node_id
+                ON elements_edge.run_id = header_cn.run_id
+                AND elements_edge.parent_node_id = header_cn.node_id
                 AND elements_edge.link_name = 'array_elements'
                 AND elements_edge.is_tree = 1
             LEFT JOIN context_node_locations table_loc
-                ON table_loc.node_id = elements_edge.child_node_id
+                ON table_loc.run_id = elements_edge.run_id
+                AND table_loc.node_id = elements_edge.child_node_id
                 AND table_loc.location_type = 'ZendArrayTableMemoryLocation'
             LEFT JOIN context_node_attributes cnt
-                ON cnt.node_id = elements_edge.child_node_id
+                ON cnt.run_id = elements_edge.run_id
+                AND cnt.node_id = elements_edge.child_node_id
                 AND cnt.{$qi('key')} = '#count'
         ");
+    }
+
+    private function insertRun(\PDO $db): int
+    {
+        $db->exec("INSERT INTO runs (created_at) VALUES ('" . gmdate('Y-m-d\TH:i:s\Z') . "')");
+        return (int)$db->lastInsertId();
     }
 
     /**
      * @param array<int, array<string, mixed>> $summary
      */
-    private function insertSummary(\PDO $db, array $summary): void
+    private function insertSummary(\PDO $db, int $run_id, array $summary): void
     {
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
-        $stmt = $db->prepare("INSERT INTO summary ({$qi('key')}, {$qi('value')}) VALUES (:key, :value)");
+        $stmt = $db->prepare(
+            "INSERT INTO summary (run_id, {$qi('key')}, {$qi('value')}) VALUES (:run_id, :key, :value)"
+        );
         foreach ($summary as $entry) {
             /** @psalm-suppress MixedAssignment -- $entry is array<string, mixed> */
             foreach ($entry as $key => $value) {
                 $string_value = is_scalar($value) ? (string)$value : json_encode($value);
                 assert(is_string($string_value));
                 $stmt->execute([
+                    ':run_id' => $run_id,
                     ':key' => $key,
                     ':value' => $string_value,
                 ]);
@@ -210,32 +254,36 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         }
     }
 
-    private function insertLocationTypesSummaryFromDb(\PDO $db): void
+    private function insertLocationTypesSummaryFromDb(\PDO $db, int $run_id): void
     {
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
-        $db->exec("
-            INSERT INTO location_types_summary ({$qi('type')}, {$qi('count')}, memory_usage)
-            SELECT location_type, COUNT(*), SUM(size)
+        $stmt = $db->prepare("
+            INSERT INTO location_types_summary (run_id, {$qi('type')}, {$qi('count')}, memory_usage)
+            SELECT ?, location_type, COUNT(*), SUM(size)
             FROM context_node_locations
-            WHERE region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
-               OR region IS NULL
+            WHERE run_id = ?
+              AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
+                   OR region IS NULL)
             GROUP BY location_type
             ORDER BY SUM(size) DESC
         ");
+        $stmt->execute([$run_id, $run_id]);
     }
 
-    private function insertClassObjectsSummaryFromDb(\PDO $db): void
+    private function insertClassObjectsSummaryFromDb(\PDO $db, int $run_id): void
     {
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
-        $db->exec("
-            INSERT INTO class_objects_summary (class_name, {$qi('count')}, memory_usage)
-            SELECT class_name, COUNT(*), SUM(size)
+        $stmt = $db->prepare("
+            INSERT INTO class_objects_summary (run_id, class_name, {$qi('count')}, memory_usage)
+            SELECT ?, class_name, COUNT(*), SUM(size)
             FROM context_node_locations
-            WHERE class_name IS NOT NULL
+            WHERE run_id = ?
+              AND class_name IS NOT NULL
               AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
                    OR region IS NULL)
             GROUP BY class_name
             ORDER BY SUM(size) DESC
         ");
+        $stmt->execute([$run_id, $run_id]);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -59,32 +59,34 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     private function createTables(\PDO $db): void
     {
         $autoId = $this->driver->autoIncrementPrimaryKey();
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $pkText = $this->driver->primaryKeyTextType();
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS summary (
-                key TEXT NOT NULL,
-                value TEXT,
-                PRIMARY KEY (key)
+                {$qi('key')} {$pkText} NOT NULL,
+                {$qi('value')} TEXT,
+                PRIMARY KEY ({$qi('key')})
             )
-        ');
+        ");
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS location_types_summary (
-                type TEXT NOT NULL,
-                count INTEGER NOT NULL,
+                {$qi('type')} {$pkText} NOT NULL,
+                {$qi('count')} INTEGER NOT NULL,
                 memory_usage INTEGER NOT NULL,
-                PRIMARY KEY (type)
+                PRIMARY KEY ({$qi('type')})
             )
-        ');
+        ");
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS class_objects_summary (
-                class_name TEXT NOT NULL,
-                count INTEGER NOT NULL,
+                class_name {$pkText} NOT NULL,
+                {$qi('count')} INTEGER NOT NULL,
                 memory_usage INTEGER NOT NULL,
                 PRIMARY KEY (class_name)
             )
-        ');
+        ");
 
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_nodes (
@@ -122,8 +124,8 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             CREATE TABLE IF NOT EXISTS context_node_attributes (
                 id {$autoId},
                 node_id INTEGER NOT NULL,
-                key TEXT NOT NULL,
-                value TEXT
+                {$qi('key')} TEXT NOT NULL,
+                {$qi('value')} TEXT
             )
         ");
     }
@@ -141,6 +143,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     {
         $concat = fn (string $a, string $b) => $this->driver->concatExpr($a, $b);
         $createView = fn (string $name) => $this->driver->createViewSql($name);
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
 
         $pathExpr = $concat('np.path', $concat("' -> '", 'e.link_name'));
 
@@ -167,7 +170,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 header_loc.size AS header_size,
                 COALESCE(table_loc.size, 0) AS table_size,
                 header_loc.size + COALESCE(table_loc.size, 0) AS total_size,
-                CAST(cnt.value AS INTEGER) AS element_count,
+                {$this->driver->castAsInteger("cnt.{$qi('value')}")} AS element_count,
                 header_loc.refcount
             FROM context_nodes header_cn
             JOIN context_node_locations header_loc
@@ -182,7 +185,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 AND table_loc.location_type = 'ZendArrayTableMemoryLocation'
             LEFT JOIN context_node_attributes cnt
                 ON cnt.node_id = elements_edge.child_node_id
-                AND cnt.key = '#count'
+                AND cnt.{$qi('key')} = '#count'
         ");
     }
 
@@ -191,7 +194,8 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      */
     private function insertSummary(\PDO $db, array $summary): void
     {
-        $stmt = $db->prepare('INSERT INTO summary (key, value) VALUES (:key, :value)');
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $stmt = $db->prepare("INSERT INTO summary ({$qi('key')}, {$qi('value')}) VALUES (:key, :value)");
         foreach ($summary as $entry) {
             foreach ($entry as $key => $value) {
                 $stmt->execute([
@@ -204,8 +208,9 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertLocationTypesSummaryFromDb(\PDO $db): void
     {
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
         $db->exec("
-            INSERT INTO location_types_summary (type, count, memory_usage)
+            INSERT INTO location_types_summary ({$qi('type')}, {$qi('count')}, memory_usage)
             SELECT location_type, COUNT(*), SUM(size)
             FROM context_node_locations
             WHERE region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
@@ -217,8 +222,9 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertClassObjectsSummaryFromDb(\PDO $db): void
     {
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
         $db->exec("
-            INSERT INTO class_objects_summary (class_name, count, memory_usage)
+            INSERT INTO class_objects_summary (class_name, {$qi('count')}, memory_usage)
             SELECT class_name, COUNT(*), SUM(size)
             FROM context_node_locations
             WHERE class_name IS NOT NULL

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -108,12 +108,12 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 id {$autoId},
                 node_id INTEGER NOT NULL,
                 address BIGINT,
-                size INTEGER,
+                size BIGINT,
                 location_type TEXT NOT NULL,
                 class_name TEXT,
                 string_value TEXT,
-                refcount INTEGER,
-                type_info INTEGER,
+                refcount BIGINT,
+                type_info BIGINT,
                 region TEXT
             )
         ");
@@ -140,11 +140,12 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     private function createViews(\PDO $db): void
     {
         $concat = fn (string $a, string $b) => $this->driver->concatExpr($a, $b);
+        $createView = fn (string $name) => $this->driver->createViewSql($name);
 
         $pathExpr = $concat('np.path', $concat("' -> '", 'e.link_name'));
 
         $db->exec("
-            CREATE VIEW IF NOT EXISTS v_node_paths AS
+            {$createView('v_node_paths')}
             WITH RECURSIVE node_paths(node_id, path, depth) AS (
                 SELECT child_node_id, link_name, 0
                 FROM context_edges
@@ -159,7 +160,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         ");
 
         $db->exec("
-            CREATE VIEW IF NOT EXISTS v_arrays AS
+            {$createView('v_arrays')}
             SELECT
                 header_cn.node_id,
                 header_loc.address,

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -30,7 +30,10 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db = new \PDO('sqlite:' . $this->output_path);
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $db->exec('PRAGMA journal_mode=WAL');
-        $db->exec('PRAGMA synchronous=NORMAL');
+        $db->exec('PRAGMA synchronous=OFF');
+        $db->exec('PRAGMA cache_size=-65536'); // 64MB cache
+        $db->exec('PRAGMA temp_store=MEMORY');
+        $db->exec('PRAGMA mmap_size=268435456'); // 256MB mmap
 
         $this->createTables($db);
 
@@ -53,6 +56,10 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             $db->rollBack();
             throw $e;
         }
+
+        // Create indexes after bulk insert for much better performance
+        $this->createIndexes($db);
+        $this->createViews($db);
     }
 
     private function createTables(\PDO $db): void
@@ -96,7 +103,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_node_locations (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                id INTEGER PRIMARY KEY,
                 node_id INTEGER NOT NULL,
                 address INTEGER,
                 size INTEGER,
@@ -112,14 +119,17 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_node_attributes (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                id INTEGER PRIMARY KEY,
                 node_id INTEGER NOT NULL,
                 key TEXT NOT NULL,
                 value TEXT,
                 FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
             )
         ');
+    }
 
+    private function createIndexes(\PDO $db): void
+    {
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_type ON context_nodes(type)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
@@ -130,8 +140,6 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
-
-        $this->createViews($db);
     }
 
     private function createViews(\PDO $db): void

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -15,11 +15,13 @@ namespace Reli\Inspector\Output\MemoryOutput;
 
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 
 final class SqliteMemoryOutput implements MemoryOutputInterface
 {
     public function __construct(
         private string $output_path,
+        private ?RegionBoundaries $region_boundaries = null,
     ) {
     }
 
@@ -35,12 +37,16 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->beginTransaction();
         try {
             $this->insertSummary($db, $result->summary);
-            $this->insertLocationTypesSummary($db, $result->location_types_summary);
-            $this->insertClassObjectsSummary($db, $result->class_objects_summary);
 
-            $sink = new PdoContextTreeSink($db);
+            // Emit context tree first — this writes all locations to DB
+            // and allows the ReferenceContext tree to be GC'd incrementally
+            $sink = new PdoContextTreeSink($db, $this->region_boundaries);
             $analyzer = new ContextAnalyzer();
             $analyzer->analyze($result->context, $sink);
+
+            // Compute type/class summaries from DB via GROUP BY
+            $this->insertLocationTypesSummaryFromDb($db);
+            $this->insertClassObjectsSummaryFromDb($db);
 
             $db->commit();
         } catch (\Throwable $e) {
@@ -99,6 +105,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 string_value TEXT,
                 refcount INTEGER,
                 type_info INTEGER,
+                region TEXT,
                 FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
             )
         ');
@@ -119,6 +126,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_type ON context_node_locations(location_type)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_size ON context_node_locations(size DESC)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_region ON context_node_locations(region)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
@@ -184,37 +192,30 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         }
     }
 
-    /**
-     * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
-     */
-    private function insertLocationTypesSummary(\PDO $db, array $location_types_summary): void
+    private function insertLocationTypesSummaryFromDb(\PDO $db): void
     {
-        $stmt = $db->prepare(
-            'INSERT INTO location_types_summary (type, count, memory_usage) VALUES (:type, :count, :memory_usage)'
-        );
-        foreach ($location_types_summary as $type => $usage) {
-            $stmt->execute([
-                ':type' => $type,
-                ':count' => $usage['count'],
-                ':memory_usage' => $usage['memory_usage'],
-            ]);
-        }
+        $db->exec("
+            INSERT INTO location_types_summary (type, count, memory_usage)
+            SELECT location_type, COUNT(*), SUM(size)
+            FROM context_node_locations
+            WHERE region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
+               OR region IS NULL
+            GROUP BY location_type
+            ORDER BY SUM(size) DESC
+        ");
     }
 
-    /**
-     * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
-     */
-    private function insertClassObjectsSummary(\PDO $db, array $class_objects_summary): void
+    private function insertClassObjectsSummaryFromDb(\PDO $db): void
     {
-        $stmt = $db->prepare(
-            'INSERT INTO class_objects_summary (class_name, count, memory_usage) VALUES (:class_name, :count, :memory_usage)'
-        );
-        foreach ($class_objects_summary as $class_name => $usage) {
-            $stmt->execute([
-                ':class_name' => $class_name,
-                ':count' => $usage['count'],
-                ':memory_usage' => $usage['memory_usage'],
-            ]);
-        }
+        $db->exec("
+            INSERT INTO class_objects_summary (class_name, count, memory_usage)
+            SELECT class_name, COUNT(*), SUM(size)
+            FROM context_node_locations
+            WHERE class_name IS NOT NULL
+              AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
+                   OR region IS NULL)
+            GROUP BY class_name
+            ORDER BY SUM(size) DESC
+        ");
     }
 }

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -59,8 +59,9 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             throw $e;
         }
 
-        // Create indexes after bulk insert for much better performance
+        // Create indexes and materialized tables after bulk insert
         $this->createIndexes($db);
+        $this->materializeNodePaths($db);
         $this->createViews($db);
     }
 
@@ -141,8 +142,40 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
     }
 
+    private function materializeNodePaths(\PDO $db): void
+    {
+        // Materialize shallow paths (depth <= 4) as a table.
+        // Deeper paths can still be computed via recursive CTE when needed,
+        // but most useful queries (root-level memory breakdown, top-level
+        // structure analysis) only need shallow paths.
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS node_paths (
+                node_id INTEGER NOT NULL PRIMARY KEY,
+                path TEXT NOT NULL,
+                depth INTEGER NOT NULL
+            )
+        ');
+        $db->exec("
+            INSERT INTO node_paths (node_id, path, depth)
+            WITH RECURSIVE cte(node_id, path, depth) AS (
+                SELECT node_id, link_name, 0
+                FROM context_nodes
+                WHERE parent_node_id IS NULL
+              UNION ALL
+                SELECT cn.node_id, cte.path || ' -> ' || cn.link_name, cte.depth + 1
+                FROM context_nodes cn
+                JOIN cte ON cn.parent_node_id = cte.node_id
+                WHERE cte.depth < 4
+            )
+            SELECT node_id, path, depth FROM cte
+        ");
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_node_paths_depth ON node_paths(depth)');
+    }
+
     private function createViews(\PDO $db): void
     {
+        // Full-depth path view via recursive CTE (slower but complete).
+        // For depth <= 4, prefer the materialized node_paths table.
         $db->exec("
             CREATE VIEW IF NOT EXISTS v_node_paths AS
             WITH RECURSIVE node_paths(node_id, path, depth) AS (

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
-use Reli\Lib\Process\MemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
 
 final class SqliteMemoryOutput implements MemoryOutputInterface
 {
@@ -39,7 +37,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             $this->insertSummary($db, $result->summary);
             $this->insertLocationTypesSummary($db, $result->location_types_summary);
             $this->insertClassObjectsSummary($db, $result->class_objects_summary);
-            $this->insertContext($db, $result->context);
+
+            $sink = new PdoContextTreeSink($db);
+            $analyzer = new ContextAnalyzer();
+            $analyzer->analyze($result->context, $sink);
+
             $db->commit();
         } catch (\Throwable $e) {
             $db->rollBack();
@@ -213,138 +215,6 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 ':count' => $usage['count'],
                 ':memory_usage' => $usage['memory_usage'],
             ]);
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $context
-     */
-    private function insertContext(\PDO $db, array $context): void
-    {
-        $node_stmt = $db->prepare(
-            'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
-            . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
-        );
-        $location_stmt = $db->prepare(
-            'INSERT INTO context_node_locations'
-            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info)'
-            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info)'
-        );
-        $attr_stmt = $db->prepare(
-            'INSERT INTO context_node_attributes (node_id, key, value)'
-            . ' VALUES (:node_id, :key, :value)'
-        );
-
-        $this->insertContextNodes($node_stmt, $location_stmt, $attr_stmt, $context, null);
-    }
-
-    private function insertContextNodes(
-        \PDOStatement $node_stmt,
-        \PDOStatement $location_stmt,
-        \PDOStatement $attr_stmt,
-        array $data,
-        ?int $parent_node_id,
-    ): void {
-        foreach ($data as $link_name => $node) {
-            if (!is_array($node)) {
-                continue;
-            }
-
-            if (isset($node['#reference_node_id'])) {
-                // This is a reference to another node
-                $ref_node_id = $node['#reference_node_id'];
-                $node_stmt->execute([
-                    ':node_id' => $ref_node_id,
-                    ':parent_node_id' => $parent_node_id,
-                    ':link_name' => (string)$link_name,
-                    ':type' => null,
-                    ':reference_node_id' => $ref_node_id,
-                ]);
-                continue;
-            }
-
-            if (!isset($node['#node_id'])) {
-                continue;
-            }
-
-            $node_id = $node['#node_id'];
-
-            $node_stmt->execute([
-                ':node_id' => $node_id,
-                ':parent_node_id' => $parent_node_id,
-                ':link_name' => (string)$link_name,
-                ':type' => $node['#type'] ?? null,
-                ':reference_node_id' => null,
-            ]);
-
-            // Insert locations
-            if (isset($node['#locations']) && is_iterable($node['#locations'])) {
-                foreach ($node['#locations'] as $location) {
-                    if ($location instanceof MemoryLocation) {
-                        $short_class = (new \ReflectionClass($location))->getShortName();
-
-                        $location_stmt->execute([
-                            ':node_id' => $node_id,
-                            ':address' => $location->address,
-                            ':size' => $location->size,
-                            ':location_type' => $short_class,
-                            ':class_name' => $location instanceof ZendObjectMemoryLocation
-                                ? $location->class_name : null,
-                            ':string_value' => $location instanceof ZendStringMemoryLocation
-                                ? $location->value : null,
-                            ':refcount' => $location instanceof RefcountedMemoryLocation
-                                ? $location->refcount : null,
-                            ':type_info' => $location instanceof RefcountedMemoryLocation
-                                ? $location->type_info : null,
-                        ]);
-                    }
-                }
-            }
-
-            // Insert child contexts and attributes
-            $standard_keys = ['#node_id', '#type', '#locations', '#reference_node_id'];
-            $children = [];
-            foreach ($node as $key => $value) {
-                if (is_string($key) && str_starts_with($key, '#')) {
-                    // Store non-standard #-prefixed scalar values as attributes (e.g. #count)
-                    if (!in_array($key, $standard_keys, true) && !is_array($value) && !($value instanceof MemoryLocation)) {
-                        $attr_stmt->execute([
-                            ':node_id' => $node_id,
-                            ':key' => $key,
-                            ':value' => is_scalar($value) ? (string)$value : json_encode($value),
-                        ]);
-                    }
-                    continue;
-                }
-
-                if (is_array($value)) {
-                    if (isset($value['#node_id']) || isset($value['#reference_node_id'])) {
-                        $children[$key] = $value;
-                    } else {
-                        // Could be nested children or a non-node attribute
-                        $has_node_children = false;
-                        foreach ($value as $sub_value) {
-                            if (is_array($sub_value) && (isset($sub_value['#node_id']) || isset($sub_value['#reference_node_id']))) {
-                                $has_node_children = true;
-                                break;
-                            }
-                        }
-                        if ($has_node_children) {
-                            $children[$key] = $value;
-                        } else {
-                            $attr_stmt->execute([
-                                ':node_id' => $node_id,
-                                ':key' => (string)$key,
-                                ':value' => json_encode($value),
-                            ]);
-                        }
-                    }
-                }
-            }
-
-            if ($children !== []) {
-                $this->insertContextNodes($node_stmt, $location_stmt, $attr_stmt, $children, $node_id);
-            }
         }
     }
 }

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+use SQLite3;
+
+final class SqliteMemoryOutput implements MemoryOutputInterface
+{
+    public function __construct(
+        private string $output_path,
+    ) {
+    }
+
+    public function output(MemoryAnalysisResult $result): void
+    {
+        $db = new SQLite3($this->output_path);
+        $db->enableExceptions(true);
+        $db->exec('PRAGMA journal_mode=WAL');
+        $db->exec('PRAGMA synchronous=NORMAL');
+
+        $this->createTables($db);
+
+        $db->exec('BEGIN TRANSACTION');
+        try {
+            $this->insertSummary($db, $result->summary);
+            $this->insertLocationTypesSummary($db, $result->location_types_summary);
+            $this->insertClassObjectsSummary($db, $result->class_objects_summary);
+            $this->insertContext($db, $result->context);
+            $db->exec('COMMIT');
+        } catch (\Throwable $e) {
+            $db->exec('ROLLBACK');
+            throw $e;
+        } finally {
+            $db->close();
+        }
+    }
+
+    private function createTables(SQLite3 $db): void
+    {
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS summary (
+                key TEXT NOT NULL,
+                value TEXT,
+                PRIMARY KEY (key)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS location_types_summary (
+                type TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                memory_usage INTEGER NOT NULL,
+                PRIMARY KEY (type)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS class_objects_summary (
+                class_name TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                memory_usage INTEGER NOT NULL,
+                PRIMARY KEY (class_name)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                node_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                link_name TEXT NOT NULL,
+                type TEXT,
+                reference_node_id INTEGER,
+                PRIMARY KEY (node_id)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                node_id INTEGER NOT NULL,
+                address INTEGER,
+                size INTEGER,
+                name TEXT,
+                FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_attributes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                node_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT,
+                FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
+            )
+        ');
+
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_node_id)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_type ON context_nodes(type)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     */
+    private function insertSummary(SQLite3 $db, array $summary): void
+    {
+        $stmt = $db->prepare('INSERT INTO summary (key, value) VALUES (:key, :value)');
+        foreach ($summary as $entry) {
+            foreach ($entry as $key => $value) {
+                $stmt->bindValue(':key', $key, SQLITE3_TEXT);
+                $stmt->bindValue(':value', is_scalar($value) ? (string)$value : json_encode($value), SQLITE3_TEXT);
+                $stmt->execute();
+                $stmt->reset();
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
+     */
+    private function insertLocationTypesSummary(SQLite3 $db, array $location_types_summary): void
+    {
+        $stmt = $db->prepare(
+            'INSERT INTO location_types_summary (type, count, memory_usage) VALUES (:type, :count, :memory_usage)'
+        );
+        foreach ($location_types_summary as $type => $usage) {
+            $stmt->bindValue(':type', $type, SQLITE3_TEXT);
+            $stmt->bindValue(':count', $usage['count'], SQLITE3_INTEGER);
+            $stmt->bindValue(':memory_usage', $usage['memory_usage'], SQLITE3_INTEGER);
+            $stmt->execute();
+            $stmt->reset();
+        }
+    }
+
+    /**
+     * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
+     */
+    private function insertClassObjectsSummary(SQLite3 $db, array $class_objects_summary): void
+    {
+        $stmt = $db->prepare(
+            'INSERT INTO class_objects_summary (class_name, count, memory_usage) VALUES (:class_name, :count, :memory_usage)'
+        );
+        foreach ($class_objects_summary as $class_name => $usage) {
+            $stmt->bindValue(':class_name', $class_name, SQLITE3_TEXT);
+            $stmt->bindValue(':count', $usage['count'], SQLITE3_INTEGER);
+            $stmt->bindValue(':memory_usage', $usage['memory_usage'], SQLITE3_INTEGER);
+            $stmt->execute();
+            $stmt->reset();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function insertContext(SQLite3 $db, array $context): void
+    {
+        $node_stmt = $db->prepare(
+            'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
+            . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
+        );
+        $location_stmt = $db->prepare(
+            'INSERT INTO context_node_locations (node_id, address, size, name)'
+            . ' VALUES (:node_id, :address, :size, :name)'
+        );
+        $attr_stmt = $db->prepare(
+            'INSERT INTO context_node_attributes (node_id, key, value)'
+            . ' VALUES (:node_id, :key, :value)'
+        );
+
+        $this->insertContextNodes($node_stmt, $location_stmt, $attr_stmt, $context, null);
+    }
+
+    private function insertContextNodes(
+        \SQLite3Stmt $node_stmt,
+        \SQLite3Stmt $location_stmt,
+        \SQLite3Stmt $attr_stmt,
+        array $data,
+        ?int $parent_node_id,
+    ): void {
+        foreach ($data as $link_name => $node) {
+            if (!is_array($node)) {
+                continue;
+            }
+
+            if (isset($node['#reference_node_id'])) {
+                // This is a reference to another node
+                $ref_node_id = $node['#reference_node_id'];
+                $node_stmt->bindValue(':node_id', $ref_node_id, SQLITE3_INTEGER);
+                $node_stmt->bindValue(
+                    ':parent_node_id',
+                    $parent_node_id,
+                    $parent_node_id !== null ? SQLITE3_INTEGER : SQLITE3_NULL
+                );
+                $node_stmt->bindValue(':link_name', (string)$link_name, SQLITE3_TEXT);
+                $node_stmt->bindValue(':type', null, SQLITE3_NULL);
+                $node_stmt->bindValue(':reference_node_id', $ref_node_id, SQLITE3_INTEGER);
+                $node_stmt->execute();
+                $node_stmt->reset();
+                continue;
+            }
+
+            if (!isset($node['#node_id'])) {
+                continue;
+            }
+
+            $node_id = $node['#node_id'];
+
+            $node_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
+            $node_stmt->bindValue(
+                ':parent_node_id',
+                $parent_node_id,
+                $parent_node_id !== null ? SQLITE3_INTEGER : SQLITE3_NULL
+            );
+            $node_stmt->bindValue(':link_name', (string)$link_name, SQLITE3_TEXT);
+            $node_stmt->bindValue(':type', $node['#type'] ?? null, SQLITE3_TEXT);
+            $node_stmt->bindValue(':reference_node_id', null, SQLITE3_NULL);
+            $node_stmt->execute();
+            $node_stmt->reset();
+
+            // Insert locations
+            if (isset($node['#locations']) && is_array($node['#locations'])) {
+                foreach ($node['#locations'] as $location) {
+                    if (!is_array($location)) {
+                        continue;
+                    }
+                    $location_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
+                    $location_stmt->bindValue(
+                        ':address',
+                        $location['address'] ?? null,
+                        isset($location['address']) ? SQLITE3_INTEGER : SQLITE3_NULL
+                    );
+                    $location_stmt->bindValue(
+                        ':size',
+                        $location['size'] ?? null,
+                        isset($location['size']) ? SQLITE3_INTEGER : SQLITE3_NULL
+                    );
+                    $location_stmt->bindValue(
+                        ':name',
+                        $location['name'] ?? null,
+                        isset($location['name']) ? SQLITE3_TEXT : SQLITE3_NULL
+                    );
+                    $location_stmt->execute();
+                    $location_stmt->reset();
+                }
+            }
+
+            // Insert child contexts (non-# prefixed keys that are arrays)
+            $children = [];
+            foreach ($node as $key => $value) {
+                if (is_string($key) && !str_starts_with($key, '#') && is_array($value)) {
+                    // Check if this is a context node or an attribute
+                    if (isset($value['#node_id']) || isset($value['#reference_node_id'])) {
+                        $children[$key] = $value;
+                    } else {
+                        // Could be nested children or a scalar attribute encoded as array
+                        $has_node_children = false;
+                        foreach ($value as $sub_key => $sub_value) {
+                            if (is_array($sub_value) && (isset($sub_value['#node_id']) || isset($sub_value['#reference_node_id']))) {
+                                $has_node_children = true;
+                                break;
+                            }
+                        }
+                        if ($has_node_children) {
+                            $children[$key] = $value;
+                        } else {
+                            $attr_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
+                            $attr_stmt->bindValue(':key', $key, SQLITE3_TEXT);
+                            $attr_stmt->bindValue(':value', json_encode($value), SQLITE3_TEXT);
+                            $attr_stmt->execute();
+                            $attr_stmt->reset();
+                        }
+                    }
+                } elseif (is_int($key) && is_array($value)) {
+                    if (isset($value['#node_id']) || isset($value['#reference_node_id'])) {
+                        $children[$key] = $value;
+                    }
+                }
+            }
+
+            if ($children !== []) {
+                $this->insertContextNodes($node_stmt, $location_stmt, $attr_stmt, $children, $node_id);
+            }
+        }
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -59,9 +59,8 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             throw $e;
         }
 
-        // Create indexes and materialized tables after bulk insert
+        // Create indexes and views after bulk insert
         $this->createIndexes($db);
-        $this->materializeNodePaths($db);
         $this->createViews($db);
     }
 
@@ -140,36 +139,6 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         // Frequently used in user queries
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
-    }
-
-    private function materializeNodePaths(\PDO $db): void
-    {
-        // Materialize shallow paths (depth <= 4) as a table.
-        // Deeper paths can still be computed via recursive CTE when needed,
-        // but most useful queries (root-level memory breakdown, top-level
-        // structure analysis) only need shallow paths.
-        $db->exec('
-            CREATE TABLE IF NOT EXISTS node_paths (
-                node_id INTEGER NOT NULL PRIMARY KEY,
-                path TEXT NOT NULL,
-                depth INTEGER NOT NULL
-            )
-        ');
-        $db->exec("
-            INSERT INTO node_paths (node_id, path, depth)
-            WITH RECURSIVE cte(node_id, path, depth) AS (
-                SELECT node_id, link_name, 0
-                FROM context_nodes
-                WHERE parent_node_id IS NULL
-              UNION ALL
-                SELECT cn.node_id, cte.path || ' -> ' || cn.link_name, cte.depth + 1
-                FROM context_nodes cn
-                JOIN cte ON cn.parent_node_id = cte.node_id
-                WHERE cte.depth < 4
-            )
-            SELECT node_id, path, depth FROM cte
-        ");
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_node_paths_depth ON node_paths(depth)');
     }
 
     private function createViews(\PDO $db): void

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -15,6 +15,7 @@ namespace Reli\Inspector\Output\MemoryOutput;
 
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
 use Reli\Lib\Process\MemoryLocation;
 use SQLite3;
 
@@ -96,6 +97,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 size INTEGER,
                 location_type TEXT NOT NULL,
                 class_name TEXT,
+                string_value TEXT,
                 refcount INTEGER,
                 type_info INTEGER,
                 FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
@@ -116,9 +118,30 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_type ON context_nodes(type)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_type ON context_node_locations(location_type)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_size ON context_node_locations(size DESC)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
+
+        $this->createViews($db);
+    }
+
+    private function createViews(SQLite3 $db): void
+    {
+        $db->exec("
+            CREATE VIEW IF NOT EXISTS v_node_paths AS
+            WITH RECURSIVE node_paths(node_id, path, depth) AS (
+                SELECT node_id, link_name, 0
+                FROM context_nodes
+                WHERE parent_node_id IS NULL
+              UNION ALL
+                SELECT cn.node_id, np.path || ' -> ' || cn.link_name, np.depth + 1
+                FROM context_nodes cn
+                JOIN node_paths np ON cn.parent_node_id = np.node_id
+            )
+            SELECT node_id, path, depth FROM node_paths
+        ");
     }
 
     /**
@@ -181,8 +204,9 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
         );
         $location_stmt = $db->prepare(
-            'INSERT INTO context_node_locations (node_id, address, size, location_type, class_name, refcount, type_info)'
-            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :refcount, :type_info)'
+            'INSERT INTO context_node_locations'
+            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info)'
+            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info)'
         );
         $attr_stmt = $db->prepare(
             'INSERT INTO context_node_attributes (node_id, key, value)'
@@ -254,6 +278,12 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                             $location_stmt->bindValue(':class_name', $location->class_name, SQLITE3_TEXT);
                         } else {
                             $location_stmt->bindValue(':class_name', null, SQLITE3_NULL);
+                        }
+
+                        if ($location instanceof ZendStringMemoryLocation) {
+                            $location_stmt->bindValue(':string_value', $location->value, SQLITE3_TEXT);
+                        } else {
+                            $location_stmt->bindValue(':string_value', null, SQLITE3_NULL);
                         }
 
                         if ($location instanceof RefcountedMemoryLocation) {

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -29,10 +29,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
     {
         $db = new \PDO('sqlite:' . $this->output_path);
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $db->exec('PRAGMA journal_mode=WAL');
+        $db->exec('PRAGMA journal_mode=OFF');
         $db->exec('PRAGMA synchronous=OFF');
         $db->exec('PRAGMA cache_size=-65536'); // 64MB cache
         $db->exec('PRAGMA temp_store=MEMORY');
+        $db->exec('PRAGMA locking_mode=EXCLUSIVE');
         $db->exec('PRAGMA mmap_size=268435456'); // 256MB mmap
 
         $this->createTables($db);
@@ -131,16 +132,13 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
     private function createIndexes(\PDO $db): void
     {
+        // Essential for v_node_paths recursive CTE and v_arrays join
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_node_id)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_type ON context_nodes(type)');
+        // Essential for JOIN context_node_locations ON node_id
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
+        // Frequently used in user queries
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_type ON context_node_locations(location_type)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_size ON context_node_locations(size DESC)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_region ON context_node_locations(region)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
     }
 
     private function createViews(\PDO $db): void

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -95,11 +95,17 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('
             CREATE TABLE IF NOT EXISTS context_nodes (
                 node_id INTEGER NOT NULL,
-                parent_node_id INTEGER,
-                link_name TEXT NOT NULL,
-                type TEXT,
-                reference_node_id INTEGER,
+                type TEXT NOT NULL,
                 PRIMARY KEY (node_id)
+            )
+        ');
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_edges (
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL
             )
         ');
 
@@ -132,8 +138,10 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
     private function createIndexes(\PDO $db): void
     {
-        // Essential for v_node_paths recursive CTE and v_arrays join
-        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_node_id)');
+        // Essential for v_node_paths recursive CTE (follow tree edges from parent)
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_parent_tree ON context_edges(parent_node_id, is_tree)');
+        // Essential for "find all references to node X"
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_edges_child ON context_edges(child_node_id)');
         // Essential for JOIN context_node_locations ON node_id
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
         // Frequently used in user queries
@@ -143,18 +151,20 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
     private function createViews(\PDO $db): void
     {
-        // Full-depth path view via recursive CTE (slower but complete).
-        // For depth <= 4, prefer the materialized node_paths table.
+        // Canonical path view via recursive CTE following tree edges only.
+        // Each node has exactly one path. For materialized version, use
+        // inspector:memory:optimize-db.
         $db->exec("
             CREATE VIEW IF NOT EXISTS v_node_paths AS
             WITH RECURSIVE node_paths(node_id, path, depth) AS (
-                SELECT node_id, link_name, 0
-                FROM context_nodes
-                WHERE parent_node_id IS NULL
+                SELECT child_node_id, link_name, 0
+                FROM context_edges
+                WHERE parent_node_id IS NULL AND is_tree = 1
               UNION ALL
-                SELECT cn.node_id, np.path || ' -> ' || cn.link_name, np.depth + 1
-                FROM context_nodes cn
-                JOIN node_paths np ON cn.parent_node_id = np.node_id
+                SELECT e.child_node_id, np.path || ' -> ' || e.link_name, np.depth + 1
+                FROM context_edges e
+                JOIN node_paths np ON e.parent_node_id = np.node_id
+                WHERE e.is_tree = 1
             )
             SELECT node_id, path, depth FROM node_paths
         ");
@@ -173,14 +183,15 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             JOIN context_node_locations header_loc
                 ON header_loc.node_id = header_cn.node_id
                 AND header_loc.location_type = 'ZendArrayMemoryLocation'
-            LEFT JOIN context_nodes elements_cn
-                ON elements_cn.parent_node_id = header_cn.node_id
-                AND elements_cn.link_name = 'array_elements'
+            LEFT JOIN context_edges elements_edge
+                ON elements_edge.parent_node_id = header_cn.node_id
+                AND elements_edge.link_name = 'array_elements'
+                AND elements_edge.is_tree = 1
             LEFT JOIN context_node_locations table_loc
-                ON table_loc.node_id = elements_cn.node_id
+                ON table_loc.node_id = elements_edge.child_node_id
                 AND table_loc.location_type = 'ZendArrayTableMemoryLocation'
             LEFT JOIN context_node_attributes cnt
-                ON cnt.node_id = elements_cn.node_id
+                ON cnt.node_id = elements_edge.child_node_id
                 AND cnt.key = '#count'
         ");
     }

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -142,6 +142,31 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             )
             SELECT node_id, path, depth FROM node_paths
         ");
+
+        $db->exec("
+            CREATE VIEW IF NOT EXISTS v_arrays AS
+            SELECT
+                header_cn.node_id,
+                header_loc.address,
+                header_loc.size AS header_size,
+                COALESCE(table_loc.size, 0) AS table_size,
+                header_loc.size + COALESCE(table_loc.size, 0) AS total_size,
+                CAST(cnt.value AS INTEGER) AS element_count,
+                header_loc.refcount
+            FROM context_nodes header_cn
+            JOIN context_node_locations header_loc
+                ON header_loc.node_id = header_cn.node_id
+                AND header_loc.location_type = 'ZendArrayMemoryLocation'
+            LEFT JOIN context_nodes elements_cn
+                ON elements_cn.parent_node_id = header_cn.node_id
+                AND elements_cn.link_name = 'array_elements'
+            LEFT JOIN context_node_locations table_loc
+                ON table_loc.node_id = elements_cn.node_id
+                AND table_loc.location_type = 'ZendArrayTableMemoryLocation'
+            LEFT JOIN context_node_attributes cnt
+                ON cnt.node_id = elements_cn.node_id
+                AND cnt.key = '#count'
+        ");
     }
 
     /**
@@ -300,17 +325,33 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 }
             }
 
-            // Insert child contexts (non-# prefixed keys that are arrays)
+            // Insert child contexts and attributes
+            $standard_keys = ['#node_id', '#type', '#locations', '#reference_node_id'];
             $children = [];
             foreach ($node as $key => $value) {
-                if (is_string($key) && !str_starts_with($key, '#') && is_array($value)) {
-                    // Check if this is a context node or an attribute
+                if (is_string($key) && str_starts_with($key, '#')) {
+                    // Store non-standard #-prefixed scalar values as attributes (e.g. #count)
+                    if (!in_array($key, $standard_keys, true) && !is_array($value) && !($value instanceof MemoryLocation)) {
+                        $attr_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
+                        $attr_stmt->bindValue(':key', $key, SQLITE3_TEXT);
+                        $attr_stmt->bindValue(
+                            ':value',
+                            is_scalar($value) ? (string)$value : json_encode($value),
+                            SQLITE3_TEXT
+                        );
+                        $attr_stmt->execute();
+                        $attr_stmt->reset();
+                    }
+                    continue;
+                }
+
+                if (is_array($value)) {
                     if (isset($value['#node_id']) || isset($value['#reference_node_id'])) {
                         $children[$key] = $value;
                     } else {
-                        // Could be nested children or a scalar attribute encoded as array
+                        // Could be nested children or a non-node attribute
                         $has_node_children = false;
-                        foreach ($value as $sub_key => $sub_value) {
+                        foreach ($value as $sub_value) {
                             if (is_array($sub_value) && (isset($sub_value['#node_id']) || isset($sub_value['#reference_node_id']))) {
                                 $has_node_children = true;
                                 break;
@@ -320,15 +361,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                             $children[$key] = $value;
                         } else {
                             $attr_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-                            $attr_stmt->bindValue(':key', $key, SQLITE3_TEXT);
+                            $attr_stmt->bindValue(':key', (string)$key, SQLITE3_TEXT);
                             $attr_stmt->bindValue(':value', json_encode($value), SQLITE3_TEXT);
                             $attr_stmt->execute();
                             $attr_stmt->reset();
                         }
-                    }
-                } elseif (is_int($key) && is_array($value)) {
-                    if (isset($value['#node_id']) || isset($value['#reference_node_id'])) {
-                        $children[$key] = $value;
                     }
                 }
             }

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -17,7 +17,6 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLoc
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
 use Reli\Lib\Process\MemoryLocation;
-use SQLite3;
 
 final class SqliteMemoryOutput implements MemoryOutputInterface
 {
@@ -28,29 +27,27 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
     public function output(MemoryAnalysisResult $result): void
     {
-        $db = new SQLite3($this->output_path);
-        $db->enableExceptions(true);
+        $db = new \PDO('sqlite:' . $this->output_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $db->exec('PRAGMA journal_mode=WAL');
         $db->exec('PRAGMA synchronous=NORMAL');
 
         $this->createTables($db);
 
-        $db->exec('BEGIN TRANSACTION');
+        $db->beginTransaction();
         try {
             $this->insertSummary($db, $result->summary);
             $this->insertLocationTypesSummary($db, $result->location_types_summary);
             $this->insertClassObjectsSummary($db, $result->class_objects_summary);
             $this->insertContext($db, $result->context);
-            $db->exec('COMMIT');
+            $db->commit();
         } catch (\Throwable $e) {
-            $db->exec('ROLLBACK');
+            $db->rollBack();
             throw $e;
-        } finally {
-            $db->close();
         }
     }
 
-    private function createTables(SQLite3 $db): void
+    private function createTables(\PDO $db): void
     {
         $db->exec('
             CREATE TABLE IF NOT EXISTS summary (
@@ -127,7 +124,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $this->createViews($db);
     }
 
-    private function createViews(SQLite3 $db): void
+    private function createViews(\PDO $db): void
     {
         $db->exec("
             CREATE VIEW IF NOT EXISTS v_node_paths AS
@@ -172,15 +169,15 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
     /**
      * @param array<int, array<string, mixed>> $summary
      */
-    private function insertSummary(SQLite3 $db, array $summary): void
+    private function insertSummary(\PDO $db, array $summary): void
     {
         $stmt = $db->prepare('INSERT INTO summary (key, value) VALUES (:key, :value)');
         foreach ($summary as $entry) {
             foreach ($entry as $key => $value) {
-                $stmt->bindValue(':key', $key, SQLITE3_TEXT);
-                $stmt->bindValue(':value', is_scalar($value) ? (string)$value : json_encode($value), SQLITE3_TEXT);
-                $stmt->execute();
-                $stmt->reset();
+                $stmt->execute([
+                    ':key' => $key,
+                    ':value' => is_scalar($value) ? (string)$value : json_encode($value),
+                ]);
             }
         }
     }
@@ -188,41 +185,41 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
     /**
      * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
      */
-    private function insertLocationTypesSummary(SQLite3 $db, array $location_types_summary): void
+    private function insertLocationTypesSummary(\PDO $db, array $location_types_summary): void
     {
         $stmt = $db->prepare(
             'INSERT INTO location_types_summary (type, count, memory_usage) VALUES (:type, :count, :memory_usage)'
         );
         foreach ($location_types_summary as $type => $usage) {
-            $stmt->bindValue(':type', $type, SQLITE3_TEXT);
-            $stmt->bindValue(':count', $usage['count'], SQLITE3_INTEGER);
-            $stmt->bindValue(':memory_usage', $usage['memory_usage'], SQLITE3_INTEGER);
-            $stmt->execute();
-            $stmt->reset();
+            $stmt->execute([
+                ':type' => $type,
+                ':count' => $usage['count'],
+                ':memory_usage' => $usage['memory_usage'],
+            ]);
         }
     }
 
     /**
      * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
      */
-    private function insertClassObjectsSummary(SQLite3 $db, array $class_objects_summary): void
+    private function insertClassObjectsSummary(\PDO $db, array $class_objects_summary): void
     {
         $stmt = $db->prepare(
             'INSERT INTO class_objects_summary (class_name, count, memory_usage) VALUES (:class_name, :count, :memory_usage)'
         );
         foreach ($class_objects_summary as $class_name => $usage) {
-            $stmt->bindValue(':class_name', $class_name, SQLITE3_TEXT);
-            $stmt->bindValue(':count', $usage['count'], SQLITE3_INTEGER);
-            $stmt->bindValue(':memory_usage', $usage['memory_usage'], SQLITE3_INTEGER);
-            $stmt->execute();
-            $stmt->reset();
+            $stmt->execute([
+                ':class_name' => $class_name,
+                ':count' => $usage['count'],
+                ':memory_usage' => $usage['memory_usage'],
+            ]);
         }
     }
 
     /**
      * @param array<string, mixed> $context
      */
-    private function insertContext(SQLite3 $db, array $context): void
+    private function insertContext(\PDO $db, array $context): void
     {
         $node_stmt = $db->prepare(
             'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
@@ -242,9 +239,9 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
     }
 
     private function insertContextNodes(
-        \SQLite3Stmt $node_stmt,
-        \SQLite3Stmt $location_stmt,
-        \SQLite3Stmt $attr_stmt,
+        \PDOStatement $node_stmt,
+        \PDOStatement $location_stmt,
+        \PDOStatement $attr_stmt,
         array $data,
         ?int $parent_node_id,
     ): void {
@@ -256,17 +253,13 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             if (isset($node['#reference_node_id'])) {
                 // This is a reference to another node
                 $ref_node_id = $node['#reference_node_id'];
-                $node_stmt->bindValue(':node_id', $ref_node_id, SQLITE3_INTEGER);
-                $node_stmt->bindValue(
-                    ':parent_node_id',
-                    $parent_node_id,
-                    $parent_node_id !== null ? SQLITE3_INTEGER : SQLITE3_NULL
-                );
-                $node_stmt->bindValue(':link_name', (string)$link_name, SQLITE3_TEXT);
-                $node_stmt->bindValue(':type', null, SQLITE3_NULL);
-                $node_stmt->bindValue(':reference_node_id', $ref_node_id, SQLITE3_INTEGER);
-                $node_stmt->execute();
-                $node_stmt->reset();
+                $node_stmt->execute([
+                    ':node_id' => $ref_node_id,
+                    ':parent_node_id' => $parent_node_id,
+                    ':link_name' => (string)$link_name,
+                    ':type' => null,
+                    ':reference_node_id' => $ref_node_id,
+                ]);
                 continue;
             }
 
@@ -276,51 +269,34 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
 
             $node_id = $node['#node_id'];
 
-            $node_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-            $node_stmt->bindValue(
-                ':parent_node_id',
-                $parent_node_id,
-                $parent_node_id !== null ? SQLITE3_INTEGER : SQLITE3_NULL
-            );
-            $node_stmt->bindValue(':link_name', (string)$link_name, SQLITE3_TEXT);
-            $node_stmt->bindValue(':type', $node['#type'] ?? null, SQLITE3_TEXT);
-            $node_stmt->bindValue(':reference_node_id', null, SQLITE3_NULL);
-            $node_stmt->execute();
-            $node_stmt->reset();
+            $node_stmt->execute([
+                ':node_id' => $node_id,
+                ':parent_node_id' => $parent_node_id,
+                ':link_name' => (string)$link_name,
+                ':type' => $node['#type'] ?? null,
+                ':reference_node_id' => null,
+            ]);
 
             // Insert locations
             if (isset($node['#locations']) && is_iterable($node['#locations'])) {
                 foreach ($node['#locations'] as $location) {
                     if ($location instanceof MemoryLocation) {
-                        $location_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-                        $location_stmt->bindValue(':address', $location->address, SQLITE3_INTEGER);
-                        $location_stmt->bindValue(':size', $location->size, SQLITE3_INTEGER);
-
                         $short_class = (new \ReflectionClass($location))->getShortName();
-                        $location_stmt->bindValue(':location_type', $short_class, SQLITE3_TEXT);
 
-                        if ($location instanceof ZendObjectMemoryLocation) {
-                            $location_stmt->bindValue(':class_name', $location->class_name, SQLITE3_TEXT);
-                        } else {
-                            $location_stmt->bindValue(':class_name', null, SQLITE3_NULL);
-                        }
-
-                        if ($location instanceof ZendStringMemoryLocation) {
-                            $location_stmt->bindValue(':string_value', $location->value, SQLITE3_TEXT);
-                        } else {
-                            $location_stmt->bindValue(':string_value', null, SQLITE3_NULL);
-                        }
-
-                        if ($location instanceof RefcountedMemoryLocation) {
-                            $location_stmt->bindValue(':refcount', $location->refcount, SQLITE3_INTEGER);
-                            $location_stmt->bindValue(':type_info', $location->type_info, SQLITE3_INTEGER);
-                        } else {
-                            $location_stmt->bindValue(':refcount', null, SQLITE3_NULL);
-                            $location_stmt->bindValue(':type_info', null, SQLITE3_NULL);
-                        }
-
-                        $location_stmt->execute();
-                        $location_stmt->reset();
+                        $location_stmt->execute([
+                            ':node_id' => $node_id,
+                            ':address' => $location->address,
+                            ':size' => $location->size,
+                            ':location_type' => $short_class,
+                            ':class_name' => $location instanceof ZendObjectMemoryLocation
+                                ? $location->class_name : null,
+                            ':string_value' => $location instanceof ZendStringMemoryLocation
+                                ? $location->value : null,
+                            ':refcount' => $location instanceof RefcountedMemoryLocation
+                                ? $location->refcount : null,
+                            ':type_info' => $location instanceof RefcountedMemoryLocation
+                                ? $location->type_info : null,
+                        ]);
                     }
                 }
             }
@@ -332,15 +308,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 if (is_string($key) && str_starts_with($key, '#')) {
                     // Store non-standard #-prefixed scalar values as attributes (e.g. #count)
                     if (!in_array($key, $standard_keys, true) && !is_array($value) && !($value instanceof MemoryLocation)) {
-                        $attr_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-                        $attr_stmt->bindValue(':key', $key, SQLITE3_TEXT);
-                        $attr_stmt->bindValue(
-                            ':value',
-                            is_scalar($value) ? (string)$value : json_encode($value),
-                            SQLITE3_TEXT
-                        );
-                        $attr_stmt->execute();
-                        $attr_stmt->reset();
+                        $attr_stmt->execute([
+                            ':node_id' => $node_id,
+                            ':key' => $key,
+                            ':value' => is_scalar($value) ? (string)$value : json_encode($value),
+                        ]);
                     }
                     continue;
                 }
@@ -360,11 +332,11 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                         if ($has_node_children) {
                             $children[$key] = $value;
                         } else {
-                            $attr_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-                            $attr_stmt->bindValue(':key', (string)$key, SQLITE3_TEXT);
-                            $attr_stmt->bindValue(':value', json_encode($value), SQLITE3_TEXT);
-                            $attr_stmt->execute();
-                            $attr_stmt->reset();
+                            $attr_stmt->execute([
+                                ':node_id' => $node_id,
+                                ':key' => (string)$key,
+                                ':value' => json_encode($value),
+                            ]);
                         }
                     }
                 }

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\Process\MemoryLocation;
 use SQLite3;
 
 final class SqliteMemoryOutput implements MemoryOutputInterface
@@ -91,7 +94,10 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
                 node_id INTEGER NOT NULL,
                 address INTEGER,
                 size INTEGER,
-                name TEXT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                refcount INTEGER,
+                type_info INTEGER,
                 FOREIGN KEY (node_id) REFERENCES context_nodes(node_id)
             )
         ');
@@ -109,6 +115,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_nodes_type ON context_nodes(type)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_node ON context_node_locations(node_id)');
+        $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_locations_class ON context_node_locations(class_name)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_context_node_attributes_node ON context_node_attributes(node_id)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_location_types_memory ON location_types_summary(memory_usage DESC)');
         $db->exec('CREATE INDEX IF NOT EXISTS idx_class_objects_memory ON class_objects_summary(memory_usage DESC)');
@@ -174,8 +181,8 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
         );
         $location_stmt = $db->prepare(
-            'INSERT INTO context_node_locations (node_id, address, size, name)'
-            . ' VALUES (:node_id, :address, :size, :name)'
+            'INSERT INTO context_node_locations (node_id, address, size, location_type, class_name, refcount, type_info)'
+            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :refcount, :type_info)'
         );
         $attr_stmt = $db->prepare(
             'INSERT INTO context_node_attributes (node_id, key, value)'
@@ -233,29 +240,33 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             $node_stmt->reset();
 
             // Insert locations
-            if (isset($node['#locations']) && is_array($node['#locations'])) {
+            if (isset($node['#locations']) && is_iterable($node['#locations'])) {
                 foreach ($node['#locations'] as $location) {
-                    if (!is_array($location)) {
-                        continue;
+                    if ($location instanceof MemoryLocation) {
+                        $location_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
+                        $location_stmt->bindValue(':address', $location->address, SQLITE3_INTEGER);
+                        $location_stmt->bindValue(':size', $location->size, SQLITE3_INTEGER);
+
+                        $short_class = (new \ReflectionClass($location))->getShortName();
+                        $location_stmt->bindValue(':location_type', $short_class, SQLITE3_TEXT);
+
+                        if ($location instanceof ZendObjectMemoryLocation) {
+                            $location_stmt->bindValue(':class_name', $location->class_name, SQLITE3_TEXT);
+                        } else {
+                            $location_stmt->bindValue(':class_name', null, SQLITE3_NULL);
+                        }
+
+                        if ($location instanceof RefcountedMemoryLocation) {
+                            $location_stmt->bindValue(':refcount', $location->refcount, SQLITE3_INTEGER);
+                            $location_stmt->bindValue(':type_info', $location->type_info, SQLITE3_INTEGER);
+                        } else {
+                            $location_stmt->bindValue(':refcount', null, SQLITE3_NULL);
+                            $location_stmt->bindValue(':type_info', null, SQLITE3_NULL);
+                        }
+
+                        $location_stmt->execute();
+                        $location_stmt->reset();
                     }
-                    $location_stmt->bindValue(':node_id', $node_id, SQLITE3_INTEGER);
-                    $location_stmt->bindValue(
-                        ':address',
-                        $location['address'] ?? null,
-                        isset($location['address']) ? SQLITE3_INTEGER : SQLITE3_NULL
-                    );
-                    $location_stmt->bindValue(
-                        ':size',
-                        $location['size'] ?? null,
-                        isset($location['size']) ? SQLITE3_INTEGER : SQLITE3_NULL
-                    );
-                    $location_stmt->bindValue(
-                        ':name',
-                        $location['name'] ?? null,
-                        isset($location['name']) ? SQLITE3_TEXT : SQLITE3_NULL
-                    );
-                    $location_stmt->execute();
-                    $location_stmt->reset();
                 }
             }
 

--- a/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteMemoryOutput.php
@@ -46,6 +46,7 @@ final class SqliteMemoryOutput implements MemoryOutputInterface
             $sink = new PdoContextTreeSink($db, $this->region_boundaries);
             $analyzer = new ContextAnalyzer();
             $analyzer->analyze($result->context, $sink);
+            $sink->flush();
 
             // Compute type/class summaries from DB via GROUP BY
             $this->insertLocationTypesSummaryFromDb($db);

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
@@ -19,6 +19,8 @@ final class MemoryProfilerSettings
         public bool $stop_process,
         public bool $pretty_print,
         public ?MemoryLimitErrorDetails $memory_exhaustion_error_details = null,
+        public string $output_format = 'json',
+        public ?string $output_path = null,
     ) {
     }
 }

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettings.php
@@ -21,6 +21,11 @@ final class MemoryProfilerSettings
         public ?MemoryLimitErrorDetails $memory_exhaustion_error_details = null,
         public string $output_format = 'json',
         public ?string $output_path = null,
+        public string $db_host = '127.0.0.1',
+        public ?int $db_port = null,
+        public ?string $db_name = null,
+        public ?string $db_user = null,
+        public ?string $db_password = null,
     ) {
     }
 }

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Settings\MemoryProfilerSettings;
 
 use PhpCast\Cast;
+use PhpCast\NullableCast;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,6 +37,19 @@ final class MemoryProfilerSettingsFromConsoleInput
             InputOption::VALUE_NEGATABLE,
             'pretty print the result (default: off)',
             false,
+        );
+        $command->addOption(
+            'output-format',
+            'f',
+            InputOption::VALUE_REQUIRED,
+            'output format (json, sqlite3)',
+            'json',
+        );
+        $command->addOption(
+            'output',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'output file path (required for sqlite3 format)',
         );
         $command->addOption(
             'memory-limit-error-file',
@@ -91,10 +105,15 @@ final class MemoryProfilerSettingsFromConsoleInput
                 $memory_limit_error_max_depth,
             );
         }
+        $output_format = Cast::toString($input->getOption('output-format'));
+        $output_path = NullableCast::toString($input->getOption('output'));
+
         return new MemoryProfilerSettings(
             $stop_process,
             $pretty_print,
-            $memory_exhaustion_error_details
+            $memory_exhaustion_error_details,
+            $output_format,
+            $output_path,
         );
     }
 }

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
@@ -139,8 +139,7 @@ final class MemoryProfilerSettingsFromConsoleInput
         $output_format = Cast::toString($input->getOption('output-format'));
         $output_path = NullableCast::toString($input->getOption('output'));
         $db_host = Cast::toString($input->getOption('db-host'));
-        $db_port_raw = $input->getOption('db-port');
-        $db_port = $db_port_raw !== null ? (int)$db_port_raw : null;
+        $db_port = NullableCast::toInt($input->getOption('db-port'));
         $db_name = NullableCast::toString($input->getOption('db-name'));
         $db_user = NullableCast::toString($input->getOption('db-user'));
         $db_password = NullableCast::toString($input->getOption('db-password'));

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
@@ -42,7 +42,7 @@ final class MemoryProfilerSettingsFromConsoleInput
             'output-format',
             'f',
             InputOption::VALUE_REQUIRED,
-            'output format (json, sqlite3)',
+            'output format (json, sqlite3, mysql, postgresql)',
             'json',
         );
         $command->addOption(
@@ -50,6 +50,37 @@ final class MemoryProfilerSettingsFromConsoleInput
             'o',
             InputOption::VALUE_REQUIRED,
             'output file path (required for sqlite3 format)',
+        );
+        $command->addOption(
+            'db-host',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'database host (for mysql/postgresql)',
+            '127.0.0.1',
+        );
+        $command->addOption(
+            'db-port',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'database port (for mysql/postgresql)',
+        );
+        $command->addOption(
+            'db-name',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'database name (for mysql/postgresql)',
+        );
+        $command->addOption(
+            'db-user',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'database user (for mysql/postgresql)',
+        );
+        $command->addOption(
+            'db-password',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'database password (for mysql/postgresql)',
         );
         $command->addOption(
             'memory-limit-error-file',
@@ -107,6 +138,12 @@ final class MemoryProfilerSettingsFromConsoleInput
         }
         $output_format = Cast::toString($input->getOption('output-format'));
         $output_path = NullableCast::toString($input->getOption('output'));
+        $db_host = Cast::toString($input->getOption('db-host'));
+        $db_port_raw = $input->getOption('db-port');
+        $db_port = $db_port_raw !== null ? (int)$db_port_raw : null;
+        $db_name = NullableCast::toString($input->getOption('db-name'));
+        $db_user = NullableCast::toString($input->getOption('db-user'));
+        $db_password = NullableCast::toString($input->getOption('db-password'));
 
         return new MemoryProfilerSettings(
             $stop_process,
@@ -114,6 +151,11 @@ final class MemoryProfilerSettingsFromConsoleInput
             $memory_exhaustion_error_details,
             $output_format,
             $output_path,
+            $db_host,
+            $db_port,
+            $db_name,
+            $db_user,
+            $db_password,
         );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
@@ -76,6 +76,12 @@ final class ArrayContextTreeSink implements ContextTreeSink
         }
     }
 
+    #[\Override]
+    public function allowsRelease(): bool
+    {
+        return false;
+    }
+
     /** @return array<string, mixed> */
     public function getResult(): array
     {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
@@ -41,22 +41,25 @@ final class ArrayContextTreeSink implements ContextTreeSink
             '#type' => $type,
         ];
 
-        $locations_array = $locations instanceof \Traversable
-            ? iterator_to_array($locations)
-            : (array)$locations;
+        if ($locations instanceof \Traversable) {
+            $locations_array = iterator_to_array($locations);
+        } else {
+            $locations_array = $locations;
+        }
         if ($locations_array !== []) {
             $node['#locations'] = $locations_array;
         }
 
-        foreach ($attributes as $key => $value) {
-            $node[$key] = $value;
-        }
+        $node += $attributes;
 
         if ($parent_node_id === null) {
             $this->root[$link_name] = $node;
+            /** @psalm-suppress UnsupportedPropertyReferenceUsage */
             $this->node_refs[$node_id] = &$this->root[$link_name];
         } else {
+            /** @psalm-suppress MixedArrayAssignment */
             $this->node_refs[$parent_node_id][$link_name] = $node;
+            /** @psalm-suppress UnsupportedPropertyReferenceUsage, MixedArrayAssignment */
             $this->node_refs[$node_id] = &$this->node_refs[$parent_node_id][$link_name];
         }
     }
@@ -72,6 +75,7 @@ final class ArrayContextTreeSink implements ContextTreeSink
         if ($parent_node_id === null) {
             $this->root[$link_name] = $ref;
         } else {
+            /** @psalm-suppress MixedArrayAssignment */
             $this->node_refs[$parent_node_id][$link_name] = $ref;
         }
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
+
+use Reli\Lib\Process\MemoryLocation;
+
+final class ArrayContextTreeSink implements ContextTreeSink
+{
+    /** @var array<string, mixed> */
+    private array $root = [];
+
+    /** @var array<int, mixed> */
+    private array $node_refs = [];
+
+    /**
+     * @param iterable<array-key, MemoryLocation> $locations
+     * @param array<string, mixed> $attributes
+     */
+    #[\Override]
+    public function emitNode(
+        int $node_id,
+        ?int $parent_node_id,
+        string $link_name,
+        string $type,
+        iterable $locations,
+        array $attributes,
+    ): void {
+        $node = [
+            '#node_id' => $node_id,
+            '#type' => $type,
+        ];
+
+        $locations_array = $locations instanceof \Traversable
+            ? iterator_to_array($locations)
+            : (array)$locations;
+        if ($locations_array !== []) {
+            $node['#locations'] = $locations_array;
+        }
+
+        foreach ($attributes as $key => $value) {
+            $node[$key] = $value;
+        }
+
+        if ($parent_node_id === null) {
+            $this->root[$link_name] = $node;
+            $this->node_refs[$node_id] = &$this->root[$link_name];
+        } else {
+            $this->node_refs[$parent_node_id][$link_name] = $node;
+            $this->node_refs[$node_id] = &$this->node_refs[$parent_node_id][$link_name];
+        }
+    }
+
+    #[\Override]
+    public function emitReference(
+        int $reference_node_id,
+        ?int $parent_node_id,
+        string $link_name,
+    ): void {
+        $ref = ['#reference_node_id' => $reference_node_id];
+
+        if ($parent_node_id === null) {
+            $this->root[$link_name] = $ref;
+        } else {
+            $this->node_refs[$parent_node_id][$link_name] = $ref;
+        }
+    }
+
+    /** @return array<string, mixed> */
+    public function getResult(): array
+    {
+        return $this->root;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -55,5 +55,9 @@ final class ContextAnalyzer
 
             $this->analyze($linked_context, $sink, $current_node_id, $memo);
         }
+
+        if ($sink->allowsRelease()) {
+            $reference_context->releaseLinks();
+        }
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -35,6 +35,8 @@ final class ContextAnalyzer
         }
 
         foreach ($reference_context->getLinks() as $link_name => $linked_context) {
+            /** @psalm-suppress RedundantCastGivenDocblockType -- int keys occur at runtime */
+            $link_name = (string)$link_name;
             $existing_node_id = $memo[$linked_context] ?? null;
             if ($existing_node_id !== null) {
                 $sink->emitReference($existing_node_id, $parent_node_id, $link_name);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -20,6 +20,9 @@ final class ContextAnalyzer
 {
     private int $node_id = 0;
 
+    /**
+     * @param WeakMap<ReferenceContext, int>|null $memo
+     */
     public function analyze(
         ReferenceContext $reference_context,
         ContextTreeSink $sink,
@@ -27,12 +30,14 @@ final class ContextAnalyzer
         ?WeakMap $memo = null,
     ): void {
         if ($memo === null) {
+            /** @var WeakMap<ReferenceContext, int> $memo */
             $memo = new WeakMap();
         }
 
         foreach ($reference_context->getLinks() as $link_name => $linked_context) {
-            if (isset($memo[$linked_context])) {
-                $sink->emitReference($memo[$linked_context], $parent_node_id, (string)$link_name);
+            $existing_node_id = $memo[$linked_context] ?? null;
+            if ($existing_node_id !== null) {
+                $sink->emitReference($existing_node_id, $parent_node_id, $link_name);
                 continue;
             }
 
@@ -43,11 +48,12 @@ final class ContextAnalyzer
             if (!is_array($contexts)) {
                 $contexts = iterator_to_array($contexts);
             }
+            /** @var array<string, mixed> $contexts */
 
             $sink->emitNode(
                 $current_node_id,
                 $parent_node_id,
-                (string)$link_name,
+                $link_name,
                 $linked_context->getName(),
                 $linked_context->getLocations(),
                 $contexts,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -20,38 +20,40 @@ final class ContextAnalyzer
 {
     private int $node_id = 0;
 
-    public function analyze(ReferenceContext $reference_context, WeakMap $memo = null): array
-    {
+    public function analyze(
+        ReferenceContext $reference_context,
+        ContextTreeSink $sink,
+        ?int $parent_node_id = null,
+        ?WeakMap $memo = null,
+    ): void {
         if ($memo === null) {
             $memo = new WeakMap();
         }
 
-        $result = [];
         foreach ($reference_context->getLinks() as $link_name => $linked_context) {
             if (isset($memo[$linked_context])) {
-                $result[$link_name] = [
-                    '#reference_node_id' => $memo[$linked_context],
-                ];
+                $sink->emitReference($memo[$linked_context], $parent_node_id, (string)$link_name);
                 continue;
             }
-            $memo[$linked_context] = $this->node_id;
-            $node = [
-                '#node_id' => $this->node_id,
-                '#type' => $linked_context->getName(),
-            ];
-            if ($linked_context->getLocations() !== []) {
-                $node['#locations'] = $linked_context->getLocations();
-            }
+
+            $current_node_id = $this->node_id++;
+            $memo[$linked_context] = $current_node_id;
+
             $contexts = $linked_context->getContexts();
             if (!is_array($contexts)) {
                 $contexts = iterator_to_array($contexts);
             }
-            if ($contexts !== []) {
-                $node += $contexts;
-            }
-            $this->node_id++;
-            $result[$link_name] = $node + $this->analyze($linked_context, $memo);
+
+            $sink->emitNode(
+                $current_node_id,
+                $parent_node_id,
+                (string)$link_name,
+                $linked_context->getName(),
+                $linked_context->getLocations(),
+                $contexts,
+            );
+
+            $this->analyze($linked_context, $sink, $current_node_id, $memo);
         }
-        return $result;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
+
+use Reli\Lib\Process\MemoryLocation;
+
+interface ContextTreeSink
+{
+    /**
+     * @param iterable<array-key, MemoryLocation> $locations
+     * @param array<string, mixed> $attributes
+     */
+    public function emitNode(
+        int $node_id,
+        ?int $parent_node_id,
+        string $link_name,
+        string $type,
+        iterable $locations,
+        array $attributes,
+    ): void;
+
+    public function emitReference(
+        int $reference_node_id,
+        ?int $parent_node_id,
+        string $link_name,
+    ): void;
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
@@ -35,4 +35,7 @@ interface ContextTreeSink
         ?int $parent_node_id,
         string $link_name,
     ): void;
+
+    /** Whether traversed context nodes can release their child references for GC */
+    public function allowsRelease(): bool;
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -92,6 +92,12 @@ final class PdoContextTreeSink implements ContextTreeSink
     }
 
     #[\Override]
+    public function allowsRelease(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
     public function emitReference(
         int $reference_node_id,
         ?int $parent_node_id,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -16,6 +16,7 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\Process\MemoryLocation;
 
 final class PdoContextTreeSink implements ContextTreeSink
@@ -24,16 +25,18 @@ final class PdoContextTreeSink implements ContextTreeSink
     private \PDOStatement $location_stmt;
     private \PDOStatement $attr_stmt;
 
-    public function __construct(\PDO $db)
-    {
+    public function __construct(
+        \PDO $db,
+        private ?RegionBoundaries $region_boundaries = null,
+    ) {
         $this->node_stmt = $db->prepare(
             'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
             . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
         );
         $this->location_stmt = $db->prepare(
             'INSERT INTO context_node_locations'
-            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info)'
-            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info)'
+            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info, region)'
+            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info, :region)'
         );
         $this->attr_stmt = $db->prepare(
             'INSERT INTO context_node_attributes (node_id, key, value)'
@@ -78,6 +81,7 @@ final class PdoContextTreeSink implements ContextTreeSink
                         ? $location->refcount : null,
                     ':type_info' => $location instanceof RefcountedMemoryLocation
                         ? $location->type_info : null,
+                    ':region' => $this->region_boundaries?->classifyRegion($location),
                 ]);
             }
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -175,9 +175,10 @@ final class PdoContextTreeSink implements ContextTreeSink
 
     private function getAttrBatchStmt(int $row_count): \PDOStatement
     {
+        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
         return $this->attr_batch_stmts[$row_count]
             ??= $this->db->prepare(
-                'INSERT INTO context_node_attributes (node_id, key, value)'
+                "INSERT INTO context_node_attributes (node_id, {$qi('key')}, {$qi('value')})"
                 . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?)'))
             );
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
@@ -54,10 +55,11 @@ final class PdoContextTreeSink implements ContextTreeSink
 
     public function __construct(
         private \PDO $db,
+        private PdoDriverInterface $driver,
         private ?RegionBoundaries $region_boundaries = null,
     ) {
         $this->node_stmt = $db->prepare(
-            'INSERT OR IGNORE INTO context_nodes (node_id, type) VALUES (?, ?)'
+            $driver->insertIgnoreSql('context_nodes', 'node_id, type', '?, ?')
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -21,29 +21,36 @@ use Reli\Lib\Process\MemoryLocation;
 
 final class PdoContextTreeSink implements ContextTreeSink
 {
+    private const LOCATION_BATCH_SIZE = 200;
+    private const ATTR_BATCH_SIZE = 200;
+    private const LOCATION_COLUMNS = 9;
+    private const ATTR_COLUMNS = 3;
+
     private \PDOStatement $node_stmt;
-    private \PDOStatement $location_stmt;
-    private \PDOStatement $attr_stmt;
 
     /** @var array<class-string, string> */
     private array $short_name_cache = [];
 
+    /** @var list<mixed> */
+    private array $location_buffer = [];
+    private int $location_row_count = 0;
+
+    /** @var list<mixed> */
+    private array $attr_buffer = [];
+    private int $attr_row_count = 0;
+
+    /** @var array<int, \PDOStatement> */
+    private array $location_batch_stmts = [];
+    /** @var array<int, \PDOStatement> */
+    private array $attr_batch_stmts = [];
+
     public function __construct(
-        \PDO $db,
+        private \PDO $db,
         private ?RegionBoundaries $region_boundaries = null,
     ) {
         $this->node_stmt = $db->prepare(
             'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
-            . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
-        );
-        $this->location_stmt = $db->prepare(
-            'INSERT INTO context_node_locations'
-            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info, region)'
-            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info, :region)'
-        );
-        $this->attr_stmt = $db->prepare(
-            'INSERT INTO context_node_attributes (node_id, key, value)'
-            . ' VALUES (:node_id, :key, :value)'
+            . ' VALUES (?, ?, ?, ?, ?)'
         );
     }
 
@@ -60,43 +67,43 @@ final class PdoContextTreeSink implements ContextTreeSink
         iterable $locations,
         array $attributes,
     ): void {
-        $this->node_stmt->execute([
-            ':node_id' => $node_id,
-            ':parent_node_id' => $parent_node_id,
-            ':link_name' => $link_name,
-            ':type' => $type,
-            ':reference_node_id' => null,
-        ]);
+        $this->node_stmt->execute([$node_id, $parent_node_id, $link_name, $type, null]);
 
         foreach ($locations as $location) {
             if ($location instanceof MemoryLocation) {
                 $class = $location::class;
                 $short_class = $this->short_name_cache[$class]
                     ??= (new \ReflectionClass($class))->getShortName();
-                $this->location_stmt->execute([
-                    ':node_id' => $node_id,
-                    ':address' => $location->address,
-                    ':size' => $location->size,
-                    ':location_type' => $short_class,
-                    ':class_name' => $location instanceof ZendObjectMemoryLocation
-                        ? $location->class_name : null,
-                    ':string_value' => $location instanceof ZendStringMemoryLocation
-                        ? $location->value : null,
-                    ':refcount' => $location instanceof RefcountedMemoryLocation
-                        ? $location->refcount : null,
-                    ':type_info' => $location instanceof RefcountedMemoryLocation
-                        ? $location->type_info : null,
-                    ':region' => $this->region_boundaries?->classifyRegion($location),
-                ]);
+                $this->location_buffer[] = $node_id;
+                $this->location_buffer[] = $location->address;
+                $this->location_buffer[] = $location->size;
+                $this->location_buffer[] = $short_class;
+                $this->location_buffer[] = $location instanceof ZendObjectMemoryLocation
+                    ? $location->class_name : null;
+                $this->location_buffer[] = $location instanceof ZendStringMemoryLocation
+                    ? $location->value : null;
+                $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
+                    ? $location->refcount : null;
+                $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
+                    ? $location->type_info : null;
+                $this->location_buffer[] = $this->region_boundaries?->classifyRegion($location);
+                $this->location_row_count++;
+
+                if ($this->location_row_count >= self::LOCATION_BATCH_SIZE) {
+                    $this->flushLocations();
+                }
             }
         }
 
         foreach ($attributes as $key => $value) {
-            $this->attr_stmt->execute([
-                ':node_id' => $node_id,
-                ':key' => (string)$key,
-                ':value' => is_scalar($value) ? (string)$value : json_encode($value),
-            ]);
+            $this->attr_buffer[] = $node_id;
+            $this->attr_buffer[] = (string)$key;
+            $this->attr_buffer[] = is_scalar($value) ? (string)$value : json_encode($value);
+            $this->attr_row_count++;
+
+            if ($this->attr_row_count >= self::ATTR_BATCH_SIZE) {
+                $this->flushAttributes();
+            }
         }
     }
 
@@ -112,12 +119,53 @@ final class PdoContextTreeSink implements ContextTreeSink
         ?int $parent_node_id,
         string $link_name,
     ): void {
-        $this->node_stmt->execute([
-            ':node_id' => $reference_node_id,
-            ':parent_node_id' => $parent_node_id,
-            ':link_name' => $link_name,
-            ':type' => null,
-            ':reference_node_id' => $reference_node_id,
-        ]);
+        $this->node_stmt->execute([$reference_node_id, $parent_node_id, $link_name, null, $reference_node_id]);
+    }
+
+    public function flush(): void
+    {
+        if ($this->location_row_count > 0) {
+            $this->flushLocations();
+        }
+        if ($this->attr_row_count > 0) {
+            $this->flushAttributes();
+        }
+    }
+
+    private function flushLocations(): void
+    {
+        $count = $this->location_row_count;
+        $stmt = $this->getLocationBatchStmt($count);
+        $stmt->execute($this->location_buffer);
+        $this->location_buffer = [];
+        $this->location_row_count = 0;
+    }
+
+    private function flushAttributes(): void
+    {
+        $count = $this->attr_row_count;
+        $stmt = $this->getAttrBatchStmt($count);
+        $stmt->execute($this->attr_buffer);
+        $this->attr_buffer = [];
+        $this->attr_row_count = 0;
+    }
+
+    private function getLocationBatchStmt(int $row_count): \PDOStatement
+    {
+        return $this->location_batch_stmts[$row_count]
+            ??= $this->db->prepare(
+                'INSERT INTO context_node_locations'
+                . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info, region)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?,?,?,?,?)'))
+            );
+    }
+
+    private function getAttrBatchStmt(int $row_count): \PDOStatement
+    {
+        return $this->attr_batch_stmts[$row_count]
+            ??= $this->db->prepare(
+                'INSERT INTO context_node_attributes (node_id, key, value)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?)'))
+            );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -103,6 +103,7 @@ final class PdoContextTreeSink implements ContextTreeSink
             }
         }
 
+        /** @psalm-suppress MixedAssignment -- $attributes is array<string, mixed> */
         foreach ($attributes as $key => $value) {
             $this->attr_buffer[] = $node_id;
             $this->attr_buffer[] = $key;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -80,34 +80,33 @@ final class PdoContextTreeSink implements ContextTreeSink
         $this->bufferEdge($parent_node_id, $node_id, $link_name, 1);
 
         foreach ($locations as $location) {
-            if ($location instanceof MemoryLocation) {
-                $class = $location::class;
-                $short_class = $this->short_name_cache[$class]
-                    ??= (new \ReflectionClass($class))->getShortName();
-                $this->location_buffer[] = $node_id;
-                $this->location_buffer[] = $location->address;
-                $this->location_buffer[] = $location->size;
-                $this->location_buffer[] = $short_class;
-                $this->location_buffer[] = $location instanceof ZendObjectMemoryLocation
-                    ? $location->class_name : null;
-                $this->location_buffer[] = $location instanceof ZendStringMemoryLocation
-                    ? $location->value : null;
-                $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
-                    ? $location->refcount : null;
-                $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
-                    ? $location->type_info : null;
-                $this->location_buffer[] = $this->region_boundaries?->classifyRegion($location);
-                $this->location_row_count++;
+            $class = $location::class;
+            $short_class = $this->short_name_cache[$class]
+                ??= (new \ReflectionClass($class))->getShortName();
+            $this->location_buffer[] = $node_id;
+            $this->location_buffer[] = $location->address;
+            $this->location_buffer[] = $location->size;
+            $this->location_buffer[] = $short_class;
+            $this->location_buffer[] = $location instanceof ZendObjectMemoryLocation
+                ? $location->class_name : null;
+            $this->location_buffer[] = $location instanceof ZendStringMemoryLocation
+                ? $location->value : null;
+            $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
+                ? $location->refcount : null;
+            $this->location_buffer[] = $location instanceof RefcountedMemoryLocation
+                ? $location->type_info : null;
+            $this->location_buffer[] = $this->region_boundaries?->classifyRegion($location);
+            $this->location_row_count++;
 
-                if ($this->location_row_count >= self::LOCATION_BATCH_SIZE) {
-                    $this->flushLocations();
-                }
+            if ($this->location_row_count >= self::LOCATION_BATCH_SIZE) {
+                $this->flushLocations();
             }
         }
 
+        /** @var mixed $value */
         foreach ($attributes as $key => $value) {
             $this->attr_buffer[] = $node_id;
-            $this->attr_buffer[] = (string)$key;
+            $this->attr_buffer[] = $key;
             $this->attr_buffer[] = is_scalar($value) ? (string)$value : json_encode($value);
             $this->attr_row_count++;
 
@@ -175,7 +174,7 @@ final class PdoContextTreeSink implements ContextTreeSink
 
     private function getAttrBatchStmt(int $row_count): \PDOStatement
     {
-        $qi = fn (string $id) => $this->driver->quoteIdentifier($id);
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         return $this->attr_batch_stmts[$row_count]
             ??= $this->db->prepare(
                 "INSERT INTO context_node_attributes (node_id, {$qi('key')}, {$qi('value')})"

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -103,11 +103,12 @@ final class PdoContextTreeSink implements ContextTreeSink
             }
         }
 
-        /** @var mixed $value */
         foreach ($attributes as $key => $value) {
             $this->attr_buffer[] = $node_id;
             $this->attr_buffer[] = $key;
-            $this->attr_buffer[] = is_scalar($value) ? (string)$value : json_encode($value);
+            $string_value = is_scalar($value) ? (string)$value : json_encode($value);
+            assert(is_string($string_value));
+            $this->attr_buffer[] = $string_value;
             $this->attr_row_count++;
 
             if ($this->attr_row_count >= self::ATTR_BATCH_SIZE) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -23,8 +23,10 @@ final class PdoContextTreeSink implements ContextTreeSink
 {
     private const LOCATION_BATCH_SIZE = 200;
     private const ATTR_BATCH_SIZE = 200;
+    private const EDGE_BATCH_SIZE = 200;
     private const LOCATION_COLUMNS = 9;
     private const ATTR_COLUMNS = 3;
+    private const EDGE_COLUMNS = 4;
 
     private \PDOStatement $node_stmt;
 
@@ -39,18 +41,23 @@ final class PdoContextTreeSink implements ContextTreeSink
     private array $attr_buffer = [];
     private int $attr_row_count = 0;
 
+    /** @var list<mixed> */
+    private array $edge_buffer = [];
+    private int $edge_row_count = 0;
+
     /** @var array<int, \PDOStatement> */
     private array $location_batch_stmts = [];
     /** @var array<int, \PDOStatement> */
     private array $attr_batch_stmts = [];
+    /** @var array<int, \PDOStatement> */
+    private array $edge_batch_stmts = [];
 
     public function __construct(
         private \PDO $db,
         private ?RegionBoundaries $region_boundaries = null,
     ) {
         $this->node_stmt = $db->prepare(
-            'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
-            . ' VALUES (?, ?, ?, ?, ?)'
+            'INSERT OR IGNORE INTO context_nodes (node_id, type) VALUES (?, ?)'
         );
     }
 
@@ -67,7 +74,8 @@ final class PdoContextTreeSink implements ContextTreeSink
         iterable $locations,
         array $attributes,
     ): void {
-        $this->node_stmt->execute([$node_id, $parent_node_id, $link_name, $type, null]);
+        $this->node_stmt->execute([$node_id, $type]);
+        $this->bufferEdge($parent_node_id, $node_id, $link_name, 1);
 
         foreach ($locations as $location) {
             if ($location instanceof MemoryLocation) {
@@ -119,7 +127,7 @@ final class PdoContextTreeSink implements ContextTreeSink
         ?int $parent_node_id,
         string $link_name,
     ): void {
-        $this->node_stmt->execute([$reference_node_id, $parent_node_id, $link_name, null, $reference_node_id]);
+        $this->bufferEdge($parent_node_id, $reference_node_id, $link_name, 0);
     }
 
     public function flush(): void
@@ -129,6 +137,9 @@ final class PdoContextTreeSink implements ContextTreeSink
         }
         if ($this->attr_row_count > 0) {
             $this->flushAttributes();
+        }
+        if ($this->edge_row_count > 0) {
+            $this->flushEdges();
         }
     }
 
@@ -166,6 +177,37 @@ final class PdoContextTreeSink implements ContextTreeSink
             ??= $this->db->prepare(
                 'INSERT INTO context_node_attributes (node_id, key, value)'
                 . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?)'))
+            );
+    }
+
+    private function bufferEdge(?int $parent_node_id, int $child_node_id, string $link_name, int $is_tree): void
+    {
+        $this->edge_buffer[] = $parent_node_id;
+        $this->edge_buffer[] = $child_node_id;
+        $this->edge_buffer[] = $link_name;
+        $this->edge_buffer[] = $is_tree;
+        $this->edge_row_count++;
+
+        if ($this->edge_row_count >= self::EDGE_BATCH_SIZE) {
+            $this->flushEdges();
+        }
+    }
+
+    private function flushEdges(): void
+    {
+        $count = $this->edge_row_count;
+        $stmt = $this->getEdgeBatchStmt($count);
+        $stmt->execute($this->edge_buffer);
+        $this->edge_buffer = [];
+        $this->edge_row_count = 0;
+    }
+
+    private function getEdgeBatchStmt(int $row_count): \PDOStatement
+    {
+        return $this->edge_batch_stmts[$row_count]
+            ??= $this->db->prepare(
+                'INSERT INTO context_edges (parent_node_id, child_node_id, link_name, is_tree)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?)'))
             );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -25,6 +25,9 @@ final class PdoContextTreeSink implements ContextTreeSink
     private \PDOStatement $location_stmt;
     private \PDOStatement $attr_stmt;
 
+    /** @var array<class-string, string> */
+    private array $short_name_cache = [];
+
     public function __construct(
         \PDO $db,
         private ?RegionBoundaries $region_boundaries = null,
@@ -67,7 +70,9 @@ final class PdoContextTreeSink implements ContextTreeSink
 
         foreach ($locations as $location) {
             if ($location instanceof MemoryLocation) {
-                $short_class = (new \ReflectionClass($location))->getShortName();
+                $class = $location::class;
+                $short_class = $this->short_name_cache[$class]
+                    ??= (new \ReflectionClass($class))->getShortName();
                 $this->location_stmt->execute([
                     ':node_id' => $node_id,
                     ':address' => $location->address,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -25,9 +25,9 @@ final class PdoContextTreeSink implements ContextTreeSink
     private const LOCATION_BATCH_SIZE = 200;
     private const ATTR_BATCH_SIZE = 200;
     private const EDGE_BATCH_SIZE = 200;
-    private const LOCATION_COLUMNS = 9;
-    private const ATTR_COLUMNS = 3;
-    private const EDGE_COLUMNS = 4;
+    private const LOCATION_COLUMNS = 10;
+    private const ATTR_COLUMNS = 4;
+    private const EDGE_COLUMNS = 5;
 
     private \PDOStatement $node_stmt;
 
@@ -56,10 +56,11 @@ final class PdoContextTreeSink implements ContextTreeSink
     public function __construct(
         private \PDO $db,
         private PdoDriverInterface $driver,
+        private int $run_id,
         private ?RegionBoundaries $region_boundaries = null,
     ) {
         $this->node_stmt = $db->prepare(
-            $driver->insertIgnoreSql('context_nodes', 'node_id, type', '?, ?')
+            $driver->insertIgnoreSql('context_nodes', 'run_id, node_id, type', '?, ?, ?')
         );
     }
 
@@ -76,13 +77,14 @@ final class PdoContextTreeSink implements ContextTreeSink
         iterable $locations,
         array $attributes,
     ): void {
-        $this->node_stmt->execute([$node_id, $type]);
+        $this->node_stmt->execute([$this->run_id, $node_id, $type]);
         $this->bufferEdge($parent_node_id, $node_id, $link_name, 1);
 
         foreach ($locations as $location) {
             $class = $location::class;
             $short_class = $this->short_name_cache[$class]
                 ??= (new \ReflectionClass($class))->getShortName();
+            $this->location_buffer[] = $this->run_id;
             $this->location_buffer[] = $node_id;
             $this->location_buffer[] = $location->address;
             $this->location_buffer[] = $location->size;
@@ -105,6 +107,7 @@ final class PdoContextTreeSink implements ContextTreeSink
 
         /** @psalm-suppress MixedAssignment -- $attributes is array<string, mixed> */
         foreach ($attributes as $key => $value) {
+            $this->attr_buffer[] = $this->run_id;
             $this->attr_buffer[] = $node_id;
             $this->attr_buffer[] = $key;
             $string_value = is_scalar($value) ? (string)$value : json_encode($value);
@@ -169,8 +172,9 @@ final class PdoContextTreeSink implements ContextTreeSink
         return $this->location_batch_stmts[$row_count]
             ??= $this->db->prepare(
                 'INSERT INTO context_node_locations'
-                . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info, region)'
-                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?,?,?,?,?)'))
+                . ' (run_id, node_id, address, size, location_type,'
+                . ' class_name, string_value, refcount, type_info, region)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?,?,?,?,?,?)'))
             );
     }
 
@@ -179,13 +183,14 @@ final class PdoContextTreeSink implements ContextTreeSink
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
         return $this->attr_batch_stmts[$row_count]
             ??= $this->db->prepare(
-                "INSERT INTO context_node_attributes (node_id, {$qi('key')}, {$qi('value')})"
-                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?)'))
+                "INSERT INTO context_node_attributes (run_id, node_id, {$qi('key')}, {$qi('value')})"
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?)'))
             );
     }
 
     private function bufferEdge(?int $parent_node_id, int $child_node_id, string $link_name, int $is_tree): void
     {
+        $this->edge_buffer[] = $this->run_id;
         $this->edge_buffer[] = $parent_node_id;
         $this->edge_buffer[] = $child_node_id;
         $this->edge_buffer[] = $link_name;
@@ -210,8 +215,8 @@ final class PdoContextTreeSink implements ContextTreeSink
     {
         return $this->edge_batch_stmts[$row_count]
             ??= $this->db->prepare(
-                'INSERT INTO context_edges (parent_node_id, child_node_id, link_name, is_tree)'
-                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?)'))
+                'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?)'))
             );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
+
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\Process\MemoryLocation;
+
+final class PdoContextTreeSink implements ContextTreeSink
+{
+    private \PDOStatement $node_stmt;
+    private \PDOStatement $location_stmt;
+    private \PDOStatement $attr_stmt;
+
+    public function __construct(\PDO $db)
+    {
+        $this->node_stmt = $db->prepare(
+            'INSERT OR IGNORE INTO context_nodes (node_id, parent_node_id, link_name, type, reference_node_id)'
+            . ' VALUES (:node_id, :parent_node_id, :link_name, :type, :reference_node_id)'
+        );
+        $this->location_stmt = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (node_id, address, size, location_type, class_name, string_value, refcount, type_info)'
+            . ' VALUES (:node_id, :address, :size, :location_type, :class_name, :string_value, :refcount, :type_info)'
+        );
+        $this->attr_stmt = $db->prepare(
+            'INSERT INTO context_node_attributes (node_id, key, value)'
+            . ' VALUES (:node_id, :key, :value)'
+        );
+    }
+
+    /**
+     * @param iterable<array-key, MemoryLocation> $locations
+     * @param array<string, mixed> $attributes
+     */
+    #[\Override]
+    public function emitNode(
+        int $node_id,
+        ?int $parent_node_id,
+        string $link_name,
+        string $type,
+        iterable $locations,
+        array $attributes,
+    ): void {
+        $this->node_stmt->execute([
+            ':node_id' => $node_id,
+            ':parent_node_id' => $parent_node_id,
+            ':link_name' => $link_name,
+            ':type' => $type,
+            ':reference_node_id' => null,
+        ]);
+
+        foreach ($locations as $location) {
+            if ($location instanceof MemoryLocation) {
+                $short_class = (new \ReflectionClass($location))->getShortName();
+                $this->location_stmt->execute([
+                    ':node_id' => $node_id,
+                    ':address' => $location->address,
+                    ':size' => $location->size,
+                    ':location_type' => $short_class,
+                    ':class_name' => $location instanceof ZendObjectMemoryLocation
+                        ? $location->class_name : null,
+                    ':string_value' => $location instanceof ZendStringMemoryLocation
+                        ? $location->value : null,
+                    ':refcount' => $location instanceof RefcountedMemoryLocation
+                        ? $location->refcount : null,
+                    ':type_info' => $location instanceof RefcountedMemoryLocation
+                        ? $location->type_info : null,
+                ]);
+            }
+        }
+
+        foreach ($attributes as $key => $value) {
+            $this->attr_stmt->execute([
+                ':node_id' => $node_id,
+                ':key' => (string)$key,
+                ':value' => is_scalar($value) ? (string)$value : json_encode($value),
+            ]);
+        }
+    }
+
+    #[\Override]
+    public function emitReference(
+        int $reference_node_id,
+        ?int $parent_node_id,
+        string $link_name,
+    ): void {
+        $this->node_stmt->execute([
+            ':node_id' => $reference_node_id,
+            ':parent_node_id' => $parent_node_id,
+            ':link_name' => $link_name,
+            ':type' => null,
+            ':reference_node_id' => $reference_node_id,
+        ]);
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
@@ -28,4 +28,7 @@ interface ReferenceContext
     public function getLocations(): iterable;
 
     public function getContexts(): iterable;
+
+    /** Release child references to allow GC of traversed subtrees */
+    public function releaseLinks(): void;
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
@@ -47,4 +47,9 @@ trait ReferenceContextDefault
     {
         return [];
     }
+
+    public function releaseLinks(): void
+    {
+        $this->referencing_contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionAnalyzer.php
@@ -159,9 +159,8 @@ final class RegionAnalyzer
     {
         $locations = $memory_locations->memory_locations;
 
-        usort($locations, function (MemoryLocation $a, MemoryLocation $b) {
-            return $a->address <=> $b->address;
-        });
+        $addresses = array_map(fn (MemoryLocation $l) => $l->address, $locations);
+        array_multisort($addresses, SORT_ASC, SORT_NUMERIC, $locations);
 
         $filtered_locations = [];
         foreach ($locations as $location) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundaries.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundaries.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer;
+
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
+use Reli\Lib\Process\MemoryLocation;
+
+final class RegionBoundaries
+{
+    public function __construct(
+        public readonly MemoryLocations $chunk_memory_locations,
+        public readonly MemoryLocations $huge_memory_locations,
+        public readonly MemoryLocations $vm_stack_memory_locations,
+        public readonly MemoryLocations $compiler_arena_memory_locations,
+    ) {
+    }
+
+    public function classifyRegion(MemoryLocation $location): string
+    {
+        if ($this->chunk_memory_locations->contains($location)) {
+            if ($this->vm_stack_memory_locations->contains($location)) {
+                return 'vm_stack';
+            }
+            if ($this->compiler_arena_memory_locations->contains($location)) {
+                return 'compiler_arena';
+            }
+            return 'zend_mm_heap';
+        }
+        if ($this->huge_memory_locations->contains($location)) {
+            return 'zend_mm_huge';
+        }
+        return 'outside';
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/MemoryOutputFactoryTest.php
+++ b/tests/Inspector/Output/MemoryOutput/MemoryOutputFactoryTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
+
+class MemoryOutputFactoryTest extends BaseTestCase
+{
+    public function testCreateJsonOutput(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'json',
+        );
+        $output = $factory->create($settings);
+        $this->assertInstanceOf(JsonMemoryOutput::class, $output);
+    }
+
+    public function testCreateSqliteOutput(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'reli_test_') . '.db';
+        try {
+            $factory = new MemoryOutputFactory();
+            $settings = new MemoryProfilerSettings(
+                stop_process: false,
+                pretty_print: false,
+                output_format: 'sqlite3',
+                output_path: $path,
+            );
+            $output = $factory->create($settings);
+            $this->assertInstanceOf(PdoMemoryOutput::class, $output);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testCreateSqliteOutputRequiresOutputPath(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'sqlite3',
+            output_path: null,
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('--output is required');
+        $factory->create($settings);
+    }
+
+    public function testCreateMysqlOutput(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'mysql',
+            db_name: 'test_db',
+            db_user: 'root',
+            db_password: '',
+        );
+        $output = $factory->create($settings);
+        $this->assertInstanceOf(PdoMemoryOutput::class, $output);
+    }
+
+    public function testCreateMysqlOutputRequiresDbName(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'mysql',
+            db_user: 'root',
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('--db-name is required');
+        $factory->create($settings);
+    }
+
+    public function testCreateMysqlOutputRequiresDbUser(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'mysql',
+            db_name: 'test_db',
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('--db-user is required');
+        $factory->create($settings);
+    }
+
+    public function testCreatePostgresqlOutput(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'postgresql',
+            db_name: 'test_db',
+            db_user: 'postgres',
+            db_password: '',
+        );
+        $output = $factory->create($settings);
+        $this->assertInstanceOf(PdoMemoryOutput::class, $output);
+    }
+
+    public function testCreatePostgresqlOutputRequiresDbName(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'postgresql',
+            db_user: 'postgres',
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('--db-name is required');
+        $factory->create($settings);
+    }
+
+    public function testCreatePostgresqlOutputRequiresDbUser(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'postgresql',
+            db_name: 'test_db',
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('--db-user is required');
+        $factory->create($settings);
+    }
+
+    public function testCreateUnsupportedFormatThrows(): void
+    {
+        $factory = new MemoryOutputFactory();
+        $settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'csv',
+        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('unsupported output format: csv');
+        $factory->create($settings);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriverTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoDriver/MySqlDriverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+use Reli\BaseTestCase;
+
+class MySqlDriverTest extends BaseTestCase
+{
+    public function testInsertIgnoreSql(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame(
+            'INSERT IGNORE INTO my_table (col1, col2) VALUES (?, ?)',
+            $driver->insertIgnoreSql('my_table', 'col1, col2', '?, ?'),
+        );
+    }
+
+    public function testConcatExpr(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame('CONCAT(a, b)', $driver->concatExpr('a', 'b'));
+    }
+
+    public function testAutoIncrementPrimaryKey(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame('INTEGER PRIMARY KEY AUTO_INCREMENT', $driver->autoIncrementPrimaryKey());
+    }
+
+    public function testCreateViewSql(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame(
+            'CREATE OR REPLACE VIEW my_view AS',
+            $driver->createViewSql('my_view'),
+        );
+    }
+
+    public function testQuoteIdentifier(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame('`key`', $driver->quoteIdentifier('key'));
+        $this->assertSame('`value`', $driver->quoteIdentifier('value'));
+    }
+
+    public function testPrimaryKeyTextType(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame('VARCHAR(255)', $driver->primaryKeyTextType());
+    }
+
+    public function testCastAsInteger(): void
+    {
+        $driver = new MySqlDriver('localhost', 3306, 'test', 'root', '');
+        $this->assertSame('CAST(x AS SIGNED)', $driver->castAsInteger('x'));
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriverTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoDriver/PostgreSqlDriverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+use Reli\BaseTestCase;
+
+class PostgreSqlDriverTest extends BaseTestCase
+{
+    public function testInsertIgnoreSql(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame(
+            'INSERT INTO my_table (col1, col2) VALUES (?, ?) ON CONFLICT DO NOTHING',
+            $driver->insertIgnoreSql('my_table', 'col1, col2', '?, ?'),
+        );
+    }
+
+    public function testConcatExpr(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame('a || b', $driver->concatExpr('a', 'b'));
+    }
+
+    public function testAutoIncrementPrimaryKey(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame('SERIAL PRIMARY KEY', $driver->autoIncrementPrimaryKey());
+    }
+
+    public function testCreateViewSql(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame(
+            'CREATE OR REPLACE VIEW my_view AS',
+            $driver->createViewSql('my_view'),
+        );
+    }
+
+    public function testQuoteIdentifier(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame('"key"', $driver->quoteIdentifier('key'));
+        $this->assertSame('"value"', $driver->quoteIdentifier('value'));
+    }
+
+    public function testPrimaryKeyTextType(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame('TEXT', $driver->primaryKeyTextType());
+    }
+
+    public function testCastAsInteger(): void
+    {
+        $driver = new PostgreSqlDriver('localhost', 5432, 'test', 'postgres', '');
+        $this->assertSame('CAST(x AS INTEGER)', $driver->castAsInteger('x'));
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriverTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoDriver/SqliteDriverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\PdoDriver;
+
+use Reli\BaseTestCase;
+
+class SqliteDriverTest extends BaseTestCase
+{
+    public function testCreateConnection(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'reli_test_') . '.db';
+        try {
+            $driver = new SqliteDriver($path);
+            $db = $driver->createConnection();
+            $this->assertInstanceOf(\PDO::class, $db);
+            $this->assertSame(
+                \PDO::ERRMODE_EXCEPTION,
+                $db->getAttribute(\PDO::ATTR_ERRMODE),
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testInsertIgnoreSql(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame(
+            'INSERT OR IGNORE INTO my_table (col1, col2) VALUES (?, ?)',
+            $driver->insertIgnoreSql('my_table', 'col1, col2', '?, ?'),
+        );
+    }
+
+    public function testConcatExpr(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame('a || b', $driver->concatExpr('a', 'b'));
+    }
+
+    public function testAutoIncrementPrimaryKey(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame('INTEGER PRIMARY KEY', $driver->autoIncrementPrimaryKey());
+    }
+
+    public function testTuneForBulkInsert(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $db = $driver->createConnection();
+        $driver->tuneForBulkInsert($db);
+        $journal = $db->query('PRAGMA journal_mode')->fetchColumn();
+        $this->assertSame('off', strtolower($journal));
+    }
+
+    public function testCreateViewSql(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame(
+            'CREATE VIEW IF NOT EXISTS my_view AS',
+            $driver->createViewSql('my_view'),
+        );
+    }
+
+    public function testQuoteIdentifier(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame('"key"', $driver->quoteIdentifier('key'));
+        $this->assertSame('"value"', $driver->quoteIdentifier('value'));
+    }
+
+    public function testPrimaryKeyTextType(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame('TEXT', $driver->primaryKeyTextType());
+    }
+
+    public function testCastAsInteger(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+        $this->assertSame('CAST(x AS INTEGER)', $driver->castAsInteger('x'));
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
@@ -45,6 +45,7 @@ class PdoMemoryOutputTest extends BaseTestCase
         $db = new \PDO('sqlite:' . $this->db_path);
         $tables = $this->getTableNames($db);
 
+        $this->assertContains('runs', $tables);
         $this->assertContains('summary', $tables);
         $this->assertContains('context_nodes', $tables);
         $this->assertContains('context_edges', $tables);
@@ -74,11 +75,11 @@ class PdoMemoryOutputTest extends BaseTestCase
         $db = new \PDO('sqlite:' . $this->db_path);
         $indexes = $this->getIndexNames($db);
 
-        $this->assertContains('idx_context_edges_parent_tree', $indexes);
-        $this->assertContains('idx_context_edges_child', $indexes);
-        $this->assertContains('idx_context_node_locations_node', $indexes);
-        $this->assertContains('idx_context_node_locations_class', $indexes);
-        $this->assertContains('idx_context_node_attributes_node', $indexes);
+        $this->assertContains('idx_context_edges_run_parent_tree', $indexes);
+        $this->assertContains('idx_context_edges_run_child', $indexes);
+        $this->assertContains('idx_context_node_locations_run_node', $indexes);
+        $this->assertContains('idx_context_node_locations_run_class', $indexes);
+        $this->assertContains('idx_context_node_attributes_run_node', $indexes);
     }
 
     public function testOutputInsertsSummaryData(): void
@@ -91,10 +92,33 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($this->createMinimalResult($summary));
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $rows = $db->query('SELECT "key", "value" FROM summary ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
+        $rows = $db->query('SELECT "key", "value" FROM summary WHERE run_id = 1 ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
 
         $this->assertSame('1024', $rows['memory_usage']);
         $this->assertSame('2048', $rows['peak_memory_usage']);
+    }
+
+    public function testOutputInsertsRunRecord(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($this->createMinimalResult());
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $runs = $db->query('SELECT run_id, created_at FROM runs')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $runs);
+        $this->assertEquals(1, $runs[0]['run_id']);
+        $this->assertNotEmpty($runs[0]['created_at']);
+    }
+
+    public function testMultipleRunsGetDistinctIds(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($this->createMinimalResult());
+        $output->output($this->createMinimalResult());
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $runs = $db->query('SELECT run_id FROM runs ORDER BY run_id')->fetchAll(\PDO::FETCH_COLUMN);
+        $this->assertSame([1, 2], $runs);
     }
 
     public function testOutputInsertsNodesAndEdges(): void
@@ -110,19 +134,21 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $nodes = $db->query('SELECT node_id, type FROM context_nodes ORDER BY node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $nodes = $db->query('SELECT run_id, node_id, type FROM context_nodes ORDER BY node_id')->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $nodes);
+        $this->assertEquals(1, $nodes[0]['run_id']);
         $this->assertSame('root_type', $nodes[0]['type']);
         $this->assertSame('child_type', $nodes[1]['type']);
 
         $edges = $db->query(
-            'SELECT parent_node_id, child_node_id, link_name, is_tree'
+            'SELECT run_id, parent_node_id, child_node_id, link_name, is_tree'
             . ' FROM context_edges ORDER BY child_node_id'
         )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $edges);
 
         // Root node edge (parent=null)
         $root_edge = $edges[0];
+        $this->assertEquals(1, $root_edge['run_id']);
         $this->assertNull($root_edge['parent_node_id']);
         $this->assertEquals(0, $root_edge['child_node_id']);
         $this->assertSame('root_link', $root_edge['link_name']);
@@ -156,6 +182,7 @@ class PdoMemoryOutputTest extends BaseTestCase
         $db = new \PDO('sqlite:' . $this->db_path);
         $locs = $db->query('SELECT * FROM context_node_locations')->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(1, $locs);
+        $this->assertEquals(1, $locs[0]['run_id']);
         $this->assertEquals(0, $locs[0]['node_id']);
         $this->assertEquals(4096, $locs[0]['address']); // 0x1000
         $this->assertEquals(64, $locs[0]['size']);
@@ -204,7 +231,7 @@ class PdoMemoryOutputTest extends BaseTestCase
 
         $db = new \PDO('sqlite:' . $this->db_path);
         $attrs = $db->query(
-            'SELECT "key", "value" FROM context_node_attributes ORDER BY "key"'
+            'SELECT "key", "value" FROM context_node_attributes WHERE run_id = 1 ORDER BY "key"'
         )->fetchAll(\PDO::FETCH_KEY_PAIR);
         $this->assertSame('5', $attrs['#count']);
         $this->assertSame('array', $attrs['#type']);
@@ -242,10 +269,11 @@ class PdoMemoryOutputTest extends BaseTestCase
 
         $db = new \PDO('sqlite:' . $this->db_path);
         $paths = $db->query(
-            'SELECT node_id, path, depth FROM v_node_paths ORDER BY depth, node_id'
+            'SELECT run_id, node_id, path, depth FROM v_node_paths ORDER BY depth, node_id'
         )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $paths);
         // depth 0: to_middle
+        $this->assertEquals(1, $paths[0]['run_id']);
         $this->assertEquals(0, $paths[0]['depth']);
         $this->assertSame('to_middle', $paths[0]['path']);
         // depth 1: to_middle -> to_leaf
@@ -271,9 +299,10 @@ class PdoMemoryOutputTest extends BaseTestCase
 
         $db = new \PDO('sqlite:' . $this->db_path);
         $rows = $db->query(
-            'SELECT "type", "count", memory_usage FROM location_types_summary'
+            'SELECT run_id, "type", "count", memory_usage FROM location_types_summary'
         )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(1, $rows);
+        $this->assertEquals(1, $rows[0]['run_id']);
         $this->assertSame('ZendObjectMemoryLocation', $rows[0]['type']);
         $this->assertEquals(1, $rows[0]['count']);
         $this->assertEquals(128, $rows[0]['memory_usage']);
@@ -292,9 +321,10 @@ class PdoMemoryOutputTest extends BaseTestCase
 
         $db = new \PDO('sqlite:' . $this->db_path);
         $rows = $db->query(
-            'SELECT class_name, "count", memory_usage FROM class_objects_summary'
+            'SELECT run_id, class_name, "count", memory_usage FROM class_objects_summary'
         )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(1, $rows);
+        $this->assertEquals(1, $rows[0]['run_id']);
         $this->assertSame('App\\Foo', $rows[0]['class_name']);
         $this->assertEquals(2, $rows[0]['count']);
         $this->assertEquals(192, $rows[0]['memory_usage']); // 64 + 128

--- a/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
@@ -1,0 +1,364 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
+use Reli\Lib\Process\MemoryLocation;
+
+class PdoMemoryOutputTest extends BaseTestCase
+{
+    private string $db_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db_path = tempnam(sys_get_temp_dir(), 'reli_test_') . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    public function testOutputCreatesAllTables(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($this->createMinimalResult());
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $tables = $this->getTableNames($db);
+
+        $this->assertContains('summary', $tables);
+        $this->assertContains('context_nodes', $tables);
+        $this->assertContains('context_edges', $tables);
+        $this->assertContains('context_node_locations', $tables);
+        $this->assertContains('context_node_attributes', $tables);
+        $this->assertContains('location_types_summary', $tables);
+        $this->assertContains('class_objects_summary', $tables);
+    }
+
+    public function testOutputCreatesViews(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($this->createMinimalResult());
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $views = $this->getViewNames($db);
+
+        $this->assertContains('v_node_paths', $views);
+        $this->assertContains('v_arrays', $views);
+    }
+
+    public function testOutputCreatesIndexes(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($this->createMinimalResult());
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $indexes = $this->getIndexNames($db);
+
+        $this->assertContains('idx_context_edges_parent_tree', $indexes);
+        $this->assertContains('idx_context_edges_child', $indexes);
+        $this->assertContains('idx_context_node_locations_node', $indexes);
+        $this->assertContains('idx_context_node_locations_class', $indexes);
+        $this->assertContains('idx_context_node_attributes_node', $indexes);
+    }
+
+    public function testOutputInsertsSummaryData(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $summary = [
+            ['memory_usage' => '1024'],
+            ['peak_memory_usage' => '2048'],
+        ];
+        $output->output($this->createMinimalResult($summary));
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $rows = $db->query('SELECT "key", "value" FROM summary ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
+
+        $this->assertSame('1024', $rows['memory_usage']);
+        $this->assertSame('2048', $rows['peak_memory_usage']);
+    }
+
+    public function testOutputInsertsNodesAndEdges(): void
+    {
+        // ContextAnalyzer iterates the top context's getLinks(), so we need:
+        // top -> "root_link" -> rootNode -> "child_link" -> childNode
+        $child = $this->createMockContext('child_type', [], []);
+        $root = $this->createMockContext('root_type', ['child_link' => $child], []);
+        $top = $this->createMockContext('top', ['root_link' => $root], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $nodes = $db->query('SELECT node_id, type FROM context_nodes ORDER BY node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(2, $nodes);
+        $this->assertSame('root_type', $nodes[0]['type']);
+        $this->assertSame('child_type', $nodes[1]['type']);
+
+        $edges = $db->query('SELECT parent_node_id, child_node_id, link_name, is_tree FROM context_edges ORDER BY child_node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(2, $edges);
+
+        // Root node edge (parent=null)
+        $root_edge = $edges[0];
+        $this->assertNull($root_edge['parent_node_id']);
+        $this->assertEquals(0, $root_edge['child_node_id']);
+        $this->assertSame('root_link', $root_edge['link_name']);
+        $this->assertEquals(1, $root_edge['is_tree']);
+
+        // Child node edge (parent=root)
+        $child_edge = $edges[1];
+        $this->assertEquals(0, $child_edge['parent_node_id']);
+        $this->assertEquals(1, $child_edge['child_node_id']);
+        $this->assertSame('child_link', $child_edge['link_name']);
+        $this->assertEquals(1, $child_edge['is_tree']);
+    }
+
+    public function testOutputInsertsLocations(): void
+    {
+        $location = new ZendObjectMemoryLocation(
+            address: 0x1000,
+            size: 64,
+            refcount: 1,
+            type_info: 7,
+            class_name: 'App\\MyClass',
+        );
+        // Wrap: top -> "entry" -> holder (with location)
+        $holder = $this->createMockContext('object_holder', [], [$location]);
+        $top = $this->createMockContext('top', ['entry' => $holder], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $locs = $db->query('SELECT * FROM context_node_locations')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $locs);
+        $this->assertEquals(0, $locs[0]['node_id']);
+        $this->assertEquals(4096, $locs[0]['address']); // 0x1000
+        $this->assertEquals(64, $locs[0]['size']);
+        $this->assertSame('ZendObjectMemoryLocation', $locs[0]['location_type']);
+        $this->assertSame('App\\MyClass', $locs[0]['class_name']);
+        $this->assertEquals(1, $locs[0]['refcount']);
+    }
+
+    public function testOutputInsertsStringLocations(): void
+    {
+        $location = new ZendStringMemoryLocation(
+            address: 0x2000,
+            size: 48,
+            refcount: 2,
+            type_info: 6,
+            value: 'hello world',
+        );
+        $holder = $this->createMockContext('string_holder', [], [$location]);
+        $top = $this->createMockContext('top', ['entry' => $holder], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $locs = $db->query('SELECT * FROM context_node_locations')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $locs);
+        $this->assertSame('ZendStringMemoryLocation', $locs[0]['location_type']);
+        $this->assertSame('hello world', $locs[0]['string_value']);
+        $this->assertNull($locs[0]['class_name']);
+    }
+
+    public function testOutputInsertsAttributes(): void
+    {
+        $holder = $this->createMockContext(
+            'node_with_attrs',
+            [],
+            [],
+            ['#count' => '5', '#type' => 'array'],
+        );
+        $top = $this->createMockContext('top', ['entry' => $holder], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $attrs = $db->query('SELECT "key", "value" FROM context_node_attributes ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
+        $this->assertSame('5', $attrs['#count']);
+        $this->assertSame('array', $attrs['#type']);
+    }
+
+    public function testSharedReferenceCreatesNonTreeEdge(): void
+    {
+        // shared is linked from both parent1 and parent2
+        // ContextAnalyzer uses WeakMap: first visit -> is_tree=1, re-visit -> is_tree=0
+        $shared = $this->createMockContext('shared_type', [], []);
+        $parent1 = $this->createMockContext('parent1', ['link_a' => $shared], []);
+        $parent2 = $this->createMockContext('parent2', ['link_b' => $shared], []);
+        $top = $this->createMockContext('top', ['p1' => $parent1, 'p2' => $parent2], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $edges = $db->query('SELECT * FROM context_edges WHERE is_tree = 0')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $edges);
+        $this->assertSame('link_b', $edges[0]['link_name']);
+        $this->assertEquals(0, $edges[0]['is_tree']);
+    }
+
+    public function testNodePathsViewWorks(): void
+    {
+        $leaf = $this->createMockContext('leaf', [], []);
+        $middle = $this->createMockContext('middle', ['to_leaf' => $leaf], []);
+        $top = $this->createMockContext('top', ['to_middle' => $middle], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $paths = $db->query('SELECT node_id, path, depth FROM v_node_paths ORDER BY depth, node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(2, $paths);
+        // depth 0: to_middle
+        $this->assertEquals(0, $paths[0]['depth']);
+        $this->assertSame('to_middle', $paths[0]['path']);
+        // depth 1: to_middle -> to_leaf
+        $this->assertEquals(1, $paths[1]['depth']);
+        $this->assertSame('to_middle -> to_leaf', $paths[1]['path']);
+    }
+
+    public function testLocationTypesSummaryPopulated(): void
+    {
+        $location = new ZendObjectMemoryLocation(
+            address: 0x1000,
+            size: 128,
+            refcount: 1,
+            type_info: 7,
+            class_name: 'App\\Foo',
+        );
+        $holder = $this->createMockContext('holder', [], [$location]);
+        $top = $this->createMockContext('top', ['entry' => $holder], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $rows = $db->query('SELECT "type", "count", memory_usage FROM location_types_summary')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $rows);
+        $this->assertSame('ZendObjectMemoryLocation', $rows[0]['type']);
+        $this->assertEquals(1, $rows[0]['count']);
+        $this->assertEquals(128, $rows[0]['memory_usage']);
+    }
+
+    public function testClassObjectsSummaryPopulated(): void
+    {
+        $loc1 = new ZendObjectMemoryLocation(0x1000, 64, 1, 7, 'App\\Foo');
+        $loc2 = new ZendObjectMemoryLocation(0x2000, 128, 1, 7, 'App\\Foo');
+        $holder = $this->createMockContext('holder', [], [$loc1, $loc2]);
+        $top = $this->createMockContext('top', ['entry' => $holder], []);
+
+        $result = new MemoryAnalysisResult([], $top);
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $output->output($result);
+
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $rows = $db->query('SELECT class_name, "count", memory_usage FROM class_objects_summary')->fetchAll(\PDO::FETCH_ASSOC);
+        $this->assertCount(1, $rows);
+        $this->assertSame('App\\Foo', $rows[0]['class_name']);
+        $this->assertEquals(2, $rows[0]['count']);
+        $this->assertEquals(192, $rows[0]['memory_usage']); // 64 + 128
+    }
+
+    public function testTransactionRollsBackOnError(): void
+    {
+        $driver = new SqliteDriver(':memory:');
+
+        // Create a context that will throw during analysis
+        $badContext = \Mockery::mock(ReferenceContext::class);
+        $badContext->allows('getLinks')->andThrows(new \RuntimeException('test error'));
+        $badContext->allows('getName')->andReturns('bad');
+        $badContext->allows('getLocations')->andReturns([]);
+        $badContext->allows('getContexts')->andReturns([]);
+        $badContext->allows('releaseLinks');
+
+        $result = new MemoryAnalysisResult([], $badContext);
+        $output = new PdoMemoryOutput($driver);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('test error');
+        $output->output($result);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     */
+    private function createMinimalResult(array $summary = []): MemoryAnalysisResult
+    {
+        $context = $this->createMockContext('empty', [], []);
+        return new MemoryAnalysisResult($summary, $context);
+    }
+
+    /**
+     * @param array<string, ReferenceContext> $links
+     * @param list<MemoryLocation> $locations
+     * @param array<string, mixed> $attributes
+     */
+    private function createMockContext(
+        string $name,
+        array $links,
+        array $locations,
+        array $attributes = [],
+    ): ReferenceContext {
+        $context = \Mockery::mock(ReferenceContext::class);
+        $context->allows('getName')->andReturns($name);
+        $context->allows('getLinks')->andReturns($links);
+        $context->allows('getLocations')->andReturns($locations);
+        $context->allows('getContexts')->andReturns($attributes);
+        $context->allows('releaseLinks');
+        return $context;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getTableNames(\PDO $db): array
+    {
+        return $db->query("SELECT name FROM sqlite_master WHERE type='table'")->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getViewNames(\PDO $db): array
+    {
+        return $db->query("SELECT name FROM sqlite_master WHERE type='view'")->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getIndexNames(\PDO $db): array
+    {
+        return $db->query("SELECT name FROM sqlite_master WHERE type='index'")->fetchAll(\PDO::FETCH_COLUMN);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
@@ -115,7 +115,10 @@ class PdoMemoryOutputTest extends BaseTestCase
         $this->assertSame('root_type', $nodes[0]['type']);
         $this->assertSame('child_type', $nodes[1]['type']);
 
-        $edges = $db->query('SELECT parent_node_id, child_node_id, link_name, is_tree FROM context_edges ORDER BY child_node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $edges = $db->query(
+            'SELECT parent_node_id, child_node_id, link_name, is_tree'
+            . ' FROM context_edges ORDER BY child_node_id'
+        )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $edges);
 
         // Root node edge (parent=null)
@@ -200,7 +203,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $attrs = $db->query('SELECT "key", "value" FROM context_node_attributes ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
+        $attrs = $db->query(
+            'SELECT "key", "value" FROM context_node_attributes ORDER BY "key"'
+        )->fetchAll(\PDO::FETCH_KEY_PAIR);
         $this->assertSame('5', $attrs['#count']);
         $this->assertSame('array', $attrs['#type']);
     }
@@ -236,7 +241,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $paths = $db->query('SELECT node_id, path, depth FROM v_node_paths ORDER BY depth, node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $paths = $db->query(
+            'SELECT node_id, path, depth FROM v_node_paths ORDER BY depth, node_id'
+        )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $paths);
         // depth 0: to_middle
         $this->assertEquals(0, $paths[0]['depth']);
@@ -263,7 +270,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $rows = $db->query('SELECT "type", "count", memory_usage FROM location_types_summary')->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $db->query(
+            'SELECT "type", "count", memory_usage FROM location_types_summary'
+        )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(1, $rows);
         $this->assertSame('ZendObjectMemoryLocation', $rows[0]['type']);
         $this->assertEquals(1, $rows[0]['count']);
@@ -282,7 +291,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $rows = $db->query('SELECT class_name, "count", memory_usage FROM class_objects_summary')->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $db->query(
+            'SELECT class_name, "count", memory_usage FROM class_objects_summary'
+        )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(1, $rows);
         $this->assertSame('App\\Foo', $rows[0]['class_name']);
         $this->assertEquals(2, $rows[0]['count']);

--- a/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
@@ -92,7 +92,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($this->createMinimalResult($summary));
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $rows = $db->query('SELECT "key", "value" FROM summary WHERE run_id = 1 ORDER BY "key"')->fetchAll(\PDO::FETCH_KEY_PAIR);
+        $rows = $db->query(
+            'SELECT "key", "value" FROM summary WHERE run_id = 1 ORDER BY "key"'
+        )->fetchAll(\PDO::FETCH_KEY_PAIR);
 
         $this->assertSame('1024', $rows['memory_usage']);
         $this->assertSame('2048', $rows['peak_memory_usage']);
@@ -134,7 +136,9 @@ class PdoMemoryOutputTest extends BaseTestCase
         $output->output($result);
 
         $db = new \PDO('sqlite:' . $this->db_path);
-        $nodes = $db->query('SELECT run_id, node_id, type FROM context_nodes ORDER BY node_id')->fetchAll(\PDO::FETCH_ASSOC);
+        $nodes = $db->query(
+            'SELECT run_id, node_id, type FROM context_nodes ORDER BY node_id'
+        )->fetchAll(\PDO::FETCH_ASSOC);
         $this->assertCount(2, $nodes);
         $this->assertEquals(1, $nodes[0]['run_id']);
         $this->assertSame('root_type', $nodes[0]['type']);

--- a/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
@@ -20,9 +20,23 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
 {
-    public function testFromConsoleInput()
+    /**
+     * @return \Mockery\MockInterface&InputInterface
+     */
+    private function createBaseMock(): \Mockery\MockInterface
     {
         $input = Mockery::mock(InputInterface::class);
+        $input->allows()->getOption('db-host')->andReturns('127.0.0.1');
+        $input->allows()->getOption('db-port')->andReturns(null);
+        $input->allows()->getOption('db-name')->andReturns(null);
+        $input->allows()->getOption('db-user')->andReturns(null);
+        $input->allows()->getOption('db-password')->andReturns(null);
+        return $input;
+    }
+
+    public function testFromConsoleInput(): void
+    {
+        $input = $this->createBaseMock();
         $input->expects()->getOption('stop-process')->andReturns(true)->atLeast()->once();
         $input->expects()->getOption('pretty-print')->andReturns(false)->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -42,9 +56,9 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertNull($settings->output_path);
     }
 
-    public function testFromConsoleInputDepthNotInteger()
+    public function testFromConsoleInputDepthNotInteger(): void
     {
-        $input = Mockery::mock(InputInterface::class);
+        $input = $this->createBaseMock();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -59,9 +73,9 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
     }
 
-    public function testFromConsoleInputDepthNotPositive()
+    public function testFromConsoleInputDepthNotPositive(): void
     {
-        $input = Mockery::mock(InputInterface::class);
+        $input = $this->createBaseMock();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -76,9 +90,9 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
     }
 
-    public function testFromConsoleInputLineNotInteger()
+    public function testFromConsoleInputLineNotInteger(): void
     {
-        $input = Mockery::mock(InputInterface::class);
+        $input = $this->createBaseMock();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();

--- a/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
@@ -28,6 +28,8 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(512)->atLeast()->once();
+        $input->expects()->getOption('output-format')->andReturns('json')->atLeast()->once();
+        $input->expects()->getOption('output')->andReturns(null)->atLeast()->once();
 
         $settings = (new MemoryProfilerSettingsFromConsoleInput())->createSettings($input);
 
@@ -36,6 +38,8 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertSame('abc.php', $settings->memory_exhaustion_error_details->file);
         $this->assertSame(20, $settings->memory_exhaustion_error_details->line);
         $this->assertSame(512, $settings->memory_exhaustion_error_details->max_challenge_depth);
+        $this->assertSame('json', $settings->output_format);
+        $this->assertNull($settings->output_path);
     }
 
     public function testFromConsoleInputDepthNotInteger()
@@ -46,6 +50,8 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-max-depth')->andReturns('abc');
+        $input->expects()->getOption('output-format')->andReturns('json')->zeroOrMoreTimes();
+        $input->expects()->getOption('output')->andReturns(null)->zeroOrMoreTimes();
         $this->expectException(MemoryProfilerSettingsException::class);
         $this->expectExceptionCode(
             MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
@@ -61,6 +67,8 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-line')->andReturns(20)->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(-1);
+        $input->expects()->getOption('output-format')->andReturns('json')->zeroOrMoreTimes();
+        $input->expects()->getOption('output')->andReturns(null)->zeroOrMoreTimes();
         $this->expectException(MemoryProfilerSettingsException::class);
         $this->expectExceptionCode(
             MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
@@ -76,6 +84,8 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-line')->andReturns('abc')->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-max-depth')->andReturns(512)->zeroOrMoreTimes();
+        $input->expects()->getOption('output-format')->andReturns('json')->zeroOrMoreTimes();
+        $input->expects()->getOption('output')->andReturns(null)->zeroOrMoreTimes();
         $this->expectException(MemoryProfilerSettingsException::class);
         $this->expectExceptionCode(
             MemoryProfilerSettingsException::MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -32,6 +32,7 @@ use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ArrayContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
@@ -228,9 +229,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $this->assertSame(1, $object_class_analyzer_result->per_class_usage['A']['count']);
         $context_analyzer = new ContextAnalyzer();
-        $contexts_analyzed = $context_analyzer->analyze(
-            $collected_memories->top_reference_context
+        $sink = new ArrayContextTreeSink();
+        $context_analyzer->analyze(
+            $collected_memories->top_reference_context,
+            $sink,
         );
+        $contexts_analyzed = $sink->getResult();
         $this->assertSame(
             'fgets',
             $contexts_analyzed['call_frames']['0']['function_name']


### PR DESCRIPTION
## Summary

This PR adds support for outputting memory profiler analysis results to relational databases (SQLite, MySQL, PostgreSQL) in addition to the existing JSON format. This enables powerful SQL-based querying of large memory snapshots that would be unwieldy to analyze with JSON tools.

## Key Changes

- **New output formats**: Added `-f/--output-format` option supporting `json` (default), `sqlite3`, `mysql`, and `postgresql`
- **Database drivers**: Implemented `PdoDriverInterface` with concrete drivers for SQLite, MySQL, and PostgreSQL, handling database-specific SQL syntax differences
- **Schema design**: Created comprehensive relational schema with:
  - Summary tables for metadata and aggregated statistics
  - Context graph tables (nodes, edges, locations, attributes) representing the reference graph
  - Indexes and views for efficient querying (including recursive CTE for canonical paths)
- **Output abstraction**: Refactored memory output to use `MemoryOutputInterface` with implementations for JSON and database formats
- **Context analysis refactor**: Modified `ContextAnalyzer` to use a sink pattern (`ContextTreeSink`) enabling flexible output backends
  - `ArrayContextTreeSink` for JSON output
  - `PdoContextTreeSink` for database output with batched inserts
- **Database optimization**: Added `inspector:optimize-memory-db` command to materialize node paths for faster queries on large databases
- **Configuration**: Extended `MemoryProfilerSettings` with database connection options (`--db-host`, `--db-port`, `--db-name`, `--db-user`, `--db-password`)
- **Documentation**: Added comprehensive guide covering quick start, schema documentation, and example queries

## Implementation Details

- Database operations use transactions with rollback on error
- Bulk insert optimization with pragma tuning (SQLite) and deferred constraints
- Batched statement execution to balance memory usage and performance
- Region classification for memory locations (heap, huge, stack, compiler arena)
- Weak reference tracking during context traversal to detect shared/circular references
- DFS spanning tree edges marked separately from back-references for canonical path queries

https://claude.ai/code/session_01MaixqTadsvZci149yiz5W3