### PR TITLE
Add persistent binary analysis caching for ELF symbol resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Options:
       --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                             disable the binary analysis cache
       --with-native-trace                    collect native (C-level) stack traces alongside PHP traces
       --native-trace-anytime                 collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
   -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
@@ -161,6 +162,7 @@ Options:
       --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                             disable the binary analysis cache
   -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
   -o, --output=OUTPUT                        path to write output from this tool (default: stdout)
   -h, --help                                 Display help for the given command. When no command is given display help for the list command
@@ -192,6 +194,7 @@ Options:
       --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                             disable the binary analysis cache
   -h, --help                                 Display help for the given command. When no command is given display help for the list command
   -q, --quiet                                Do not output any message
   -V, --version                              Display this application version
@@ -220,6 +223,7 @@ Options:
       --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                             disable the binary analysis cache
   -h, --help                                 Display help for the given command. When no command is given display help for the list command
   -q, --quiet                                Do not output any message
   -V, --version                              Display this application version
@@ -253,6 +257,7 @@ Options:
       --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                                          path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]                            path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                                                     disable the binary analysis cache
   -h, --help                                                         Display help for the given command. When no command is given display help for the list command
   -q, --quiet                                                        Do not output any message
   -V, --version                                                      Display this application version
@@ -579,6 +584,23 @@ $ cat 2183131.memory_dump.json | jq 'path(..|objects|select(."#reference_node_id
 The refcount of the object recorded in the memory location is 6 in this example. Calling methods via `$obj->call()` adds refcount by 1, but `$this->call()` doesn't add refcount. References from objects_store don't add refcount too. So all 6 references are analyzed here.
 
 See [./docs/memory-profiler.md](https://github.com/reliforp/reli-prof/blob/0.11.x/docs/memory-profiler.md) for more info.
+
+## Binary analysis cache
+Reli caches the results of expensive binary analysis operations (ELF symbol resolution, TLS brute force offsets, PHP version detection, etc.) to disk. This dramatically speeds up repeated profiling of the same PHP binary -- for example, ZTS target initialization drops from ~8 seconds to ~5 milliseconds on warm cache.
+
+Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode). The cache is automatically invalidated when the target binary is updated (inode changes).
+
+### Clear the cache
+```bash
+./reli cache:clear
+```
+
+### Disable the cache
+All inspector commands accept `--no-cache` to bypass the cache for a single run:
+```bash
+./reli inspector:trace --no-cache -p <pid>
+./reli inspector:daemon --no-cache -P "^php-fpm"
+```
 
 ## Troubleshooting
 ### I get an error message "php module not found" and can't get a trace!

--- a/config/di.php
+++ b/config/di.php
@@ -34,6 +34,7 @@ use Reli\Lib\File\NativeFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\File\PathResolver\ProcessPathResolver;
 use Reli\Lib\Directory\AppDirectory;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
 use Reli\Lib\Log\StateCollector\CallerStateCollector;
@@ -91,6 +92,9 @@ return [
         $logger->pushHandler($handler);
         return $logger;
     },
+    BinaryAnalysisCache::class => fn () => new BinaryAnalysisCache(
+        AppDirectory::getCacheDir() . '/binary-analysis'
+    ),
     Ptrace::class => autowire(PtraceX64::class),
     Reli\Lib\Dwarf\NativeTraceCollector::class => autowire(),
     Reli\Command\Inspector\GetTraceCommand::class => autowire()

--- a/src/Command/Cache/ClearCommand.php
+++ b/src/Command/Cache/ClearCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Cache;
+
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ClearCommand extends Command
+{
+    public function __construct(
+        private BinaryAnalysisCache $binary_analysis_cache,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('cache:clear')
+            ->setDescription('clear the binary analysis cache')
+        ;
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $count = $this->binary_analysis_cache->clear();
+        $output->writeln("cleared {$count} cached entries");
+        return 0;
+    }
+}

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettingsFromCon
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
 use Reli\Lib\Log\Log;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
@@ -39,6 +40,7 @@ final class CoreDumpCommand extends Command
         private MemoryProfilerSettingsFromConsoleInput $memory_profiler_settings_from_console_input,
         private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,
         private CoreDumpReaderFactory $core_dump_reader_factory,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
         parent::__construct();
     }
@@ -68,11 +70,15 @@ final class CoreDumpCommand extends Command
             InputOption::VALUE_REQUIRED,
             'dependency root directory'
         );
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
         Log::info('start core-dump command');
         $memory_profiler_settings = $this->memory_profiler_settings_from_console_input->createSettings($input);
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -31,6 +31,7 @@ use Reli\Lib\Log\Log;
 use Revolt\EventLoop;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Amp\async;
@@ -65,11 +66,13 @@ final class DaemonCommand extends Command
         $this->trace_loop_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $no_cache = (bool)$input->getOption('no-cache');
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
@@ -89,6 +92,7 @@ final class DaemonCommand extends Command
             $daemon_settings->target_regex,
             $target_php_settings,
             $my_pid,
+            $no_cache,
         );
 
         $worker_pool = WorkerPool::create(

--- a/src/Command/Inspector/GetEgAddressCommand.php
+++ b/src/Command/Inspector/GetEgAddressCommand.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Lib\Elf\Parser\ElfParserException;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Tls\TlsFinderException;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
@@ -26,6 +27,7 @@ use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function dechex;
@@ -40,6 +42,7 @@ final class GetEgAddressCommand extends Command
         private TargetProcessResolver $target_process_resolver,
         private PhpVersionDetector $php_version_detector,
         private RetryingLoopProvider $retrying_loop_provider,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
         parent::__construct();
     }
@@ -52,6 +55,7 @@ final class GetEgAddressCommand extends Command
         ;
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     /**
@@ -64,6 +68,9 @@ final class GetEgAddressCommand extends Command
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
         $target_process_settings = $this->target_process_settings_from_console_input->createSettings($input);
 

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -28,6 +28,7 @@ use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Inspector\TraceLoopProvider;
 use Reli\Lib\Dwarf\NativeTraceCollector;
 use Reli\Lib\Elf\Parser\ElfParserException;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Elf\Tls\TlsFinderException;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
@@ -40,6 +41,7 @@ use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Reli\Lib\Defer\defer;
@@ -60,6 +62,7 @@ final class GetTraceCommand extends Command
         private ProcessStopper $process_stopper,
         private TargetProcessResolver $target_process_resolver,
         private RetryingLoopProvider $retrying_loop_provider,
+        private BinaryAnalysisCache $binary_analysis_cache,
         private ?NativeTraceCollector $native_trace_collector = null,
     ) {
         parent::__construct();
@@ -76,6 +79,7 @@ final class GetTraceCommand extends Command
         $this->trace_loop_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     /**
@@ -88,6 +92,9 @@ final class GetTraceCommand extends Command
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
         $target_process_settings = $this->target_process_settings_from_console_input->createSettings($input);

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -29,8 +29,10 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Reli\ReliProfiler;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Reli\Lib\Defer\defer;
@@ -46,6 +48,7 @@ final class MemoryCommand extends Command
         private PhpVersionDetector $php_version_detector,
         private MemoryLocationsCollector $memory_locations_collector,
         private ProcessStopper $process_stopper,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
         parent::__construct();
     }
@@ -59,11 +62,15 @@ final class MemoryCommand extends Command
         $this->memory_profiler_settings_from_console_input->setOptions($this);
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
         Log::info('start memory command');
         $memory_profiler_settings = $this->memory_profiler_settings_from_console_input->createSettings($input);
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -32,6 +32,7 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 use Revolt\EventLoop;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Amp\async;
@@ -63,11 +64,13 @@ final class TopLikeCommand extends Command
         $this->get_trace_settings_from_console_input->setOptions($this);
         $this->trace_loop_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $no_cache = (bool)$input->getOption('no-cache');
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
@@ -87,6 +90,7 @@ final class TopLikeCommand extends Command
             $daemon_settings->target_regex,
             $target_php_settings,
             $my_pid,
+            $no_cache,
         );
 
         $worker_pool = WorkerPool::create(

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
@@ -52,11 +52,13 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
         string $regex,
         TargetPhpSettings $target_php_settings,
         int $pid,
+        bool $no_cache = false,
     ): void {
         $message = new TargetPhpSettingsMessage(
             $regex,
             $target_php_settings,
-            $pid
+            $pid,
+            $no_cache,
         );
         $this->auto_context_recovering->withAutoRecover(
             function (PhpSearcherControllerProtocolInterface $protocol) use ($message) {

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
@@ -21,7 +21,12 @@ interface PhpSearcherControllerInterface
     public function start(): void;
 
     /** @param non-empty-string $regex */
-    public function sendTarget(string $regex, TargetPhpSettings $target_php_settings, int $pid): void;
+    public function sendTarget(
+        string $regex,
+        TargetPhpSettings $target_php_settings,
+        int $pid,
+        bool $no_cache = false,
+    ): void;
 
     public function receivePidList(): UpdateTargetProcessMessage;
 }

--- a/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
+++ b/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
@@ -26,6 +26,7 @@ final class TargetPhpSettingsMessage
         public string $regex,
         public TargetPhpSettings $target_php_settings,
         public int $parent_pid,
+        public bool $no_cache = false,
     ) {
     }
 }

--- a/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
+++ b/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Daemon\Searcher\Protocol\Message\UpdateTargetProcessMessage;
 use Reli\Inspector\Daemon\Dispatcher\TargetProcessList;
 use Reli\Inspector\Daemon\Searcher\Protocol\PhpSearcherWorkerProtocolInterface;
 use Reli\Lib\Amphp\WorkerEntryPointInterface;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Loop\LoopCondition\InfiniteLoopCondition;
 use Reli\Lib\Loop\LoopCondition\LoopConditionInterface;
 use Reli\Lib\Process\ProcFileSystem\ThreadEnumerator;
@@ -32,6 +33,7 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
         private ProcessSearcherInterface $process_searcher,
         private ProcessDescriptorRetriever $process_descriptor_retriever,
         private ThreadEnumerator $thread_enumerator,
+        private BinaryAnalysisCache $binary_analysis_cache,
         private LoopConditionInterface $loop_condition = new InfiniteLoopCondition(),
     ) {
     }
@@ -40,6 +42,9 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
     public function run(): void
     {
         $target_php_settings_message = $this->protocol->receiveTargetPhpSettings();
+        if ($target_php_settings_message->no_cache) {
+            $this->binary_analysis_cache->disable();
+        }
         $cache = new ProcessDescriptorCache();
 
         while ($this->loop_condition->shouldContinue()) {

--- a/src/Lib/Elf/Process/BinaryAnalysisCache.php
+++ b/src/Lib/Elf/Process/BinaryAnalysisCache.php
@@ -17,14 +17,32 @@ use Reli\Lib\Directory\AppDirectory;
 
 final class BinaryAnalysisCache
 {
+    private bool $enabled = true;
+
     public function __construct(
         private string $baseDirectory,
     ) {
     }
 
+    public function disable(): void
+    {
+        $this->enabled = false;
+    }
+
+    public function clear(): int
+    {
+        if (!is_dir($this->baseDirectory)) {
+            return 0;
+        }
+        return $this->removeDirectoryContents($this->baseDirectory);
+    }
+
     /** @return array<array-key, mixed>|null */
     public function get(BinaryFingerprint $fingerprint, string $namespace): ?array
     {
+        if (!$this->enabled) {
+            return null;
+        }
         $path = $this->getPath($fingerprint, $namespace);
         if (!is_file($path)) {
             return null;
@@ -47,6 +65,9 @@ final class BinaryAnalysisCache
     /** @param array<array-key, mixed> $data */
     public function set(BinaryFingerprint $fingerprint, string $namespace, array $data): void
     {
+        if (!$this->enabled) {
+            return;
+        }
         $path = $this->getPath($fingerprint, $namespace);
         $dir = dirname($path);
         AppDirectory::ensureDirectoryExists($dir);
@@ -69,5 +90,29 @@ final class BinaryAnalysisCache
         return $this->baseDirectory
             . '/' . $fingerprint->getCacheKey()
             . '/' . $namespace . '.json';
+    }
+
+    private function removeDirectoryContents(string $dir): int
+    {
+        $count = 0;
+        $items = @scandir($dir);
+        if ($items === false) {
+            return 0;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $count += $this->removeDirectoryContents($path);
+                @rmdir($path);
+            } else {
+                if (@unlink($path)) {
+                    $count++;
+                }
+            }
+        }
+        return $count;
     }
 }

--- a/src/Lib/Elf/Process/BinaryAnalysisCache.php
+++ b/src/Lib/Elf/Process/BinaryAnalysisCache.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use Reli\Lib\Directory\AppDirectory;
+
+final class BinaryAnalysisCache
+{
+    public function __construct(
+        private string $baseDirectory,
+    ) {
+    }
+
+    /** @return array<array-key, mixed>|null */
+    public function get(BinaryFingerprint $fingerprint, string $namespace): ?array
+    {
+        $path = $this->getPath($fingerprint, $namespace);
+        if (!is_file($path)) {
+            return null;
+        }
+        $content = @file_get_contents($path);
+        if ($content === false) {
+            return null;
+        }
+        try {
+            $data = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+        if (!is_array($data)) {
+            return null;
+        }
+        return $data;
+    }
+
+    /** @param array<array-key, mixed> $data */
+    public function set(BinaryFingerprint $fingerprint, string $namespace, array $data): void
+    {
+        $path = $this->getPath($fingerprint, $namespace);
+        $dir = dirname($path);
+        AppDirectory::ensureDirectoryExists($dir);
+
+        $pid = getmypid();
+        $tmpPath = $path . '.tmp.' . ($pid !== false ? $pid : mt_rand());
+        try {
+            $json = json_encode($data, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return;
+        }
+        if (@file_put_contents($tmpPath, $json) === false) {
+            return;
+        }
+        @rename($tmpPath, $path);
+    }
+
+    private function getPath(BinaryFingerprint $fingerprint, string $namespace): string
+    {
+        return $this->baseDirectory
+            . '/' . $fingerprint->getCacheKey()
+            . '/' . $namespace . '.json';
+    }
+}

--- a/src/Lib/Elf/Process/BinaryFingerprint.php
+++ b/src/Lib/Elf/Process/BinaryFingerprint.php
@@ -37,6 +37,11 @@ final class BinaryFingerprint
         );
     }
 
+    public function getCacheKey(): string
+    {
+        return hash('sha256', $this->fingerprint);
+    }
+
     public function __toString(): string
     {
         return $this->fingerprint;

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -56,6 +56,7 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
         $module_name = $module_memory_map->getModuleName();
         $path = $binary_path ?? $this->process_path_resolver->resolve($pid, $module_name);
 
+        $binary_fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_memory_map);
         $symbol_resolver = new Elf64CachedSymbolResolver(
             new Elf64LazyParseSymbolResolver(
                 $path,
@@ -64,9 +65,9 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                 $module_memory_map,
                 $this->symbol_resolver_creator,
             ),
-            $this->per_binary_symbol_cache_retriever->get(
-                BinaryFingerprint::fromProcessModuleMemoryMap($module_memory_map)
-            ),
+            $this->per_binary_symbol_cache_retriever->get($binary_fingerprint),
+            $this->binary_analysis_cache,
+            $binary_fingerprint,
         );
 
         $tls_block_address = null;

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -34,6 +34,7 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
         private IntegerByteSequenceReader $integer_reader,
         private LinkMapLoader $link_map_loader,
         private ProcessPathResolver $process_path_resolver,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
     }
 
@@ -71,11 +72,21 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
         $tls_block_address = null;
         if (!is_null($libpthread_symbol_reader) and !is_null($root_link_map_address)) {
             try {
+                $libpthread_memory_areas = $process_memory_map->findByNameRegex('/libpthread/');
+                $libpthread_fingerprint = null;
+                if ($libpthread_memory_areas !== []) {
+                    $libpthread_module_map = new ProcessModuleMemoryMap($libpthread_memory_areas);
+                    $libpthread_fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap(
+                        $libpthread_module_map
+                    );
+                }
                 $tls_finder = new LibThreadDbTlsFinder(
                     $libpthread_symbol_reader,
                     X64LinuxThreadPointerRetriever::createDefault(),
                     $this->memory_reader,
-                    $this->integer_reader
+                    $this->integer_reader,
+                    $this->binary_analysis_cache,
+                    $libpthread_fingerprint,
                 );
                 $link_map = $this->link_map_loader->searchByName(
                     $module_name,

--- a/src/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolver.php
@@ -13,38 +13,186 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\SymbolResolver;
 
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Integer\UInt64;
 
 final class Elf64CachedSymbolResolver implements Elf64SymbolResolver
 {
+    private ?UInt64 $base_address_cache = null;
+    private ?int $dt_debug_address_cache = null;
+    private bool $dt_debug_resolved = false;
+    private bool $base_address_resolved = false;
+
     public function __construct(
         private Elf64SymbolResolver $resolver,
         private Elf64SymbolCache $symbol_cache,
+        private ?BinaryAnalysisCache $binary_analysis_cache = null,
+        private ?BinaryFingerprint $fingerprint = null,
     ) {
     }
 
     #[\Override]
     public function resolve(string $symbol_name): Elf64SymbolTableEntry
     {
-        if (!$this->symbol_cache->has($symbol_name)) {
-            $this->symbol_cache->set(
-                $symbol_name,
-                $this->resolver->resolve($symbol_name),
-            );
+        if ($this->symbol_cache->has($symbol_name)) {
+            return $this->symbol_cache->get($symbol_name);
         }
-        return $this->symbol_cache->get($symbol_name);
+
+        $entry = $this->resolveFromFileCache($symbol_name);
+        if ($entry !== null) {
+            $this->symbol_cache->set($symbol_name, $entry);
+            return $entry;
+        }
+
+        $entry = $this->resolver->resolve($symbol_name);
+        $this->symbol_cache->set($symbol_name, $entry);
+        $this->saveSymbolToFileCache($symbol_name, $entry);
+        return $entry;
     }
 
     #[\Override]
     public function getDtDebugAddress(): ?int
     {
-        return $this->resolver->getDtDebugAddress();
+        if ($this->dt_debug_resolved) {
+            return $this->dt_debug_address_cache;
+        }
+
+        $cached = $this->getResolverCache();
+        if ($cached !== null && array_key_exists('dt_debug_address', $cached)) {
+            $this->dt_debug_address_cache = is_int($cached['dt_debug_address'])
+                ? $cached['dt_debug_address']
+                : null;
+            $this->dt_debug_resolved = true;
+            return $this->dt_debug_address_cache;
+        }
+
+        $this->dt_debug_address_cache = $this->resolver->getDtDebugAddress();
+        $this->dt_debug_resolved = true;
+        $this->saveResolverMeta();
+        return $this->dt_debug_address_cache;
     }
 
     #[\Override]
     public function getBaseAddress(): UInt64
     {
-        return $this->resolver->getBaseAddress();
+        if ($this->base_address_resolved) {
+            return $this->base_address_cache ?? new UInt64(0, 0);
+        }
+
+        $cached = $this->getResolverCache();
+        if (
+            $cached !== null
+            && isset($cached['base_address_hi'], $cached['base_address_lo'])
+            && is_int($cached['base_address_hi'])
+            && is_int($cached['base_address_lo'])
+        ) {
+            $this->base_address_cache = new UInt64($cached['base_address_hi'], $cached['base_address_lo']);
+            $this->base_address_resolved = true;
+            return $this->base_address_cache;
+        }
+
+        $this->base_address_cache = $this->resolver->getBaseAddress();
+        $this->base_address_resolved = true;
+        $this->saveResolverMeta();
+        return $this->base_address_cache;
+    }
+
+    private function resolveFromFileCache(string $symbol_name): ?Elf64SymbolTableEntry
+    {
+        if ($this->binary_analysis_cache === null || $this->fingerprint === null) {
+            return null;
+        }
+        $cached = $this->binary_analysis_cache->get($this->fingerprint, 'elf_symbols');
+        if ($cached === null || !isset($cached[$symbol_name]) || !is_array($cached[$symbol_name])) {
+            return null;
+        }
+        return $this->deserializeSymbol($cached[$symbol_name]);
+    }
+
+    private function saveSymbolToFileCache(string $symbol_name, Elf64SymbolTableEntry $entry): void
+    {
+        if ($this->binary_analysis_cache === null || $this->fingerprint === null) {
+            return;
+        }
+        $cached = $this->binary_analysis_cache->get($this->fingerprint, 'elf_symbols') ?? [];
+        $cached[$symbol_name] = $this->serializeSymbol($entry);
+        $this->binary_analysis_cache->set($this->fingerprint, 'elf_symbols', $cached);
+    }
+
+    /** @return array<string, int> */
+    private function serializeSymbol(Elf64SymbolTableEntry $entry): array
+    {
+        return [
+            'st_name' => $entry->st_name,
+            'st_info' => $entry->st_info,
+            'st_other' => $entry->st_other,
+            'st_shndx' => $entry->st_shndx,
+            'st_value_hi' => $entry->st_value->hi,
+            'st_value_lo' => $entry->st_value->lo,
+            'st_size_hi' => $entry->st_size->hi,
+            'st_size_lo' => $entry->st_size->lo,
+        ];
+    }
+
+    /** @param array<array-key, mixed> $data */
+    private function deserializeSymbol(array $data): ?Elf64SymbolTableEntry
+    {
+        if (
+            !isset(
+                $data['st_name'],
+                $data['st_info'],
+                $data['st_other'],
+                $data['st_shndx'],
+                $data['st_value_hi'],
+                $data['st_value_lo'],
+                $data['st_size_hi'],
+                $data['st_size_lo'],
+            )
+            || !is_int($data['st_name'])
+            || !is_int($data['st_info'])
+            || !is_int($data['st_other'])
+            || !is_int($data['st_shndx'])
+            || !is_int($data['st_value_hi'])
+            || !is_int($data['st_value_lo'])
+            || !is_int($data['st_size_hi'])
+            || !is_int($data['st_size_lo'])
+        ) {
+            return null;
+        }
+        return new Elf64SymbolTableEntry(
+            $data['st_name'],
+            $data['st_info'],
+            $data['st_other'],
+            $data['st_shndx'],
+            new UInt64($data['st_value_hi'], $data['st_value_lo']),
+            new UInt64($data['st_size_hi'], $data['st_size_lo']),
+        );
+    }
+
+    /** @return array<array-key, mixed>|null */
+    private function getResolverCache(): ?array
+    {
+        if ($this->binary_analysis_cache === null || $this->fingerprint === null) {
+            return null;
+        }
+        return $this->binary_analysis_cache->get($this->fingerprint, 'elf_resolver');
+    }
+
+    private function saveResolverMeta(): void
+    {
+        if ($this->binary_analysis_cache === null || $this->fingerprint === null) {
+            return;
+        }
+        $data = $this->binary_analysis_cache->get($this->fingerprint, 'elf_resolver') ?? [];
+        if ($this->base_address_resolved && $this->base_address_cache !== null) {
+            $data['base_address_hi'] = $this->base_address_cache->hi;
+            $data['base_address_lo'] = $this->base_address_cache->lo;
+        }
+        if ($this->dt_debug_resolved) {
+            $data['dt_debug_address'] = $this->dt_debug_address_cache;
+        }
+        $this->binary_analysis_cache->set($this->fingerprint, 'elf_resolver', $data);
     }
 }

--- a/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
+++ b/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
@@ -15,6 +15,8 @@ namespace Reli\Lib\Elf\Tls;
 
 use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
@@ -31,6 +33,8 @@ final class LibThreadDbTlsFinder implements TlsFinderInterface
         private ThreadPointerRetrieverInterface $thread_pointer_retriever,
         private MemoryReaderInterface $memory_reader,
         private IntegerByteSequenceReader $integer_reader,
+        private ?BinaryAnalysisCache $binary_analysis_cache = null,
+        private ?BinaryFingerprint $libpthread_fingerprint = null,
     ) {
     }
 
@@ -44,18 +48,15 @@ final class LibThreadDbTlsFinder implements TlsFinderInterface
     {
         $thread_pointer = $this->thread_pointer_retriever->getThreadPointer($pid);
 
-        [,,$thread_db_pthread_dtvp_offset] = $this->getLibThreadDbDescriptor('_thread_db_pthread_dtvp');
-        [$thread_db_dtv_dtv_size,,] = $this->getLibThreadDbDescriptor('_thread_db_dtv_dtv');
-        [,,$thread_db_dtv_t_pointer_val_offset] = $this->getLibThreadDbDescriptor('_thread_db_dtv_t_pointer_val');
-        [,,$thread_db_link_map_l_tls_modid_offset] = $this->getLibThreadDbDescriptor('_thread_db_link_map_l_tls_modid');
+        $descriptors = $this->resolveDescriptors();
 
-        $dtv_pointer_address = $thread_pointer + $thread_db_pthread_dtvp_offset;
+        $dtv_pointer_address = $thread_pointer + $descriptors['pthread_dtvp_offset'];
         $dtv_pointer_cdata = $this->memory_reader->read($pid, $dtv_pointer_address, 8);
         $dtv_pointer = $this->integer_reader->read64(new CDataByteReader($dtv_pointer_cdata), 0)->toInt();
 
         $module_id = 1;
         if (!is_null($link_map_address)) {
-            $module_id_address = $thread_db_link_map_l_tls_modid_offset + $link_map_address;
+            $module_id_address = $descriptors['link_map_l_tls_modid_offset'] + $link_map_address;
             $module_id = $this->integer_reader->read32(
                 new CDataByteReader(
                     $this->memory_reader->read(
@@ -68,11 +69,63 @@ final class LibThreadDbTlsFinder implements TlsFinderInterface
             );
         }
 
-        $dtv_slot = $thread_db_dtv_dtv_size * $module_id;
-        $tls_address_pointer = $dtv_pointer + $dtv_slot + $thread_db_dtv_t_pointer_val_offset;
+        $dtv_slot = $descriptors['dtv_dtv_size'] * $module_id;
+        $tls_address_pointer = $dtv_pointer + $dtv_slot + $descriptors['dtv_t_pointer_val_offset'];
 
         $tls_address_cdata = $this->memory_reader->read($pid, $tls_address_pointer, 8);
         return $this->integer_reader->read64(new CDataByteReader($tls_address_cdata), 0)->toInt();
+    }
+
+    /**
+     * @return array{
+     *     pthread_dtvp_offset: int,
+     *     dtv_dtv_size: int,
+     *     dtv_t_pointer_val_offset: int,
+     *     link_map_l_tls_modid_offset: int,
+     * }
+     * @throws MemoryReaderException
+     * @throws ProcessSymbolReaderException
+     * @throws TlsFinderException
+     */
+    private function resolveDescriptors(): array
+    {
+        if ($this->binary_analysis_cache !== null && $this->libpthread_fingerprint !== null) {
+            $cached = $this->binary_analysis_cache->get($this->libpthread_fingerprint, 'libpthread_descriptors');
+            if (
+                $cached !== null
+                && isset(
+                    $cached['pthread_dtvp_offset'],
+                    $cached['dtv_dtv_size'],
+                    $cached['dtv_t_pointer_val_offset'],
+                    $cached['link_map_l_tls_modid_offset'],
+                )
+                && is_int($cached['pthread_dtvp_offset'])
+                && is_int($cached['dtv_dtv_size'])
+                && is_int($cached['dtv_t_pointer_val_offset'])
+                && is_int($cached['link_map_l_tls_modid_offset'])
+            ) {
+                /** @var array{pthread_dtvp_offset: int, dtv_dtv_size: int, dtv_t_pointer_val_offset: int, link_map_l_tls_modid_offset: int} */
+                return $cached;
+            }
+        }
+
+        [,,$pthread_dtvp_offset] = $this->getLibThreadDbDescriptor('_thread_db_pthread_dtvp');
+        [$dtv_dtv_size,,] = $this->getLibThreadDbDescriptor('_thread_db_dtv_dtv');
+        [,,$dtv_t_pointer_val_offset] = $this->getLibThreadDbDescriptor('_thread_db_dtv_t_pointer_val');
+        [,,$link_map_l_tls_modid_offset] = $this->getLibThreadDbDescriptor('_thread_db_link_map_l_tls_modid');
+
+        $result = [
+            'pthread_dtvp_offset' => $pthread_dtvp_offset,
+            'dtv_dtv_size' => $dtv_dtv_size,
+            'dtv_t_pointer_val_offset' => $dtv_t_pointer_val_offset,
+            'link_map_l_tls_modid_offset' => $link_map_l_tls_modid_offset,
+        ];
+
+        if ($this->binary_analysis_cache !== null && $this->libpthread_fingerprint !== null) {
+            $this->binary_analysis_cache->set($this->libpthread_fingerprint, 'libpthread_descriptors', $result);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -33,6 +33,12 @@ use RuntimeException;
 /** @psalm-suppress ClassMustBeFinal */
 class PhpGlobalsFinder
 {
+    /** @var array<int, ProcessSymbolReaderInterface> */
+    private array $symbol_reader_cache = [];
+
+    /** @var array<int, int|null> */
+    private array $tsrm_ls_cache_cache = [];
+
     public function __construct(
         private PhpSymbolReaderCreator $php_symbol_reader_creator,
         private IntegerByteSequenceReader $integer_reader,
@@ -54,10 +60,15 @@ class PhpGlobalsFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): ?int {
+        if (array_key_exists($process_specifier->pid, $this->tsrm_ls_cache_cache)) {
+            return $this->tsrm_ls_cache_cache[$process_specifier->pid];
+        }
+
         $fingerprint = $this->getPhpFingerprint($process_specifier, $target_php_settings->php_regex);
         $cached = $this->binary_analysis_cache->get($fingerprint, 'tsrm_ls_cache');
         if ($cached !== null && isset($cached['has_tsrm_ls_cache'])) {
             if ($cached['has_tsrm_ls_cache'] === false) {
+                $this->tsrm_ls_cache_cache[$process_specifier->pid] = null;
                 return null;
             }
         }
@@ -73,8 +84,10 @@ class PhpGlobalsFinder
                 0
             )->toInt();
             if ($tsrm_ls_cache_address === 0) {
+                $this->tsrm_ls_cache_cache[$process_specifier->pid] = null;
                 return null;
             }
+            $this->tsrm_ls_cache_cache[$process_specifier->pid] = $tsrm_ls_cache_address;
             return $tsrm_ls_cache_address;
         }
         assert($target_php_settings->isDecided());
@@ -88,6 +101,7 @@ class PhpGlobalsFinder
                 'has_tsrm_ls_cache' => true,
             ]);
         }
+        $this->tsrm_ls_cache_cache[$process_specifier->pid] = $result;
         return $result;
     }
 
@@ -100,13 +114,16 @@ class PhpGlobalsFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): ProcessSymbolReaderInterface {
-        return $this->php_symbol_reader_creator->create(
-            $process_specifier->pid,
-            $target_php_settings->php_regex,
-            $target_php_settings->libpthread_regex,
-            $target_php_settings->php_path,
-            $target_php_settings->libpthread_path
-        );
+        if (!isset($this->symbol_reader_cache[$process_specifier->pid])) {
+            $this->symbol_reader_cache[$process_specifier->pid] = $this->php_symbol_reader_creator->create(
+                $process_specifier->pid,
+                $target_php_settings->php_regex,
+                $target_php_settings->libpthread_regex,
+                $target_php_settings->php_path,
+                $target_php_settings->libpthread_path
+            );
+        }
+        return $this->symbol_reader_cache[$process_specifier->pid];
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -54,11 +54,20 @@ class PhpGlobalsFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): ?int {
-        $tsrm_ls_cache_cdata = $this->getSymbolReader(
-            $process_specifier,
-            $target_php_settings
-        )->read('_tsrm_ls_cache');
+        $fingerprint = $this->getPhpFingerprint($process_specifier, $target_php_settings->php_regex);
+        $cached = $this->binary_analysis_cache->get($fingerprint, 'tsrm_ls_cache');
+        if ($cached !== null && isset($cached['has_tsrm_ls_cache'])) {
+            if ($cached['has_tsrm_ls_cache'] === false) {
+                return null;
+            }
+        }
+
+        $symbol_reader = $this->getSymbolReader($process_specifier, $target_php_settings);
+        $tsrm_ls_cache_cdata = $symbol_reader->read('_tsrm_ls_cache');
         if (isset($tsrm_ls_cache_cdata)) {
+            $this->binary_analysis_cache->set($fingerprint, 'tsrm_ls_cache', [
+                'has_tsrm_ls_cache' => true,
+            ]);
             $tsrm_ls_cache_address = $this->integer_reader->read64(
                 new CDataByteReader($tsrm_ls_cache_cdata),
                 0
@@ -69,7 +78,17 @@ class PhpGlobalsFinder
             return $tsrm_ls_cache_address;
         }
         assert($target_php_settings->isDecided());
-        return $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
+        $result = $this->tsrm_ls_cache_finder->findByBruteForcing($process_specifier, $target_php_settings);
+        if ($result === null) {
+            $this->binary_analysis_cache->set($fingerprint, 'tsrm_ls_cache', [
+                'has_tsrm_ls_cache' => false,
+            ]);
+        } else {
+            $this->binary_analysis_cache->set($fingerprint, 'tsrm_ls_cache', [
+                'has_tsrm_ls_cache' => true,
+            ]);
+        }
+        return $result;
     }
 
     /**
@@ -162,6 +181,14 @@ class PhpGlobalsFinder
         TargetPhpSettings $target_php_settings,
         string $symbol_name,
     ): int {
+        $module_map = $this->getPhpModuleMemoryMap($process_specifier, $target_php_settings->php_regex);
+        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+
+        $cached_nts = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
+        if ($cached_nts !== null && isset($cached_nts[$symbol_name]) && is_int($cached_nts[$symbol_name])) {
+            return $module_map->getBaseAddress() + $cached_nts[$symbol_name];
+        }
+
         $tsrm_ls_cache = $this->findTsrmLsCache($process_specifier, $target_php_settings);
         if (isset($tsrm_ls_cache)) {
             return $this->tsrm_globals_resolver->resolveGlobalsAddress(
@@ -172,24 +199,25 @@ class PhpGlobalsFinder
             );
         }
 
-        $module_map = $this->getPhpModuleMemoryMap($process_specifier, $target_php_settings->php_regex);
-        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
-        $cached = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
-        if ($cached !== null && isset($cached[$symbol_name]) && is_int($cached[$symbol_name])) {
-            return $module_map->getBaseAddress() + $cached[$symbol_name];
-        }
-
         $globals_address = $this->getSymbolReader($process_specifier, $target_php_settings)
             ->resolveAddress($symbol_name);
         if (is_null($globals_address)) {
             throw new RuntimeException('global symbol not found ' . $symbol_name);
         }
 
-        $cache_data = $cached ?? [];
+        $cache_data = $cached_nts ?? [];
         $cache_data[$symbol_name] = $globals_address - $module_map->getBaseAddress();
         $this->binary_analysis_cache->set($fingerprint, 'nts_globals', $cache_data);
 
         return $globals_address;
+    }
+
+    private function getPhpFingerprint(
+        ProcessSpecifier $process_specifier,
+        string $regex,
+    ): BinaryFingerprint {
+        $module_map = $this->getPhpModuleMemoryMap($process_specifier, $regex);
+        return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
     }
 
     private function getPhpModuleMemoryMap(

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -19,6 +19,7 @@ use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReader;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Elf\Tls\TlsFinderException;
@@ -71,6 +72,15 @@ class PhpGlobalsFinder
                 $this->tsrm_ls_cache_cache[$process_specifier->pid] = null;
                 return null;
             }
+            $result = $this->tryResolveTsrmLsCacheFromCachedOffset(
+                $process_specifier,
+                $target_php_settings,
+                $fingerprint,
+            );
+            if ($result !== null) {
+                $this->tsrm_ls_cache_cache[$process_specifier->pid] = $result;
+                return $result;
+            }
         }
 
         $symbol_reader = $this->getSymbolReader($process_specifier, $target_php_settings);
@@ -103,6 +113,45 @@ class PhpGlobalsFinder
         }
         $this->tsrm_ls_cache_cache[$process_specifier->pid] = $result;
         return $result;
+    }
+
+    private function tryResolveTsrmLsCacheFromCachedOffset(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        BinaryFingerprint $fingerprint,
+    ): ?int {
+        $tls_cached = $this->binary_analysis_cache->get($fingerprint, 'tls_offset');
+        if ($tls_cached === null || !isset($tls_cached['offset']) || !is_int($tls_cached['offset'])) {
+            return null;
+        }
+
+        $symbol_reader = $this->getSymbolReader($process_specifier, $target_php_settings);
+        if (!($symbol_reader instanceof ProcessModuleSymbolReader)) {
+            return null;
+        }
+        $tls_block_address = $symbol_reader->getTlsBlockAddress();
+        if ($tls_block_address === null) {
+            return null;
+        }
+
+        try {
+            $candidate_address = $tls_block_address + $tls_cached['offset'];
+            $candidate_cdata = $this->memory_reader->read(
+                $process_specifier->pid,
+                $candidate_address,
+                8
+            );
+            $tsrm_ls_cache_address = $this->integer_reader->read64(
+                new CDataByteReader($candidate_cdata),
+                0
+            )->toInt();
+            if ($tsrm_ls_cache_address === 0) {
+                return null;
+            }
+            return $tsrm_ls_cache_address;
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -17,10 +17,14 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Elf\Tls\TlsFinderException;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -35,6 +39,8 @@ class PhpGlobalsFinder
         private MemoryReaderInterface $memory_reader,
         private PhpTsrmLsCacheFinder $tsrm_ls_cache_finder,
         private TsrmGlobalsResolver $tsrm_globals_resolver,
+        private BinaryAnalysisCache $binary_analysis_cache,
+        private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
     ) {
     }
 
@@ -124,11 +130,30 @@ class PhpGlobalsFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): ?int {
+        $module_map = $this->getPhpModuleMemoryMap(
+            $process_specifier,
+            $target_php_settings->zts_globals_regex,
+        );
+        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        $cached = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
+        if ($cached !== null && isset($cached['module_registry']) && is_int($cached['module_registry'])) {
+            return $module_map->getBaseAddress() + $cached['module_registry'];
+        }
+
         $symbol_reader = $this->tsrm_globals_resolver->getZtsGlobalsSymbolReader(
             $process_specifier,
             $target_php_settings
         );
-        return $symbol_reader->resolveAddress('module_registry');
+        $address = $symbol_reader->resolveAddress('module_registry');
+        if ($address === null) {
+            return null;
+        }
+
+        $cache_data = $cached ?? [];
+        $cache_data['module_registry'] = $address - $module_map->getBaseAddress();
+        $this->binary_analysis_cache->set($fingerprint, 'nts_globals', $cache_data);
+
+        return $address;
     }
 
     /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */
@@ -146,12 +171,36 @@ class PhpGlobalsFinder
                 $tsrm_ls_cache,
             );
         }
+
+        $module_map = $this->getPhpModuleMemoryMap($process_specifier, $target_php_settings->php_regex);
+        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        $cached = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
+        if ($cached !== null && isset($cached[$symbol_name]) && is_int($cached[$symbol_name])) {
+            return $module_map->getBaseAddress() + $cached[$symbol_name];
+        }
+
         $globals_address = $this->getSymbolReader($process_specifier, $target_php_settings)
             ->resolveAddress($symbol_name);
         if (is_null($globals_address)) {
             throw new RuntimeException('global symbol not found ' . $symbol_name);
         }
+
+        $cache_data = $cached ?? [];
+        $cache_data[$symbol_name] = $globals_address - $module_map->getBaseAddress();
+        $this->binary_analysis_cache->set($fingerprint, 'nts_globals', $cache_data);
+
         return $globals_address;
+    }
+
+    private function getPhpModuleMemoryMap(
+        ProcessSpecifier $process_specifier,
+        string $regex,
+    ): ProcessModuleMemoryMap {
+        $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap(
+            $process_specifier->pid,
+        );
+        $php_areas = $process_memory_map->findByNameRegex($regex);
+        return new ProcessModuleMemoryMap($php_areas);
     }
 
     /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */

--- a/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
+++ b/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader;
 
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReader;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Elf\Tls\TlsFinderException;
-use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 
 use function readlink;
@@ -28,6 +31,7 @@ final class PhpSymbolReaderCreator
     public function __construct(
         private ProcessModuleSymbolReaderCreator $process_module_symbol_reader_creator,
         private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
     }
 
@@ -45,28 +49,13 @@ final class PhpSymbolReaderCreator
     ): ProcessModuleSymbolReader {
         $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap($pid);
 
-        $libpthread_symbol_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+        $libpthread_symbol_reader = $this->resolveThreadDbReader(
             $pid,
             $process_memory_map,
             $libpthread_finder_regex,
-            $libpthread_binary_path
+            $libpthread_binary_path,
         );
-        // On glibc 2.34+, libpthread.so is a stub that lacks _thread_db_*
-        // symbols needed for TLS resolution; fall back to libc.so
-        if (
-            is_null($libpthread_symbol_reader)
-            || is_null($libpthread_symbol_reader->resolveAddress('_thread_db_pthread_dtvp'))
-        ) {
-            $libc_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
-                $pid,
-                $process_memory_map,
-                '.*/libc\.so.*',
-                null
-            );
-            if (!is_null($libc_reader)) {
-                $libpthread_symbol_reader = $libc_reader;
-            }
-        }
+
         $root_link_map_address = null;
         if (!is_null($libpthread_symbol_reader)) {
             $executable_path = readlink("/proc/{$pid}/exe");
@@ -99,5 +88,87 @@ final class PhpSymbolReaderCreator
             throw new \RuntimeException('php module not found');
         }
         return $php_symbol_reader;
+    }
+
+    private function resolveThreadDbReader(
+        int $pid,
+        ProcessMemoryMap $process_memory_map,
+        string $libpthread_finder_regex,
+        ?string $libpthread_binary_path,
+    ): ?ProcessModuleSymbolReader {
+        $libpthread_fingerprint = $this->getModuleFingerprint(
+            $process_memory_map,
+            $libpthread_finder_regex,
+        );
+
+        if ($libpthread_fingerprint !== null) {
+            $cached = $this->binary_analysis_cache->get($libpthread_fingerprint, 'thread_db_source');
+            if ($cached !== null && isset($cached['source']) && is_string($cached['source'])) {
+                if ($cached['source'] === 'libc') {
+                    return $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+                        $pid,
+                        $process_memory_map,
+                        '.*/libc\.so.*',
+                        null,
+                    );
+                }
+                // source === 'libpthread': use libpthread directly (below)
+            }
+        }
+
+        $libpthread_symbol_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+            $pid,
+            $process_memory_map,
+            $libpthread_finder_regex,
+            $libpthread_binary_path,
+        );
+
+        if (
+            !is_null($libpthread_symbol_reader)
+            && !is_null($libpthread_symbol_reader->resolveAddress('_thread_db_pthread_dtvp'))
+        ) {
+            if ($libpthread_fingerprint !== null) {
+                $this->binary_analysis_cache->set(
+                    $libpthread_fingerprint,
+                    'thread_db_source',
+                    ['source' => 'libpthread'],
+                );
+            }
+            return $libpthread_symbol_reader;
+        }
+
+        // On glibc 2.34+, libpthread.so is a stub that lacks _thread_db_*
+        // symbols needed for TLS resolution; fall back to libc.so
+        $libc_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+            $pid,
+            $process_memory_map,
+            '.*/libc\.so.*',
+            null,
+        );
+
+        if (!is_null($libc_reader)) {
+            if ($libpthread_fingerprint !== null) {
+                $this->binary_analysis_cache->set(
+                    $libpthread_fingerprint,
+                    'thread_db_source',
+                    ['source' => 'libc'],
+                );
+            }
+            return $libc_reader;
+        }
+
+        return $libpthread_symbol_reader;
+    }
+
+    private function getModuleFingerprint(
+        ProcessMemoryMap $process_memory_map,
+        string $regex,
+    ): ?BinaryFingerprint {
+        $areas = $process_memory_map->findByNameRegex($regex);
+        if ($areas === []) {
+            return null;
+        }
+        $module_map = new ProcessModuleMemoryMap($areas);
+        return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
     }
 }

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -18,6 +18,8 @@ use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
@@ -44,10 +46,11 @@ final class PhpTsrmLsCacheFinder
         private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
         private ContainerAwarePathResolver $process_path_resolver,
         private ZendTypeReaderCreator $zend_type_reader_creator,
+        private BinaryAnalysisCache $binary_analysis_cache,
     ) {
     }
 
-    /** @return array{int, int}|null */
+    /** @return array{int, int, ProcessModuleMemoryMap}|null */
     public function resolveTlsBlock(
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
@@ -83,7 +86,7 @@ final class PhpTsrmLsCacheFinder
             return null;
         }
 
-        return [$tls_block_address, $tls_entries[0]->p_memsz->toInt()];
+        return [$tls_block_address, $tls_entries[0]->p_memsz->toInt(), $php_module_memory_map];
     }
 
     /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */
@@ -98,7 +101,18 @@ final class PhpTsrmLsCacheFinder
         if (is_null($tls_block)) {
             return null;
         }
-        [$tls_block_address, $tls_block_size] = $tls_block;
+        [$tls_block_address, $tls_block_size, $php_module_memory_map] = $tls_block;
+        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($php_module_memory_map);
+
+        $cached = $this->binary_analysis_cache->get($fingerprint, 'tls_offset');
+        if ($cached !== null && isset($cached['offset']) && is_int($cached['offset'])) {
+            $candidate_address = $tls_block_address + $cached['offset'];
+            assert($target_php_settings->isDecided());
+            if ($this->validateCandidate($process_specifier, $target_php_settings, $candidate_address)) {
+                return $candidate_address;
+            }
+        }
+
         for ($current = $tls_block_address; $current < $tls_block_address + $tls_block_size; $current += 8) {
             $tsrm_ls_cache_candidate = $this->memory_reader->read(
                 $process_specifier->pid,
@@ -111,6 +125,11 @@ final class PhpTsrmLsCacheFinder
             )->toInt();
             assert($target_php_settings->isDecided());
             if ($this->validateCandidate($process_specifier, $target_php_settings, $tsrm_ls_cache_address_candidate)) {
+                $this->binary_analysis_cache->set(
+                    $fingerprint,
+                    'tls_offset',
+                    ['offset' => $tsrm_ls_cache_address_candidate - $tls_block_address],
+                );
                 return $tsrm_ls_cache_address_candidate;
             }
         }

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -14,12 +14,16 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader;
 
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendModuleEntry;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -36,6 +40,8 @@ class PhpVersionDetector
         private PhpGlobalsFinder $php_globals_finder,
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
+        private BinaryAnalysisCache $binary_analysis_cache,
+        private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
     ) {
     }
 
@@ -74,6 +80,29 @@ class PhpVersionDetector
             /** @var TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>> */
             return $target_php_settings;
         }
+
+        $fingerprint = $this->getFingerprint($process_specifier, $target_php_settings);
+        if ($fingerprint !== null) {
+            $cached = $this->binary_analysis_cache->get($fingerprint, 'php_version');
+            if (
+                $cached !== null
+                && isset($cached['version'])
+                && is_string($cached['version'])
+                && ZendTypeReader::isSupported($cached['version'])
+            ) {
+                /** @var value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $cached_version */
+                $cached_version = $cached['version'];
+                return new TargetPhpSettings(
+                    php_regex: $target_php_settings->php_regex,
+                    libpthread_regex: $target_php_settings->libpthread_regex,
+                    zts_globals_regex: $target_php_settings->zts_globals_regex,
+                    php_version: $cached_version,
+                    php_path: $target_php_settings->php_path,
+                    libpthread_path: $target_php_settings->libpthread_path,
+                );
+            }
+        }
+
         $module_registry_address = $this->php_globals_finder->findModuleRegistry(
             $process_specifier,
             $target_php_settings,
@@ -89,6 +118,10 @@ class PhpVersionDetector
             Assert::true(ZendTypeReader::isSupported($version));
         }
 
+        if ($fingerprint !== null) {
+            $this->binary_analysis_cache->set($fingerprint, 'php_version', ['version' => $version]);
+        }
+
         return new TargetPhpSettings(
             php_regex: $target_php_settings->php_regex,
             libpthread_regex: $target_php_settings->libpthread_regex,
@@ -97,6 +130,25 @@ class PhpVersionDetector
             php_path: $target_php_settings->php_path,
             libpthread_path: $target_php_settings->libpthread_path,
         );
+    }
+
+    private function getFingerprint(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+    ): ?BinaryFingerprint {
+        try {
+            $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap(
+                $process_specifier->pid,
+            );
+            $php_areas = $process_memory_map->findByNameRegex($target_php_settings->php_regex);
+            if ($php_areas === []) {
+                return null;
+            }
+            $module_map = new ProcessModuleMemoryMap($php_areas);
+            return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /** @return value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|null */

--- a/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
+++ b/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
@@ -16,8 +16,12 @@ namespace Reli\Lib\PhpProcessReader;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\ProcessSpecifier;
 use RuntimeException;
@@ -28,6 +32,8 @@ final class TsrmGlobalsResolver
         private PhpSymbolReaderCreator $php_symbol_reader_creator,
         private IntegerByteSequenceReader $integer_reader,
         private MemoryReaderInterface $memory_reader,
+        private BinaryAnalysisCache $binary_analysis_cache,
+        private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
     ) {
     }
 
@@ -50,41 +56,38 @@ final class TsrmGlobalsResolver
         string $symbol_name,
         int $tsrm_ls_cache,
     ): int {
+        $fingerprint = $this->getFingerprint($process_specifier, $target_php_settings);
+        $cached = $this->binary_analysis_cache->get($fingerprint, 'zts_globals');
+
+        if ($cached !== null && isset($cached[$symbol_name]) && is_array($cached[$symbol_name])) {
+            $entry = $cached[$symbol_name];
+            if (
+                isset($entry['method'], $entry['value'])
+                && is_string($entry['method'])
+                && is_int($entry['value'])
+            ) {
+                if ($entry['method'] === 'offset') {
+                    return $tsrm_ls_cache + $entry['value'];
+                }
+                if ($entry['method'] === 'id') {
+                    return $this->resolveById($process_specifier, $tsrm_ls_cache, $entry['value']);
+                }
+            }
+        }
+
         switch ($target_php_settings->php_version) {
             case ZendTypeReader::V70:
             case ZendTypeReader::V71:
             case ZendTypeReader::V72:
             case ZendTypeReader::V73:
-                $id_symbol = $symbol_name . '_id';
-                $globals_id_cdata = $this->getZtsGlobalsSymbolReader($process_specifier, $target_php_settings)
-                    ->read($id_symbol);
-                if (is_null($globals_id_cdata)) {
-                    throw new RuntimeException('global symbol id not found');
-                }
-                $tsrm_ls_cache_dereferenced = $this->integer_reader->read64(
-                    new CDataByteReader(
-                        $this->memory_reader->read(
-                            $process_specifier->pid,
-                            $tsrm_ls_cache,
-                            8
-                        )
-                    ),
-                    0
-                )->toInt();
-                $globals_id = $this->integer_reader->read32(
-                    new CDataByteReader($globals_id_cdata),
-                    0
+                return $this->resolveByIdSymbol(
+                    $process_specifier,
+                    $target_php_settings,
+                    $symbol_name,
+                    $tsrm_ls_cache,
+                    $fingerprint,
+                    $cached,
                 );
-                return $this->integer_reader->read64(
-                    new CDataByteReader(
-                        $this->memory_reader->read(
-                            $process_specifier->pid,
-                            $tsrm_ls_cache_dereferenced + ($globals_id - 1) * 8,
-                            8
-                        )
-                    ),
-                    0
-                )->toInt();
 
             case ZendTypeReader::V74:
             case ZendTypeReader::V80:
@@ -92,54 +95,108 @@ final class TsrmGlobalsResolver
             case ZendTypeReader::V82:
             case ZendTypeReader::V83:
             case ZendTypeReader::V84:
-                $offset = $symbol_name . '_offset';
+                $offset_symbol = $symbol_name . '_offset';
                 $globals_offset_cdata = $this->getZtsGlobalsSymbolReader(
                     $process_specifier,
                     $target_php_settings
-                )->read($offset);
+                )->read($offset_symbol);
                 if (!is_null($globals_offset_cdata)) {
                     $globals_offset = $this->integer_reader->read64(
                         new CDataByteReader($globals_offset_cdata),
                         0
                     )->toInt();
                     if ($globals_offset !== 0) {
+                        $this->cacheEntry($fingerprint, $cached, $symbol_name, 'offset', $globals_offset);
                         return $tsrm_ls_cache + $globals_offset;
                     }
                 }
                 // Fallback to _id approach when _offset is 0 or not found
                 // (e.g. libphp.so built as PIC where ZEND_ENABLE_STATIC_TSRMLS_CACHE is not defined)
-                $id_symbol = $symbol_name . '_id';
-                $globals_id_cdata = $this->getZtsGlobalsSymbolReader($process_specifier, $target_php_settings)
-                    ->read($id_symbol);
-                if (is_null($globals_id_cdata)) {
-                    throw new RuntimeException('globals offset and id not found for ' . $symbol_name);
-                }
-                $tsrm_ls_cache_dereferenced = $this->integer_reader->read64(
-                    new CDataByteReader(
-                        $this->memory_reader->read(
-                            $process_specifier->pid,
-                            $tsrm_ls_cache,
-                            8
-                        )
-                    ),
-                    0
-                )->toInt();
-                $globals_id = $this->integer_reader->read32(
-                    new CDataByteReader($globals_id_cdata),
-                    0
+                return $this->resolveByIdSymbol(
+                    $process_specifier,
+                    $target_php_settings,
+                    $symbol_name,
+                    $tsrm_ls_cache,
+                    $fingerprint,
+                    $cached,
                 );
-                return $this->integer_reader->read64(
-                    new CDataByteReader(
-                        $this->memory_reader->read(
-                            $process_specifier->pid,
-                            $tsrm_ls_cache_dereferenced + ($globals_id - 1) * 8,
-                            8
-                        )
-                    ),
-                    0
-                )->toInt();
             default:
                 throw new \LogicException('this should never happen');
         }
+    }
+
+    private function resolveById(
+        ProcessSpecifier $process_specifier,
+        int $tsrm_ls_cache,
+        int $globals_id,
+    ): int {
+        $tsrm_ls_cache_dereferenced = $this->integer_reader->read64(
+            new CDataByteReader(
+                $this->memory_reader->read(
+                    $process_specifier->pid,
+                    $tsrm_ls_cache,
+                    8
+                )
+            ),
+            0
+        )->toInt();
+        return $this->integer_reader->read64(
+            new CDataByteReader(
+                $this->memory_reader->read(
+                    $process_specifier->pid,
+                    $tsrm_ls_cache_dereferenced + ($globals_id - 1) * 8,
+                    8
+                )
+            ),
+            0
+        )->toInt();
+    }
+
+    /** @param array<array-key, mixed>|null $cached */
+    private function resolveByIdSymbol(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        string $symbol_name,
+        int $tsrm_ls_cache,
+        BinaryFingerprint $fingerprint,
+        ?array $cached,
+    ): int {
+        $id_symbol = $symbol_name . '_id';
+        $globals_id_cdata = $this->getZtsGlobalsSymbolReader($process_specifier, $target_php_settings)
+            ->read($id_symbol);
+        if (is_null($globals_id_cdata)) {
+            throw new RuntimeException('globals offset and id not found for ' . $symbol_name);
+        }
+        $globals_id = $this->integer_reader->read32(
+            new CDataByteReader($globals_id_cdata),
+            0
+        );
+        $this->cacheEntry($fingerprint, $cached, $symbol_name, 'id', $globals_id);
+        return $this->resolveById($process_specifier, $tsrm_ls_cache, $globals_id);
+    }
+
+    /** @param array<array-key, mixed>|null $cached */
+    private function cacheEntry(
+        BinaryFingerprint $fingerprint,
+        ?array $cached,
+        string $symbol_name,
+        string $method,
+        int $value,
+    ): void {
+        $cache_data = $cached ?? [];
+        $cache_data[$symbol_name] = ['method' => $method, 'value' => $value];
+        $this->binary_analysis_cache->set($fingerprint, 'zts_globals', $cache_data);
+    }
+
+    private function getFingerprint(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+    ): BinaryFingerprint {
+        $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap(
+            $process_specifier->pid,
+        );
+        $php_areas = $process_memory_map->findByNameRegex($target_php_settings->zts_globals_regex);
+        $module_map = new ProcessModuleMemoryMap($php_areas);
+        return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
     }
 }

--- a/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
+++ b/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
@@ -18,9 +18,6 @@ use Reli\Lib\String\LineFetcher;
 
 final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
 {
-    /** @var array<int, ProcessMemoryMap> */
-    private array $cache = [];
-
     public static function create(): self
     {
         return new self(
@@ -38,22 +35,7 @@ final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
     #[\Override]
     public function getProcessMemoryMap(int $pid): ProcessMemoryMap
     {
-        if (isset($this->cache[$pid])) {
-            return $this->cache[$pid];
-        }
-
         $memory_map_raw = $this->memory_map_reader->read($pid);
-        $map = $this->memory_map_parser->parse($memory_map_raw);
-        $this->cache[$pid] = $map;
-        return $map;
-    }
-
-    public function flushCache(?int $pid = null): void
-    {
-        if ($pid !== null) {
-            unset($this->cache[$pid]);
-        } else {
-            $this->cache = [];
-        }
+        return $this->memory_map_parser->parse($memory_map_raw);
     }
 }

--- a/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
+++ b/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
@@ -18,6 +18,11 @@ use Reli\Lib\String\LineFetcher;
 
 final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
 {
+    private const CACHE_TTL_NS = 100_000_000; // 100ms
+
+    /** @var array<int, array{map: ProcessMemoryMap, time: int}> */
+    private array $cache = [];
+
     public static function create(): self
     {
         return new self(
@@ -35,7 +40,17 @@ final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
     #[\Override]
     public function getProcessMemoryMap(int $pid): ProcessMemoryMap
     {
+        $now = hrtime(true);
+        if (
+            isset($this->cache[$pid])
+            && ($now - $this->cache[$pid]['time']) < self::CACHE_TTL_NS
+        ) {
+            return $this->cache[$pid]['map'];
+        }
+
         $memory_map_raw = $this->memory_map_reader->read($pid);
-        return $this->memory_map_parser->parse($memory_map_raw);
+        $map = $this->memory_map_parser->parse($memory_map_raw);
+        $this->cache[$pid] = ['map' => $map, 'time' => $now];
+        return $map;
     }
 }

--- a/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
+++ b/src/Lib/Process/MemoryMap/ProcessMemoryMapCreator.php
@@ -18,9 +18,7 @@ use Reli\Lib\String\LineFetcher;
 
 final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
 {
-    private const CACHE_TTL_NS = 100_000_000; // 100ms
-
-    /** @var array<int, array{map: ProcessMemoryMap, time: int}> */
+    /** @var array<int, ProcessMemoryMap> */
     private array $cache = [];
 
     public static function create(): self
@@ -40,17 +38,22 @@ final class ProcessMemoryMapCreator implements ProcessMemoryMapCreatorInterface
     #[\Override]
     public function getProcessMemoryMap(int $pid): ProcessMemoryMap
     {
-        $now = hrtime(true);
-        if (
-            isset($this->cache[$pid])
-            && ($now - $this->cache[$pid]['time']) < self::CACHE_TTL_NS
-        ) {
-            return $this->cache[$pid]['map'];
+        if (isset($this->cache[$pid])) {
+            return $this->cache[$pid];
         }
 
         $memory_map_raw = $this->memory_map_reader->read($pid);
         $map = $this->memory_map_parser->parse($memory_map_raw);
-        $this->cache[$pid] = ['map' => $map, 'time' => $now];
+        $this->cache[$pid] = $map;
         return $map;
+    }
+
+    public function flushCache(?int $pid = null): void
+    {
+        if ($pid !== null) {
+            unset($this->cache[$pid]);
+        } else {
+            $this->cache = [];
+        }
     }
 }

--- a/tests/Command/Cache/ClearCommandTest.php
+++ b/tests/Command/Cache/ClearCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ClearCommandTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/reli-test-cmd-' . getmypid() . '-' . mt_rand();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testClearCommandRemovesCacheEntries(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $cache->set(new BinaryFingerprint('fp1'), 'ns', ['data' => 1]);
+        $cache->set(new BinaryFingerprint('fp2'), 'ns', ['data' => 2]);
+
+        $command = new ClearCommand($cache);
+        $output = new BufferedOutput();
+        $result = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(0, $result);
+        $this->assertStringContainsString('cleared 2 cached entries', $output->fetch());
+    }
+
+    public function testClearCommandWithEmptyCache(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $command = new ClearCommand($cache);
+        $output = new BufferedOutput();
+        $result = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(0, $result);
+        $this->assertStringContainsString('cleared 0 cached entries', $output->fetch());
+    }
+
+    public function testClearCommandActuallyDeletesFiles(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('fp1');
+        $cache->set($fp, 'ns', ['data' => 1]);
+        $this->assertNotNull($cache->get($fp, 'ns'));
+
+        $command = new ClearCommand($cache);
+        $command->run(new ArrayInput([]), new BufferedOutput());
+
+        $cache2 = new BinaryAnalysisCache($this->tmpDir);
+        $this->assertNull($cache2->get($fp, 'ns'));
+    }
+}

--- a/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
+++ b/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
@@ -21,6 +21,7 @@ use Reli\Inspector\Daemon\Searcher\Protocol\Message\UpdateTargetProcessMessage;
 use Reli\Inspector\Daemon\Dispatcher\TargetProcessList;
 use Reli\Inspector\Daemon\Searcher\Protocol\PhpSearcherWorkerProtocolInterface;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Loop\LoopCondition\OnlyOnceCondition;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\ProcFileSystem\ThreadEnumerator;
@@ -61,6 +62,7 @@ class PhpSearcherEntryPointTest extends BaseTestCase
             $process_searcher,
             $process_descriptor_retriever,
             new ThreadEnumerator(),
+            new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             new OnlyOnceCondition(),
         );
 

--- a/tests/Lib/Dwarf/NativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/NativeTraceCollectorTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Parser\Elf64Parser;
 use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
@@ -142,6 +143,10 @@ class NativeTraceCollectorTest extends BaseTestCase
 
             // Also get PHP trace for merge test
             $integer_reader = new LittleEndianReader();
+            $binary_analysis_cache = new BinaryAnalysisCache(
+                sys_get_temp_dir() . '/reli-test-' . uniqid()
+            );
+            $process_memory_map_creator = ProcessMemoryMapCreator::create();
             $php_symbol_reader_creator = new PhpSymbolReaderCreator(
                 new ProcessModuleSymbolReaderCreator(
                     new Elf64SymbolResolverCreator(
@@ -156,13 +161,17 @@ class NativeTraceCollectorTest extends BaseTestCase
                         $integer_reader
                     ),
                     new ContainerAwarePathResolver(),
+                    $binary_analysis_cache,
                 ),
-                ProcessMemoryMapCreator::create(),
+                $process_memory_map_creator,
+                $binary_analysis_cache,
             );
             $tsrm_globals_resolver = new TsrmGlobalsResolver(
                 $php_symbol_reader_creator,
                 $integer_reader,
                 $memory_reader,
+                $binary_analysis_cache,
+                $process_memory_map_creator,
             );
             $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
                 $php_symbol_reader_creator,
@@ -174,6 +183,7 @@ class NativeTraceCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 new ContainerAwarePathResolver(),
                 new ZendTypeReaderCreator(),
+                $binary_analysis_cache,
             );
             $php_globals_finder = new PhpGlobalsFinder(
                 $php_symbol_reader_creator,
@@ -181,6 +191,8 @@ class NativeTraceCollectorTest extends BaseTestCase
                 $memory_reader,
                 $tsrm_ls_cache_finder,
                 $tsrm_globals_resolver,
+                $binary_analysis_cache,
+                $process_memory_map_creator,
             );
             $eg_address = $php_globals_finder->findExecutorGlobals(
                 new ProcessSpecifier($pid),

--- a/tests/Lib/Elf/Process/BinaryAnalysisCacheTest.php
+++ b/tests/Lib/Elf/Process/BinaryAnalysisCacheTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use PHPUnit\Framework\TestCase;
+
+class BinaryAnalysisCacheTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/reli-test-cache-' . getmypid() . '-' . mt_rand();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    public function testGetReturnsNullOnCacheMiss(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $this->assertNull($cache->get($fingerprint, 'test_namespace'));
+    }
+
+    public function testSetThenGetReturnsCachedData(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $data = ['key' => 'value', 'number' => 42];
+        $cache->set($fingerprint, 'test_namespace', $data);
+        $this->assertSame($data, $cache->get($fingerprint, 'test_namespace'));
+    }
+
+    public function testGetReturnsNullOnCorruptedFile(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $path = $this->tmpDir . '/' . $fingerprint->getCacheKey() . '/test_namespace.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, 'not valid json{{{');
+        $this->assertNull($cache->get($fingerprint, 'test_namespace'));
+    }
+
+    public function testDifferentNamespacesAreIndependent(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $cache->set($fingerprint, 'ns_a', ['a' => 1]);
+        $cache->set($fingerprint, 'ns_b', ['b' => 2]);
+        $this->assertSame(['a' => 1], $cache->get($fingerprint, 'ns_a'));
+        $this->assertSame(['b' => 2], $cache->get($fingerprint, 'ns_b'));
+    }
+
+    public function testDifferentFingerprintsAreIndependent(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp1 = new BinaryFingerprint('fingerprint_1');
+        $fp2 = new BinaryFingerprint('fingerprint_2');
+        $cache->set($fp1, 'ns', ['fp' => 1]);
+        $cache->set($fp2, 'ns', ['fp' => 2]);
+        $this->assertSame(['fp' => 1], $cache->get($fp1, 'ns'));
+        $this->assertSame(['fp' => 2], $cache->get($fp2, 'ns'));
+    }
+
+    public function testGetReturnsNullForNonArrayJson(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $path = $this->tmpDir . '/' . $fingerprint->getCacheKey() . '/test_namespace.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, '"just a string"');
+        $this->assertNull($cache->get($fingerprint, 'test_namespace'));
+    }
+
+    public function testSetOverwritesExistingData(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $cache->set($fingerprint, 'ns', ['v' => 1]);
+        $cache->set($fingerprint, 'ns', ['v' => 2]);
+        $this->assertSame(['v' => 2], $cache->get($fingerprint, 'ns'));
+    }
+
+    public function testCacheKeyIsDeterministic(): void
+    {
+        $fp1 = new BinaryFingerprint('same_value');
+        $fp2 = new BinaryFingerprint('same_value');
+        $this->assertSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+
+    public function testCacheKeyDiffersForDifferentFingerprints(): void
+    {
+        $fp1 = new BinaryFingerprint('value_a');
+        $fp2 = new BinaryFingerprint('value_b');
+        $this->assertNotSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+}

--- a/tests/Lib/Elf/Process/BinaryAnalysisCacheTest.php
+++ b/tests/Lib/Elf/Process/BinaryAnalysisCacheTest.php
@@ -131,4 +131,133 @@ class BinaryAnalysisCacheTest extends TestCase
         $fp2 = new BinaryFingerprint('value_b');
         $this->assertNotSame($fp1->getCacheKey(), $fp2->getCacheKey());
     }
+
+    public function testDisableSkipsGetAndSet(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $cache->set($fingerprint, 'ns', ['before' => 1]);
+        $this->assertSame(['before' => 1], $cache->get($fingerprint, 'ns'));
+
+        $cache->disable();
+        $this->assertNull($cache->get($fingerprint, 'ns'));
+
+        $cache->set($fingerprint, 'ns', ['after' => 2]);
+        // Re-create cache instance to verify nothing was written
+        $cache2 = new BinaryAnalysisCache($this->tmpDir);
+        $this->assertSame(['before' => 1], $cache2->get($fingerprint, 'ns'));
+    }
+
+    public function testClearRemovesAllCachedEntries(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp1 = new BinaryFingerprint('fp1');
+        $fp2 = new BinaryFingerprint('fp2');
+        $cache->set($fp1, 'ns_a', ['a' => 1]);
+        $cache->set($fp1, 'ns_b', ['b' => 2]);
+        $cache->set($fp2, 'ns_a', ['c' => 3]);
+
+        $count = $cache->clear();
+        $this->assertSame(3, $count);
+
+        $this->assertNull($cache->get($fp1, 'ns_a'));
+        $this->assertNull($cache->get($fp1, 'ns_b'));
+        $this->assertNull($cache->get($fp2, 'ns_a'));
+    }
+
+    public function testClearReturnsZeroOnEmptyCache(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $this->assertSame(0, $cache->clear());
+    }
+
+    public function testClearReturnsZeroOnNonExistentDirectory(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir . '/nonexistent');
+        $this->assertSame(0, $cache->clear());
+    }
+
+    public function testSetCreatesDirectoryStructure(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $this->assertDirectoryDoesNotExist($this->tmpDir);
+
+        $cache->set($fingerprint, 'ns', ['data' => 1]);
+        $this->assertDirectoryExists($this->tmpDir);
+        $this->assertDirectoryExists($this->tmpDir . '/' . $fingerprint->getCacheKey());
+    }
+
+    public function testEmptyArrayCanBeCached(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $cache->set($fingerprint, 'ns', []);
+        $this->assertSame([], $cache->get($fingerprint, 'ns'));
+    }
+
+    public function testNestedArrayCanBeCached(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $data = [
+            'method' => 'offset',
+            'value' => 42,
+            'nested' => ['a' => 1, 'b' => [2, 3]],
+        ];
+        $cache->set($fingerprint, 'ns', $data);
+        $this->assertSame($data, $cache->get($fingerprint, 'ns'));
+    }
+
+    public function testGetReturnsNullForEmptyFile(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $path = $this->tmpDir . '/' . $fingerprint->getCacheKey() . '/ns.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, '');
+        $this->assertNull($cache->get($fingerprint, 'ns'));
+    }
+
+    public function testGetReturnsNullForJsonNull(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $path = $this->tmpDir . '/' . $fingerprint->getCacheKey() . '/ns.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, 'null');
+        $this->assertNull($cache->get($fingerprint, 'ns'));
+    }
+
+    public function testGetReturnsNullForJsonInteger(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $path = $this->tmpDir . '/' . $fingerprint->getCacheKey() . '/ns.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, '42');
+        $this->assertNull($cache->get($fingerprint, 'ns'));
+    }
+
+    public function testPersistenceAcrossInstances(): void
+    {
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $data = ['persisted' => true, 'count' => 99];
+
+        $cache1 = new BinaryAnalysisCache($this->tmpDir);
+        $cache1->set($fingerprint, 'ns', $data);
+
+        $cache2 = new BinaryAnalysisCache($this->tmpDir);
+        $this->assertSame($data, $cache2->get($fingerprint, 'ns'));
+    }
+
+    public function testClearThenSetWorks(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fingerprint = new BinaryFingerprint('test_fingerprint');
+        $cache->set($fingerprint, 'ns', ['v' => 1]);
+        $cache->clear();
+        $cache->set($fingerprint, 'ns', ['v' => 2]);
+        $this->assertSame(['v' => 2], $cache->get($fingerprint, 'ns'));
+    }
 }

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderCreatorTest.php
@@ -20,6 +20,7 @@ use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\SymbolResolverCreatorInterface;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\File\PathResolver\PassthroughPathResolver;
 use Reli\Lib\Integer\UInt64;
@@ -70,6 +71,7 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
                 new LittleEndianReader(),
             ),
             new ContainerAwarePathResolver(),
+            new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
         );
         $process_memory_map = new ProcessMemoryMap([
             new ProcessMemoryArea(
@@ -153,6 +155,7 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
                 new LittleEndianReader(),
             ),
             new ContainerAwarePathResolver(),
+            new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
         );
         $process_memory_map = new ProcessMemoryMap([
             new ProcessMemoryArea(
@@ -194,6 +197,7 @@ class ProcessModuleSymbolReaderCreatorTest extends BaseTestCase
                 new LittleEndianReader(),
             ),
             new ContainerAwarePathResolver(),
+            new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
         );
         $process_memory_map = new ProcessMemoryMap([]);
 

--- a/tests/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolverTest.php
+++ b/tests/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolverTest.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\SymbolResolver;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
+use Reli\Lib\Integer\UInt64;
+
+class Elf64CachedSymbolResolverTest extends BaseTestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tmpDir = sys_get_temp_dir() . '/reli-test-resolver-' . getmypid() . '-' . mt_rand();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    private function makeEntry(int $value = 100, int $size = 8, int $info = 1): Elf64SymbolTableEntry
+    {
+        return new Elf64SymbolTableEntry(
+            1, $info, 0, 1,
+            UInt64::fromInt($value),
+            UInt64::fromInt($size),
+        );
+    }
+
+    public function testResolveUsesInMemoryCacheFirst(): void
+    {
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('test_sym')->once()->andReturns($this->makeEntry());
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        $resolver = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache());
+
+        $first = $resolver->resolve('test_sym');
+        $second = $resolver->resolve('test_sym');
+        $this->assertSame($first, $second);
+    }
+
+    public function testResolvePopulatesFileCache(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+        $entry = $this->makeEntry(42, 16);
+
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('my_symbol')->andReturns($entry);
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        $resolver = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache(), $cache, $fp);
+        $resolver->resolve('my_symbol');
+
+        $cached = $cache->get($fp, 'elf_symbols');
+        $this->assertNotNull($cached);
+        $this->assertArrayHasKey('my_symbol', $cached);
+        $this->assertSame(42, $cached['my_symbol']['st_value_lo']);
+        $this->assertSame(16, $cached['my_symbol']['st_size_lo']);
+    }
+
+    public function testResolveReadsFromFileCacheWithoutInnerCall(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+        $entry = $this->makeEntry(99, 4);
+
+        // First resolver populates file cache
+        $inner1 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner1->expects()->resolve('cached_sym')->andReturns($entry);
+        $inner1->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+        $r1 = new Elf64CachedSymbolResolver($inner1, new Elf64SymbolCache(), $cache, $fp);
+        $r1->resolve('cached_sym');
+
+        // Second resolver should NOT call inner->resolve (file cache hit)
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('resolve');
+        $inner2->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $result = $r2->resolve('cached_sym');
+
+        $this->assertSame(99, $result->st_value->toInt());
+        $this->assertSame(4, $result->st_size->toInt());
+    }
+
+    public function testResolveHandlesUndefinedSymbol(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+        $undefined = new Elf64SymbolTableEntry(0, 0, 0, 0, new UInt64(0, 0), new UInt64(0, 0));
+
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('nonexistent')->andReturns($undefined);
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        $r1 = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache(), $cache, $fp);
+        $result = $r1->resolve('nonexistent');
+        $this->assertTrue($result->isUndefined());
+
+        // Second resolver reads undefined from file cache
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('resolve');
+        $inner2->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $result2 = $r2->resolve('nonexistent');
+        $this->assertTrue($result2->isUndefined());
+    }
+
+    public function testResolveTlsSymbol(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+        $tls_entry = new Elf64SymbolTableEntry(
+            1,
+            Elf64SymbolTableEntry::createInfo(Elf64SymbolTableEntry::STB_GLOBAL, Elf64SymbolTableEntry::STT_TLS),
+            0, 1,
+            UInt64::fromInt(64),
+            UInt64::fromInt(8),
+        );
+
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('tls_var')->andReturns($tls_entry);
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+        $r1 = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache(), $cache, $fp);
+        $r1->resolve('tls_var');
+
+        // Verify TLS type is preserved through file cache
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('resolve');
+        $inner2->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $result = $r2->resolve('tls_var');
+        $this->assertTrue($result->isTls());
+        $this->assertSame(64, $result->st_value->toInt());
+    }
+
+    public function testGetBaseAddressCachesInFile(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+
+        $inner1 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner1->expects()->getBaseAddress()->once()->andReturns(new UInt64(0, 0x400000));
+        $r1 = new Elf64CachedSymbolResolver($inner1, new Elf64SymbolCache(), $cache, $fp);
+        $base1 = $r1->getBaseAddress();
+        $this->assertSame(0x400000, $base1->toInt());
+
+        // Second resolver reads from file cache
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('getBaseAddress');
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $base2 = $r2->getBaseAddress();
+        $this->assertSame(0x400000, $base2->toInt());
+    }
+
+    public function testGetDtDebugAddressCachesInFile(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+
+        $inner1 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner1->expects()->getDtDebugAddress()->once()->andReturns(0x601000);
+        $r1 = new Elf64CachedSymbolResolver($inner1, new Elf64SymbolCache(), $cache, $fp);
+        $this->assertSame(0x601000, $r1->getDtDebugAddress());
+
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('getDtDebugAddress');
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $this->assertSame(0x601000, $r2->getDtDebugAddress());
+    }
+
+    public function testGetDtDebugAddressCachesNullValue(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+
+        $inner1 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner1->expects()->getDtDebugAddress()->once()->andReturns(null);
+        $r1 = new Elf64CachedSymbolResolver($inner1, new Elf64SymbolCache(), $cache, $fp);
+        $this->assertNull($r1->getDtDebugAddress());
+
+        $inner2 = Mockery::mock(Elf64SymbolResolver::class);
+        $inner2->shouldNotReceive('getDtDebugAddress');
+        $r2 = new Elf64CachedSymbolResolver($inner2, new Elf64SymbolCache(), $cache, $fp);
+        $this->assertNull($r2->getDtDebugAddress());
+    }
+
+    public function testMultipleSymbolsAccumulateInFileCache(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('sym_a')->andReturns($this->makeEntry(10));
+        $inner->expects()->resolve('sym_b')->andReturns($this->makeEntry(20));
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        $r = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache(), $cache, $fp);
+        $r->resolve('sym_a');
+        $r->resolve('sym_b');
+
+        $cached = $cache->get($fp, 'elf_symbols');
+        $this->assertNotNull($cached);
+        $this->assertArrayHasKey('sym_a', $cached);
+        $this->assertArrayHasKey('sym_b', $cached);
+    }
+
+    public function testWithoutFileCacheFallsBackToInner(): void
+    {
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('sym')->andReturns($this->makeEntry(55));
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        // No BinaryAnalysisCache or BinaryFingerprint
+        $r = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache());
+        $result = $r->resolve('sym');
+        $this->assertSame(55, $result->st_value->toInt());
+    }
+
+    public function testCorruptedFileCacheFallsBackToInner(): void
+    {
+        $cache = new BinaryAnalysisCache($this->tmpDir);
+        $fp = new BinaryFingerprint('test_fp');
+
+        // Write garbage to the symbols file
+        $path = $this->tmpDir . '/' . $fp->getCacheKey() . '/elf_symbols.json';
+        mkdir(dirname($path), 0777, true);
+        file_put_contents($path, '{invalid json');
+
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->resolve('sym')->andReturns($this->makeEntry(77));
+        $inner->allows()->getBaseAddress()->andReturns(new UInt64(0, 0));
+
+        $r = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache(), $cache, $fp);
+        $result = $r->resolve('sym');
+        $this->assertSame(77, $result->st_value->toInt());
+    }
+
+    public function testGetBaseAddressReturnsCachedValueOnRepeatCall(): void
+    {
+        $inner = Mockery::mock(Elf64SymbolResolver::class);
+        $inner->expects()->getBaseAddress()->once()->andReturns(new UInt64(0, 0x1000));
+
+        $r = new Elf64CachedSymbolResolver($inner, new Elf64SymbolCache());
+        $this->assertSame(0x1000, $r->getBaseAddress()->toInt());
+        $this->assertSame(0x1000, $r->getBaseAddress()->toInt()); // in-memory hit
+    }
+}

--- a/tests/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolverTest.php
+++ b/tests/Lib/Elf/SymbolResolver/Elf64CachedSymbolResolverTest.php
@@ -58,7 +58,10 @@ class Elf64CachedSymbolResolverTest extends BaseTestCase
     private function makeEntry(int $value = 100, int $size = 8, int $info = 1): Elf64SymbolTableEntry
     {
         return new Elf64SymbolTableEntry(
-            1, $info, 0, 1,
+            1,
+            $info,
+            0,
+            1,
             UInt64::fromInt($value),
             UInt64::fromInt($size),
         );
@@ -151,7 +154,8 @@ class Elf64CachedSymbolResolverTest extends BaseTestCase
         $tls_entry = new Elf64SymbolTableEntry(
             1,
             Elf64SymbolTableEntry::createInfo(Elf64SymbolTableEntry::STB_GLOBAL, Elf64SymbolTableEntry::STT_TLS),
-            0, 1,
+            0,
+            1,
             UInt64::fromInt(64),
             UInt64::fromInt(8),
         );

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -99,13 +99,13 @@ class ZendArrayTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
-                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
+                $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
-        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -21,6 +21,7 @@ use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
@@ -98,15 +99,20 @@ class ZendArrayTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -118,6 +124,7 @@ class ZendArrayTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -125,6 +132,8 @@ class ZendArrayTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -104,13 +104,13 @@ class CallTraceReaderTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
-                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
+                $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
-        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -23,6 +23,7 @@ use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\Opcodes\OpcodeFactory;
@@ -103,15 +104,20 @@ class CallTraceReaderTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -123,6 +129,7 @@ class CallTraceReaderTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -130,6 +137,8 @@ class CallTraceReaderTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
@@ -18,6 +18,7 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
@@ -108,6 +109,10 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
 
         foreach ($tids as $tid) {
             try {
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                );
+                $process_memory_map_creator = ProcessMemoryMapCreator::create();
                 $php_symbol_reader_creator = new PhpSymbolReaderCreator(
                     new ProcessModuleSymbolReaderCreator(
                         new Elf64SymbolResolverCreator(
@@ -124,8 +129,10 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                             new LittleEndianReader()
                         ),
                         new ContainerAwarePathResolver(),
+                        $binary_analysis_cache,
                     ),
-                    ProcessMemoryMapCreator::create(),
+                    $process_memory_map_creator,
+                    $binary_analysis_cache,
                 );
                 $integer_reader = new LittleEndianReader();
                 $memory_reader_for_finder = new MemoryReader();
@@ -133,6 +140,8 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                     $php_symbol_reader_creator,
                     $integer_reader,
                     $memory_reader_for_finder,
+                    $binary_analysis_cache,
+                    $process_memory_map_creator,
                 );
                 $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
                     $php_symbol_reader_creator,
@@ -144,6 +153,7 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                     ProcessMemoryMapCreator::create(),
                     new ContainerAwarePathResolver(),
                     new ZendTypeReaderCreator(),
+                    $binary_analysis_cache,
                 );
                 $php_globals_finder = new PhpGlobalsFinder(
                     $php_symbol_reader_creator,
@@ -151,6 +161,8 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                     $memory_reader_for_finder,
                     $tsrm_ls_cache_finder,
                     $tsrm_globals_resolver,
+                    $binary_analysis_cache,
+                    $process_memory_map_creator,
                 );
 
                 $eg_addr = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -66,13 +66,13 @@ class PhpGlobalsFinderTest extends BaseTestCase
                     new LittleEndianReader(),
                 ),
                 new ContainerAwarePathResolver(),
-                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
+                $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
-        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -21,6 +21,7 @@ use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
@@ -65,15 +66,20 @@ class PhpGlobalsFinderTest extends BaseTestCase
                     new LittleEndianReader(),
                 ),
                 new ContainerAwarePathResolver(),
+                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -85,6 +91,7 @@ class PhpGlobalsFinderTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -92,6 +99,8 @@ class PhpGlobalsFinderTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $module_registry = $php_globals_finder->findModuleRegistry(
             new ProcessSpecifier($child_status['pid']),

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -24,6 +24,7 @@ use Reli\Lib\Elf\Parser\Elf64Parser;
 use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
@@ -139,8 +140,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
             ),
-            ProcessMemoryMapCreator::create(),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
@@ -148,6 +153,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -159,6 +166,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -166,6 +174,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -407,8 +417,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
             ),
-            ProcessMemoryMapCreator::create(),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
@@ -416,6 +430,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -427,6 +443,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -434,6 +451,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -579,8 +598,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
             ),
-            ProcessMemoryMapCreator::create(),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
@@ -588,6 +611,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -599,6 +624,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -606,6 +632,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -768,8 +796,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
             ),
-            ProcessMemoryMapCreator::create(),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
@@ -777,6 +809,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -788,6 +822,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -795,6 +830,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $memory_reader_for_finder,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -66,12 +66,12 @@ class PhpVersionDetectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
-                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
+                $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
         );
         $memory_reader = new MemoryReader();
-        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -21,6 +21,7 @@ use Reli\Lib\Elf\Process\LinkMapLoader;
 use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
@@ -65,14 +66,19 @@ class PhpVersionDetectorTest extends BaseTestCase
                     new LittleEndianReader()
                 ),
                 new ContainerAwarePathResolver(),
+                new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid()),
             ),
             ProcessMemoryMapCreator::create(),
         );
         $memory_reader = new MemoryReader();
+        $binary_analysis_cache = new BinaryAnalysisCache(sys_get_temp_dir() . '/reli-test-' . uniqid());
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             $memory_reader,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $integer_reader = new LittleEndianReader();
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
@@ -85,6 +91,7 @@ class PhpVersionDetectorTest extends BaseTestCase
             ProcessMemoryMapCreator::create(),
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -92,6 +99,8 @@ class PhpVersionDetectorTest extends BaseTestCase
             $memory_reader,
             $tsrm_ls_cache_finder,
             $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $module_registry_address = $php_globals_finder->findModuleRegistry(
             new ProcessSpecifier($child_status['pid']),
@@ -100,7 +109,9 @@ class PhpVersionDetectorTest extends BaseTestCase
         $php_version_detector = new PhpVersionDetector(
             $php_globals_finder,
             $memory_reader,
-            new ZendTypeReaderCreator()
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $process_memory_map_creator,
         );
         $version = $php_version_detector->detectPhpVersion(
             $child_status['pid'],


### PR DESCRIPTION
## Summary
This PR introduces a persistent file-based caching system for ELF binary analysis results, significantly improving performance when analyzing the same PHP binaries across multiple profiling runs. The cache stores symbol resolution data, base addresses, and TLS information to disk, reducing redundant parsing and symbol lookups.

## Key Changes

- **New `BinaryAnalysisCache` class**: Implements persistent JSON-based caching with fingerprint-based organization. Supports enabling/disabling and clearing cached entries.

- **Enhanced `Elf64CachedSymbolResolver`**: Extended to use both in-memory and file-based caching. Now serializes/deserializes symbol table entries and caches base addresses and debug information across resolver instances.

- **Updated symbol resolution pipeline**: Modified `PhpSymbolReaderCreator`, `PhpGlobalsFinder`, `TsrmGlobalsResolver`, `LibThreadDbTlsFinder`, and `PhpVersionDetector` to utilize the binary analysis cache, reducing redundant ELF parsing and symbol lookups.

- **New `cache:clear` command**: Added console command to manually clear all cached binary analysis data.

- **Binary fingerprinting**: Added `getCacheKey()` method to `BinaryFingerprint` for deterministic cache key generation using SHA256 hashing.

- **Comprehensive test coverage**: Added extensive tests for cache functionality, symbol resolution caching, and the clear command.

## Implementation Details

- Cache entries are organized by binary fingerprint and namespace (e.g., 'elf_symbols', 'tsrm_ls_cache', 'zts_globals')
- Symbol entries are serialized with all relevant fields (st_value, st_size, st_info, etc.) to enable full reconstruction
- Cache can be disabled at runtime to bypass file I/O when needed
- Graceful fallback to resolver if cache misses or is disabled
- Thread-safe temporary file writes with atomic rename operations
- Proper handling of corrupted cache files (returns null on JSON decode errors)

https://claude.ai/code/session_01HxH6g3DZgKGfwYxxFuz3ZD