### PR TITLE
Update documentation for improved ZTS support and new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Much of what can be done with phpspy will be done with reli in the future.
 - PHP 7.0+ (NTS / ZTS)
 - 64bit Linux x86_64
 
-On targeting ZTS, the target process must load libpthread.so, and also you must have unstripped binary of the interpreter and the libpthread.so, to find EG from the TLS.
+On targeting ZTS, reli finds EG from the TLS. Stripped binaries are supported (TLS segments are scanned via brute force). On glibc 2.34+, where libpthread is merged into libc, reli automatically falls back to libc.so, so no extra options are needed in most cases.
 
 ## Installation
 ### From Composer
@@ -608,9 +608,6 @@ If your PHP binary uses a non-standard binary name that does not end with `/php`
 
 ### I don't think the trace is accurate.
 The `-S` option will give you better results. Using this option stops the execution of the target process for a moment at every sampling, but the trace obtained will be more accurate. If you don't stop the VMs from running when profiling CPU-heavy programs such as benchmarking programs, you may misjudge the bottleneck, because you will miss more VM states that transition very quickly and are not detected well.
-
-### Trace retrieval from ZTS target does not work on Ubuntu 21.10 or later.
-Try to specify `--libpthread-regex="libc.so"` as an option.
 
 ### I can't get traces on Amazon Linux 2.
 First, try `cat /proc/<pid>/maps` to check the memory map of the target PHP process. If the first module does not indicate the location of the PHP binary and looks like an anonymous region, try to specify `--php-regex="^$"` as an option.

--- a/README.md
+++ b/README.md
@@ -118,27 +118,28 @@ Arguments:
   args                                       command line arguments for cmd
 
 Options:
-  -p, --pid=PID                              process id
-  -d, --depth[=DEPTH]                        max depth
-  -s, --sleep-ns[=SLEEP-NS]                  nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]            max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
-      --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                             disable the binary analysis cache
-      --with-native-trace                    collect native (C-level) stack traces alongside PHP traces
-      --native-trace-anytime                 collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
-  -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
-  -o, --output=OUTPUT                        path to write output from this tool (default: stdout)
-  -h, --help                                 Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                Do not output any message
-  -V, --version                              Display this application version
-      --ansi|--no-ansi                       Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                       Do not ask any interactive question
-  -v|vv|vvv, --verbose                       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -p, --pid=PID                                process id
+  -d, --depth[=DEPTH]                          max depth
+      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
+      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
+  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
+  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
+  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
+      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
+      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
+      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
+      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
+      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
+  -t, --template[=TEMPLATE]                    template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
+  -o, --output=OUTPUT                          path to write output from this tool (default: stdout)
+      --no-cache                               disable the binary analysis cache
+  -h, --help                                   Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                                  Do not output any message
+  -V, --version                                Display this application version
+      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction                         Do not ask any interactive question
+  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 ### Daemon mode
@@ -151,26 +152,29 @@ Usage:
   inspector:daemon [options]
 
 Options:
-  -P, --target-regex=TARGET-REGEX            regex to find target processes which have matching command-line (required)
-  -T, --threads[=THREADS]                    number of workers (default: 8)
-  -d, --depth[=DEPTH]                        max depth
-  -s, --sleep-ns[=SLEEP-NS]                  nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]            max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
-      --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                             disable the binary analysis cache
-  -t, --template[=TEMPLATE]                  template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
-  -o, --output=OUTPUT                        path to write output from this tool (default: stdout)
-  -h, --help                                 Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                Do not output any message
-  -V, --version                              Display this application version
-      --ansi|--no-ansi                       Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                       Do not ask any interactive question
-  -v|vv|vvv, --verbose                       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
+  -T, --threads[=THREADS]                      number of workers (default: 8)
+  -d, --depth[=DEPTH]                          max depth
+      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
+      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
+  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
+  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
+  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
+      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
+      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
+      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
+      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
+      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
+  -t, --template[=TEMPLATE]                    template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
+  -o, --output=OUTPUT                          path to write output from this tool (default: stdout)
+      --no-cache                               disable the binary analysis cache
+  -h, --help                                   Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                                  Do not output any message
+  -V, --version                                Display this application version
+      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction                         Do not ask any interactive question
+  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 ### top-like mode
@@ -183,24 +187,27 @@ Usage:
   inspector:top [options]
 
 Options:
-  -P, --target-regex=TARGET-REGEX            regex to find target processes which have matching command-line (required)
-  -T, --threads[=THREADS]                    number of workers (default: 8)
-  -d, --depth[=DEPTH]                        max depth
-  -s, --sleep-ns[=SLEEP-NS]                  nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]            max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]          stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
-      --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                             disable the binary analysis cache
-  -h, --help                                 Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                Do not output any message
-  -V, --version                              Display this application version
-      --ansi|--no-ansi                       Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                       Do not ask any interactive question
-  -v|vv|vvv, --verbose                       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
+  -T, --threads[=THREADS]                      number of workers (default: 8)
+  -d, --depth[=DEPTH]                          max depth
+      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
+      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
+  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
+  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
+  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
+      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
+      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
+      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
+      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
+      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                               disable the binary analysis cache
+  -h, --help                                   Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                                  Do not output any message
+  -V, --version                                Display this application version
+      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction                         Do not ask any interactive question
+  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 ### Get the address of EG
@@ -217,19 +224,20 @@ Arguments:
   args                                       command line arguments for cmd
 
 Options:
-  -p, --pid=PID                              process id
-      --php-regex[=PHP-REGEX]                regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]  regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]            php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
-      --php-path[=PHP-PATH]                  path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]    path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                             disable the binary analysis cache
-  -h, --help                                 Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                Do not output any message
-  -V, --version                              Display this application version
-      --ansi|--no-ansi                       Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                       Do not ask any interactive question
-  -v|vv|vvv, --verbose                       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -p, --pid=PID                                process id
+      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
+      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
+      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
+      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
+      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --no-cache                               disable the binary analysis cache
+  -h, --help                                   Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                                  Do not output any message
+  -V, --version                                Display this application version
+      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction                         Do not ask any interactive question
+  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
 ## [Experimental] Dump the memory usage of the target process
@@ -248,12 +256,20 @@ Arguments:
 Options:
       --stop-process|--no-stop-process                               stop the process while inspecting (default: on)
       --pretty-print|--no-pretty-print                               pretty print the result (default: off)
+  -f, --output-format=OUTPUT-FORMAT                                  output format (json, sqlite3, mysql, postgresql) [default: "json"]
+  -o, --output=OUTPUT                                                output file path (required for sqlite3 format)
+      --db-host=DB-HOST                                              database host (for mysql/postgresql) [default: "127.0.0.1"]
+      --db-port=DB-PORT                                              database port (for mysql/postgresql)
+      --db-name=DB-NAME                                              database name (for mysql/postgresql)
+      --db-user=DB-USER                                              database user (for mysql/postgresql)
+      --db-password=DB-PASSWORD                                      database password (for mysql/postgresql)
       --memory-limit-error-file=MEMORY-LIMIT-ERROR-FILE              file path where memory_limit is exceeded
       --memory-limit-error-line=MEMORY-LIMIT-ERROR-LINE              line number where memory_limit is exceeded
       --memory-limit-error-max-depth[=MEMORY-LIMIT-ERROR-MAX-DEPTH]  max attempts to trace back the VM stack on memory_limit error [default: 512]
   -p, --pid=PID                                                      process id
       --php-regex[=PHP-REGEX]                                        regex to find the php binary loaded in the target process
       --libpthread-regex[=LIBPTHREAD-REGEX]                          regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]                        regex to find the binary containing globals symbols for ZTS loaded in the target process
       --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[01234]) of the target (default: auto)
       --php-path[=PHP-PATH]                                          path to the php binary (only needed in tracing chrooted ZTS target)
       --libpthread-path[=LIBPTHREAD-PATH]                            path to the libpthread.so (only needed in tracing chrooted ZTS target)


### PR DESCRIPTION
## Summary
This PR updates the README documentation to reflect improvements in ZTS (Zend Thread Safety) support and adds documentation for new command-line options.

## Key Changes

- **Improved ZTS documentation**: Updated the ZTS requirements section to clarify that reli now supports stripped binaries through TLS segment brute force scanning, and automatically falls back to libc.so on glibc 2.34+ where libpthread is merged into libc.

- **New `--zts-globals-regex` option**: Added documentation for a new regex option to find the binary containing globals symbols for ZTS targets across all commands (inspector, daemon, top, and get-eg).

- **Native trace options in daemon/top modes**: Added `--with-native-trace` and `--native-trace-anytime` options to the daemon and top-like mode command documentation.

- **Memory dump output format options**: Added new output format options for the memory dump command:
  - `-f, --output-format`: Support for json, sqlite3, mysql, and postgresql formats
  - Database connection options: `--db-host`, `--db-port`, `--db-name`, `--db-user`, `--db-password`
  - `-o, --output`: Output file path for sqlite3 format

- **Formatting improvements**: Improved alignment and spacing of option descriptions across all command sections for better readability.

- **Removed outdated troubleshooting note**: Removed the Ubuntu 21.10+ specific workaround note about specifying `--libpthread-regex="libc.so"` as this is now handled automatically.

## Notable Details

- The changes maintain backward compatibility while expanding functionality
- All new options are properly documented with their purposes and default values
- The documentation now reflects the automatic fallback behavior for modern glibc versions, reducing the need for manual configuration

https://claude.ai/code/session_01RP8n2jB6PXYnRQ1rQACRCf