### PR TITLE
Add support for PHP 8.5

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -138,6 +138,8 @@ jobs:
             targets: "v83"
           - name: "PHP 8.4"
             targets: "v84"
+          - name: "PHP 8.5"
+            targets: "v85"
           - name: "PHP 7.3 ZTS"
             targets: "v73_zts"
           - name: "PHP 7.4 ZTS"
@@ -152,6 +154,8 @@ jobs:
             targets: "v83_zts"
           - name: "PHP 8.4 ZTS"
             targets: "v84_zts"
+          - name: "PHP 8.5 ZTS"
+            targets: "v85_zts"
     steps:
       - uses: actions/checkout@v6
 

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettings.php
@@ -22,7 +22,7 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
  */
 final class TargetPhpSettings
 {
-    public const PHP_REGEX_DEFAULT = '.*/((php|php-fpm)(7\.?[01234]|8\.?[01234])?|libphp[78]?.*\.so)$';
+    public const PHP_REGEX_DEFAULT = '.*/((php|php-fpm)(7\.?[01234]|8\.?[012345])?|libphp[78]?.*\.so)$';
     public const LIBPTHREAD_REGEX_DEFAULT = '.*/libpthread.*\.so';
     public const ZTS_GLOBALS_REGEX_DEFAULT = self::PHP_REGEX_DEFAULT;
     public const TARGET_PHP_VERSION_DEFAULT = 'auto';
@@ -38,7 +38,7 @@ final class TargetPhpSettings
     ) {
     }
 
-    /** @psalm-assert-if-true self<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'> $this */
+    /** @psalm-assert-if-true self<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $this */
     public function isDecided(): bool
     {
         return $this->php_version !== 'auto';

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV85.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV85.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Constants;
+
+final class PhpInternalsConstantsV85 extends VersionAwareConstants
+{
+}

--- a/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
+++ b/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
@@ -46,6 +46,7 @@ abstract class VersionAwareConstants
             ZendTypeReader::V82 => PhpInternalsConstantsV82::class,
             ZendTypeReader::V83 => PhpInternalsConstantsV83::class,
             ZendTypeReader::V84 => PhpInternalsConstantsV84::class,
+            ZendTypeReader::V85 => PhpInternalsConstantsV85::class,
         });
     }
 }

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1,0 +1,1572 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright (c) Zend Technologies Ltd. (http://www.zend.com)           |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | The contents of this file are extracted from some headers in php-src |
+   +----------------------------------------------------------------------+
+*/
+
+// zend_atomic.h
+typedef struct zend_atomic_bool_s {
+	volatile bool value;
+} zend_atomic_bool;
+
+// zend_long.h
+typedef int64_t zend_long;
+typedef uint64_t zend_ulong;
+typedef int64_t zend_off_t;
+
+// zend_types.h
+typedef struct _zend_object_handlers zend_object_handlers;
+typedef struct _zend_class_entry     zend_class_entry;
+typedef union  _zend_function        zend_function;
+typedef struct _zend_execute_data    zend_execute_data;
+
+typedef struct _zval_struct     zval;
+
+typedef struct _zend_refcounted zend_refcounted;
+typedef struct _zend_string     zend_string;
+typedef struct _zend_array      zend_array;
+typedef struct _zend_object     zend_object;
+typedef struct _zend_resource   zend_resource;
+typedef struct _zend_reference  zend_reference;
+typedef struct _zend_ast_ref    zend_ast_ref;
+typedef struct _zend_ast        zend_ast;
+
+typedef int  (*compare_func_t)(const void *, const void *);
+typedef void (*swap_func_t)(void *, void *);
+typedef void (*sort_func_t)(void *, size_t, size_t, compare_func_t, swap_func_t);
+typedef void (*dtor_func_t)(zval *pDest);
+typedef void (*copy_ctor_func_t)(zval *pElement);
+
+typedef struct _zend_refcounted_h {
+	uint32_t         refcount;			/* reference counter 32-bit */
+	union {
+		uint32_t type_info;
+	} u;
+} zend_refcounted_h;
+
+struct _zend_refcounted {
+	zend_refcounted_h gc;
+};
+
+struct _zend_string {
+	zend_refcounted_h gc;
+	zend_ulong        h;                /* hash value */
+	size_t            len;
+	char              val[1];
+};
+
+typedef union _zend_value {
+	zend_long         lval;				/* long value */
+	double            dval;				/* double value */
+	zend_refcounted  *counted;
+	zend_string      *str;
+	zend_array       *arr;
+	zend_object      *obj;
+	zend_resource    *res;
+	zend_reference   *ref;
+	zend_ast_ref     *ast;
+	zval             *zv;
+	void             *ptr;
+	zend_class_entry *ce;
+	zend_function    *func;
+	struct {
+		uint32_t w1;
+		uint32_t w2;
+	} ww;
+} zend_value;
+
+struct _zval_struct {
+	zend_value        value;			/* value */
+	union {
+		uint32_t type_info;
+		struct {
+				uint8_t    type;			/* active type */
+				uint8_t    type_flags;
+				union {
+					uint16_t  extra;        /* not further specified */
+				} u
+		} v;
+	} u1;
+	union {
+		uint32_t     next;                 /* hash collision chain */
+		uint32_t     cache_slot;           /* cache slot (for RECV_INIT) */
+		uint32_t     opline_num;           /* opline number (for FAST_CALL) */
+		uint32_t     lineno;               /* line number (for ast nodes) */
+		uint32_t     num_args;             /* arguments number for EX(This) */
+		uint32_t     fe_pos;               /* foreach position */
+		uint32_t     fe_iter_idx;          /* foreach iterator index */
+		uint32_t     guard;                /* recursion and single property guard */
+		uint32_t     constant_flags;       /* constant flags */
+		uint32_t     extra;                /* not further specified */
+	} u2;
+};
+
+typedef struct _Bucket {
+	zval              val;
+	zend_ulong        h;                /* hash value (or numeric index)   */
+	zend_string      *key;              /* string key or NULL for numerics */
+} Bucket;
+
+struct _zend_array {
+	zend_refcounted_h gc;
+	union {
+		struct {
+				uint8_t    flags;
+				uint8_t    _unused;
+				uint8_t    nIteratorsCount;
+				uint8_t    _unused2;
+		} v;
+		uint32_t flags;
+	} u;
+	uint32_t          nTableMask;
+	union {
+		uint32_t     *arHash;   /* hash table (allocated above this pointer) */
+		Bucket       *arData;   /* array of hash buckets */
+		zval         *arPacked; /* packed array of zvals */
+	};
+	uint32_t          nNumUsed;
+	uint32_t          nNumOfElements;
+	uint32_t          nTableSize;
+	uint32_t          nInternalPointer;
+	zend_long         nNextFreeElement;
+	dtor_func_t       pDestructor;
+};
+
+typedef struct _zend_array HashTable;
+typedef uint32_t HashPosition;
+
+typedef struct _HashTableIterator {
+	HashTable    *ht;
+	HashPosition  pos;
+	uint32_t      next_copy; // circular linked list via index into EG(ht_iterators)
+} HashTableIterator;
+
+struct _zend_object {
+	zend_refcounted_h gc;
+	uint32_t          handle; // TODO: may be removed ???
+	uint32_t          extra_flags; /* OBJ_EXTRA_FLAGS() */
+	zend_class_entry *ce;
+	const zend_object_handlers *handlers;
+	HashTable        *properties;
+	zval              properties_table[1];
+};
+
+struct _zend_resource {
+	zend_refcounted_h gc;
+	zend_long         handle; // TODO: may be removed ???
+	int               type;
+	void             *ptr;
+};
+
+typedef struct {
+	/* Not using a union here, because there's no good way to initialize them
+	 * in a way that is supported in both C and C++ (designated initializers
+	 * are only supported since C++20). */
+	void *ptr;
+	uint32_t type_mask;
+	/* TODO: We could use the extra 32-bit of padding on 64-bit systems. */
+} zend_type;
+
+// zend_compile.h
+typedef struct _zend_property_info {
+	uint32_t offset; /* property offset for object properties or
+	                      property index for static properties */
+	uint32_t flags;
+	zend_string *name;
+	zend_string *doc_comment;
+	HashTable *attributes;
+	zend_class_entry *ce;
+	zend_type type;
+	const struct _zend_property_info *prototype;
+	zend_function **hooks;
+} zend_property_info;
+
+// zend_types.h
+typedef struct {
+	size_t num;
+	size_t num_allocated;
+	struct _zend_property_info *ptr[1];
+} zend_property_info_list;
+
+typedef union {
+	struct _zend_property_info *ptr;
+	uintptr_t list;
+} zend_property_info_source_list;
+
+struct _zend_reference {
+	zend_refcounted_h              gc;
+	zval                           val;
+	zend_property_info_source_list sources;
+};
+
+struct _zend_ast_ref {
+	zend_refcounted_h gc;
+	/*zend_ast        ast; zend_ast follows the zend_ast_ref structure */
+};
+
+typedef enum {
+  SUCCESS =  0,
+  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
+} ZEND_RESULT_CODE;
+
+typedef ZEND_RESULT_CODE zend_result;
+
+
+// zend_object_handlers.h
+struct _zend_object_handlers {
+	/* offset of real object header (usually zero) */
+	int  offset;
+	/* object handlers */
+	void *free_obj;             /* required */
+	void *dtor_obj;             /* required */
+	void *clone_obj;            /* optional */
+	void *read_property;        /* required */
+	void *write_property;       /* required */
+	void *read_dimension;       /* required */
+	void *write_dimension;      /* required */
+	void *get_property_ptr_ptr; /* required */
+	void *has_property;         /* required */
+	void *unset_property;       /* required */
+	void *has_dimension;        /* required */
+	void *unset_dimension;      /* required */
+	void *get_properties;       /* required */
+	void *get_method;           /* required */
+	void *get_constructor;      /* required */
+	void *get_class_name;       /* required */
+	void *cast_object;          /* required */
+	void *count_elements;       /* optional */
+	void *get_debug_info;       /* optional */
+	void *get_closure;          /* optional */
+	void *get_gc;               /* required */
+	void *do_operation;         /* optional */
+	void *compare;              /* required */
+	void *get_properties_for;   /* optional */
+};
+
+// zend_globals.h
+typedef struct _zend_vm_stack *zend_vm_stack;
+
+// zend_execute.h
+struct _zend_vm_stack {
+	zval *top;
+	zval *end;
+	zend_vm_stack prev;
+};
+
+// zend_globals_macros.h
+typedef struct _zend_compiler_globals zend_compiler_globals;
+typedef struct _zend_executor_globals zend_executor_globals;
+typedef struct _zend_php_scanner_globals zend_php_scanner_globals;
+typedef struct _zend_ini_scanner_globals zend_ini_scanner_globals;
+
+// zend_globals.h
+typedef struct _zend_ini_entry zend_ini_entry;
+
+// zend_ini.h
+struct _zend_ini_entry {
+	zend_string *name;
+	int (*on_modify)(zend_ini_entry *entry, zend_string *new_value, void *mh_arg1, void *mh_arg2, void *mh_arg3, int stage);
+	void *mh_arg1;
+	void *mh_arg2;
+	void *mh_arg3;
+	zend_string *value;
+	zend_string *orig_value;
+	void (*displayer)(zend_ini_entry *ini_entry, int type);
+
+	int module_number;
+
+	uint8_t modifiable;
+	uint8_t orig_modifiable;
+	uint8_t modified;
+
+};
+
+// zend_iterators.h
+typedef struct _zend_object_iterator zend_object_iterator;
+
+typedef struct _zend_object_iterator_funcs {
+	/* release all resources associated with this iterator instance */
+	void (*dtor)(zend_object_iterator *iter);
+
+	/* check for end of iteration (FAILURE or SUCCESS if data is valid) */
+	int (*valid)(zend_object_iterator *iter);
+
+	/* fetch the item data for the current element */
+	zval *(*get_current_data)(zend_object_iterator *iter);
+
+	/* fetch the key for the current element (optional, may be NULL). The key
+	 * should be written into the provided zval* using the ZVAL_* macros. If
+	 * this handler is not provided auto-incrementing integer keys will be
+	 * used. */
+	void (*get_current_key)(zend_object_iterator *iter, zval *key);
+
+	/* step forwards to next element */
+	void (*move_forward)(zend_object_iterator *iter);
+
+	/* rewind to start of data (optional, may be NULL) */
+	void (*rewind)(zend_object_iterator *iter);
+
+	/* invalidate current value/key (optional, may be NULL) */
+	void (*invalidate_current)(zend_object_iterator *iter);
+
+	/* Expose owned values to GC.
+	 * This has the same semantics as the corresponding object handler. */
+	HashTable *(*get_gc)(zend_object_iterator *iter, zval **table, int *n);
+} zend_object_iterator_funcs;
+
+struct _zend_object_iterator {
+	zend_object std;
+	zval data;
+	const zend_object_iterator_funcs *funcs;
+	zend_ulong index; /* private to fe_reset/fe_fetch opcodes */
+};
+
+typedef struct _zend_class_iterator_funcs {
+	zend_function *zf_new_iterator;
+	zend_function *zf_valid;
+	zend_function *zf_current;
+	zend_function *zf_key;
+	zend_function *zf_next;
+	zend_function *zf_rewind;
+} zend_class_iterator_funcs;
+
+// zend.h
+typedef enum {
+	EH_NORMAL = 0,
+	EH_THROW
+} zend_error_handling_t;
+
+typedef struct {
+	zend_error_handling_t  handling;
+	zend_class_entry       *exception;
+} zend_error_handling;
+
+typedef struct _zend_error_info {
+	int type;
+	uint32_t lineno;
+	zend_string *filename;
+	zend_string *message;
+} zend_error_info;
+
+// zend_objects_API.h
+typedef struct _zend_objects_store {
+	zend_object **object_buckets;
+	uint32_t top;
+	uint32_t size;
+	int free_list_head;
+} zend_objects_store;
+
+// zend_modules.h
+typedef struct _zend_module_entry zend_module_entry;
+typedef struct _zend_module_dep zend_module_dep;
+struct _zend_module_dep {
+	const char *name;		/* module name */
+	const char *rel;		/* version relationship: NULL (exists), lt|le|eq|ge|gt (to given version) */
+	const char *version;	/* version */
+	unsigned char type;		/* dependency type */
+};
+
+// zend_compile.h
+typedef void (*zif_handler)(zend_execute_data *execute_data, zval *return_value);
+
+// zend_frameless_function
+typedef struct {
+	void *handler;
+	uint32_t num_args;
+} zend_frameless_function_info;
+
+// zend_API.h
+typedef struct _zend_function_entry {
+	const char *fname;
+	zif_handler handler;
+	const struct _zend_internal_arg_info *arg_info;
+	uint32_t num_args;
+	uint32_t flags;
+	const zend_frameless_function_info *frameless_function_infos;
+	const char *doc_comment;
+} zend_function_entry;
+
+typedef struct _zend_fcall_info_cache {
+	zend_function *function_handler;
+	zend_class_entry *calling_scope;
+	zend_class_entry *called_scope;
+	zend_object *object; /* Instance of object for method calls */
+	zend_object *closure; /* Closure reference, only if the callable *is* the object */
+} zend_fcall_info_cache;
+
+typedef struct _zend_fcall_info {
+	size_t size;
+	zval function_name;
+	zval *retval;
+	zval *params;
+	zend_object *object;
+	uint32_t param_count;
+	/* This hashtable can also contain positional arguments (with integer keys),
+	 * which will be appended to the normal params[]. This makes it easier to
+	 * integrate APIs like call_user_func_array(). The usual restriction that
+	 * there may not be position arguments after named arguments applies. */
+	HashTable *named_params;
+} zend_fcall_info;
+
+// zend_modules.h
+struct _zend_module_entry {
+	unsigned short size;
+	unsigned int zend_api;
+	unsigned char zend_debug;
+	unsigned char zts;
+	const struct _zend_ini_entry *ini_entry;
+	const struct _zend_module_dep *deps;
+	const char *name;
+	const struct _zend_function_entry *functions;
+	zend_result (*module_startup_func)(int type, int module_number);
+	zend_result (*module_shutdown_func)(int type, int module_number);
+	zend_result (*request_startup_func)(int type, int module_number);
+	zend_result (*request_shutdown_func)(int type, int module_number);
+	void (*info_func)(zend_module_entry *zend_module);
+	const char *version;
+	size_t globals_size;
+	void* globals_ptr; // ts_rsrc_id* globals_id_ptr; in ZTS
+	void (*globals_ctor)(void *global);
+	void (*globals_dtor)(void *global);
+	zend_result (*post_deactivate_func)(void);
+	int module_started;
+	unsigned char type;
+	void *handle;
+	int module_number;
+	const char *build_id;
+};
+
+// zend_stack.h
+typedef struct _zend_stack {
+	int size, top, max;
+	void *elements;
+} zend_stack;
+
+// zend_compile.h
+typedef struct _zend_op zend_op;
+typedef struct _zend_op_array zend_op_array;
+
+typedef union _znode_op {
+	uint32_t      constant;
+	uint32_t      var;
+	uint32_t      num;
+	uint32_t      opline_num; /*  Needs to be signed */
+	uint32_t      jmp_offset;
+} znode_op;
+
+struct _zend_op {
+	const void *handler;
+	znode_op op1;
+	znode_op op2;
+	znode_op result;
+	uint32_t extended_value;
+	uint32_t lineno;
+	uint8_t opcode;
+	uint8_t op1_type;
+	uint8_t op2_type;
+	uint8_t result_type;
+};
+
+typedef struct _zend_arg_info {
+	zend_string *name;
+	zend_type type;
+	zend_string *default_value;
+} zend_arg_info;
+
+typedef struct _zend_internal_arg_info {
+	const char *name;
+	zend_type type;
+	const char *default_value;
+} zend_internal_arg_info;
+
+typedef struct _zend_live_range {
+	uint32_t var; /* low bits are used for variable type (ZEND_LIVE_* macros) */
+	uint32_t start;
+	uint32_t end;
+} zend_live_range;
+
+typedef struct _zend_try_catch_element {
+	uint32_t try_op;
+	uint32_t catch_op;  /* ketchup! */
+	uint32_t finally_op;
+	uint32_t finally_end;
+} zend_try_catch_element;
+
+struct _zend_op_array {
+	/* Common elements */
+	uint8_t type;
+	uint8_t arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+	uint32_t fn_flags;
+	zend_string *function_name;
+	zend_class_entry *scope;
+	zend_function *prototype;
+	uint32_t num_args;
+	uint32_t required_num_args;
+	zend_arg_info *arg_info;
+	HashTable *attributes;
+	void **run_time_cache__ptr;
+	zend_string *doc_comment;
+	uint32_t T;         /* number of temporary variables */
+	const zend_property_info *prop_info; /* The corresponding prop_info if this is a hook. */
+    /* END of common elements */
+
+	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
+	int last_var;       /* number of CV variables */
+	uint32_t last;      /* number of opcodes */
+
+	zend_op *opcodes;
+	HashTable **static_variables_ptr__ptr;
+	HashTable *static_variables;
+	zend_string **vars; /* names of CV variables */
+
+	uint32_t *refcount;
+
+	int last_live_range;
+	int last_try_catch;
+	zend_live_range *live_range;
+	zend_try_catch_element *try_catch_array;
+
+	zend_string *filename;
+	uint32_t line_start;
+	uint32_t line_end;
+
+	int last_literal;
+	uint32_t num_dynamic_func_defs;
+	zval *literals;
+
+	/* Functions that are declared dynamically are stored here and
+	 * referenced by index from opcodes. */
+	zend_op_array **dynamic_func_defs;
+
+	void *reserved[6];
+};
+
+typedef struct _zend_internal_function_info {
+	uintptr_t required_num_args;
+	zend_type type;
+	const char *default_value;
+} zend_internal_function_info;
+
+
+typedef struct _zend_internal_function {
+	/* Common elements */
+	uint8_t type;
+	uint8_t arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+	uint32_t fn_flags;
+	zend_string* function_name;
+	zend_class_entry *scope;
+	zend_function *prototype;
+	uint32_t num_args;
+	uint32_t required_num_args;
+	zend_internal_arg_info *arg_info;
+	HashTable *attributes;
+	void **run_time_cache__ptr;
+	zend_string *doc_comment;
+	uint32_t T;         /* number of temporary variables */
+	const zend_property_info *prop_info;
+	/* END of common elements */
+
+	zif_handler handler;
+	struct _zend_module_entry *module;
+	const zend_frameless_function_info *frameless_function_infos;
+	void *reserved[6];
+} zend_internal_function;
+
+union _zend_function {
+	uint8_t type;	/* MUST be the first element of this struct! */
+	uint32_t   quick_arg_flags;
+
+	struct {
+		uint8_t type;  /* never used */
+		uint8_t arg_flags[3]; /* bitset of arg_info.pass_by_reference */
+		uint32_t fn_flags;
+		zend_string *function_name;
+		zend_class_entry *scope;
+		zend_function *prototype;
+		uint32_t num_args;
+		uint32_t required_num_args;
+		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
+		HashTable   *attributes;
+		void **run_time_cache__ptr;
+		zend_string *doc_comment;
+		uint32_t T;         /* number of temporary variables */
+		const zend_property_info *prop_info;
+	} common;
+
+	zend_op_array op_array;
+	zend_internal_function internal_function;
+};
+
+// zend_gc.h
+typedef struct {
+	zval *cur;
+	zval *end;
+	zval *start;
+} zend_get_gc_buffer;
+
+
+// zend_compile.h
+typedef struct _zend_class_constant {
+	zval value; /* access flags are stored in reserved: zval.u2.access_flags */
+	zend_string *doc_comment;
+	HashTable *attributes;
+	zend_class_entry *ce;
+	zend_type type;
+} zend_class_constant;
+
+struct _zend_execute_data {
+	const zend_op       *opline;           /* executed opline                */
+	zend_execute_data   *call;             /* current call                   */
+	zval                *return_value;
+	zend_function       *func;             /* executed function              */
+	zval                 This;             /* this + call_info + num_args    */
+	zend_execute_data   *prev_execute_data;
+	zend_array          *symbol_table;
+	void               **run_time_cache;   /* cache op_array->run_time_cache */
+	zend_array          *extra_named_params;
+};
+
+typedef struct _zend_brk_cont_element {
+	int start;
+	int cont;
+	int brk;
+	int parent;
+	bool is_switch;
+} zend_brk_cont_element;
+
+// zend_property_hooks.h
+typedef enum {
+	ZEND_PROPERTY_HOOK_GET = 0,
+	ZEND_PROPERTY_HOOK_SET = 1,
+} zend_property_hook_kind;
+
+// zend_compile.h
+typedef struct _zend_oparray_context {
+	struct _zend_oparray_context *prev;
+	zend_op_array *op_array;
+	uint32_t   opcodes_size;
+	int        vars_size;
+	int        literals_size;
+	uint32_t   fast_call_var;
+	uint32_t   try_catch_offset;
+	int        current_brk_cont;
+	int        last_brk_cont;
+	zend_brk_cont_element *brk_cont_array;
+	HashTable *labels;
+	zend_string *active_property_info_name;
+	zend_property_hook_kind active_property_hook_kind;
+	bool       in_jmp_frameless_branch;
+	bool has_assigned_to_http_response_header;
+} zend_oparray_context;
+
+typedef struct _zend_declarables {
+	zend_long ticks;
+} zend_declarables;
+
+typedef struct _zend_file_context {
+	zend_declarables declarables;
+
+	zend_string *current_namespace;
+	bool in_namespace;
+	bool has_bracketed_namespaces;
+
+	HashTable *imports;
+	HashTable *imports_function;
+	HashTable *imports_const;
+
+	HashTable seen_symbols;
+} zend_file_context;
+
+/** zend_llist.h */
+
+typedef void (*llist_dtor_func_t)(void *);
+typedef struct _zend_llist_element {
+	struct _zend_llist_element *next;
+	struct _zend_llist_element *prev;
+	char data[1]; /* Needs to always be last in the struct */
+} zend_llist_element;
+
+typedef struct _zend_llist {
+	zend_llist_element *head;
+	zend_llist_element *tail;
+	size_t count;
+	size_t size;
+	llist_dtor_func_t dtor;
+	unsigned char persistent;
+	zend_llist_element *traverse_ptr;
+} zend_llist;
+
+// zend_arena.h
+typedef struct _zend_arena zend_arena;
+
+struct _zend_arena {
+	char		*ptr;
+	char		*end;
+	zend_arena  *prev;
+};
+
+// zend_multibyte.h
+typedef struct _zend_encoding zend_encoding;
+
+// zend_constants.h
+typedef struct _zend_constant {
+	zval value;
+	zend_string *name;
+} zend_constant;
+
+// zend_call_stack.h
+typedef struct _zend_call_stack {
+	void *base;
+	size_t max_size;
+} zend_call_stack;
+
+// zend_globals.h
+typedef enum {
+	ZEND_MEMOIZE_NONE,
+	ZEND_MEMOIZE_COMPILE,
+	ZEND_MEMOIZE_FETCH,
+} zend_memoize_mode;
+
+struct _zend_compiler_globals {
+	zend_stack loop_var_stack;
+
+	zend_class_entry *active_class_entry;
+
+	zend_string *compiled_filename;
+
+	int zend_lineno;
+
+	zend_op_array *active_op_array;
+
+	HashTable *function_table;	/* function symbol table */
+	HashTable *class_table;		/* class table */
+
+	HashTable *auto_globals;
+
+	/* Refer to zend_yytnamerr() in zend_language_parser.y for meaning of values */
+	uint8_t parse_error;
+	bool in_compilation;
+	bool short_tags;
+
+	bool unclean_shutdown;
+
+	bool ini_parser_unbuffered_errors;
+
+	zend_llist open_files;
+
+	struct _zend_ini_parser_param *ini_parser_param;
+
+	bool skip_shebang;
+	bool increment_lineno;
+
+	bool variable_width_locale;   /* UTF-8, Shift-JIS, Big5, ISO 2022, EUC, etc */
+	bool ascii_compatible_locale; /* locale uses ASCII characters as singletons */
+	                              /* and don't use them as lead/trail units     */
+
+	zend_string *doc_comment;
+	uint32_t extra_fn_flags;
+
+	uint32_t compiler_options; /* set of ZEND_COMPILE_* constants */
+
+	zend_oparray_context context;
+	zend_file_context file_context;
+
+	zend_arena *arena;
+
+	HashTable interned_strings;
+
+	const zend_encoding **script_encoding_list;
+	size_t script_encoding_list_size;
+	bool multibyte;
+	bool detect_unicode;
+	bool encoding_declared;
+
+	zend_ast *ast;
+	zend_arena *ast_arena;
+
+	zend_stack delayed_oplines_stack;
+	HashTable *memoized_exprs;
+	zend_memoize_mode memoize_mode;
+
+	void   *map_ptr_real_base;
+	unsigned long map_ptr_base;
+	size_t  map_ptr_size;
+	size_t  map_ptr_last;
+
+	HashTable *delayed_variance_obligations;
+	HashTable *delayed_autoloads;
+	HashTable *unlinked_uses;
+	zend_class_entry *current_linking_class;
+
+	uint32_t rtd_key_counter;
+
+	void *internal_run_time_cache;
+	uint32_t internal_run_time_cache_size;
+
+	zend_stack short_circuiting_opnums;
+	/*uint32_t copied_functions_count;*/
+};
+typedef struct _zend_fiber_context zend_fiber_context;
+typedef struct _zend_fiber zend_fiber;
+
+// zend_strtod.h
+typedef struct _zend_strtod_bigint zend_strtod_bigint;
+typedef struct _zend_strtod_state {
+	zend_strtod_bigint *freelist[7+1];
+	zend_strtod_bigint *p5s;
+	char *result;
+} zend_strtod_state;
+
+// zend_lazy_objects.h
+typedef struct _zend_lazy_objects_store {
+	/* object handle -> *zend_lazy_object_info */
+	HashTable infos;
+} zend_lazy_objects_store;
+
+// zend_globals.h
+struct _zend_executor_globals {
+	zval uninitialized_zval;
+	zval error_zval;
+
+	/* symbol table cache */
+	zend_array *symtable_cache[32];
+	/* Pointer to one past the end of the symtable_cache */
+	zend_array **symtable_cache_limit;
+	/* Pointer to first unused symtable_cache slot */
+	zend_array **symtable_cache_ptr;
+
+	zend_array symbol_table;		/* main symbol table */
+
+	HashTable included_files;	/* files already included */
+
+	void *bailout;
+
+	int error_reporting;
+	bool fatal_error_backtrace_on;
+	zval last_fatal_error_backtrace;
+	int exit_status;
+
+	HashTable *function_table;	/* function symbol table */
+	HashTable *class_table;		/* class table */
+	HashTable *zend_constants;	/* constants table */
+
+	zval          *vm_stack_top;
+	zval          *vm_stack_end;
+	zend_vm_stack  vm_stack;
+	size_t         vm_stack_page_size;
+
+	struct _zend_execute_data *current_execute_data;
+	zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
+
+	uint32_t jit_trace_num; /* Used by tracing JIT to reference the currently running trace */
+
+	zend_execute_data *current_observed_frame;
+
+	int ticks_count;
+
+	zend_long precision;
+
+	uint32_t persistent_constants_count;
+	uint32_t persistent_functions_count;
+	uint32_t persistent_classes_count;
+
+	/* for extended information support */
+	bool no_extensions;
+
+	bool full_tables_cleanup;
+
+	zend_atomic_bool vm_interrupt;
+	zend_atomic_bool timed_out;
+
+	HashTable *in_autoload;
+
+	zend_long hard_timeout;
+	void *stack_base;
+	void *stack_limit;
+
+	HashTable regular_list;
+	HashTable persistent_list;
+
+	int user_error_handler_error_reporting;
+	bool exception_ignore_args;
+	zval user_error_handler;
+	zval user_exception_handler;
+	zend_stack user_error_handlers_error_reporting;
+	zend_stack user_error_handlers;
+	zend_stack user_exception_handlers;
+
+	zend_class_entry      *exception_class;
+	zend_error_handling_t  error_handling;
+
+	int capture_warnings_during_sccp;
+
+	/* timeout support */
+	zend_long timeout_seconds;
+
+	HashTable *ini_directives;
+	HashTable *modified_ini_directives;
+	zend_ini_entry *error_reporting_ini_entry;
+
+	zend_objects_store objects_store;
+	zend_lazy_objects_store lazy_objects_store;
+	zend_object *exception;
+	zend_object *prev_exception;
+	const zend_op *opline_before_exception;
+	zend_op exception_op[3];
+
+	struct _zend_module_entry *current_module;
+
+	bool active;
+	uint8_t flags;
+
+	zend_long assertions;
+
+	uint32_t           ht_iterators_count;     /* number of allocatd slots */
+	uint32_t           ht_iterators_used;      /* number of used slots */
+	HashTableIterator *ht_iterators;
+	HashTableIterator  ht_iterators_slots[16];
+
+	void *saved_fpu_cw_ptr;
+
+	zend_function trampoline;
+	zend_op       call_trampoline_op;
+
+	HashTable weakrefs;
+
+	zend_long exception_string_param_max_len;
+
+	zend_get_gc_buffer get_gc_buffer;
+
+	zend_fiber_context *main_fiber_context;
+	zend_fiber_context *current_fiber_context;
+
+	/* Active instance of Fiber. */
+	zend_fiber *active_fiber;
+
+	/* Default fiber C stack size. */
+	size_t fiber_stack_size;
+
+	/* If record_errors is enabled, all emitted diagnostics will be recorded,
+	 * in addition to being processed as usual. */
+	bool record_errors;
+	uint32_t num_errors;
+	zend_error_info **errors;
+
+	/* Override filename or line number of thrown errors and exceptions */
+	zend_string *filename_override;
+	zend_long lineno_override;
+
+	zend_call_stack call_stack;
+	zend_long max_allowed_stack_size;
+	zend_ulong reserved_stack_size;
+
+/*
+	timer_t max_execution_timer_timer;
+	pid_t pid;
+	struct sigaction oldact;
+*/
+
+	zend_strtod_state strtod_state;
+
+	void *reserved[6];
+};
+
+// zend_fibers.h
+typedef enum {
+	ZEND_FIBER_STATUS_INIT,
+	ZEND_FIBER_STATUS_RUNNING,
+	ZEND_FIBER_STATUS_SUSPENDED,
+	ZEND_FIBER_STATUS_DEAD,
+} zend_fiber_status;
+
+typedef enum {
+	ZEND_FIBER_FLAG_THREW     = 1 << 0,
+	ZEND_FIBER_FLAG_BAILOUT   = 1 << 1,
+	ZEND_FIBER_FLAG_DESTROYED = 1 << 2,
+} zend_fiber_flag;
+
+typedef enum {
+	ZEND_FIBER_TRANSFER_FLAG_ERROR = 1 << 0,
+	ZEND_FIBER_TRANSFER_FLAG_BAILOUT = 1 << 1
+} zend_fiber_transfer_flag;
+
+typedef struct _zend_fiber_stack zend_fiber_stack;
+
+/* Encapsulates data needed for a context switch. */
+typedef struct _zend_fiber_transfer {
+	/* Fiber that will be switched to / has resumed us. */
+	zend_fiber_context *context;
+
+	/* Value to that should be send to (or was received from) a fiber. */
+	zval value;
+
+	/* Bitmask of flags defined in enum zend_fiber_transfer_flag. */
+	uint8_t flags;
+} zend_fiber_transfer;
+
+/* Coroutine functions must populate the given transfer with a new context
+ * and (optional) data before they return. */
+typedef void (*zend_fiber_coroutine)(zend_fiber_transfer *transfer);
+typedef void (*zend_fiber_clean)(zend_fiber_context *context);
+
+struct _zend_fiber_context {
+	/* Pointer to boost.context or ucontext_t data. */
+	void *handle;
+
+	/* Pointer that identifies the fiber type. */
+	void *kind;
+
+	/* Entrypoint function of the fiber. */
+	zend_fiber_coroutine function;
+
+	/* Cleanup function for fiber. */
+	zend_fiber_clean cleanup;
+
+	/* Assigned C stack. */
+	zend_fiber_stack *stack;
+
+	/* Fiber status. */
+	zend_fiber_status status;
+
+	/* Observer state */
+	zend_execute_data *top_observed_frame;
+
+	/* Reserved for extensions */
+	void *reserved[6];
+};
+
+struct _zend_fiber {
+	/* PHP object handle. */
+	zend_object std;
+
+	/* Flags are defined in enum zend_fiber_flag. */
+	uint8_t flags;
+
+	/* Native C fiber context. */
+	zend_fiber_context context;
+
+	/* Fiber that resumed us. */
+	zend_fiber_context *caller;
+
+	/* Fiber that suspended us. */
+	zend_fiber_context *previous;
+
+	/* Callback and info / cache to be used when fiber is started. */
+	zend_fcall_info fci;
+	zend_fcall_info_cache fci_cache;
+
+	/* Current Zend VM execute data being run by the fiber. */
+	zend_execute_data *execute_data;
+
+	/* Frame on the bottom of the fiber vm stack. */
+	zend_execute_data *stack_bottom;
+
+	/* Active fiber vm stack. */
+	zend_vm_stack vm_stack;
+
+	/* Storage for fiber return value. */
+	zval result;
+};
+
+// zend.h
+typedef struct _zend_class_name {
+	zend_string *name;
+	zend_string *lc_name;
+} zend_class_name;
+
+typedef struct _zend_trait_method_reference {
+	zend_string *method_name;
+	zend_string *class_name;
+} zend_trait_method_reference;
+
+typedef struct _zend_trait_precedence {
+	zend_trait_method_reference trait_method;
+	uint32_t num_excludes;
+	zend_string *exclude_class_names[1];
+} zend_trait_precedence;
+
+typedef struct _zend_trait_alias {
+	zend_trait_method_reference trait_method;
+
+	/**
+	* name for method to be added
+	*/
+	zend_string *alias;
+
+	/**
+	* modifiers to be set on trait method
+	*/
+	uint32_t modifiers;
+} zend_trait_alias;
+
+typedef struct _zend_class_mutable_data {
+	zval      *default_properties_table;
+	HashTable *constants_table;
+	uint32_t   ce_flags;
+	HashTable *backed_enum_table;
+} zend_class_mutable_data;
+
+struct _zend_serialize_data;
+struct _zend_unserialize_data;
+
+typedef struct _zend_serialize_data zend_serialize_data;
+typedef struct _zend_unserialize_data zend_unserialize_data;
+
+typedef struct _zend_class_dependency {
+	zend_string      *name;
+	zend_class_entry *ce;
+} zend_class_dependency;
+
+typedef struct _zend_inheritance_cache_entry zend_inheritance_cache_entry;
+
+struct _zend_inheritance_cache_entry {
+	zend_inheritance_cache_entry *next;
+	zend_class_entry             *ce;
+	zend_class_entry             *parent;
+	zend_class_dependency        *dependencies;
+	uint32_t                      dependencies_count;
+	uint32_t                      num_warnings;
+	zend_error_info             **warnings;
+	zend_class_entry             *traits_and_interfaces[1];
+};
+
+typedef struct _zend_class_arrayaccess_funcs {
+	zend_function *zf_offsetget;
+	zend_function *zf_offsetexists;
+	zend_function *zf_offsetset;
+	zend_function *zf_offsetunset;
+} zend_class_arrayaccess_funcs;
+
+struct _zend_class_entry {
+	char type;
+	zend_string *name;
+	/* class_entry or string depending on ZEND_ACC_LINKED */
+	union {
+		zend_class_entry *parent;
+		zend_string *parent_name;
+	};
+	int refcount;
+	uint32_t ce_flags;
+
+	int default_properties_count;
+	int default_static_members_count;
+	zval *default_properties_table;
+	zval *default_static_members_table;
+	zval *static_members_table__ptr;
+	HashTable function_table;
+	HashTable properties_info;
+	HashTable constants_table;
+
+	zend_class_mutable_data *mutable_data__ptr;
+	zend_inheritance_cache_entry *inheritance_cache;
+
+	struct _zend_property_info **properties_info_table;
+
+	zend_function *constructor;
+	zend_function *destructor;
+	zend_function *clone;
+	zend_function *__get;
+	zend_function *__set;
+	zend_function *__unset;
+	zend_function *__isset;
+	zend_function *__call;
+	zend_function *__callstatic;
+	zend_function *__tostring;
+	zend_function *__debugInfo;
+	zend_function *__serialize;
+	zend_function *__unserialize;
+
+	const zend_object_handlers *default_object_handlers;
+
+	/* allocated only if class implements Iterator or IteratorAggregate interface */
+	zend_class_iterator_funcs *iterator_funcs_ptr;
+	/* allocated only if class implements ArrayAccess interface */
+	zend_class_arrayaccess_funcs *arrayaccess_funcs_ptr;
+
+	/* handlers */
+	union {
+		zend_object* (*create_object)(zend_class_entry *class_type);
+		int (*interface_gets_implemented)(zend_class_entry *iface, zend_class_entry *class_type); /* a class implements this interface */
+	};
+	zend_object_iterator *(*get_iterator)(zend_class_entry *ce, zval *object, int by_ref);
+	zend_function *(*get_static_method)(zend_class_entry *ce, zend_string* method);
+
+	/* serializer callbacks */
+	int (*serialize)(zval *object, unsigned char **buffer, size_t *buf_len, zend_serialize_data *data);
+	int (*unserialize)(zval *object, zend_class_entry *ce, const unsigned char *buf, size_t buf_len, zend_unserialize_data *data);
+
+	uint32_t num_interfaces;
+	uint32_t num_traits;
+	uint32_t num_hooked_props;
+	uint32_t num_hooked_prop_variance_checks;
+
+	/* class_entry or string(s) depending on ZEND_ACC_LINKED */
+	union {
+		zend_class_entry **interfaces;
+		zend_class_name *interface_names;
+	};
+
+	zend_class_name *trait_names;
+	zend_trait_alias **trait_aliases;
+	zend_trait_precedence **trait_precedences;
+	HashTable *attributes;
+
+	uint32_t enum_backing_type;
+	HashTable *backed_enum_table;
+
+	zend_string *doc_comment;
+
+	union {
+		struct {
+			zend_string *filename;
+			uint32_t line_start;
+			uint32_t line_end;
+		} user;
+		struct {
+			const struct _zend_function_entry *builtin_functions;
+			struct _zend_module_entry *module;
+		} internal;
+	} info;
+};
+
+/** libc */
+typedef unsigned int mode_t;
+typedef unsigned long int dev_t;
+typedef unsigned long int ino_t;
+typedef long int off_t;
+typedef long int nlink_t;
+typedef unsigned int uid_t;
+typedef unsigned int gid_t;
+typedef int pid_t;
+typedef long int blksize_t;
+typedef long int blkcnt_t;
+typedef unsigned long int fsblkcnt64_t;
+typedef unsigned long int uint64_t;
+
+struct timespec
+{
+    long tv_sec;
+    long tv_nsec;
+};
+
+struct stat
+{
+    dev_t st_dev;
+    ino_t st_ino;
+    nlink_t st_nlink;
+    mode_t st_mode;
+    uid_t st_uid;
+    gid_t st_gid;
+    int __pad0;
+    dev_t st_rdev;
+    off_t st_size;
+    blksize_t st_blksize;
+    blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    long int reserved[3];
+};
+
+/** zend_stream.h */
+typedef struct stat zend_stat_t;
+
+/** zend_alloc.h */
+typedef struct  _zend_mm_heap zend_mm_heap;
+
+typedef struct _zend_mm_storage zend_mm_storage;
+typedef	void* (*zend_mm_chunk_alloc_t)(zend_mm_storage *storage, size_t size, size_t alignment);
+typedef void  (*zend_mm_chunk_free_t)(zend_mm_storage *storage, void *chunk, size_t size);
+typedef bool   (*zend_mm_chunk_truncate_t)(zend_mm_storage *storage, void *chunk, size_t old_size, size_t new_size);
+typedef bool   (*zend_mm_chunk_extend_t)(zend_mm_storage *storage, void *chunk, size_t old_size, size_t new_size);
+typedef struct _zend_mm_handlers {
+	zend_mm_chunk_alloc_t       chunk_alloc;
+	zend_mm_chunk_free_t        chunk_free;
+	zend_mm_chunk_truncate_t    chunk_truncate;
+	zend_mm_chunk_extend_t      chunk_extend;
+} zend_mm_handlers;
+struct _zend_mm_storage {
+	const zend_mm_handlers handlers;
+	void *data;
+};
+
+// zend_portability.h
+typedef union {
+	char c;
+	short s;
+	int i;
+	long l;
+	long long ll;
+	float f;
+	double d;
+	long double ld;
+	void *p;
+	void (*fun)(void);
+} zend_max_align_t;
+
+// zend.h
+typedef union {
+	zend_max_align_t align;
+	uint64_t opaque[5];
+} zend_random_bytes_insecure_state;
+
+/** zend_alloc.c */
+typedef uint32_t   zend_mm_page_info; /* 4-byte integer */
+typedef zend_ulong zend_mm_bitset;    /* 4-byte or 8-byte integer */
+
+typedef zend_mm_bitset zend_mm_page_map[(((size_t) (2 * 1024 * 1024)) / (4 * 1024)) / (sizeof(zend_mm_bitset) * 8)];     /* 64B */
+
+typedef struct  _zend_mm_page      zend_mm_page;
+typedef struct  _zend_mm_bin       zend_mm_bin;
+typedef struct  _zend_mm_free_slot zend_mm_free_slot;
+typedef struct  _zend_mm_chunk     zend_mm_chunk;
+typedef struct  _zend_mm_huge_list zend_mm_huge_list;
+
+struct _zend_mm_heap {
+	int                use_custom_heap;
+	zend_mm_storage   *storage;
+	size_t             size;                    /* current memory usage */
+	size_t             peak;                    /* peak memory usage */
+	uintptr_t          shadow_key;              /* free slot shadow ptr xor key */
+	zend_mm_free_slot *free_slot[30];           /* free lists for small sizes */
+	size_t             real_size;               /* current size of allocated pages */
+	size_t             real_peak;               /* peak size of allocated pages */
+	size_t             limit;                   /* memory limit */
+	int                overflow;                /* memory overflow flag */
+
+	zend_mm_huge_list *huge_list;               /* list of huge allocated blocks */
+
+	zend_mm_chunk     *main_chunk;
+	zend_mm_chunk     *cached_chunks;			/* list of unused chunks */
+	int                chunks_count;			/* number of allocated chunks */
+	int                peak_chunks_count;		/* peak number of allocated chunks for current request */
+	int                cached_chunks_count;		/* number of cached chunks */
+	double             avg_chunks_count;		/* average number of chunks allocated per request */
+	int                last_chunks_delete_boundary; /* number of chunks after last deletion */
+	int                last_chunks_delete_count;    /* number of deletion over the last boundary */
+	union {
+		struct {
+			void      *(*_malloc)(size_t);
+			void       (*_free)(void*);
+			void      *(*_realloc)(void*, size_t);
+            size_t     (*_gc)(void);
+            void       (*_shutdown)(bool full, bool silent);
+		} std;
+	} custom_heap;
+	HashTable *tracked_allocs;
+	pid_t pid;
+	zend_random_bytes_insecure_state rand_state;
+};
+
+struct _zend_mm_chunk {
+	zend_mm_heap      *heap;
+	zend_mm_chunk     *next;
+	zend_mm_chunk     *prev;
+	uint32_t           free_pages;				/* number of free pages */
+	uint32_t           free_tail;               /* number of free pages at the end of chunk */
+	uint32_t           num;
+	char               reserve[64 - (sizeof(void*) * 3 + sizeof(uint32_t) * 3)];
+	zend_mm_heap       heap_slot;               /* used only in main chunk */
+	zend_mm_page_map   free_map;                /* 512 bits or 64 bytes */
+	zend_mm_page_info  map[((size_t) (2 * 1024 * 1024)) / (4 * 1024)];      /* 2 KB = 512 * 4 */
+};
+
+struct _zend_mm_page {
+	char               bytes[(4 * 1024)];
+};
+
+struct _zend_mm_bin {
+	char               bytes[(4 * 1024) * 8];
+};
+
+struct _zend_mm_free_slot {
+	zend_mm_free_slot *next_free_slot;
+};
+
+struct _zend_mm_huge_list {
+	intptr_t           ptr;
+	size_t             size;
+	zend_mm_huge_list *next;
+};
+
+/* zend_closures.c */
+typedef struct _zend_closure {
+	zend_object       std;
+	zend_function     func;
+	zval              this_ptr;
+	zend_class_entry *called_scope;
+	zif_handler       orig_internal_handler;
+} zend_closure;
+
+/** zend_genereators.h */
+typedef struct _zend_generator zend_generator;
+typedef struct _zend_generator_node zend_generator_node;
+
+struct _zend_generator_node {
+	zend_generator *parent; /* NULL for root */
+	uint32_t children;
+	union {
+		HashTable *ht; /* if multiple children */
+		zend_generator *single; /* if one child */
+	} child;
+	/* One generator can cache a direct pointer to the current root.
+	 * The leaf member points back to the generator using the root cache. */
+	union {
+		zend_generator *leaf; /* if parent != NULL */
+		zend_generator *root; /* if parent == NULL */
+	} ptr;
+};
+
+struct _zend_generator {
+	zend_object std;
+
+	/* The suspended execution context. */
+	zend_execute_data *execute_data;
+
+	/* Frozen call stack for "yield" used in context of other calls */
+	zend_execute_data *frozen_call_stack;
+
+	/* Current value */
+	zval value;
+	/* Current key */
+	zval key;
+	/* Return value */
+	zval retval;
+	/* Variable to put sent value into */
+	zval *send_target;
+	/* Largest used integer key for auto-incrementing keys */
+	zend_long largest_used_integer_key;
+
+	/* Values specified by "yield from" to yield from this generator.
+	 * This is only used for arrays or non-generator Traversables.
+	 * This zval also uses the u2 structure in the same way as
+	 * by-value foreach. */
+	zval values;
+
+	/* Node of waiting generators when multiple "yield from" expressions
+	 * are nested. */
+	zend_generator_node node;
+
+	/* Fake execute_data for stacktraces */
+	zend_execute_data execute_fake;
+
+	/* The underlying function, equivalent to execute_data->func while
+	 * the generator is alive. */
+	zend_function *func;
+
+	/* ZEND_GENERATOR_* flags */
+	uint8_t flags;
+};
+
+/* main/SAPI.h */
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author:  Zeev Suraski <zeev@php.net>                                 |
+   +----------------------------------------------------------------------+
+*/
+
+typedef struct {
+	char *header;
+	size_t header_len;
+} sapi_header_struct;
+
+typedef struct {
+	zend_llist headers;
+	int http_response_code;
+	unsigned char send_default_content_type;
+	char *mimetype;
+	char *http_status_line;
+} sapi_headers_struct;
+
+typedef struct _sapi_post_entry sapi_post_entry;
+typedef struct _sapi_module_struct sapi_module_struct;
+
+typedef struct {
+	const char *request_method;
+	char *query_string;
+	char *cookie_data;
+	zend_long content_length;
+
+	char *path_translated;
+	char *request_uri;
+
+	/* Do not use request_body directly, but the php://input stream wrapper instead */
+	struct _php_stream *request_body;
+
+	const char *content_type;
+
+	bool headers_only;
+	bool no_headers;
+	bool headers_read;
+
+	sapi_post_entry *post_entry;
+
+	char *content_type_dup;
+
+	/* for HTTP authentication */
+	char *auth_user;
+	char *auth_password;
+	char *auth_digest;
+
+	/* this is necessary for the CGI SAPI module */
+	char *argv0;
+
+	char *current_user;
+	int current_user_length;
+
+	/* this is necessary for CLI module */
+	int argc;
+	char **argv;
+	int proto_num;
+} sapi_request_info;
+
+typedef struct {
+	bool throw_exceptions;
+	struct {
+		bool set;
+		zend_long value;
+	} options_cache[5];
+} sapi_request_parse_body_context;
+
+typedef struct _sapi_globals_struct {
+	void *server_context;
+	sapi_request_info request_info;
+	sapi_headers_struct sapi_headers;
+	int64_t read_post_bytes;
+	unsigned char post_read;
+	unsigned char headers_sent;
+	zend_stat_t global_stat;
+	char *default_mimetype;
+	char *default_charset;
+	HashTable *rfc1867_uploaded_files;
+	zend_long post_max_size;
+	int options;
+	bool sapi_started;
+	double global_request_time;
+	HashTable known_post_content_types;
+	zval callback_func;
+	zend_fcall_info_cache fci_cache;
+	sapi_request_parse_body_context request_parse_body_context;
+} sapi_globals_struct;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -868,7 +868,7 @@ struct _zend_executor_globals {
 	size_t         vm_stack_page_size;
 
 	struct _zend_execute_data *current_execute_data;
-	zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
+	const zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
 
 	uint32_t jit_trace_num; /* Used by tracing JIT to reference the currently running trace */
 

--- a/src/Lib/PhpInternals/Opcodes/OpcodeFactory.php
+++ b/src/Lib/PhpInternals/Opcodes/OpcodeFactory.php
@@ -27,6 +27,7 @@ final class OpcodeFactory
         'v82' => OpcodeV82::class,
         'v83' => OpcodeV83::class,
         'v84' => OpcodeV84::class,
+        'v85' => OpcodeV85::class,
     ];
 
     /**
@@ -42,7 +43,8 @@ final class OpcodeFactory
      *   TVersion is 'v81' ? OpcodeV81 :
      *   TVersion is 'v82' ? OpcodeV82 :
      *   TVersion is 'v83' ? OpcodeV83 :
-     *   OpcodeV84
+     *   TVersion is 'v84' ? OpcodeV84 :
+     *   OpcodeV85
      * )
      */
     public function create(string $version, int $opcode): Opcode
@@ -58,6 +60,7 @@ final class OpcodeFactory
             'v82' => new OpcodeV82($opcode),
             'v83' => new OpcodeV83($opcode),
             'v84' => new OpcodeV84($opcode),
+            'v85' => new OpcodeV85($opcode),
         };
     }
 }

--- a/src/Lib/PhpInternals/Opcodes/OpcodeV85.php
+++ b/src/Lib/PhpInternals/Opcodes/OpcodeV85.php
@@ -94,7 +94,6 @@ final class OpcodeV85 implements Opcode
     public const ZEND_UNSET_OBJ = 76;
     public const ZEND_FE_RESET_R = 77;
     public const ZEND_FE_FETCH_R = 78;
-    public const ZEND_EXIT = 79;
     public const ZEND_FETCH_R = 80;
     public const ZEND_FETCH_DIM_R = 81;
     public const ZEND_FETCH_OBJ_R = 82;
@@ -307,7 +306,6 @@ final class OpcodeV85 implements Opcode
         self::ZEND_UNSET_OBJ,
         self::ZEND_FE_RESET_R,
         self::ZEND_FE_FETCH_R,
-        self::ZEND_EXIT,
         self::ZEND_FETCH_R,
         self::ZEND_FETCH_DIM_R,
         self::ZEND_FETCH_OBJ_R,
@@ -521,7 +519,6 @@ final class OpcodeV85 implements Opcode
         'ZEND_UNSET_OBJ',
         'ZEND_FE_RESET_R',
         'ZEND_FE_FETCH_R',
-        'ZEND_EXIT',
         'ZEND_FETCH_R',
         'ZEND_FETCH_DIM_R',
         'ZEND_FETCH_OBJ_R',

--- a/src/Lib/PhpInternals/Opcodes/OpcodeV85.php
+++ b/src/Lib/PhpInternals/Opcodes/OpcodeV85.php
@@ -1,0 +1,668 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Opcodes;
+
+/** @psalm-immutable */
+final class OpcodeV85 implements Opcode
+{
+    public const ZEND_NOP = 0;
+    public const ZEND_ADD = 1;
+    public const ZEND_SUB = 2;
+    public const ZEND_MUL = 3;
+    public const ZEND_DIV = 4;
+    public const ZEND_MOD = 5;
+    public const ZEND_SL = 6;
+    public const ZEND_SR = 7;
+    public const ZEND_CONCAT = 8;
+    public const ZEND_BW_OR = 9;
+    public const ZEND_BW_AND = 10;
+    public const ZEND_BW_XOR = 11;
+    public const ZEND_POW = 12;
+    public const ZEND_BW_NOT = 13;
+    public const ZEND_BOOL_NOT = 14;
+    public const ZEND_BOOL_XOR = 15;
+    public const ZEND_IS_IDENTICAL = 16;
+    public const ZEND_IS_NOT_IDENTICAL = 17;
+    public const ZEND_IS_EQUAL = 18;
+    public const ZEND_IS_NOT_EQUAL = 19;
+    public const ZEND_IS_SMALLER = 20;
+    public const ZEND_IS_SMALLER_OR_EQUAL = 21;
+    public const ZEND_ASSIGN = 22;
+    public const ZEND_ASSIGN_DIM = 23;
+    public const ZEND_ASSIGN_OBJ = 24;
+    public const ZEND_ASSIGN_STATIC_PROP = 25;
+    public const ZEND_ASSIGN_OP = 26;
+    public const ZEND_ASSIGN_DIM_OP = 27;
+    public const ZEND_ASSIGN_OBJ_OP = 28;
+    public const ZEND_ASSIGN_STATIC_PROP_OP = 29;
+    public const ZEND_ASSIGN_REF = 30;
+    public const ZEND_QM_ASSIGN = 31;
+    public const ZEND_ASSIGN_OBJ_REF = 32;
+    public const ZEND_ASSIGN_STATIC_PROP_REF = 33;
+    public const ZEND_PRE_INC = 34;
+    public const ZEND_PRE_DEC = 35;
+    public const ZEND_POST_INC = 36;
+    public const ZEND_POST_DEC = 37;
+    public const ZEND_PRE_INC_STATIC_PROP = 38;
+    public const ZEND_PRE_DEC_STATIC_PROP = 39;
+    public const ZEND_POST_INC_STATIC_PROP = 40;
+    public const ZEND_POST_DEC_STATIC_PROP = 41;
+    public const ZEND_JMP = 42;
+    public const ZEND_JMPZ = 43;
+    public const ZEND_JMPNZ = 44;
+    public const ZEND_JMPZ_EX = 46;
+    public const ZEND_JMPNZ_EX = 47;
+    public const ZEND_CASE = 48;
+    public const ZEND_CHECK_VAR = 49;
+    public const ZEND_SEND_VAR_NO_REF_EX = 50;
+    public const ZEND_CAST = 51;
+    public const ZEND_BOOL = 52;
+    public const ZEND_FAST_CONCAT = 53;
+    public const ZEND_ROPE_INIT = 54;
+    public const ZEND_ROPE_ADD = 55;
+    public const ZEND_ROPE_END = 56;
+    public const ZEND_BEGIN_SILENCE = 57;
+    public const ZEND_END_SILENCE = 58;
+    public const ZEND_INIT_FCALL_BY_NAME = 59;
+    public const ZEND_DO_FCALL = 60;
+    public const ZEND_INIT_FCALL = 61;
+    public const ZEND_RETURN = 62;
+    public const ZEND_RECV = 63;
+    public const ZEND_RECV_INIT = 64;
+    public const ZEND_SEND_VAL = 65;
+    public const ZEND_SEND_VAR_EX = 66;
+    public const ZEND_SEND_REF = 67;
+    public const ZEND_NEW = 68;
+    public const ZEND_INIT_NS_FCALL_BY_NAME = 69;
+    public const ZEND_FREE = 70;
+    public const ZEND_INIT_ARRAY = 71;
+    public const ZEND_ADD_ARRAY_ELEMENT = 72;
+    public const ZEND_INCLUDE_OR_EVAL = 73;
+    public const ZEND_UNSET_VAR = 74;
+    public const ZEND_UNSET_DIM = 75;
+    public const ZEND_UNSET_OBJ = 76;
+    public const ZEND_FE_RESET_R = 77;
+    public const ZEND_FE_FETCH_R = 78;
+    public const ZEND_EXIT = 79;
+    public const ZEND_FETCH_R = 80;
+    public const ZEND_FETCH_DIM_R = 81;
+    public const ZEND_FETCH_OBJ_R = 82;
+    public const ZEND_FETCH_W = 83;
+    public const ZEND_FETCH_DIM_W = 84;
+    public const ZEND_FETCH_OBJ_W = 85;
+    public const ZEND_FETCH_RW = 86;
+    public const ZEND_FETCH_DIM_RW = 87;
+    public const ZEND_FETCH_OBJ_RW = 88;
+    public const ZEND_FETCH_IS = 89;
+    public const ZEND_FETCH_DIM_IS = 90;
+    public const ZEND_FETCH_OBJ_IS = 91;
+    public const ZEND_FETCH_FUNC_ARG = 92;
+    public const ZEND_FETCH_DIM_FUNC_ARG = 93;
+    public const ZEND_FETCH_OBJ_FUNC_ARG = 94;
+    public const ZEND_FETCH_UNSET = 95;
+    public const ZEND_FETCH_DIM_UNSET = 96;
+    public const ZEND_FETCH_OBJ_UNSET = 97;
+    public const ZEND_FETCH_LIST_R = 98;
+    public const ZEND_FETCH_CONSTANT = 99;
+    public const ZEND_CHECK_FUNC_ARG = 100;
+    public const ZEND_EXT_STMT = 101;
+    public const ZEND_EXT_FCALL_BEGIN = 102;
+    public const ZEND_EXT_FCALL_END = 103;
+    public const ZEND_EXT_NOP = 104;
+    public const ZEND_TICKS = 105;
+    public const ZEND_SEND_VAR_NO_REF = 106;
+    public const ZEND_CATCH = 107;
+    public const ZEND_THROW = 108;
+    public const ZEND_FETCH_CLASS = 109;
+    public const ZEND_CLONE = 110;
+    public const ZEND_RETURN_BY_REF = 111;
+    public const ZEND_INIT_METHOD_CALL = 112;
+    public const ZEND_INIT_STATIC_METHOD_CALL = 113;
+    public const ZEND_ISSET_ISEMPTY_VAR = 114;
+    public const ZEND_ISSET_ISEMPTY_DIM_OBJ = 115;
+    public const ZEND_SEND_VAL_EX = 116;
+    public const ZEND_SEND_VAR = 117;
+    public const ZEND_INIT_USER_CALL = 118;
+    public const ZEND_SEND_ARRAY = 119;
+    public const ZEND_SEND_USER = 120;
+    public const ZEND_STRLEN = 121;
+    public const ZEND_DEFINED = 122;
+    public const ZEND_TYPE_CHECK = 123;
+    public const ZEND_VERIFY_RETURN_TYPE = 124;
+    public const ZEND_FE_RESET_RW = 125;
+    public const ZEND_FE_FETCH_RW = 126;
+    public const ZEND_FE_FREE = 127;
+    public const ZEND_INIT_DYNAMIC_CALL = 128;
+    public const ZEND_DO_ICALL = 129;
+    public const ZEND_DO_UCALL = 130;
+    public const ZEND_DO_FCALL_BY_NAME = 131;
+    public const ZEND_PRE_INC_OBJ = 132;
+    public const ZEND_PRE_DEC_OBJ = 133;
+    public const ZEND_POST_INC_OBJ = 134;
+    public const ZEND_POST_DEC_OBJ = 135;
+    public const ZEND_ECHO = 136;
+    public const ZEND_OP_DATA = 137;
+    public const ZEND_INSTANCEOF = 138;
+    public const ZEND_GENERATOR_CREATE = 139;
+    public const ZEND_MAKE_REF = 140;
+    public const ZEND_DECLARE_FUNCTION = 141;
+    public const ZEND_DECLARE_LAMBDA_FUNCTION = 142;
+    public const ZEND_DECLARE_CONST = 143;
+    public const ZEND_DECLARE_CLASS = 144;
+    public const ZEND_DECLARE_CLASS_DELAYED = 145;
+    public const ZEND_DECLARE_ANON_CLASS = 146;
+    public const ZEND_ADD_ARRAY_UNPACK = 147;
+    public const ZEND_ISSET_ISEMPTY_PROP_OBJ = 148;
+    public const ZEND_HANDLE_EXCEPTION = 149;
+    public const ZEND_USER_OPCODE = 150;
+    public const ZEND_ASSERT_CHECK = 151;
+    public const ZEND_JMP_SET = 152;
+    public const ZEND_UNSET_CV = 153;
+    public const ZEND_ISSET_ISEMPTY_CV = 154;
+    public const ZEND_FETCH_LIST_W = 155;
+    public const ZEND_SEPARATE = 156;
+    public const ZEND_FETCH_CLASS_NAME = 157;
+    public const ZEND_CALL_TRAMPOLINE = 158;
+    public const ZEND_DISCARD_EXCEPTION = 159;
+    public const ZEND_YIELD = 160;
+    public const ZEND_GENERATOR_RETURN = 161;
+    public const ZEND_FAST_CALL = 162;
+    public const ZEND_FAST_RET = 163;
+    public const ZEND_RECV_VARIADIC = 164;
+    public const ZEND_SEND_UNPACK = 165;
+    public const ZEND_YIELD_FROM = 166;
+    public const ZEND_COPY_TMP = 167;
+    public const ZEND_BIND_GLOBAL = 168;
+    public const ZEND_COALESCE = 169;
+    public const ZEND_SPACESHIP = 170;
+    public const ZEND_FUNC_NUM_ARGS = 171;
+    public const ZEND_FUNC_GET_ARGS = 172;
+    public const ZEND_FETCH_STATIC_PROP_R = 173;
+    public const ZEND_FETCH_STATIC_PROP_W = 174;
+    public const ZEND_FETCH_STATIC_PROP_RW = 175;
+    public const ZEND_FETCH_STATIC_PROP_IS = 176;
+    public const ZEND_FETCH_STATIC_PROP_FUNC_ARG = 177;
+    public const ZEND_FETCH_STATIC_PROP_UNSET = 178;
+    public const ZEND_UNSET_STATIC_PROP = 179;
+    public const ZEND_ISSET_ISEMPTY_STATIC_PROP = 180;
+    public const ZEND_FETCH_CLASS_CONSTANT = 181;
+    public const ZEND_BIND_LEXICAL = 182;
+    public const ZEND_BIND_STATIC = 183;
+    public const ZEND_FETCH_THIS = 184;
+    public const ZEND_SEND_FUNC_ARG = 185;
+    public const ZEND_ISSET_ISEMPTY_THIS = 186;
+    public const ZEND_SWITCH_LONG = 187;
+    public const ZEND_SWITCH_STRING = 188;
+    public const ZEND_IN_ARRAY = 189;
+    public const ZEND_COUNT = 190;
+    public const ZEND_GET_CLASS = 191;
+    public const ZEND_GET_CALLED_CLASS = 192;
+    public const ZEND_GET_TYPE = 193;
+    public const ZEND_ARRAY_KEY_EXISTS = 194;
+    public const ZEND_MATCH = 195;
+    public const ZEND_CASE_STRICT = 196;
+    public const ZEND_MATCH_ERROR = 197;
+    public const ZEND_JMP_NULL = 198;
+    public const ZEND_CHECK_UNDEF_ARGS = 199;
+    public const ZEND_FETCH_GLOBALS = 200;
+    public const ZEND_VERIFY_NEVER_TYPE = 201;
+    public const ZEND_CALLABLE_CONVERT = 202;
+    public const ZEND_BIND_INIT_STATIC_OR_JMP = 203;
+    public const ZEND_FRAMELESS_ICALL_0 = 204;
+    public const ZEND_FRAMELESS_ICALL_1 = 205;
+    public const ZEND_FRAMELESS_ICALL_2 = 206;
+    public const ZEND_FRAMELESS_ICALL_3 = 207;
+    public const ZEND_JMP_FRAMELESS = 208;
+    public const ZEND_INIT_PARENT_PROPERTY_HOOK_CALL = 209;
+    public const ZEND_DECLARE_ATTRIBUTED_CONST = 210;
+
+    public const OPCODES = [
+        self::ZEND_NOP,
+        self::ZEND_ADD,
+        self::ZEND_SUB,
+        self::ZEND_MUL,
+        self::ZEND_DIV,
+        self::ZEND_MOD,
+        self::ZEND_SL,
+        self::ZEND_SR,
+        self::ZEND_CONCAT,
+        self::ZEND_BW_OR,
+        self::ZEND_BW_AND,
+        self::ZEND_BW_XOR,
+        self::ZEND_POW,
+        self::ZEND_BW_NOT,
+        self::ZEND_BOOL_NOT,
+        self::ZEND_BOOL_XOR,
+        self::ZEND_IS_IDENTICAL,
+        self::ZEND_IS_NOT_IDENTICAL,
+        self::ZEND_IS_EQUAL,
+        self::ZEND_IS_NOT_EQUAL,
+        self::ZEND_IS_SMALLER,
+        self::ZEND_IS_SMALLER_OR_EQUAL,
+        self::ZEND_ASSIGN,
+        self::ZEND_ASSIGN_DIM,
+        self::ZEND_ASSIGN_OBJ,
+        self::ZEND_ASSIGN_STATIC_PROP,
+        self::ZEND_ASSIGN_OP,
+        self::ZEND_ASSIGN_DIM_OP,
+        self::ZEND_ASSIGN_OBJ_OP,
+        self::ZEND_ASSIGN_STATIC_PROP_OP,
+        self::ZEND_ASSIGN_REF,
+        self::ZEND_QM_ASSIGN,
+        self::ZEND_ASSIGN_OBJ_REF,
+        self::ZEND_ASSIGN_STATIC_PROP_REF,
+        self::ZEND_PRE_INC,
+        self::ZEND_PRE_DEC,
+        self::ZEND_POST_INC,
+        self::ZEND_POST_DEC,
+        self::ZEND_PRE_INC_STATIC_PROP,
+        self::ZEND_PRE_DEC_STATIC_PROP,
+        self::ZEND_POST_INC_STATIC_PROP,
+        self::ZEND_POST_DEC_STATIC_PROP,
+        self::ZEND_JMP,
+        self::ZEND_JMPZ,
+        self::ZEND_JMPNZ,
+        null,
+        self::ZEND_JMPZ_EX,
+        self::ZEND_JMPNZ_EX,
+        self::ZEND_CASE,
+        self::ZEND_CHECK_VAR,
+        self::ZEND_SEND_VAR_NO_REF_EX,
+        self::ZEND_CAST,
+        self::ZEND_BOOL,
+        self::ZEND_FAST_CONCAT,
+        self::ZEND_ROPE_INIT,
+        self::ZEND_ROPE_ADD,
+        self::ZEND_ROPE_END,
+        self::ZEND_BEGIN_SILENCE,
+        self::ZEND_END_SILENCE,
+        self::ZEND_INIT_FCALL_BY_NAME,
+        self::ZEND_DO_FCALL,
+        self::ZEND_INIT_FCALL,
+        self::ZEND_RETURN,
+        self::ZEND_RECV,
+        self::ZEND_RECV_INIT,
+        self::ZEND_SEND_VAL,
+        self::ZEND_SEND_VAR_EX,
+        self::ZEND_SEND_REF,
+        self::ZEND_NEW,
+        self::ZEND_INIT_NS_FCALL_BY_NAME,
+        self::ZEND_FREE,
+        self::ZEND_INIT_ARRAY,
+        self::ZEND_ADD_ARRAY_ELEMENT,
+        self::ZEND_INCLUDE_OR_EVAL,
+        self::ZEND_UNSET_VAR,
+        self::ZEND_UNSET_DIM,
+        self::ZEND_UNSET_OBJ,
+        self::ZEND_FE_RESET_R,
+        self::ZEND_FE_FETCH_R,
+        self::ZEND_EXIT,
+        self::ZEND_FETCH_R,
+        self::ZEND_FETCH_DIM_R,
+        self::ZEND_FETCH_OBJ_R,
+        self::ZEND_FETCH_W,
+        self::ZEND_FETCH_DIM_W,
+        self::ZEND_FETCH_OBJ_W,
+        self::ZEND_FETCH_RW,
+        self::ZEND_FETCH_DIM_RW,
+        self::ZEND_FETCH_OBJ_RW,
+        self::ZEND_FETCH_IS,
+        self::ZEND_FETCH_DIM_IS,
+        self::ZEND_FETCH_OBJ_IS,
+        self::ZEND_FETCH_FUNC_ARG,
+        self::ZEND_FETCH_DIM_FUNC_ARG,
+        self::ZEND_FETCH_OBJ_FUNC_ARG,
+        self::ZEND_FETCH_UNSET,
+        self::ZEND_FETCH_DIM_UNSET,
+        self::ZEND_FETCH_OBJ_UNSET,
+        self::ZEND_FETCH_LIST_R,
+        self::ZEND_FETCH_CONSTANT,
+        self::ZEND_CHECK_FUNC_ARG,
+        self::ZEND_EXT_STMT,
+        self::ZEND_EXT_FCALL_BEGIN,
+        self::ZEND_EXT_FCALL_END,
+        self::ZEND_EXT_NOP,
+        self::ZEND_TICKS,
+        self::ZEND_SEND_VAR_NO_REF,
+        self::ZEND_CATCH,
+        self::ZEND_THROW,
+        self::ZEND_FETCH_CLASS,
+        self::ZEND_CLONE,
+        self::ZEND_RETURN_BY_REF,
+        self::ZEND_INIT_METHOD_CALL,
+        self::ZEND_INIT_STATIC_METHOD_CALL,
+        self::ZEND_ISSET_ISEMPTY_VAR,
+        self::ZEND_ISSET_ISEMPTY_DIM_OBJ,
+        self::ZEND_SEND_VAL_EX,
+        self::ZEND_SEND_VAR,
+        self::ZEND_INIT_USER_CALL,
+        self::ZEND_SEND_ARRAY,
+        self::ZEND_SEND_USER,
+        self::ZEND_STRLEN,
+        self::ZEND_DEFINED,
+        self::ZEND_TYPE_CHECK,
+        self::ZEND_VERIFY_RETURN_TYPE,
+        self::ZEND_FE_RESET_RW,
+        self::ZEND_FE_FETCH_RW,
+        self::ZEND_FE_FREE,
+        self::ZEND_INIT_DYNAMIC_CALL,
+        self::ZEND_DO_ICALL,
+        self::ZEND_DO_UCALL,
+        self::ZEND_DO_FCALL_BY_NAME,
+        self::ZEND_PRE_INC_OBJ,
+        self::ZEND_PRE_DEC_OBJ,
+        self::ZEND_POST_INC_OBJ,
+        self::ZEND_POST_DEC_OBJ,
+        self::ZEND_ECHO,
+        self::ZEND_OP_DATA,
+        self::ZEND_INSTANCEOF,
+        self::ZEND_GENERATOR_CREATE,
+        self::ZEND_MAKE_REF,
+        self::ZEND_DECLARE_FUNCTION,
+        self::ZEND_DECLARE_LAMBDA_FUNCTION,
+        self::ZEND_DECLARE_CONST,
+        self::ZEND_DECLARE_CLASS,
+        self::ZEND_DECLARE_CLASS_DELAYED,
+        self::ZEND_DECLARE_ANON_CLASS,
+        self::ZEND_ADD_ARRAY_UNPACK,
+        self::ZEND_ISSET_ISEMPTY_PROP_OBJ,
+        self::ZEND_HANDLE_EXCEPTION,
+        self::ZEND_USER_OPCODE,
+        self::ZEND_ASSERT_CHECK,
+        self::ZEND_JMP_SET,
+        self::ZEND_UNSET_CV,
+        self::ZEND_ISSET_ISEMPTY_CV,
+        self::ZEND_FETCH_LIST_W,
+        self::ZEND_SEPARATE,
+        self::ZEND_FETCH_CLASS_NAME,
+        self::ZEND_CALL_TRAMPOLINE,
+        self::ZEND_DISCARD_EXCEPTION,
+        self::ZEND_YIELD,
+        self::ZEND_GENERATOR_RETURN,
+        self::ZEND_FAST_CALL,
+        self::ZEND_FAST_RET,
+        self::ZEND_RECV_VARIADIC,
+        self::ZEND_SEND_UNPACK,
+        self::ZEND_YIELD_FROM,
+        self::ZEND_COPY_TMP,
+        self::ZEND_BIND_GLOBAL,
+        self::ZEND_COALESCE,
+        self::ZEND_SPACESHIP,
+        self::ZEND_FUNC_NUM_ARGS,
+        self::ZEND_FUNC_GET_ARGS,
+        self::ZEND_FETCH_STATIC_PROP_R,
+        self::ZEND_FETCH_STATIC_PROP_W,
+        self::ZEND_FETCH_STATIC_PROP_RW,
+        self::ZEND_FETCH_STATIC_PROP_IS,
+        self::ZEND_FETCH_STATIC_PROP_FUNC_ARG,
+        self::ZEND_FETCH_STATIC_PROP_UNSET,
+        self::ZEND_UNSET_STATIC_PROP,
+        self::ZEND_ISSET_ISEMPTY_STATIC_PROP,
+        self::ZEND_FETCH_CLASS_CONSTANT,
+        self::ZEND_BIND_LEXICAL,
+        self::ZEND_BIND_STATIC,
+        self::ZEND_FETCH_THIS,
+        self::ZEND_SEND_FUNC_ARG,
+        self::ZEND_ISSET_ISEMPTY_THIS,
+        self::ZEND_SWITCH_LONG,
+        self::ZEND_SWITCH_STRING,
+        self::ZEND_IN_ARRAY,
+        self::ZEND_COUNT,
+        self::ZEND_GET_CLASS,
+        self::ZEND_GET_CALLED_CLASS,
+        self::ZEND_GET_TYPE,
+        self::ZEND_ARRAY_KEY_EXISTS,
+        self::ZEND_MATCH,
+        self::ZEND_CASE_STRICT,
+        self::ZEND_MATCH_ERROR,
+        self::ZEND_JMP_NULL,
+        self::ZEND_CHECK_UNDEF_ARGS,
+        self::ZEND_FETCH_GLOBALS,
+        self::ZEND_VERIFY_NEVER_TYPE,
+        self::ZEND_CALLABLE_CONVERT,
+        self::ZEND_BIND_INIT_STATIC_OR_JMP,
+        self::ZEND_FRAMELESS_ICALL_0,
+        self::ZEND_FRAMELESS_ICALL_1,
+        self::ZEND_FRAMELESS_ICALL_2,
+        self::ZEND_FRAMELESS_ICALL_3,
+        self::ZEND_JMP_FRAMELESS,
+        self::ZEND_INIT_PARENT_PROPERTY_HOOK_CALL,
+        self::ZEND_DECLARE_ATTRIBUTED_CONST,
+    ];
+
+    private const OPCODE_NAMES = [
+        'ZEND_NOP',
+        'ZEND_ADD',
+        'ZEND_SUB',
+        'ZEND_MUL',
+        'ZEND_DIV',
+        'ZEND_MOD',
+        'ZEND_SL',
+        'ZEND_SR',
+        'ZEND_CONCAT',
+        'ZEND_BW_OR',
+        'ZEND_BW_AND',
+        'ZEND_BW_XOR',
+        'ZEND_POW',
+        'ZEND_BW_NOT',
+        'ZEND_BOOL_NOT',
+        'ZEND_BOOL_XOR',
+        'ZEND_IS_IDENTICAL',
+        'ZEND_IS_NOT_IDENTICAL',
+        'ZEND_IS_EQUAL',
+        'ZEND_IS_NOT_EQUAL',
+        'ZEND_IS_SMALLER',
+        'ZEND_IS_SMALLER_OR_EQUAL',
+        'ZEND_ASSIGN',
+        'ZEND_ASSIGN_DIM',
+        'ZEND_ASSIGN_OBJ',
+        'ZEND_ASSIGN_STATIC_PROP',
+        'ZEND_ASSIGN_OP',
+        'ZEND_ASSIGN_DIM_OP',
+        'ZEND_ASSIGN_OBJ_OP',
+        'ZEND_ASSIGN_STATIC_PROP_OP',
+        'ZEND_ASSIGN_REF',
+        'ZEND_QM_ASSIGN',
+        'ZEND_ASSIGN_OBJ_REF',
+        'ZEND_ASSIGN_STATIC_PROP_REF',
+        'ZEND_PRE_INC',
+        'ZEND_PRE_DEC',
+        'ZEND_POST_INC',
+        'ZEND_POST_DEC',
+        'ZEND_PRE_INC_STATIC_PROP',
+        'ZEND_PRE_DEC_STATIC_PROP',
+        'ZEND_POST_INC_STATIC_PROP',
+        'ZEND_POST_DEC_STATIC_PROP',
+        'ZEND_JMP',
+        'ZEND_JMPZ',
+        'ZEND_JMPNZ',
+        null,
+        'ZEND_JMPZ_EX',
+        'ZEND_JMPNZ_EX',
+        'ZEND_CASE',
+        'ZEND_CHECK_VAR',
+        'ZEND_SEND_VAR_NO_REF_EX',
+        'ZEND_CAST',
+        'ZEND_BOOL',
+        'ZEND_FAST_CONCAT',
+        'ZEND_ROPE_INIT',
+        'ZEND_ROPE_ADD',
+        'ZEND_ROPE_END',
+        'ZEND_BEGIN_SILENCE',
+        'ZEND_END_SILENCE',
+        'ZEND_INIT_FCALL_BY_NAME',
+        'ZEND_DO_FCALL',
+        'ZEND_INIT_FCALL',
+        'ZEND_RETURN',
+        'ZEND_RECV',
+        'ZEND_RECV_INIT',
+        'ZEND_SEND_VAL',
+        'ZEND_SEND_VAR_EX',
+        'ZEND_SEND_REF',
+        'ZEND_NEW',
+        'ZEND_INIT_NS_FCALL_BY_NAME',
+        'ZEND_FREE',
+        'ZEND_INIT_ARRAY',
+        'ZEND_ADD_ARRAY_ELEMENT',
+        'ZEND_INCLUDE_OR_EVAL',
+        'ZEND_UNSET_VAR',
+        'ZEND_UNSET_DIM',
+        'ZEND_UNSET_OBJ',
+        'ZEND_FE_RESET_R',
+        'ZEND_FE_FETCH_R',
+        'ZEND_EXIT',
+        'ZEND_FETCH_R',
+        'ZEND_FETCH_DIM_R',
+        'ZEND_FETCH_OBJ_R',
+        'ZEND_FETCH_W',
+        'ZEND_FETCH_DIM_W',
+        'ZEND_FETCH_OBJ_W',
+        'ZEND_FETCH_RW',
+        'ZEND_FETCH_DIM_RW',
+        'ZEND_FETCH_OBJ_RW',
+        'ZEND_FETCH_IS',
+        'ZEND_FETCH_DIM_IS',
+        'ZEND_FETCH_OBJ_IS',
+        'ZEND_FETCH_FUNC_ARG',
+        'ZEND_FETCH_DIM_FUNC_ARG',
+        'ZEND_FETCH_OBJ_FUNC_ARG',
+        'ZEND_FETCH_UNSET',
+        'ZEND_FETCH_DIM_UNSET',
+        'ZEND_FETCH_OBJ_UNSET',
+        'ZEND_FETCH_LIST_R',
+        'ZEND_FETCH_CONSTANT',
+        'ZEND_CHECK_FUNC_ARG',
+        'ZEND_EXT_STMT',
+        'ZEND_EXT_FCALL_BEGIN',
+        'ZEND_EXT_FCALL_END',
+        'ZEND_EXT_NOP',
+        'ZEND_TICKS',
+        'ZEND_SEND_VAR_NO_REF',
+        'ZEND_CATCH',
+        'ZEND_THROW',
+        'ZEND_FETCH_CLASS',
+        'ZEND_CLONE',
+        'ZEND_RETURN_BY_REF',
+        'ZEND_INIT_METHOD_CALL',
+        'ZEND_INIT_STATIC_METHOD_CALL',
+        'ZEND_ISSET_ISEMPTY_VAR',
+        'ZEND_ISSET_ISEMPTY_DIM_OBJ',
+        'ZEND_SEND_VAL_EX',
+        'ZEND_SEND_VAR',
+        'ZEND_INIT_USER_CALL',
+        'ZEND_SEND_ARRAY',
+        'ZEND_SEND_USER',
+        'ZEND_STRLEN',
+        'ZEND_DEFINED',
+        'ZEND_TYPE_CHECK',
+        'ZEND_VERIFY_RETURN_TYPE',
+        'ZEND_FE_RESET_RW',
+        'ZEND_FE_FETCH_RW',
+        'ZEND_FE_FREE',
+        'ZEND_INIT_DYNAMIC_CALL',
+        'ZEND_DO_ICALL',
+        'ZEND_DO_UCALL',
+        'ZEND_DO_FCALL_BY_NAME',
+        'ZEND_PRE_INC_OBJ',
+        'ZEND_PRE_DEC_OBJ',
+        'ZEND_POST_INC_OBJ',
+        'ZEND_POST_DEC_OBJ',
+        'ZEND_ECHO',
+        'ZEND_OP_DATA',
+        'ZEND_INSTANCEOF',
+        'ZEND_GENERATOR_CREATE',
+        'ZEND_MAKE_REF',
+        'ZEND_DECLARE_FUNCTION',
+        'ZEND_DECLARE_LAMBDA_FUNCTION',
+        'ZEND_DECLARE_CONST',
+        'ZEND_DECLARE_CLASS',
+        'ZEND_DECLARE_CLASS_DELAYED',
+        'ZEND_DECLARE_ANON_CLASS',
+        'ZEND_ADD_ARRAY_UNPACK',
+        'ZEND_ISSET_ISEMPTY_PROP_OBJ',
+        'ZEND_HANDLE_EXCEPTION',
+        'ZEND_USER_OPCODE',
+        'ZEND_ASSERT_CHECK',
+        'ZEND_JMP_SET',
+        'ZEND_UNSET_CV',
+        'ZEND_ISSET_ISEMPTY_CV',
+        'ZEND_FETCH_LIST_W',
+        'ZEND_SEPARATE',
+        'ZEND_FETCH_CLASS_NAME',
+        'ZEND_CALL_TRAMPOLINE',
+        'ZEND_DISCARD_EXCEPTION',
+        'ZEND_YIELD',
+        'ZEND_GENERATOR_RETURN',
+        'ZEND_FAST_CALL',
+        'ZEND_FAST_RET',
+        'ZEND_RECV_VARIADIC',
+        'ZEND_SEND_UNPACK',
+        'ZEND_YIELD_FROM',
+        'ZEND_COPY_TMP',
+        'ZEND_BIND_GLOBAL',
+        'ZEND_COALESCE',
+        'ZEND_SPACESHIP',
+        'ZEND_FUNC_NUM_ARGS',
+        'ZEND_FUNC_GET_ARGS',
+        'ZEND_FETCH_STATIC_PROP_R',
+        'ZEND_FETCH_STATIC_PROP_W',
+        'ZEND_FETCH_STATIC_PROP_RW',
+        'ZEND_FETCH_STATIC_PROP_IS',
+        'ZEND_FETCH_STATIC_PROP_FUNC_ARG',
+        'ZEND_FETCH_STATIC_PROP_UNSET',
+        'ZEND_UNSET_STATIC_PROP',
+        'ZEND_ISSET_ISEMPTY_STATIC_PROP',
+        'ZEND_FETCH_CLASS_CONSTANT',
+        'ZEND_BIND_LEXICAL',
+        'ZEND_BIND_STATIC',
+        'ZEND_FETCH_THIS',
+        'ZEND_SEND_FUNC_ARG',
+        'ZEND_ISSET_ISEMPTY_THIS',
+        'ZEND_SWITCH_LONG',
+        'ZEND_SWITCH_STRING',
+        'ZEND_IN_ARRAY',
+        'ZEND_COUNT',
+        'ZEND_GET_CLASS',
+        'ZEND_GET_CALLED_CLASS',
+        'ZEND_GET_TYPE',
+        'ZEND_ARRAY_KEY_EXISTS',
+        'ZEND_MATCH',
+        'ZEND_CASE_STRICT',
+        'ZEND_MATCH_ERROR',
+        'ZEND_JMP_NULL',
+        'ZEND_CHECK_UNDEF_ARGS',
+        'ZEND_FETCH_GLOBALS',
+        'ZEND_VERIFY_NEVER_TYPE',
+        'ZEND_CALLABLE_CONVERT',
+        'ZEND_BIND_INIT_STATIC_OR_JMP',
+        'ZEND_FRAMELESS_ICALL_0',
+        'ZEND_FRAMELESS_ICALL_1',
+        'ZEND_FRAMELESS_ICALL_2',
+        'ZEND_FRAMELESS_ICALL_3',
+        'ZEND_JMP_FRAMELESS',
+        'ZEND_INIT_PARENT_PROPERTY_HOOK_CALL',
+        'ZEND_DECLARE_ATTRIBUTED_CONST',
+    ];
+
+    public function __construct(
+        private int $opcode
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return self::OPCODE_NAMES[$this->opcode] ?? '';
+    }
+}

--- a/src/Lib/PhpInternals/ZendTypeReader.php
+++ b/src/Lib/PhpInternals/ZendTypeReader.php
@@ -37,6 +37,7 @@ final class ZendTypeReader
     public const V82 = 'v82';
     public const V83 = 'v83';
     public const V84 = 'v84';
+    public const V85 = 'v85';
 
     public const ALL_SUPPORTED_VERSIONS = [
         self::V70,
@@ -49,6 +50,7 @@ final class ZendTypeReader
         self::V82,
         self::V83,
         self::V84,
+        self::V85,
     ];
 
     public VersionAwareConstants $constants;

--- a/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
+++ b/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
@@ -95,6 +95,7 @@ final class TsrmGlobalsResolver
             case ZendTypeReader::V82:
             case ZendTypeReader::V83:
             case ZendTypeReader::V84:
+            case ZendTypeReader::V85:
                 $offset_symbol = $symbol_name . '_offset';
                 $globals_offset_cdata = $this->getZtsGlobalsSymbolReader(
                     $process_specifier,

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -393,13 +393,23 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        fgets($pipes[1]);
-        $error_message = fgets($pipes[1]);
+        // Read lines until we find the fatal error message and JSON.
+        // PHP 8.5+ outputs a stack trace after the fatal error on stdout,
+        // so we need to skip past it to find the JSON from the shutdown function.
+        $error_message = '';
+        $error_json = '';
+        while (($line = fgets($pipes[1])) !== false) {
+            if ($error_message === '' && str_starts_with($line, 'Fatal error: Allowed memory size of')) {
+                $error_message = $line;
+            } elseif ($error_message !== '' && str_starts_with($line, '{')) {
+                $error_json = $line;
+                break;
+            }
+        }
         $this->assertStringStartsWith(
             'Fatal error: Allowed memory size of',
             $error_message
         );
-        $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -574,13 +584,23 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        fgets($pipes[1]);
-        $error_message = fgets($pipes[1]);
+        // Read lines until we find the fatal error message and JSON.
+        // PHP 8.5+ outputs a stack trace after the fatal error on stdout,
+        // so we need to skip past it to find the JSON from the shutdown function.
+        $error_message = '';
+        $error_json = '';
+        while (($line = fgets($pipes[1])) !== false) {
+            if ($error_message === '' && str_starts_with($line, 'Fatal error: Allowed memory size of')) {
+                $error_message = $line;
+            } elseif ($error_message !== '' && str_starts_with($line, '{')) {
+                $error_json = $line;
+                break;
+            }
+        }
         $this->assertStringStartsWith(
             'Fatal error: Allowed memory size of',
             $error_message
         );
-        $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -772,13 +792,23 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        fgets($pipes[1]);
-        $error_message = fgets($pipes[1]);
+        // Read lines until we find the fatal error message and JSON.
+        // PHP 8.5+ outputs a stack trace after the fatal error on stdout,
+        // so we need to skip past it to find the JSON from the shutdown function.
+        $error_message = '';
+        $error_json = '';
+        while (($line = fgets($pipes[1])) !== false) {
+            if ($error_message === '' && str_starts_with($line, 'Fatal error: Allowed memory size of')) {
+                $error_message = $line;
+            } elseif ($error_message !== '' && str_starts_with($line, '{')) {
+                $error_json = $line;
+                break;
+            }
+        }
         $this->assertStringStartsWith(
             'Fatal error: Allowed memory size of',
             $error_message
         );
-        $error_json = fgets($pipes[1]);
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -28,6 +28,7 @@ class TargetPhpVmProvider
         ZendTypeReader::V82,
         ZendTypeReader::V83,
         ZendTypeReader::V84,
+        ZendTypeReader::V85,
         // ZTS variants (PHP 7.3+)
         'v73_zts',
         'v74_zts',
@@ -36,6 +37,7 @@ class TargetPhpVmProvider
         'v82_zts',
         'v83_zts',
         'v84_zts',
+        'v85_zts',
     ];
 
     private static function isZts(string $target): bool
@@ -101,6 +103,7 @@ class TargetPhpVmProvider
             ZendTypeReader::V82 => 'php:8.2' . $suffix,
             ZendTypeReader::V83 => 'php:8.3' . $suffix,
             ZendTypeReader::V84 => 'php:8.4' . $suffix,
+            ZendTypeReader::V85 => 'php:8.5' . $suffix,
             default => throw new \InvalidArgumentException("unsupported php version: $phpVersion"),
         };
     }


### PR DESCRIPTION
This PR adds support for PHP 8.5 to reli-prof by providing the necessary type definitions, opcodes, and infrastructure for the new PHP version.

## Summary
Added comprehensive support for PHP 8.5 including Zend Engine internals definitions, opcode mappings, and version-aware configuration updates.

## Key Changes

- **PHP 8.5 Header Definitions** (`src/Lib/PhpInternals/Headers/v85.h`): Added complete C header definitions extracted from PHP 8.5 source, including:
  - Core Zend Engine types (zval, zend_array, zend_object, zend_string, etc.)
  - Object handlers and class entry structures
  - Executor and compiler globals
  - Fiber context and related structures
  - Property hooks and other PHP 8.5-specific features

- **Opcode Definitions** (`src/Lib/PhpInternals/Opcodes/OpcodeV85.php`): Defined all 211 opcodes for PHP 8.5, including new opcodes:
  - `ZEND_INIT_PARENT_PROPERTY_HOOK_CALL` (209)
  - `ZEND_DECLARE_ATTRIBUTED_CONST` (210)

- **Version Registration**: Updated version-aware components to recognize PHP 8.5:
  - Added `V85` constant to `ZendTypeReader`
  - Registered opcode factory mapping for v85
  - Added PHP 8.5 to CI workflow (phpunit.yml)
  - Updated target PHP settings regex to include PHP 8.5
  - Registered PHP 8.5 in test provider and constants resolver
  - Added TSRM globals resolver support for PHP 8.5

- **Test Improvements**: Enhanced memory reader test to handle PHP 8.5+ stack trace output on stdout during fatal errors

## Implementation Details

The PHP 8.5 support follows the existing pattern used for previous versions (8.0-8.4), ensuring consistency with the codebase architecture. The header definitions capture all necessary Zend Engine structures including the new property hooks feature introduced in PHP 8.5.

https://claude.ai/code/session_01F7R4HtqvyY2HK6iCKSaBBK