### PR TITLE
Add hybrid phpspy mode with ZTS support and EG address resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ If customizability for PHP developers matters, you can use this software at the 
 Additionally, reli can find VM state from ZTS interpreters. For example, in the daemon mode, traces of threads started via [ext-parallel](https://github.com/krakjoe/parallel) are automatically retrieved. Currently this cannot be done with phpspy only.
 Reli also provides functionality to only get the address of EG from targets, so you can use actual profiling with phpspy if you want, even when the target is ZTS.
 
+Furthermore, reli provides a **hybrid phpspy mode** (`phpspy:trace`, `phpspy:daemon`) that combines reli's ZTS-aware EG resolution with phpspy's fast C-based tracing. Reli resolves the EG address (including for ZTS targets where phpspy alone cannot), then launches phpspy as the actual tracer with the resolved address. This gives you phpspy's speed with reli's ZTS support. See [Hybrid phpspy mode](#hybrid-phpspy-mode) for details.
+
 Other features of reli that phpspy does not currently have include:
 
 - Output more accurate line numbers
@@ -61,7 +63,6 @@ There is no particular reason why these features cannot be implemented on the ph
 On the other hand, there are a few things that phpspy can do but reli cannot yet.
 
 - Redirecting output of child processes
-- Forcing the address of EG
 - Run more faster with lower overhead.
 - etc.
 
@@ -240,6 +241,78 @@ Options:
   -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
+### Hybrid phpspy mode
+Reli can use [phpspy](https://github.com/adsr/phpspy) as the tracing backend while handling EG address resolution (including ZTS). This combines phpspy's fast C-based tracing with reli's ZTS support.
+
+#### Install phpspy
+```bash
+./reli phpspy:install --help
+Description:
+  install or check phpspy binary
+
+Usage:
+  phpspy:install [options]
+
+Options:
+      --check                      only check if phpspy is installed, do not install
+      --install-path=INSTALL-PATH  install location (default: ~/.reli/bin/phpspy)
+      --phpspy-path=PHPSPY-PATH    path to an existing phpspy binary to check
+  -h, --help                       Display help for the given command. When no command is given display help for the list command
+```
+
+#### Single process tracing with phpspy
+```bash
+./reli phpspy:trace --help
+Description:
+  get call traces using phpspy as the tracer backend (reli resolves EG address for ZTS support, then delegates tracing to phpspy)
+
+Usage:
+  phpspy:trace [options] [--] [<cmd> [<args>...]]
+
+Arguments:
+  cmd                                          command to execute as a target: either pid (via -p/--pid) or cmd must be specified
+  args                                         command line arguments for cmd
+
+Options:
+  -p, --pid=PID                                process id
+  -d, --depth[=DEPTH]                          max depth
+      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
+      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
+      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
+      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
+      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
+      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
+      --phpspy-path=PHPSPY-PATH                path to the phpspy binary
+  -s, --sleep-ns[=SLEEP-NS]                    phpspy sleep between samples in nanoseconds (default: 10101010)
+  -b, --buffer-size[=BUFFER-SIZE]              phpspy buffer size (default: 4096)
+  -H, --rate-hz[=RATE-HZ]                      phpspy sampling rate in Hz (default: 99)
+      --phpspy-args=PHPSPY-ARGS                extra arguments to pass to phpspy
+      --no-cache                               disable the binary analysis cache
+  -o, --output=OUTPUT                          output file path (default: stdout)
+```
+
+#### Multi-process daemon mode with phpspy
+```bash
+./reli phpspy:daemon --help
+Description:
+  concurrently get call traces from multiple processes using phpspy as the tracer backend (reli resolves EG addresses for ZTS support, then delegates tracing to phpspy)
+
+Usage:
+  phpspy:daemon [options]
+
+Options:
+  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
+  -T, --threads[=THREADS]                      number of workers (default: 8)
+  -d, --depth[=DEPTH]                          max depth
+      --phpspy-path=PHPSPY-PATH                path to the phpspy binary
+  -s, --sleep-ns[=SLEEP-NS]                    phpspy sleep between samples in nanoseconds (default: 10101010)
+  -b, --buffer-size[=BUFFER-SIZE]              phpspy buffer size (default: 4096)
+  -H, --rate-hz[=RATE-HZ]                      phpspy sampling rate in Hz (default: 99)
+      --phpspy-args=PHPSPY-ARGS                extra arguments to pass to phpspy
+      --no-cache                               disable the binary analysis cache
+  -o, --output=OUTPUT                          output file path (default: stdout)
+```
+
 ## [Experimental] Dump the memory usage of the target process
 ```bash
 ./reli inspector:memory --help
@@ -342,8 +415,40 @@ The executing process must have the CAP_SYS_PTRACE capability. (Usually run as r
 ```bash
 $ sudo php ./reli i:eg -p 2183131
 0x555ae7825d80
-``` 
+```
 The executing process must have the CAP_SYS_PTRACE capability. (Usually run as root is enough.)
+
+### Hybrid phpspy mode
+Install phpspy via reli and use it as the tracing backend:
+```bash
+# Install phpspy (builds from source, installs to ~/.reli/bin/phpspy)
+$ ./reli phpspy:install
+
+# Trace a single process (reli resolves EG, phpspy does the fast tracing)
+$ sudo php ./reli phpspy:trace -p <pid>
+resolving EG address...
+EG address resolved: 0x564102620bc0
+SG address resolved: 0x564102620600
+starting phpspy for pid 12345...
+0 usleep <internal>:-1
+1 <main> Command line code:1
+```
+
+This is especially useful for ZTS PHP where phpspy alone cannot resolve the EG address:
+```bash
+# Trace a ZTS PHP process — reli handles ZTS EG resolution, phpspy traces
+$ sudo php ./reli phpspy:trace -p <zts-pid>
+```
+
+Daemon mode discovers processes automatically and launches phpspy per process:
+```bash
+$ sudo php ./reli phpspy:daemon -P "^php-fpm"
+```
+
+You can pass extra phpspy flags via `--phpspy-args`:
+```bash
+$ sudo php ./reli phpspy:trace -p <pid> --phpspy-args="-c -1"
+```
 
 ### Show currently executing opcodes at traces
 If a user wants to profile a really CPU-bound application, then he or she wouldn't only want to know what line is slow, but what opcode is. In such cases, use `--template=phpspy_with_opcode` with `inspector:trace` or `inspector:daemon`.
@@ -604,7 +709,7 @@ See [./docs/memory-profiler.md](https://github.com/reliforp/reli-prof/blob/0.11.
 ## Binary analysis cache
 Reli caches the results of expensive binary analysis operations (ELF symbol resolution, TLS brute force offsets, PHP version detection, etc.) to disk. This dramatically speeds up repeated profiling of the same PHP binary -- for example, ZTS target initialization drops from ~8 seconds to ~5 milliseconds on warm cache.
 
-Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode). The cache is automatically invalidated when the target binary is updated (inode changes).
+Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode + ELF header content). The cache is automatically invalidated when the target binary is updated (inode changes) or replaced in-place (ELF header differs). NTS and ZTS builds of the same PHP version are cached independently because their ELF headers differ.
 
 ### Clear the cache
 ```bash

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ See [./docs/memory-profiler.md](https://github.com/reliforp/reli-prof/blob/0.11.
 ## Binary analysis cache
 Reli caches the results of expensive binary analysis operations (ELF symbol resolution, TLS brute force offsets, PHP version detection, etc.) to disk. This dramatically speeds up repeated profiling of the same PHP binary -- for example, ZTS target initialization drops from ~8 seconds to ~5 milliseconds on warm cache.
 
-Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode + ELF header content). The cache is automatically invalidated when the target binary is updated (inode changes) or replaced in-place (ELF header differs). NTS and ZTS builds of the same PHP version are cached independently because their ELF headers differ.
+Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode + ELF header content). In container environments, Docker's overlayfs can assign the same device ID and inode to different binaries across different images (e.g. `php:8.3` and `php:8.3-zts`), so the ELF header content is included to ensure different binaries always produce different cache keys.
 
 ### Clear the cache
 ```bash

--- a/config/di.php
+++ b/config/di.php
@@ -25,6 +25,7 @@ use Reli\Lib\Amphp\ContextCreator;
 use Reli\Lib\Amphp\ContextCreatorInterface;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreatorInterface;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
@@ -92,6 +93,7 @@ return [
         $logger->pushHandler($handler);
         return $logger;
     },
+    BinaryFingerprintCreator::class => autowire(),
     BinaryAnalysisCache::class => fn () => new BinaryAnalysisCache(
         AppDirectory::getCacheDir() . '/binary-analysis'
     ),

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\PhpSpy;
+
+use Reli\Inspector\Daemon\Dispatcher\TargetProcessDescriptor;
+use Reli\Inspector\Daemon\PhpSpy\PhpSpyProcessPool;
+use Reli\Inspector\Daemon\Searcher\Context\PhpSearcherContextCreator;
+use Reli\Inspector\Settings\DaemonSettings\DaemonSettingsFromConsoleInput;
+use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettingsFromConsoleInput;
+use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettingsFromConsoleInput;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
+use Reli\Lib\PhpSpy\PhpSpyFinder;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PhpSpyDaemonCommand extends Command
+{
+    public function __construct(
+        private PhpSearcherContextCreator $php_searcher_context_creator,
+        private PhpSpyFinder $phpspy_finder,
+        private DaemonSettingsFromConsoleInput $daemon_settings_from_console_input,
+        private GetTraceSettingsFromConsoleInput $get_trace_settings_from_console_input,
+        private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,
+        private PhpSpySettingsFromConsoleInput $phpspy_settings_from_console_input,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('phpspy:daemon')
+            ->setDescription(
+                'concurrently get call traces from multiple processes using phpspy as the tracer backend'
+                . ' (reli resolves EG addresses for ZTS support, then delegates tracing to phpspy)'
+            )
+        ;
+        $this->daemon_settings_from_console_input->setOptions($this);
+        $this->get_trace_settings_from_console_input->setOptions($this);
+        $this->target_php_settings_from_console_input->setOptions($this);
+        $this->phpspy_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'output',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'output file path (default: stdout)'
+        );
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $no_cache = (bool)$input->getOption('no-cache');
+        $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);
+        $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
+        $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
+        $phpspy_settings = $this->phpspy_settings_from_console_input->createSettings($input);
+
+        // Verify phpspy is available before starting
+        $phpspy_path = $this->phpspy_finder->find($phpspy_settings->phpspy_path);
+        $output->writeln('<info>using phpspy: ' . $phpspy_path . '</info>');
+
+        /** @var string|null $output_path */
+        $output_path = $input->getOption('output');
+        $output_stream = \STDOUT;
+        if (is_string($output_path)) {
+            $stream = fopen($output_path, 'w');
+            if ($stream === false) {
+                throw new \RuntimeException('Failed to open output file: ' . $output_path);
+            }
+            $output_stream = $stream;
+        }
+
+        $process_pool = new PhpSpyProcessPool($this->phpspy_finder);
+
+        $searcher_context = $this->php_searcher_context_creator->create();
+        $searcher_context->start();
+        $my_pid = getmypid();
+        if ($my_pid === false) {
+            throw new \RuntimeException('Failed to get current process ID');
+        }
+        $searcher_context->sendTarget(
+            $daemon_settings->target_regex,
+            $target_php_settings,
+            $my_pid,
+            $no_cache,
+        );
+
+        $interrupted = false;
+        pcntl_signal(SIGINT, function () use (&$interrupted) {
+            $interrupted = true;
+        });
+        pcntl_signal(SIGTERM, function () use (&$interrupted) {
+            $interrupted = true;
+        });
+
+        $output->writeln('<info>searching for target processes...</info>');
+
+        while (!$interrupted) {
+            pcntl_signal_dispatch();
+
+            // Receive updated process list from searcher (non-blocking via short timeout)
+            try {
+                $update_message = $searcher_context->receivePidList();
+                $target_list = $update_message->target_process_list;
+
+                // Get current target PIDs
+                /** @var list<int> $target_pids */
+                $target_pids = [];
+                foreach ($target_list->getArray() as $descriptor) {
+                    if ($descriptor === TargetProcessDescriptor::getInvalid()) {
+                        continue;
+                    }
+                    $target_pids[] = $descriptor->pid;
+
+                    // Start phpspy for new processes
+                    if (!$process_pool->hasProcess($descriptor->pid)) {
+                        $output->writeln(
+                            '<info>attaching phpspy to pid ' . $descriptor->pid
+                            . ' (EG: 0x' . dechex($descriptor->eg_address) . ')</info>',
+                            OutputInterface::VERBOSITY_VERBOSE,
+                        );
+                        $process_pool->attach(
+                            $descriptor->pid,
+                            $descriptor->eg_address,
+                            $get_trace_settings->depth,
+                            $phpspy_settings,
+                        );
+                    }
+                }
+
+                // Detach phpspy from processes that are no longer targets
+                foreach ($process_pool->getActivePids() as $active_pid) {
+                    if (!in_array($active_pid, $target_pids, true)) {
+                        $output->writeln(
+                            '<info>detaching phpspy from pid ' . $active_pid . '</info>',
+                            OutputInterface::VERBOSITY_VERBOSE,
+                        );
+                        $process_pool->detach($active_pid);
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Searcher may not have results yet, continue
+            }
+
+            // Passthrough output from all running phpspy processes
+            $process_pool->passthroughAll($output_stream);
+
+            usleep(1000); // 1ms poll interval
+        }
+
+        $output->writeln('<info>stopping all phpspy processes...</info>');
+        $process_pool->stopAll();
+
+        if ($output_stream !== \STDOUT) {
+            fclose($output_stream);
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -137,6 +137,7 @@ final class PhpSpyDaemonCommand extends Command
                         $process_pool->attach(
                             $descriptor->pid,
                             $descriptor->eg_address,
+                            $descriptor->sg_address,
                             $get_trace_settings->depth,
                             $phpspy_settings,
                         );

--- a/src/Command/PhpSpy/PhpSpyInstallCommand.php
+++ b/src/Command/PhpSpy/PhpSpyInstallCommand.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\PhpSpy;
+
+use Reli\Lib\PhpSpy\PhpSpyFinder;
+use Reli\Lib\PhpSpy\PhpSpyNotFoundException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PhpSpyInstallCommand extends Command
+{
+    public function __construct(
+        private PhpSpyFinder $phpspy_finder,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('phpspy:install')
+            ->setDescription('install or check phpspy binary')
+        ;
+        $this->addOption(
+            'check',
+            null,
+            InputOption::VALUE_NONE,
+            'only check if phpspy is installed, do not install'
+        );
+        $this->addOption(
+            'install-path',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'install location (default: ~/.reli/bin/phpspy)'
+        );
+        $this->addOption(
+            'phpspy-path',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'path to an existing phpspy binary to check'
+        );
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $check_only = (bool)$input->getOption('check');
+        /** @var string|null $phpspy_path_option */
+        $phpspy_path_option = $input->getOption('phpspy-path');
+
+        // Check if phpspy is already available
+        try {
+            $path = $this->phpspy_finder->find(
+                is_string($phpspy_path_option) ? $phpspy_path_option : null
+            );
+            $version = $this->getPhpSpyVersion($path);
+            $output->writeln('<info>phpspy found: ' . $path . '</info>');
+            if ($version !== null) {
+                $output->writeln('<info>version: ' . $version . '</info>');
+            }
+            return 0;
+        } catch (PhpSpyNotFoundException) {
+            if ($check_only) {
+                $output->writeln('<error>phpspy not found</error>');
+                return 1;
+            }
+        }
+
+        // Install phpspy
+        /** @var string|null $install_path_option */
+        $install_path_option = $input->getOption('install-path');
+        $install_path = is_string($install_path_option)
+            ? $install_path_option
+            : PhpSpyFinder::getDefaultInstallPath();
+        $install_dir = dirname($install_path);
+
+        $output->writeln('<info>installing phpspy to ' . $install_path . '...</info>');
+
+        // Ensure install directory exists
+        if (!is_dir($install_dir)) {
+            if (!mkdir($install_dir, 0755, true)) {
+                $output->writeln('<error>failed to create directory: ' . $install_dir . '</error>');
+                return 1;
+            }
+        }
+
+        // Clone and build
+        $my_pid = getmypid();
+        if ($my_pid === false) {
+            throw new \RuntimeException('Failed to get current process ID');
+        }
+        $tmp_dir = sys_get_temp_dir() . '/phpspy-build-' . $my_pid;
+        $output->writeln('cloning phpspy repository...');
+        $clone_result = $this->runCommand(
+            'git clone --depth 1 https://github.com/adsr/phpspy ' . escapeshellarg($tmp_dir),
+            $output,
+        );
+        if ($clone_result !== 0) {
+            $output->writeln('<error>failed to clone phpspy repository</error>');
+            return 1;
+        }
+
+        $output->writeln('building phpspy...');
+        $build_result = $this->runCommand(
+            'cd ' . escapeshellarg($tmp_dir) . ' && make',
+            $output,
+        );
+        if ($build_result !== 0) {
+            $this->cleanup($tmp_dir);
+            $output->writeln('<error>failed to build phpspy (make sure gcc and make are installed)</error>');
+            return 1;
+        }
+
+        // Copy binary
+        $source = $tmp_dir . '/phpspy';
+        if (!is_file($source)) {
+            $this->cleanup($tmp_dir);
+            $output->writeln('<error>phpspy binary not found after build</error>');
+            return 1;
+        }
+
+        if (!copy($source, $install_path)) {
+            $this->cleanup($tmp_dir);
+            $output->writeln('<error>failed to copy phpspy binary to ' . $install_path . '</error>');
+            return 1;
+        }
+        chmod($install_path, 0755);
+
+        // Cleanup
+        $this->cleanup($tmp_dir);
+
+        // Verify
+        $version = $this->getPhpSpyVersion($install_path);
+        $output->writeln('<info>phpspy installed successfully: ' . $install_path . '</info>');
+        if ($version !== null) {
+            $output->writeln('<info>version: ' . $version . '</info>');
+        }
+
+        return 0;
+    }
+
+    private function getPhpSpyVersion(string $path): ?string
+    {
+        $result = exec(escapeshellarg($path) . ' --version 2>&1', $lines, $result_code);
+        if ($result === false || $result_code !== 0) {
+            return null;
+        }
+        return trim($result);
+    }
+
+    private function runCommand(string $command, OutputInterface $output): int
+    {
+        $result_code = 0;
+        /** @var list<string> $command_output */
+        $command_output = [];
+        exec($command . ' 2>&1', $command_output, $result_code);
+        if ($output->isVerbose()) {
+            /** @var string $line */
+            foreach ($command_output as $line) {
+                $output->writeln('  ' . $line);
+            }
+        }
+        return $result_code;
+    }
+
+    private function cleanup(string $dir): void
+    {
+        if (is_dir($dir)) {
+            exec('rm -rf ' . escapeshellarg($dir));
+        }
+    }
+}

--- a/src/Command/PhpSpy/PhpSpyTraceCommand.php
+++ b/src/Command/PhpSpy/PhpSpyTraceCommand.php
@@ -110,8 +110,16 @@ final class PhpSpyTraceCommand extends Command
             interval_on_retry_ns: 1000 * 1000 * 10,
         );
 
+        $sg_address = $this->php_globals_finder->findSAPIGlobals(
+            $process_specifier,
+            $target_php_settings
+        );
+
         $output->writeln(
             '<info>EG address resolved: 0x' . dechex($eg_address) . '</info>'
+        );
+        $output->writeln(
+            '<info>SG address resolved: 0x' . dechex($sg_address) . '</info>'
         );
         $output->writeln(
             '<info>starting phpspy for pid ' . $process_specifier->pid . '...</info>'
@@ -131,6 +139,7 @@ final class PhpSpyTraceCommand extends Command
         $this->phpspy_process->start(
             $process_specifier->pid,
             $eg_address,
+            $sg_address,
             $get_trace_settings->depth,
             $phpspy_settings,
             $output_stream,
@@ -150,6 +159,7 @@ final class PhpSpyTraceCommand extends Command
             pcntl_signal_dispatch();
             usleep(1000); // 1ms poll interval
         }
+
         // Drain remaining output
         $this->phpspy_process->passthrough($output_stream);
         $this->phpspy_process->stop();

--- a/src/Command/PhpSpy/PhpSpyTraceCommand.php
+++ b/src/Command/PhpSpy/PhpSpyTraceCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\PhpSpy;
+
+use Reli\Inspector\RetryingLoopProvider;
+use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettingsFromConsoleInput;
+use Reli\Inspector\Settings\InspectorSettingsException;
+use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettingsFromConsoleInput;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
+use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
+use Reli\Inspector\TargetProcess\TargetProcessResolver;
+use Reli\Lib\Elf\Parser\ElfParserException;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
+use Reli\Lib\Elf\Tls\TlsFinderException;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpVersionDetector;
+use Reli\Lib\PhpSpy\PhpSpyProcess;
+use Reli\Lib\Process\MemoryReader\MemoryReaderException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PhpSpyTraceCommand extends Command
+{
+    public function __construct(
+        private PhpGlobalsFinder $php_globals_finder,
+        private PhpVersionDetector $php_version_detector,
+        private PhpSpyProcess $phpspy_process,
+        private TargetProcessSettingsFromConsoleInput $target_process_settings_from_console_input,
+        private GetTraceSettingsFromConsoleInput $get_trace_settings_from_console_input,
+        private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,
+        private PhpSpySettingsFromConsoleInput $phpspy_settings_from_console_input,
+        private TargetProcessResolver $target_process_resolver,
+        private RetryingLoopProvider $retrying_loop_provider,
+        private BinaryAnalysisCache $binary_analysis_cache,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('phpspy:trace')
+            ->setDescription(
+                'get call traces using phpspy as the tracer backend'
+                . ' (reli resolves EG address for ZTS support, then delegates tracing to phpspy)'
+            )
+        ;
+        $this->target_process_settings_from_console_input->setOptions($this);
+        $this->get_trace_settings_from_console_input->setOptions($this);
+        $this->target_php_settings_from_console_input->setOptions($this);
+        $this->phpspy_settings_from_console_input->setOptions($this);
+        $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'output',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'output file path (default: stdout)'
+        );
+    }
+
+    /**
+     * @throws MemoryReaderException
+     * @throws ProcessSymbolReaderException
+     * @throws ElfParserException
+     * @throws TlsFinderException
+     * @throws InspectorSettingsException
+     */
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
+
+        $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
+        $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
+        $target_process_settings = $this->target_process_settings_from_console_input->createSettings($input);
+        $phpspy_settings = $this->phpspy_settings_from_console_input->createSettings($input);
+
+        $process_specifier = $this->target_process_resolver->resolve($target_process_settings);
+
+        $target_php_settings = $this->php_version_detector->decidePhpVersion(
+            $process_specifier,
+            $target_php_settings
+        );
+
+        $output->writeln('<info>resolving EG address...</info>');
+
+        $eg_address = $this->retrying_loop_provider->do(
+            try: fn () => $this->php_globals_finder->findExecutorGlobals(
+                $process_specifier,
+                $target_php_settings
+            ),
+            retry_on: [\Throwable::class],
+            max_retry: 10,
+            interval_on_retry_ns: 1000 * 1000 * 10,
+        );
+
+        $output->writeln(
+            '<info>EG address resolved: 0x' . dechex($eg_address) . '</info>'
+        );
+        $output->writeln(
+            '<info>starting phpspy for pid ' . $process_specifier->pid . '...</info>'
+        );
+
+        /** @var string|null $output_path */
+        $output_path = $input->getOption('output');
+        $output_stream = \STDOUT;
+        if (is_string($output_path)) {
+            $stream = fopen($output_path, 'w');
+            if ($stream === false) {
+                throw new \RuntimeException('Failed to open output file: ' . $output_path);
+            }
+            $output_stream = $stream;
+        }
+
+        $this->phpspy_process->start(
+            $process_specifier->pid,
+            $eg_address,
+            $get_trace_settings->depth,
+            $phpspy_settings,
+            $output_stream,
+        );
+
+        // Main loop: passthrough phpspy output until it exits or we get interrupted
+        $interrupted = false;
+        pcntl_signal(SIGINT, function () use (&$interrupted) {
+            $interrupted = true;
+        });
+        pcntl_signal(SIGTERM, function () use (&$interrupted) {
+            $interrupted = true;
+        });
+
+        while ($this->phpspy_process->isRunning() && !$interrupted) {
+            $this->phpspy_process->passthrough($output_stream);
+            pcntl_signal_dispatch();
+            usleep(1000); // 1ms poll interval
+        }
+        // Drain remaining output
+        $this->phpspy_process->passthrough($output_stream);
+        $this->phpspy_process->stop();
+
+        if ($output_stream !== \STDOUT) {
+            fclose($output_stream);
+        }
+
+        return 0;
+    }
+}

--- a/src/Inspector/Daemon/PhpSpy/PhpSpyProcessPool.php
+++ b/src/Inspector/Daemon/PhpSpy/PhpSpyProcessPool.php
@@ -30,6 +30,7 @@ final class PhpSpyProcessPool
     public function attach(
         int $pid,
         int $eg_address,
+        int $sg_address,
         int $depth,
         PhpSpySettings $settings,
     ): void {
@@ -37,7 +38,7 @@ final class PhpSpyProcessPool
             return;
         }
         $process = new PhpSpyProcess($this->phpspy_finder);
-        $process->start($pid, $eg_address, $depth, $settings);
+        $process->start($pid, $eg_address, $sg_address, $depth, $settings);
         $this->processes[$pid] = $process;
     }
 

--- a/src/Inspector/Daemon/PhpSpy/PhpSpyProcessPool.php
+++ b/src/Inspector/Daemon/PhpSpy/PhpSpyProcessPool.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Daemon\PhpSpy;
+
+use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettings;
+use Reli\Lib\PhpSpy\PhpSpyFinder;
+use Reli\Lib\PhpSpy\PhpSpyProcess;
+
+final class PhpSpyProcessPool
+{
+    /** @var array<int, PhpSpyProcess> pid => process */
+    private array $processes = [];
+
+    public function __construct(
+        private PhpSpyFinder $phpspy_finder,
+    ) {
+    }
+
+    public function attach(
+        int $pid,
+        int $eg_address,
+        int $depth,
+        PhpSpySettings $settings,
+    ): void {
+        if (isset($this->processes[$pid])) {
+            return;
+        }
+        $process = new PhpSpyProcess($this->phpspy_finder);
+        $process->start($pid, $eg_address, $depth, $settings);
+        $this->processes[$pid] = $process;
+    }
+
+    public function detach(int $pid): void
+    {
+        if (isset($this->processes[$pid])) {
+            $this->processes[$pid]->stop();
+            unset($this->processes[$pid]);
+        }
+    }
+
+    /**
+     * Passthrough output from all running phpspy processes.
+     *
+     * @param resource $output_stream
+     */
+    public function passthroughAll($output_stream): void
+    {
+        foreach ($this->processes as $pid => $process) {
+            if (!$process->isRunning()) {
+                $process->passthrough($output_stream);
+                $process->stop();
+                unset($this->processes[$pid]);
+                continue;
+            }
+            $process->passthrough($output_stream);
+        }
+    }
+
+    /** @return list<int> */
+    public function getActivePids(): array
+    {
+        return array_keys($this->processes);
+    }
+
+    public function hasProcess(int $pid): bool
+    {
+        return isset($this->processes[$pid]);
+    }
+
+    public function stopAll(): void
+    {
+        foreach ($this->processes as $process) {
+            $process->stop();
+        }
+        $this->processes = [];
+    }
+
+    public function count(): int
+    {
+        return count($this->processes);
+    }
+}

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettings.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettings.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\PhpSpySettings;
+
+final class PhpSpySettings
+{
+    public const DEFAULT_SLEEP_US = 10000;
+    public const DEFAULT_BUFFER_SIZE = 4096;
+    public const DEFAULT_RATE_HZ = 99;
+
+    public function __construct(
+        public ?string $phpspy_path = null,
+        public int $sleep_us = self::DEFAULT_SLEEP_US,
+        public int $buffer_size = self::DEFAULT_BUFFER_SIZE,
+        public int $rate_hz = self::DEFAULT_RATE_HZ,
+        public ?string $extra_args = null,
+    ) {
+    }
+}

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettings.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettings.php
@@ -15,13 +15,13 @@ namespace Reli\Inspector\Settings\PhpSpySettings;
 
 final class PhpSpySettings
 {
-    public const DEFAULT_SLEEP_US = 10000;
+    public const DEFAULT_SLEEP_NS = 10101010;
     public const DEFAULT_BUFFER_SIZE = 4096;
     public const DEFAULT_RATE_HZ = 99;
 
     public function __construct(
         public ?string $phpspy_path = null,
-        public int $sleep_us = self::DEFAULT_SLEEP_US,
+        public int $sleep_ns = self::DEFAULT_SLEEP_NS,
         public int $buffer_size = self::DEFAULT_BUFFER_SIZE,
         public int $rate_hz = self::DEFAULT_RATE_HZ,
         public ?string $extra_args = null,

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\PhpSpySettings;
+
+use Reli\Inspector\Settings\InspectorSettingsException;
+
+final class PhpSpySettingsException extends InspectorSettingsException
+{
+    public const SLEEP_US_IS_NOT_INTEGER = 1;
+    public const BUFFER_SIZE_IS_NOT_INTEGER = 2;
+    public const RATE_HZ_IS_NOT_INTEGER = 3;
+
+    protected const ERRORS = [
+        self::SLEEP_US_IS_NOT_INTEGER => 'sleep-us is not integer',
+        self::BUFFER_SIZE_IS_NOT_INTEGER => 'buffer-size is not integer',
+        self::RATE_HZ_IS_NOT_INTEGER => 'rate-hz is not integer',
+    ];
+}

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
@@ -17,12 +17,12 @@ use Reli\Inspector\Settings\InspectorSettingsException;
 
 final class PhpSpySettingsException extends InspectorSettingsException
 {
-    public const SLEEP_US_IS_NOT_INTEGER = 1;
+    public const SLEEP_NS_IS_NOT_INTEGER = 1;
     public const BUFFER_SIZE_IS_NOT_INTEGER = 2;
     public const RATE_HZ_IS_NOT_INTEGER = 3;
 
     protected const ERRORS = [
-        self::SLEEP_US_IS_NOT_INTEGER => 'sleep-us is not integer',
+        self::SLEEP_NS_IS_NOT_INTEGER => 'sleep-ns is not integer',
         self::BUFFER_SIZE_IS_NOT_INTEGER => 'buffer-size is not integer',
         self::RATE_HZ_IS_NOT_INTEGER => 'rate-hz is not integer',
     ];

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInput.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\PhpSpySettings;
+
+use PhpCast\NullableCast;
+use Reli\Inspector\Settings\InspectorSettingsException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+use function filter_var;
+use function is_null;
+
+use const FILTER_VALIDATE_INT;
+
+final class PhpSpySettingsFromConsoleInput
+{
+    /** @codeCoverageIgnore */
+    public function setOptions(Command $command): void
+    {
+        $command
+            ->addOption(
+                'phpspy-path',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to the phpspy binary'
+            )
+            ->addOption(
+                'sleep-us',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'phpspy sleep between samples in microseconds (default: 10000)'
+            )
+            ->addOption(
+                'buffer-size',
+                'b',
+                InputOption::VALUE_OPTIONAL,
+                'phpspy buffer size (default: 4096)'
+            )
+            ->addOption(
+                'rate-hz',
+                'H',
+                InputOption::VALUE_OPTIONAL,
+                'phpspy sampling rate in Hz (default: 99)'
+            )
+            ->addOption(
+                'phpspy-args',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'extra arguments to pass to phpspy'
+            )
+        ;
+    }
+
+    /**
+     * @throws InspectorSettingsException
+     */
+    public function createSettings(InputInterface $input): PhpSpySettings
+    {
+        $phpspy_path = NullableCast::toString($input->getOption('phpspy-path'));
+
+        $sleep_us = NullableCast::toString($input->getOption('sleep-us'));
+        if (is_null($sleep_us)) {
+            $sleep_us = PhpSpySettings::DEFAULT_SLEEP_US;
+        } else {
+            $sleep_us = filter_var($sleep_us, FILTER_VALIDATE_INT);
+            if ($sleep_us === false) {
+                throw PhpSpySettingsException::create(PhpSpySettingsException::SLEEP_US_IS_NOT_INTEGER);
+            }
+        }
+
+        $buffer_size = NullableCast::toString($input->getOption('buffer-size'));
+        if (is_null($buffer_size)) {
+            $buffer_size = PhpSpySettings::DEFAULT_BUFFER_SIZE;
+        } else {
+            $buffer_size = filter_var($buffer_size, FILTER_VALIDATE_INT);
+            if ($buffer_size === false) {
+                throw PhpSpySettingsException::create(PhpSpySettingsException::BUFFER_SIZE_IS_NOT_INTEGER);
+            }
+        }
+
+        $rate_hz = NullableCast::toString($input->getOption('rate-hz'));
+        if (is_null($rate_hz)) {
+            $rate_hz = PhpSpySettings::DEFAULT_RATE_HZ;
+        } else {
+            $rate_hz = filter_var($rate_hz, FILTER_VALIDATE_INT);
+            if ($rate_hz === false) {
+                throw PhpSpySettingsException::create(PhpSpySettingsException::RATE_HZ_IS_NOT_INTEGER);
+            }
+        }
+
+        $extra_args = NullableCast::toString($input->getOption('phpspy-args'));
+
+        return new PhpSpySettings(
+            $phpspy_path,
+            $sleep_us,
+            $buffer_size,
+            $rate_hz,
+            $extra_args,
+        );
+    }
+}

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInput.php
@@ -37,10 +37,10 @@ final class PhpSpySettingsFromConsoleInput
                 'path to the phpspy binary'
             )
             ->addOption(
-                'sleep-us',
+                'sleep-ns',
                 's',
                 InputOption::VALUE_OPTIONAL,
-                'phpspy sleep between samples in microseconds (default: 10000)'
+                'phpspy sleep between samples in nanoseconds (default: 10101010)'
             )
             ->addOption(
                 'buffer-size',
@@ -70,13 +70,13 @@ final class PhpSpySettingsFromConsoleInput
     {
         $phpspy_path = NullableCast::toString($input->getOption('phpspy-path'));
 
-        $sleep_us = NullableCast::toString($input->getOption('sleep-us'));
-        if (is_null($sleep_us)) {
-            $sleep_us = PhpSpySettings::DEFAULT_SLEEP_US;
+        $sleep_ns = NullableCast::toString($input->getOption('sleep-ns'));
+        if (is_null($sleep_ns)) {
+            $sleep_ns = PhpSpySettings::DEFAULT_SLEEP_NS;
         } else {
-            $sleep_us = filter_var($sleep_us, FILTER_VALIDATE_INT);
-            if ($sleep_us === false) {
-                throw PhpSpySettingsException::create(PhpSpySettingsException::SLEEP_US_IS_NOT_INTEGER);
+            $sleep_ns = filter_var($sleep_ns, FILTER_VALIDATE_INT);
+            if ($sleep_ns === false) {
+                throw PhpSpySettingsException::create(PhpSpySettingsException::SLEEP_NS_IS_NOT_INTEGER);
             }
         }
 
@@ -104,7 +104,7 @@ final class PhpSpySettingsFromConsoleInput
 
         return new PhpSpySettings(
             $phpspy_path,
-            $sleep_us,
+            $sleep_ns,
             $buffer_size,
             $rate_hz,
             $extra_args,

--- a/src/Lib/Elf/Process/BinaryFingerprint.php
+++ b/src/Lib/Elf/Process/BinaryFingerprint.php
@@ -37,6 +37,32 @@ final class BinaryFingerprint
         );
     }
 
+    /**
+     * Create a fingerprint that includes actual ELF header content from the binary.
+     *
+     * This is more reliable than filesystem metadata alone because it detects
+     * differences between NTS/ZTS builds, in-place binary replacements, and
+     * overlayfs inode reuse across container restarts.
+     *
+     * @param string $elf_header_bytes Raw bytes from the ELF header (typically first 64 bytes)
+     */
+    public static function fromProcessModuleMemoryMapAndElfHeader(
+        ProcessModuleMemoryMap $process_module_memory_map,
+        string $elf_header_bytes,
+    ): self {
+        return new self(
+            join(
+                '_',
+                [
+                    $process_module_memory_map->getDeviceId(),
+                    $process_module_memory_map->getInodeNumber(),
+                    $process_module_memory_map->getModuleName(),
+                    bin2hex($elf_header_bytes),
+                ]
+            )
+        );
+    }
+
     public function getCacheKey(): string
     {
         return hash('sha256', $this->fingerprint);

--- a/src/Lib/Elf/Process/BinaryFingerprint.php
+++ b/src/Lib/Elf/Process/BinaryFingerprint.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
-use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
 
 final class BinaryFingerprint
 {
@@ -23,7 +23,7 @@ final class BinaryFingerprint
     }
 
     public static function fromProcessModuleMemoryMap(
-        ProcessModuleMemoryMap $process_module_memory_map
+        ProcessModuleMemoryMapInterface $process_module_memory_map
     ): self {
         return new self(
             join(
@@ -47,7 +47,7 @@ final class BinaryFingerprint
      * @param string $elf_header_bytes Raw bytes from the ELF header (typically first 64 bytes)
      */
     public static function fromProcessModuleMemoryMapAndElfHeader(
-        ProcessModuleMemoryMap $process_module_memory_map,
+        ProcessModuleMemoryMapInterface $process_module_memory_map,
         string $elf_header_bytes,
     ): self {
         return new self(

--- a/src/Lib/Elf/Process/BinaryFingerprint.php
+++ b/src/Lib/Elf/Process/BinaryFingerprint.php
@@ -40,9 +40,12 @@ final class BinaryFingerprint
     /**
      * Create a fingerprint that includes actual ELF header content from the binary.
      *
-     * This is more reliable than filesystem metadata alone because it detects
-     * differences between NTS/ZTS builds, in-place binary replacements, and
-     * overlayfs inode reuse across container restarts.
+     * Filesystem metadata (device_id + inode) alone is not sufficient for reliable
+     * cache keying in container environments: Docker's overlayfs can assign the same
+     * device_id and inode to different binaries across different images (e.g. php:8.3
+     * and php:8.3-zts). Including the ELF header content ensures that different
+     * binaries always produce different fingerprints, even when their filesystem
+     * metadata happens to collide.
      *
      * @param string $elf_header_bytes Raw bytes from the ELF header (typically first 64 bytes)
      */

--- a/src/Lib/Elf/Process/BinaryFingerprintCreator.php
+++ b/src/Lib/Elf/Process/BinaryFingerprintCreator.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+
+final class BinaryFingerprintCreator
+{
+    private const ELF_HEADER_SIZE = 64;
+
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+    ) {
+    }
+
+    public function createFromProcessModuleMemoryMap(
+        int $pid,
+        ProcessModuleMemoryMap $process_module_memory_map,
+    ): BinaryFingerprint {
+        $base_address = $process_module_memory_map->getBaseAddress();
+        try {
+            $header_cdata = $this->memory_reader->read($pid, $base_address, self::ELF_HEADER_SIZE);
+            $header_bytes = '';
+            for ($i = 0; $i < self::ELF_HEADER_SIZE; $i++) {
+                /** @var int $byte */
+                $byte = $header_cdata[$i];
+                $header_bytes .= chr($byte);
+            }
+            return BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader(
+                $process_module_memory_map,
+                $header_bytes,
+            );
+        } catch (\Throwable) {
+            return BinaryFingerprint::fromProcessModuleMemoryMap($process_module_memory_map);
+        }
+    }
+}

--- a/src/Lib/Elf/Process/BinaryFingerprintCreator.php
+++ b/src/Lib/Elf/Process/BinaryFingerprintCreator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
-use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 
 final class BinaryFingerprintCreator
@@ -27,7 +27,7 @@ final class BinaryFingerprintCreator
 
     public function createFromProcessModuleMemoryMap(
         int $pid,
-        ProcessModuleMemoryMap $process_module_memory_map,
+        ProcessModuleMemoryMapInterface $process_module_memory_map,
     ): BinaryFingerprint {
         $base_address = $process_module_memory_map->getBaseAddress();
         try {

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -250,11 +250,10 @@ class PhpGlobalsFinder
         $module_map = $this->getPhpModuleMemoryMap($process_specifier, $target_php_settings->php_regex);
         $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
 
-        $cached_nts = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
-        if ($cached_nts !== null && isset($cached_nts[$symbol_name]) && is_int($cached_nts[$symbol_name])) {
-            return $module_map->getBaseAddress() + $cached_nts[$symbol_name];
-        }
-
+        // Check ZTS (TSRM) path first: if the binary is known to have TSRM LS cache,
+        // or if we can detect it now, use the ZTS resolution path.
+        // This must be checked BEFORE the NTS globals cache to avoid using a cached NTS
+        // offset for a ZTS binary (where globals are in TLS, not at a static offset).
         $tsrm_ls_cache = $this->findTsrmLsCache($process_specifier, $target_php_settings);
         if (isset($tsrm_ls_cache)) {
             return $this->tsrm_globals_resolver->resolveGlobalsAddress(
@@ -263,6 +262,11 @@ class PhpGlobalsFinder
                 $symbol_name,
                 $tsrm_ls_cache,
             );
+        }
+
+        $cached_nts = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
+        if ($cached_nts !== null && isset($cached_nts[$symbol_name]) && is_int($cached_nts[$symbol_name])) {
+            return $module_map->getBaseAddress() + $cached_nts[$symbol_name];
         }
 
         $globals_address = $this->getSymbolReader($process_specifier, $target_php_settings)

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -19,6 +19,7 @@ use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReader;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
@@ -48,6 +49,7 @@ class PhpGlobalsFinder
         private TsrmGlobalsResolver $tsrm_globals_resolver,
         private BinaryAnalysisCache $binary_analysis_cache,
         private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
+        private BinaryFingerprintCreator $binary_fingerprint_creator,
     ) {
     }
 
@@ -219,7 +221,7 @@ class PhpGlobalsFinder
             $process_specifier,
             $target_php_settings->zts_globals_regex,
         );
-        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        $fingerprint = $this->createFingerprint($process_specifier, $module_map);
         $cached = $this->binary_analysis_cache->get($fingerprint, 'nts_globals');
         if ($cached !== null && isset($cached['module_registry']) && is_int($cached['module_registry'])) {
             return $module_map->getBaseAddress() + $cached['module_registry'];
@@ -248,7 +250,7 @@ class PhpGlobalsFinder
         string $symbol_name,
     ): int {
         $module_map = $this->getPhpModuleMemoryMap($process_specifier, $target_php_settings->php_regex);
-        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        $fingerprint = $this->createFingerprint($process_specifier, $module_map);
 
         // Check ZTS (TSRM) path first: if the binary is known to have TSRM LS cache,
         // or if we can detect it now, use the ZTS resolution path.
@@ -287,7 +289,17 @@ class PhpGlobalsFinder
         string $regex,
     ): BinaryFingerprint {
         $module_map = $this->getPhpModuleMemoryMap($process_specifier, $regex);
-        return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        return $this->createFingerprint($process_specifier, $module_map);
+    }
+
+    private function createFingerprint(
+        ProcessSpecifier $process_specifier,
+        ProcessModuleMemoryMap $module_map,
+    ): BinaryFingerprint {
+        return $this->binary_fingerprint_creator->createFromProcessModuleMemoryMap(
+            $process_specifier->pid,
+            $module_map,
+        );
     }
 
     private function getPhpModuleMemoryMap(

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -20,6 +20,7 @@ use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
@@ -47,6 +48,7 @@ final class PhpTsrmLsCacheFinder
         private ContainerAwarePathResolver $process_path_resolver,
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private BinaryAnalysisCache $binary_analysis_cache,
+        private BinaryFingerprintCreator $binary_fingerprint_creator,
     ) {
     }
 
@@ -102,7 +104,10 @@ final class PhpTsrmLsCacheFinder
             return null;
         }
         [$tls_block_address, $tls_block_size, $php_module_memory_map] = $tls_block;
-        $fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($php_module_memory_map);
+        $fingerprint = $this->binary_fingerprint_creator->createFromProcessModuleMemoryMap(
+            $process_specifier->pid,
+            $php_module_memory_map,
+        );
 
         $cached = $this->binary_analysis_cache->get($fingerprint, 'tls_offset');
         if ($cached !== null && isset($cached['offset']) && is_int($cached['offset'])) {

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -106,10 +106,16 @@ final class PhpTsrmLsCacheFinder
 
         $cached = $this->binary_analysis_cache->get($fingerprint, 'tls_offset');
         if ($cached !== null && isset($cached['offset']) && is_int($cached['offset'])) {
-            $candidate_address = $tls_block_address + $cached['offset'];
+            $tls_variable_address = $tls_block_address + $cached['offset'];
+            $tsrm_ls_cache_value = $this->integer_reader->read64(
+                new CDataByteReader(
+                    $this->memory_reader->read($process_specifier->pid, $tls_variable_address, 8)
+                ),
+                0
+            )->toInt();
             assert($target_php_settings->isDecided());
-            if ($this->validateCandidate($process_specifier, $target_php_settings, $candidate_address)) {
-                return $candidate_address;
+            if ($this->validateCandidate($process_specifier, $target_php_settings, $tsrm_ls_cache_value)) {
+                return $tsrm_ls_cache_value;
             }
         }
 
@@ -128,7 +134,7 @@ final class PhpTsrmLsCacheFinder
                 $this->binary_analysis_cache->set(
                     $fingerprint,
                     'tls_offset',
-                    ['offset' => $tsrm_ls_cache_address_candidate - $tls_block_address],
+                    ['offset' => $current - $tls_block_address],
                 );
                 return $tsrm_ls_cache_address_candidate;
             }

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -16,6 +16,7 @@ namespace Reli\Lib\PhpProcessReader;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendModuleEntry;
@@ -42,6 +43,7 @@ class PhpVersionDetector
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private BinaryAnalysisCache $binary_analysis_cache,
         private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
+        private BinaryFingerprintCreator $binary_fingerprint_creator,
     ) {
     }
 
@@ -145,7 +147,10 @@ class PhpVersionDetector
                 return null;
             }
             $module_map = new ProcessModuleMemoryMap($php_areas);
-            return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+            return $this->binary_fingerprint_creator->createFromProcessModuleMemoryMap(
+                $process_specifier->pid,
+                $module_map,
+            );
         } catch (\Throwable) {
             return null;
         }

--- a/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
+++ b/src/Lib/PhpProcessReader/TsrmGlobalsResolver.php
@@ -18,6 +18,7 @@ use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
@@ -34,6 +35,7 @@ final class TsrmGlobalsResolver
         private MemoryReaderInterface $memory_reader,
         private BinaryAnalysisCache $binary_analysis_cache,
         private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
+        private BinaryFingerprintCreator $binary_fingerprint_creator,
     ) {
     }
 
@@ -198,6 +200,9 @@ final class TsrmGlobalsResolver
         );
         $php_areas = $process_memory_map->findByNameRegex($target_php_settings->zts_globals_regex);
         $module_map = new ProcessModuleMemoryMap($php_areas);
-        return BinaryFingerprint::fromProcessModuleMemoryMap($module_map);
+        return $this->binary_fingerprint_creator->createFromProcessModuleMemoryMap(
+            $process_specifier->pid,
+            $module_map,
+        );
     }
 }

--- a/src/Lib/PhpSpy/PhpSpyFinder.php
+++ b/src/Lib/PhpSpy/PhpSpyFinder.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpSpy;
+
+final class PhpSpyFinder
+{
+    public const DEFAULT_INSTALL_PATH = '/.reli/bin/phpspy';
+
+    public function find(?string $explicit_path = null): string
+    {
+        // 1. Explicit path from --phpspy-path option
+        if ($explicit_path !== null) {
+            if (is_executable($explicit_path)) {
+                return $explicit_path;
+            }
+            throw new PhpSpyNotFoundException();
+        }
+
+        // 2. PHPSPY_PATH env var
+        $env_path = getenv('PHPSPY_PATH');
+        if ($env_path !== false && $env_path !== '' && is_executable($env_path)) {
+            return $env_path;
+        }
+
+        // 3. ~/.reli/bin/phpspy
+        $home = getenv('HOME');
+        if ($home !== false && $home !== '') {
+            $reli_path = $home . self::DEFAULT_INSTALL_PATH;
+            if (is_executable($reli_path)) {
+                return $reli_path;
+            }
+        }
+
+        // 4. which phpspy
+        $which_result = exec('which phpspy 2>/dev/null', $output_lines, $result_code);
+        if ($result_code === 0 && $which_result !== false && $which_result !== '') {
+            $which_result = trim($which_result);
+            if ($which_result !== '' && is_executable($which_result)) {
+                return $which_result;
+            }
+        }
+
+        throw new PhpSpyNotFoundException();
+    }
+
+    public static function getDefaultInstallDir(): string
+    {
+        $home = getenv('HOME');
+        if ($home === false || $home === '') {
+            throw new \RuntimeException('HOME environment variable is not set');
+        }
+        return $home . '/.reli/bin';
+    }
+
+    public static function getDefaultInstallPath(): string
+    {
+        return self::getDefaultInstallDir() . '/phpspy';
+    }
+}

--- a/src/Lib/PhpSpy/PhpSpyNotFoundException.php
+++ b/src/Lib/PhpSpy/PhpSpyNotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpSpy;
+
+final class PhpSpyNotFoundException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'phpspy binary not found. Install it with "phpspy:install" or specify the path with --phpspy-path.'
+        );
+    }
+}

--- a/src/Lib/PhpSpy/PhpSpyProcess.php
+++ b/src/Lib/PhpSpy/PhpSpyProcess.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpSpy;
+
+use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettings;
+
+final class PhpSpyProcess
+{
+    /** @var resource|false|null */
+    private $process = null;
+
+    /** @var resource|null */
+    private $stdout_pipe = null;
+
+    private string $phpspy_path = '';
+
+    public function __construct(
+        private PhpSpyFinder $phpspy_finder,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function buildArgs(
+        int $pid,
+        int $eg_address,
+        int $depth,
+        PhpSpySettings $settings,
+    ): array {
+        $args = [
+            '-p', (string)$pid,
+            '-e', '0x' . dechex($eg_address),
+            '-n', (string)$depth,
+        ];
+
+        if ($settings->sleep_us !== PhpSpySettings::DEFAULT_SLEEP_US) {
+            $args[] = '-s';
+            $args[] = (string)$settings->sleep_us;
+        }
+
+        if ($settings->buffer_size !== PhpSpySettings::DEFAULT_BUFFER_SIZE) {
+            $args[] = '-b';
+            $args[] = (string)$settings->buffer_size;
+        }
+
+        if ($settings->rate_hz !== PhpSpySettings::DEFAULT_RATE_HZ) {
+            $args[] = '-H';
+            $args[] = (string)$settings->rate_hz;
+        }
+
+        return $args;
+    }
+
+    /**
+     * @param resource $output_stream
+     */
+    public function start(
+        int $pid,
+        int $eg_address,
+        int $depth,
+        PhpSpySettings $settings,
+        $output_stream = \STDOUT,
+    ): void {
+        $this->phpspy_path = $this->phpspy_finder->find($settings->phpspy_path);
+        $args = $this->buildArgs($pid, $eg_address, $depth, $settings);
+
+        $command = escapeshellarg($this->phpspy_path);
+        foreach ($args as $arg) {
+            $command .= ' ' . escapeshellarg($arg);
+        }
+
+        if ($settings->extra_args !== null) {
+            $command .= ' ' . $settings->extra_args;
+        }
+
+        $descriptors = [
+            0 => ['pipe', 'r'],  // stdin
+            1 => ['pipe', 'w'],  // stdout
+            2 => ['pipe', 'w'],  // stderr
+        ];
+
+        $this->process = proc_open($command, $descriptors, $pipes);
+        if (!is_resource($this->process)) {
+            throw new \RuntimeException('Failed to start phpspy process: ' . $command);
+        }
+
+        // Close stdin - phpspy doesn't need it
+        fclose($pipes[0]);
+        $this->stdout_pipe = $pipes[1];
+
+        // Set stdout to non-blocking for polling
+        stream_set_blocking($this->stdout_pipe, false);
+
+        // Close stderr (or we could log it)
+        fclose($pipes[2]);
+    }
+
+    /**
+     * @return resource|null
+     */
+    public function getStdoutPipe()
+    {
+        return $this->stdout_pipe;
+    }
+
+    public function isRunning(): bool
+    {
+        if (!is_resource($this->process)) {
+            return false;
+        }
+        $status = proc_get_status($this->process);
+        return $status['running'];
+    }
+
+    /**
+     * Read available output from the phpspy process and write to the output stream.
+     *
+     * @param resource $output_stream
+     * @return bool true if data was written
+     */
+    public function passthrough($output_stream): bool
+    {
+        if ($this->stdout_pipe === null) {
+            return false;
+        }
+        $data = stream_get_contents($this->stdout_pipe);
+        if ($data !== false && $data !== '') {
+            fwrite($output_stream, $data);
+            return true;
+        }
+        return false;
+    }
+
+    public function stop(): void
+    {
+        $pipe = $this->stdout_pipe;
+        $this->stdout_pipe = null;
+        if (is_resource($pipe)) {
+            fclose($pipe);
+        }
+        if (is_resource($this->process)) {
+            // Send SIGTERM first
+            proc_terminate($this->process, 15);
+            // Give it a moment, then force kill if needed
+            $status = proc_get_status($this->process);
+            if ($status['running']) {
+                usleep(100_000); // 100ms
+                proc_terminate($this->process, 9);
+            }
+            proc_close($this->process);
+        }
+        $this->process = null;
+    }
+
+    public function __destruct()
+    {
+        $this->stop();
+    }
+}

--- a/src/Lib/PhpSpy/PhpSpyProcess.php
+++ b/src/Lib/PhpSpy/PhpSpyProcess.php
@@ -23,6 +23,9 @@ final class PhpSpyProcess
     /** @var resource|null */
     private $stdout_pipe = null;
 
+    /** @var resource|null */
+    private $stderr_pipe = null;
+
     private string $phpspy_path = '';
 
     public function __construct(
@@ -36,18 +39,22 @@ final class PhpSpyProcess
     public function buildArgs(
         int $pid,
         int $eg_address,
+        int $sg_address,
         int $depth,
         PhpSpySettings $settings,
     ): array {
+        // phpspy uses -1 for unlimited depth; reli uses PHP_INT_MAX
+        $phpspy_depth = ($depth >= PHP_INT_MAX) ? -1 : $depth;
         $args = [
             '-p', (string)$pid,
-            '-e', '0x' . dechex($eg_address),
-            '-n', (string)$depth,
+            '-x', dechex($eg_address),
+            '-a', dechex($sg_address),
+            '-n', (string)$phpspy_depth,
         ];
 
-        if ($settings->sleep_us !== PhpSpySettings::DEFAULT_SLEEP_US) {
+        if ($settings->sleep_ns !== PhpSpySettings::DEFAULT_SLEEP_NS) {
             $args[] = '-s';
-            $args[] = (string)$settings->sleep_us;
+            $args[] = (string)$settings->sleep_ns;
         }
 
         if ($settings->buffer_size !== PhpSpySettings::DEFAULT_BUFFER_SIZE) {
@@ -69,12 +76,13 @@ final class PhpSpyProcess
     public function start(
         int $pid,
         int $eg_address,
+        int $sg_address,
         int $depth,
         PhpSpySettings $settings,
         $output_stream = \STDOUT,
     ): void {
         $this->phpspy_path = $this->phpspy_finder->find($settings->phpspy_path);
-        $args = $this->buildArgs($pid, $eg_address, $depth, $settings);
+        $args = $this->buildArgs($pid, $eg_address, $sg_address, $depth, $settings);
 
         $command = escapeshellarg($this->phpspy_path);
         foreach ($args as $arg) {
@@ -103,8 +111,9 @@ final class PhpSpyProcess
         // Set stdout to non-blocking for polling
         stream_set_blocking($this->stdout_pipe, false);
 
-        // Close stderr (or we could log it)
-        fclose($pipes[2]);
+        // Keep stderr for diagnostics
+        $this->stderr_pipe = $pipes[2];
+        stream_set_blocking($this->stderr_pipe, false);
     }
 
     /**
@@ -143,12 +152,26 @@ final class PhpSpyProcess
         return false;
     }
 
+    public function getStderrContents(): string
+    {
+        if ($this->stderr_pipe === null) {
+            return '';
+        }
+        $data = stream_get_contents($this->stderr_pipe);
+        return $data !== false ? $data : '';
+    }
+
     public function stop(): void
     {
         $pipe = $this->stdout_pipe;
         $this->stdout_pipe = null;
         if (is_resource($pipe)) {
             fclose($pipe);
+        }
+        $err_pipe = $this->stderr_pipe;
+        $this->stderr_pipe = null;
+        if (is_resource($err_pipe)) {
+            fclose($err_pipe);
         }
         if (is_resource($this->process)) {
             // Send SIGTERM first

--- a/tests/Inspector/Daemon/PhpSpy/PhpSpyProcessPoolTest.php
+++ b/tests/Inspector/Daemon/PhpSpy/PhpSpyProcessPoolTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Daemon\PhpSpy;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpSpy\PhpSpyFinder;
+
+class PhpSpyProcessPoolTest extends BaseTestCase
+{
+    public function testInitialState(): void
+    {
+        $finder = new PhpSpyFinder();
+        $pool = new PhpSpyProcessPool($finder);
+
+        $this->assertSame(0, $pool->count());
+        $this->assertSame([], $pool->getActivePids());
+        $this->assertFalse($pool->hasProcess(1));
+    }
+
+    public function testDetachNonExistentPidDoesNotThrow(): void
+    {
+        $finder = new PhpSpyFinder();
+        $pool = new PhpSpyProcessPool($finder);
+
+        $pool->detach(9999);
+        $this->assertSame(0, $pool->count());
+    }
+
+    public function testStopAllOnEmptyPoolDoesNotThrow(): void
+    {
+        $finder = new PhpSpyFinder();
+        $pool = new PhpSpyProcessPool($finder);
+
+        $pool->stopAll();
+        $this->assertSame(0, $pool->count());
+    }
+
+    public function testPassthroughAllOnEmptyPool(): void
+    {
+        $finder = new PhpSpyFinder();
+        $pool = new PhpSpyProcessPool($finder);
+
+        $stream = fopen('php://memory', 'w');
+        assert($stream !== false);
+        $pool->passthroughAll($stream);
+        fclose($stream);
+
+        $this->assertSame(0, $pool->count());
+    }
+}

--- a/tests/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/PhpSpySettings/PhpSpySettingsFromConsoleInputTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\PhpSpySettings;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+class PhpSpySettingsFromConsoleInputTest extends BaseTestCase
+{
+    public function testDefaultValues(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('phpspy-path')->andReturns(null);
+        $input->expects()->getOption('sleep-ns')->andReturns(null);
+        $input->expects()->getOption('buffer-size')->andReturns(null);
+        $input->expects()->getOption('rate-hz')->andReturns(null);
+        $input->expects()->getOption('phpspy-args')->andReturns(null);
+
+        $settings = (new PhpSpySettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertNull($settings->phpspy_path);
+        $this->assertSame(PhpSpySettings::DEFAULT_SLEEP_NS, $settings->sleep_ns);
+        $this->assertSame(PhpSpySettings::DEFAULT_BUFFER_SIZE, $settings->buffer_size);
+        $this->assertSame(PhpSpySettings::DEFAULT_RATE_HZ, $settings->rate_hz);
+        $this->assertNull($settings->extra_args);
+    }
+
+    public function testCustomValues(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('phpspy-path')->andReturns('/usr/bin/phpspy');
+        $input->expects()->getOption('sleep-ns')->andReturns('5000000');
+        $input->expects()->getOption('buffer-size')->andReturns('8192');
+        $input->expects()->getOption('rate-hz')->andReturns('50');
+        $input->expects()->getOption('phpspy-args')->andReturns('-c -1');
+
+        $settings = (new PhpSpySettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame('/usr/bin/phpspy', $settings->phpspy_path);
+        $this->assertSame(5000000, $settings->sleep_ns);
+        $this->assertSame(8192, $settings->buffer_size);
+        $this->assertSame(50, $settings->rate_hz);
+        $this->assertSame('-c -1', $settings->extra_args);
+    }
+
+    public function testSleepNsNotInteger(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('phpspy-path')->andReturns(null);
+        $input->expects()->getOption('sleep-ns')->andReturns('abc');
+        $input->allows()->getOption('buffer-size')->andReturns(null);
+        $input->allows()->getOption('rate-hz')->andReturns(null);
+        $input->allows()->getOption('phpspy-args')->andReturns(null);
+
+        $this->expectException(PhpSpySettingsException::class);
+        (new PhpSpySettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testBufferSizeNotInteger(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('phpspy-path')->andReturns(null);
+        $input->expects()->getOption('sleep-ns')->andReturns(null);
+        $input->expects()->getOption('buffer-size')->andReturns('xyz');
+        $input->allows()->getOption('rate-hz')->andReturns(null);
+        $input->allows()->getOption('phpspy-args')->andReturns(null);
+
+        $this->expectException(PhpSpySettingsException::class);
+        (new PhpSpySettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testRateHzNotInteger(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('phpspy-path')->andReturns(null);
+        $input->expects()->getOption('sleep-ns')->andReturns(null);
+        $input->expects()->getOption('buffer-size')->andReturns(null);
+        $input->expects()->getOption('rate-hz')->andReturns('not_a_number');
+        $input->allows()->getOption('phpspy-args')->andReturns(null);
+
+        $this->expectException(PhpSpySettingsException::class);
+        (new PhpSpySettingsFromConsoleInput())->createSettings($input);
+    }
+}

--- a/tests/Lib/Dwarf/NativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/NativeTraceCollectorTest.php
@@ -37,6 +37,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapReader;
@@ -166,12 +167,14 @@ class NativeTraceCollectorTest extends BaseTestCase
                 $process_memory_map_creator,
                 $binary_analysis_cache,
             );
+            $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader);
             $tsrm_globals_resolver = new TsrmGlobalsResolver(
                 $php_symbol_reader_creator,
                 $integer_reader,
                 $memory_reader,
                 $binary_analysis_cache,
                 $process_memory_map_creator,
+                $binary_fingerprint_creator,
             );
             $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
                 $php_symbol_reader_creator,
@@ -184,6 +187,7 @@ class NativeTraceCollectorTest extends BaseTestCase
                 new ContainerAwarePathResolver(),
                 new ZendTypeReaderCreator(),
                 $binary_analysis_cache,
+                $binary_fingerprint_creator,
             );
             $php_globals_finder = new PhpGlobalsFinder(
                 $php_symbol_reader_creator,
@@ -193,6 +197,7 @@ class NativeTraceCollectorTest extends BaseTestCase
                 $tsrm_globals_resolver,
                 $binary_analysis_cache,
                 $process_memory_map_creator,
+                $binary_fingerprint_creator,
             );
             $eg_address = $php_globals_finder->findExecutorGlobals(
                 new ProcessSpecifier($pid),

--- a/tests/Lib/Elf/Process/BinaryFingerprintCreatorTest.php
+++ b/tests/Lib/Elf/Process/BinaryFingerprintCreatorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use FFI;
+use Mockery;
+use Reli\BaseTestCase;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
+use Reli\Lib\Process\MemoryReader\MemoryReaderException;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+
+class BinaryFingerprintCreatorTest extends BaseTestCase
+{
+    private function createMockMap(int $base_address = 0x400000): ProcessModuleMemoryMapInterface
+    {
+        $map = Mockery::mock(ProcessModuleMemoryMapInterface::class);
+        $map->allows()->getBaseAddress()->andReturns($base_address);
+        $map->allows()->getDeviceId()->andReturns('00:25');
+        $map->allows()->getInodeNumber()->andReturns(99999);
+        $map->allows()->getModuleName()->andReturns('/usr/local/bin/php');
+        return $map;
+    }
+
+    private function createCdata(string $bytes): FFI\CData
+    {
+        $len = strlen($bytes);
+        $cdata = FFI::new("unsigned char[{$len}]");
+        for ($i = 0; $i < $len; $i++) {
+            $cdata[$i] = ord($bytes[$i]);
+        }
+        return $cdata;
+    }
+
+    public function testCreatesElfHeaderFingerprint(): void
+    {
+        $elf_header = "\x7fELF" . str_repeat("\x00", 60);
+
+        $memory_reader = Mockery::mock(MemoryReaderInterface::class);
+        $memory_reader->expects()
+            ->read(1234, 0x400000, 64)
+            ->andReturns($this->createCdata($elf_header));
+
+        $map = $this->createMockMap(0x400000);
+        $creator = new BinaryFingerprintCreator($memory_reader);
+        $fp = $creator->createFromProcessModuleMemoryMap(1234, $map);
+
+        $this->assertStringContainsString(bin2hex($elf_header), (string)$fp);
+    }
+
+    public function testFallsBackToMetadataOnReadFailure(): void
+    {
+        $memory_reader = Mockery::mock(MemoryReaderInterface::class);
+        $memory_reader->expects()
+            ->read(1234, 0x400000, 64)
+            ->andThrows(new MemoryReaderException('read failed', 14));
+
+        $map = $this->createMockMap(0x400000);
+        $creator = new BinaryFingerprintCreator($memory_reader);
+        $fp = $creator->createFromProcessModuleMemoryMap(1234, $map);
+
+        $this->assertNotEmpty($fp->getCacheKey());
+        $this->assertSame(64, strlen($fp->getCacheKey()));
+        $this->assertStringNotContainsString('7f454c46', (string)$fp);
+    }
+
+    public function testDifferentElfHeadersProduceDifferentFingerprints(): void
+    {
+        // Simulates NTS vs ZTS: same metadata but different ELF headers (e_phnum differs)
+        $header_nts = "\x7fELF\x02\x01\x01\x03" . str_repeat("\x00", 52) . "\x0e\x00\x1e\x00";
+        $header_zts = "\x7fELF\x02\x01\x01\x03" . str_repeat("\x00", 52) . "\x0f\x00\x1f\x00";
+
+        $memory_reader = Mockery::mock(MemoryReaderInterface::class);
+        $memory_reader->allows()
+            ->read(100, 0x400000, 64)
+            ->andReturns($this->createCdata($header_nts));
+        $memory_reader->allows()
+            ->read(200, 0x400000, 64)
+            ->andReturns($this->createCdata($header_zts));
+
+        // Same base address and metadata — only ELF header content differs
+        $map_nts = $this->createMockMap(0x400000);
+        $map_zts = $this->createMockMap(0x400000);
+
+        $creator = new BinaryFingerprintCreator($memory_reader);
+        $fp_nts = $creator->createFromProcessModuleMemoryMap(100, $map_nts);
+        $fp_zts = $creator->createFromProcessModuleMemoryMap(200, $map_zts);
+
+        $this->assertNotSame($fp_nts->getCacheKey(), $fp_zts->getCacheKey());
+    }
+
+    public function testSameElfHeaderProducesSameFingerprint(): void
+    {
+        $header = "\x7fELF" . str_repeat("\xAA", 60);
+
+        $memory_reader = Mockery::mock(MemoryReaderInterface::class);
+        $memory_reader->expects()
+            ->read(100, 0x400000, 64)
+            ->andReturns($this->createCdata($header))
+            ->twice();
+
+        $map = $this->createMockMap(0x400000);
+        $creator = new BinaryFingerprintCreator($memory_reader);
+        $fp1 = $creator->createFromProcessModuleMemoryMap(100, $map);
+        $fp2 = $creator->createFromProcessModuleMemoryMap(100, $map);
+
+        $this->assertSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+}

--- a/tests/Lib/Elf/Process/BinaryFingerprintTest.php
+++ b/tests/Lib/Elf/Process/BinaryFingerprintTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
+
+class BinaryFingerprintTest extends BaseTestCase
+{
+    private function createMockMap(string $device_id, int $inode, string $name): ProcessModuleMemoryMapInterface
+    {
+        $map = Mockery::mock(ProcessModuleMemoryMapInterface::class);
+        $map->allows()->getDeviceId()->andReturns($device_id);
+        $map->allows()->getInodeNumber()->andReturns($inode);
+        $map->allows()->getModuleName()->andReturns($name);
+        return $map;
+    }
+
+    public function testFromProcessModuleMemoryMapDeterministic(): void
+    {
+        $map = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+
+        $fp1 = BinaryFingerprint::fromProcessModuleMemoryMap($map);
+        $fp2 = BinaryFingerprint::fromProcessModuleMemoryMap($map);
+
+        $this->assertSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+
+    public function testDifferentInodesProduceDifferentFingerprints(): void
+    {
+        $map1 = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+        $map2 = $this->createMockMap('00:25', 67890, '/usr/local/bin/php');
+
+        $fp1 = BinaryFingerprint::fromProcessModuleMemoryMap($map1);
+        $fp2 = BinaryFingerprint::fromProcessModuleMemoryMap($map2);
+
+        $this->assertNotSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+
+    public function testDifferentDeviceIdsProduceDifferentFingerprints(): void
+    {
+        $map1 = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+        $map2 = $this->createMockMap('00:23', 12345, '/usr/local/bin/php');
+
+        $fp1 = BinaryFingerprint::fromProcessModuleMemoryMap($map1);
+        $fp2 = BinaryFingerprint::fromProcessModuleMemoryMap($map2);
+
+        $this->assertNotSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+
+    public function testFromProcessModuleMemoryMapAndElfHeaderDistinguishesNtsZts(): void
+    {
+        $map = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+
+        $elf_header_nts = str_repeat("\x00", 64);
+        $elf_header_zts = str_repeat("\x01", 64);
+
+        $fp_nts = BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader($map, $elf_header_nts);
+        $fp_zts = BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader($map, $elf_header_zts);
+
+        $this->assertNotSame($fp_nts->getCacheKey(), $fp_zts->getCacheKey());
+    }
+
+    public function testElfHeaderFingerprintDiffersFromMetadataOnly(): void
+    {
+        $map = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+
+        $fp_metadata = BinaryFingerprint::fromProcessModuleMemoryMap($map);
+        $fp_with_elf = BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader(
+            $map,
+            str_repeat("\x7f", 64),
+        );
+
+        $this->assertNotSame($fp_metadata->getCacheKey(), $fp_with_elf->getCacheKey());
+    }
+
+    public function testSameElfHeaderProducesSameFingerprint(): void
+    {
+        $map = $this->createMockMap('00:25', 12345, '/usr/local/bin/php');
+        $elf_header = "\x7fELF" . str_repeat("\x00", 60);
+
+        $fp1 = BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader($map, $elf_header);
+        $fp2 = BinaryFingerprint::fromProcessModuleMemoryMapAndElfHeader($map, $elf_header);
+
+        $this->assertSame($fp1->getCacheKey(), $fp2->getCacheKey());
+    }
+
+    public function testToString(): void
+    {
+        $fp = new BinaryFingerprint('test_value');
+        $this->assertSame('test_value', (string)$fp);
+    }
+
+    public function testGetCacheKeyIsSha256(): void
+    {
+        $fp = new BinaryFingerprint('test');
+        $this->assertSame(64, strlen($fp->getCacheKey()));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $fp->getCacheKey());
+    }
+}

--- a/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendArrayTest.php
@@ -22,6 +22,7 @@ use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
@@ -107,12 +108,14 @@ class ZendArrayTest extends BaseTestCase
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -125,6 +128,7 @@ class ZendArrayTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -134,6 +138,7 @@ class ZendArrayTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -32,6 +32,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -112,12 +113,14 @@ class CallTraceReaderTest extends BaseTestCase
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -130,6 +133,7 @@ class CallTraceReaderTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -139,6 +143,7 @@ class CallTraceReaderTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         /** @var int $child_status['pid'] */

--- a/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
@@ -32,6 +32,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -136,12 +137,14 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                 );
                 $integer_reader = new LittleEndianReader();
                 $memory_reader_for_finder = new MemoryReader();
+                $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
                 $tsrm_globals_resolver = new TsrmGlobalsResolver(
                     $php_symbol_reader_creator,
                     $integer_reader,
                     $memory_reader_for_finder,
                     $binary_analysis_cache,
                     $process_memory_map_creator,
+                    $binary_fingerprint_creator,
                 );
                 $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
                     $php_symbol_reader_creator,
@@ -154,6 +157,7 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                     new ContainerAwarePathResolver(),
                     new ZendTypeReaderCreator(),
                     $binary_analysis_cache,
+                    $binary_fingerprint_creator,
                 );
                 $php_globals_finder = new PhpGlobalsFinder(
                     $php_symbol_reader_creator,
@@ -163,6 +167,7 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
                     $tsrm_globals_resolver,
                     $binary_analysis_cache,
                     $process_memory_map_creator,
+                    $binary_fingerprint_creator,
                 );
 
                 $eg_addr = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -22,6 +22,7 @@ use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
@@ -74,12 +75,14 @@ class PhpGlobalsFinderTest extends BaseTestCase
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -92,6 +95,7 @@ class PhpGlobalsFinderTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -101,6 +105,7 @@ class PhpGlobalsFinderTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $module_registry = $php_globals_finder->findModuleRegistry(
             new ProcessSpecifier($child_status['pid']),

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -33,6 +33,7 @@ use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ArrayContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
@@ -149,12 +150,14 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -167,6 +170,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -176,6 +180,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -436,12 +441,14 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -454,6 +461,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -463,6 +471,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -627,12 +636,14 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -645,6 +656,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -654,6 +666,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
@@ -835,12 +848,14 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $memory_reader_for_finder = new MemoryReader();
         $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             $integer_reader,
             $memory_reader_for_finder,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
             $php_symbol_reader_creator,
@@ -853,6 +868,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -862,6 +878,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -22,6 +22,7 @@ use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
 use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\File\CatFileReader;
 use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
@@ -73,12 +74,14 @@ class PhpVersionDetectorTest extends BaseTestCase
         );
         $memory_reader = new MemoryReader();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
             $php_symbol_reader_creator,
             new LittleEndianReader(),
             $memory_reader,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $integer_reader = new LittleEndianReader();
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
@@ -92,6 +95,7 @@ class PhpVersionDetectorTest extends BaseTestCase
             new ContainerAwarePathResolver(),
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
             $php_symbol_reader_creator,
@@ -101,6 +105,7 @@ class PhpVersionDetectorTest extends BaseTestCase
             $tsrm_globals_resolver,
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $module_registry_address = $php_globals_finder->findModuleRegistry(
             new ProcessSpecifier($child_status['pid']),
@@ -112,6 +117,7 @@ class PhpVersionDetectorTest extends BaseTestCase
             new ZendTypeReaderCreator(),
             $binary_analysis_cache,
             $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $version = $php_version_detector->detectPhpVersion(
             $child_status['pid'],

--- a/tests/Lib/PhpSpy/PhpSpyFinderTest.php
+++ b/tests/Lib/PhpSpy/PhpSpyFinderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpSpy;
+
+use Reli\BaseTestCase;
+
+class PhpSpyFinderTest extends BaseTestCase
+{
+    public function testFindWithExplicitPath(): void
+    {
+        $finder = new PhpSpyFinder();
+        // PHP binary is always executable, use it as a stand-in
+        $php_path = PHP_BINARY;
+        $this->assertSame($php_path, $finder->find($php_path));
+    }
+
+    public function testFindWithExplicitPathNotExecutableThrows(): void
+    {
+        $finder = new PhpSpyFinder();
+        $this->expectException(PhpSpyNotFoundException::class);
+        $finder->find('/nonexistent/phpspy');
+    }
+
+    public function testFindWithEnvVar(): void
+    {
+        $finder = new PhpSpyFinder();
+        $old_env = getenv('PHPSPY_PATH');
+
+        putenv('PHPSPY_PATH=' . PHP_BINARY);
+        try {
+            $result = $finder->find();
+            $this->assertSame(PHP_BINARY, $result);
+        } finally {
+            if ($old_env === false) {
+                putenv('PHPSPY_PATH');
+            } else {
+                putenv('PHPSPY_PATH=' . $old_env);
+            }
+        }
+    }
+
+    public function testFindThrowsWhenNothingFound(): void
+    {
+        $finder = new PhpSpyFinder();
+        $old_env = getenv('PHPSPY_PATH');
+
+        // Clear env var so it doesn't interfere
+        putenv('PHPSPY_PATH');
+        try {
+            // Unless phpspy is actually installed, this should throw
+            // Use explicit null to skip env check for explicit path
+            $finder->find(null);
+            // If we get here, phpspy is installed - that's ok too
+            $this->assertTrue(true);
+        } catch (PhpSpyNotFoundException) {
+            $this->assertTrue(true);
+        } finally {
+            if ($old_env !== false) {
+                putenv('PHPSPY_PATH=' . $old_env);
+            }
+        }
+    }
+
+    public function testGetDefaultInstallPath(): void
+    {
+        $path = PhpSpyFinder::getDefaultInstallPath();
+        $this->assertStringEndsWith('/phpspy', $path);
+        $this->assertStringContainsString('.reli/bin', $path);
+    }
+
+    public function testGetDefaultInstallDir(): void
+    {
+        $dir = PhpSpyFinder::getDefaultInstallDir();
+        $this->assertStringEndsWith('.reli/bin', $dir);
+    }
+}

--- a/tests/Lib/PhpSpy/PhpSpyProcessTest.php
+++ b/tests/Lib/PhpSpy/PhpSpyProcessTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpSpy;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettings;
+
+class PhpSpyProcessTest extends BaseTestCase
+{
+    private function createProcess(): PhpSpyProcess
+    {
+        return new PhpSpyProcess(new PhpSpyFinder());
+    }
+
+    public function testBuildArgsBasic(): void
+    {
+        $process = $this->createProcess();
+        $settings = new PhpSpySettings();
+
+        $args = $process->buildArgs(1234, 0x7f000000, 0x7f000100, 128, $settings);
+
+        $this->assertContains('-p', $args);
+        $this->assertContains('1234', $args);
+        $this->assertContains('-x', $args);
+        $this->assertContains('7f000000', $args);
+        $this->assertContains('-a', $args);
+        $this->assertContains('7f000100', $args);
+        $this->assertContains('-n', $args);
+        $this->assertContains('128', $args);
+        $this->assertNotContains('-s', $args);
+        $this->assertNotContains('-b', $args);
+        $this->assertNotContains('-H', $args);
+    }
+
+    public function testBuildArgsWithCustomSettings(): void
+    {
+        $process = $this->createProcess();
+        $settings = new PhpSpySettings(
+            sleep_ns: 5000000,
+            buffer_size: 8192,
+            rate_hz: 50,
+        );
+
+        $args = $process->buildArgs(999, 0xABCDEF, 0x123456, 64, $settings);
+
+        $this->assertContains('-s', $args);
+        $this->assertContains('5000000', $args);
+        $this->assertContains('-b', $args);
+        $this->assertContains('8192', $args);
+        $this->assertContains('-H', $args);
+        $this->assertContains('50', $args);
+    }
+
+    public function testBuildArgsDepthUnlimited(): void
+    {
+        $process = $this->createProcess();
+        $settings = new PhpSpySettings();
+
+        $args = $process->buildArgs(1, 0x1000, 0x2000, PHP_INT_MAX, $settings);
+
+        $this->assertContains('-1', $args);
+        $this->assertNotContains((string)PHP_INT_MAX, $args);
+    }
+
+    public function testBuildArgsEgAddressFormat(): void
+    {
+        $process = $this->createProcess();
+        $settings = new PhpSpySettings();
+
+        $args = $process->buildArgs(1, 0x564102620bc0, 0x564102620600, 10, $settings);
+
+        $this->assertContains('564102620bc0', $args);
+        $this->assertContains('564102620600', $args);
+        $this->assertNotContains('0x564102620bc0', $args);
+    }
+
+    public function testIsRunningReturnsFalseBeforeStart(): void
+    {
+        $process = $this->createProcess();
+        $this->assertFalse($process->isRunning());
+    }
+
+    public function testPassthroughReturnsFalseBeforeStart(): void
+    {
+        $process = $this->createProcess();
+        $this->assertFalse($process->passthrough(STDOUT));
+    }
+
+    public function testGetStderrContentsBeforeStart(): void
+    {
+        $process = $this->createProcess();
+        $this->assertSame('', $process->getStderrContents());
+    }
+
+    public function testStopBeforeStartDoesNotThrow(): void
+    {
+        $process = $this->createProcess();
+        $process->stop();
+        $this->assertFalse($process->isRunning());
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a hybrid phpspy mode that combines reli's ZTS-aware EG address resolution with phpspy's fast C-based tracing backend. Users can now use phpspy for tracing while reli handles the complex task of resolving executor globals (EG) addresses, including for ZTS (thread-safe) PHP builds where phpspy alone cannot operate.

## Key Changes

### New Commands
- **`phpspy:install`** - Install or verify phpspy binary availability with automatic installation from source
- **`phpspy:trace`** - Single-process tracing using phpspy as the backend (reli resolves EG, phpspy does tracing)
- **`phpspy:daemon`** - Multi-process daemon mode using phpspy backend with concurrent tracing support

### Core Components
- **`PhpSpyProcess`** - Manages phpspy subprocess lifecycle (start, stop, I/O handling)
  - Builds command-line arguments from settings
  - Handles non-blocking I/O for stdout/stderr
  - Provides process status monitoring
  
- **`PhpSpyFinder`** - Locates phpspy binary with fallback chain:
  1. Explicit `--phpspy-path` option
  2. `PHPSPY_PATH` environment variable
  3. `~/.reli/bin/phpspy` (default install location)
  4. System `which phpspy`

- **`PhpSpyProcessPool`** - Manages multiple concurrent phpspy processes for daemon mode
  - Attach/detach processes by PID
  - Passthrough output from all running processes
  - Track active process PIDs

### Settings & Configuration
- **`PhpSpySettings`** - Configuration object with defaults:
  - `sleep_ns`: 10101010 (sampling interval)
  - `buffer_size`: 4096
  - `rate_hz`: 99
  - Support for extra custom arguments

- **`PhpSpySettingsFromConsoleInput`** - Console option parsing for phpspy settings

### Binary Analysis Improvements
- **`BinaryFingerprintCreator`** - New class to create fingerprints including actual ELF header content
  - Reads ELF header from process memory to distinguish NTS vs ZTS builds
  - Falls back to metadata-based fingerprinting on read failure
  - Enables accurate binary caching even for identical metadata

- **`BinaryFingerprint`** - Enhanced with ELF header support
  - New `fromProcessModuleMemoryMapAndElfHeader()` method
  - Distinguishes between NTS and ZTS builds of same binary

### Testing
- Comprehensive test coverage for all new components
- Tests for process management, settings parsing, binary fingerprinting
- Process pool lifecycle tests

## Implementation Details

The hybrid mode workflow:
1. User specifies target process (PID or command)
2. Reli resolves the EG (executor globals) address, including ZTS support via TSRM
3. Reli launches phpspy with the resolved EG address and other parameters
4. phpspy performs fast C-based tracing and outputs results
5. Reli handles output passthrough and process management

This approach gives users phpspy's performance benefits while gaining reli's ZTS support and address resolution capabilities.

## Documentation
Updated README with new "Hybrid phpspy mode" section documenting:
- Installation instructions
- Single-process tracing usage
- Daemon mode usage
- Available options and configuration

https://claude.ai/code/session_01VeW1BBqYjvR1GxgzfdJnNP