### PR TITLE
Add disk caching for ELF symbol and DWARF frame data

### DIFF
--- a/src/Lib/Dwarf/ModuleEhFrameCache.php
+++ b/src/Lib/Dwarf/ModuleEhFrameCache.php
@@ -214,7 +214,9 @@ final class ModuleEhFrameCache
         if ($cached === null || !isset($cached['fdes']) || !is_array($cached['fdes'])) {
             return null;
         }
-        return $this->deserializeFdes($cached['fdes']);
+        /** @var array<string, mixed> $fdes_data */
+        $fdes_data = $cached['fdes'];
+        return $this->deserializeFdes($fdes_data);
     }
 
     /** @param array<Fde> $fdes */
@@ -230,7 +232,7 @@ final class ModuleEhFrameCache
 
     /**
      * @param array<Fde> $fdes
-     * @return array<array<string, mixed>>
+     * @return array{cies: array<int, array<string, mixed>>, fdes: list<array{il: int, ar: int, ins: string, ci: int}>}
      */
     private function serializeFdes(array $fdes): array
     {
@@ -284,34 +286,64 @@ final class ModuleEhFrameCache
             return null;
         }
 
+        /** @var array<int, Cie> $cies */
         $cies = [];
         foreach ($data['cies'] as $index => $cie_data) {
             if (!is_array($cie_data)) {
                 return null;
             }
+            /** @var int $caf */
+            $caf = $cie_data['caf'];
+            /** @var int $daf */
+            $daf = $cie_data['daf'];
+            /** @var int $rar */
+            $rar = $cie_data['rar'];
+            /** @var string $ii */
+            $ii = $cie_data['ii'];
+            /** @var string $aug */
+            $aug = $cie_data['aug'];
+            /** @var int $fe */
+            $fe = $cie_data['fe'];
+            /** @var int|null $le */
+            $le = $cie_data['le'] ?? null;
+            /** @var int|null $pe */
+            $pe = $cie_data['pe'] ?? null;
+            /** @var int|null $pa */
+            $pa = $cie_data['pa'] ?? null;
             $cies[$index] = new Cie(
-                codeAlignmentFactor: $cie_data['caf'],
-                dataAlignmentFactor: $cie_data['daf'],
-                returnAddressRegister: $cie_data['rar'],
-                initialInstructions: base64_decode($cie_data['ii']),
-                augmentation: $cie_data['aug'],
-                fdeEncoding: $cie_data['fe'],
-                lsdaEncoding: $cie_data['le'] ?? null,
-                personalityEncoding: $cie_data['pe'] ?? null,
-                personalityAddress: $cie_data['pa'] ?? null,
+                codeAlignmentFactor: $caf,
+                dataAlignmentFactor: $daf,
+                returnAddressRegister: $rar,
+                initialInstructions: base64_decode($ii),
+                augmentation: $aug,
+                fdeEncoding: $fe,
+                lsdaEncoding: $le,
+                personalityEncoding: $pe,
+                personalityAddress: $pa,
             );
         }
 
         $fdes = [];
         foreach ($data['fdes'] as $fde_data) {
-            if (!is_array($fde_data) || !isset($cies[$fde_data['ci']])) {
+            if (!is_array($fde_data)) {
+                return null;
+            }
+            /** @var int $il */
+            $il = $fde_data['il'];
+            /** @var int $ar */
+            $ar = $fde_data['ar'];
+            /** @var string $ins */
+            $ins = $fde_data['ins'];
+            /** @var int $ci */
+            $ci = $fde_data['ci'];
+            if (!isset($cies[$ci])) {
                 return null;
             }
             $fdes[] = new Fde(
-                initialLocation: $fde_data['il'],
-                addressRange: $fde_data['ar'],
-                instructions: base64_decode($fde_data['ins']),
-                cie: $cies[$fde_data['ci']],
+                initialLocation: $il,
+                addressRange: $ar,
+                instructions: base64_decode($ins),
+                cie: $cies[$ci],
             );
         }
 

--- a/src/Lib/Dwarf/ModuleEhFrameCache.php
+++ b/src/Lib/Dwarf/ModuleEhFrameCache.php
@@ -17,8 +17,11 @@ use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\DebugFileLocator;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\NativeFileReader;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 
 final class ModuleEhFrameCache
 {
@@ -37,6 +40,8 @@ final class ModuleEhFrameCache
         ?DebugFileLocator $debugFileLocator = null,
         private string $processRoot = '',
         ?FileReaderInterface $fileReader = null,
+        private ?BinaryAnalysisCache $binaryAnalysisCache = null,
+        private ?ProcessMemoryMap $memoryMap = null,
     ) {
         $integer_reader = new LittleEndianReader();
         $this->ehFrameParser = new EhFrameParser($integer_reader);
@@ -91,21 +96,32 @@ final class ModuleEhFrameCache
      */
     private function loadModule(string $modulePath): ?array
     {
-        // Try loading .eh_frame from the binary itself
-        $fdes = $this->tryLoadEhFrame($modulePath);
-        if ($fdes !== null) {
-            $this->cache[$modulePath] = $fdes;
-            return $fdes;
-        }
-
-        // Fallback: try separate debug file
-        $debugFile = $this->debugFileLocator->locate($modulePath);
-        if ($debugFile !== null) {
-            $fdes = $this->tryLoadEhFrame($debugFile);
+        // Try loading from disk cache
+        $fingerprint = $this->getFingerprint($modulePath);
+        if ($fingerprint !== null) {
+            $fdes = $this->loadFromCache($fingerprint);
             if ($fdes !== null) {
                 $this->cache[$modulePath] = $fdes;
                 return $fdes;
             }
+        }
+
+        // Try loading .eh_frame from the binary itself
+        $fdes = $this->tryLoadEhFrame($modulePath);
+        if ($fdes === null) {
+            // Fallback: try separate debug file
+            $debugFile = $this->debugFileLocator->locate($modulePath);
+            if ($debugFile !== null) {
+                $fdes = $this->tryLoadEhFrame($debugFile);
+            }
+        }
+
+        if ($fdes !== null) {
+            $this->cache[$modulePath] = $fdes;
+            if ($fingerprint !== null) {
+                $this->saveToCache($fingerprint, $fdes);
+            }
+            return $fdes;
         }
 
         $this->noEhFrame[$modulePath] = true;
@@ -171,5 +187,134 @@ final class ModuleEhFrameCache
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    private function getFingerprint(string $modulePath): ?BinaryFingerprint
+    {
+        if ($this->memoryMap === null) {
+            return null;
+        }
+        $areas = $this->memoryMap->findByNameRegex(preg_quote($modulePath, '/'));
+        if ($areas === []) {
+            return null;
+        }
+        $area = $areas[0];
+        return new BinaryFingerprint(
+            join('_', [$area->device_id, $area->inode_num, $area->name])
+        );
+    }
+
+    /** @return array<Fde>|null */
+    private function loadFromCache(BinaryFingerprint $fingerprint): ?array
+    {
+        if ($this->binaryAnalysisCache === null) {
+            return null;
+        }
+        $cached = $this->binaryAnalysisCache->get($fingerprint, 'eh_frame_fdes');
+        if ($cached === null || !isset($cached['fdes']) || !is_array($cached['fdes'])) {
+            return null;
+        }
+        return $this->deserializeFdes($cached['fdes']);
+    }
+
+    /** @param array<Fde> $fdes */
+    private function saveToCache(BinaryFingerprint $fingerprint, array $fdes): void
+    {
+        if ($this->binaryAnalysisCache === null) {
+            return;
+        }
+        $this->binaryAnalysisCache->set($fingerprint, 'eh_frame_fdes', [
+            'fdes' => $this->serializeFdes($fdes),
+        ]);
+    }
+
+    /**
+     * @param array<Fde> $fdes
+     * @return array<array<string, mixed>>
+     */
+    private function serializeFdes(array $fdes): array
+    {
+        $cie_map = [];
+        $result = [];
+        foreach ($fdes as $fde) {
+            $cie_id = spl_object_id($fde->cie);
+            if (!isset($cie_map[$cie_id])) {
+                $cie_map[$cie_id] = count($cie_map);
+            }
+            $result[] = [
+                'il' => $fde->initialLocation,
+                'ar' => $fde->addressRange,
+                'ins' => base64_encode($fde->instructions),
+                'ci' => $cie_map[$cie_id],
+            ];
+        }
+
+        $cies = [];
+        foreach ($cie_map as $obj_id => $index) {
+            // Find any FDE referencing this CIE to get the actual object
+            foreach ($fdes as $fde) {
+                if (spl_object_id($fde->cie) === $obj_id) {
+                    $cie = $fde->cie;
+                    $cies[$index] = [
+                        'caf' => $cie->codeAlignmentFactor,
+                        'daf' => $cie->dataAlignmentFactor,
+                        'rar' => $cie->returnAddressRegister,
+                        'ii' => base64_encode($cie->initialInstructions),
+                        'aug' => $cie->augmentation,
+                        'fe' => $cie->fdeEncoding,
+                        'le' => $cie->lsdaEncoding,
+                        'pe' => $cie->personalityEncoding,
+                        'pa' => $cie->personalityAddress,
+                    ];
+                    break;
+                }
+            }
+        }
+
+        return ['cies' => $cies, 'fdes' => $result];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<Fde>|null
+     */
+    private function deserializeFdes(array $data): ?array
+    {
+        if (!isset($data['cies'], $data['fdes']) || !is_array($data['cies']) || !is_array($data['fdes'])) {
+            return null;
+        }
+
+        $cies = [];
+        foreach ($data['cies'] as $index => $cie_data) {
+            if (!is_array($cie_data)) {
+                return null;
+            }
+            $cies[$index] = new Cie(
+                codeAlignmentFactor: $cie_data['caf'],
+                dataAlignmentFactor: $cie_data['daf'],
+                returnAddressRegister: $cie_data['rar'],
+                initialInstructions: base64_decode($cie_data['ii']),
+                augmentation: $cie_data['aug'],
+                fdeEncoding: $cie_data['fe'],
+                lsdaEncoding: $cie_data['le'] ?? null,
+                personalityEncoding: $cie_data['pe'] ?? null,
+                personalityAddress: $cie_data['pa'] ?? null,
+            );
+        }
+
+        $fdes = [];
+        foreach ($data['fdes'] as $fde_data) {
+            if (!is_array($fde_data) || !isset($cies[$fde_data['ci']])) {
+                return null;
+            }
+            $fdes[] = new Fde(
+                initialLocation: $fde_data['il'],
+                addressRange: $fde_data['ar'],
+                instructions: base64_decode($fde_data['ins']),
+                cie: $cies[$fde_data['ci']],
+            );
+        }
+
+        return $fdes;
     }
 }

--- a/src/Lib/Dwarf/NativeSymbolResolver.php
+++ b/src/Lib/Dwarf/NativeSymbolResolver.php
@@ -17,6 +17,8 @@ use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\DebugFileLocator;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\SymbolResolver\Elf64ReverseSymbolResolver;
 use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\File\NativeFileReader;
@@ -44,6 +46,7 @@ final class NativeSymbolResolver
         ?PerfMapSymbolResolver $perfMapResolver = null,
         private string $processRoot = '',
         ?FileReaderInterface $fileReader = null,
+        private ?BinaryAnalysisCache $binaryAnalysisCache = null,
     ) {
         $this->elfParser = new Elf64Parser(new LittleEndianReader());
         $this->debugFileLocator = $debugFileLocator ?? new DebugFileLocator();
@@ -92,19 +95,64 @@ final class NativeSymbolResolver
 
     private function loadResolver(string $modulePath): ?Elf64ReverseSymbolResolver
     {
+        // Try loading from disk cache
+        $fingerprint = $this->getFingerprint($modulePath);
+        if ($fingerprint !== null) {
+            $resolver = $this->loadFromCache($fingerprint);
+            if ($resolver !== null) {
+                return $resolver;
+            }
+        }
+
         // Try loading from the binary itself
         $resolver = $this->tryLoadFromFile($modulePath);
-        if ($resolver !== null) {
-            return $resolver;
+        if ($resolver === null) {
+            // Fallback: try separate debug file for .symtab
+            $debugFile = $this->debugFileLocator->locate($modulePath);
+            if ($debugFile !== null) {
+                $resolver = $this->tryLoadFromFile($debugFile);
+            }
         }
 
-        // Fallback: try separate debug file for .symtab
-        $debugFile = $this->debugFileLocator->locate($modulePath);
-        if ($debugFile !== null) {
-            return $this->tryLoadFromFile($debugFile);
+        if ($resolver !== null && $fingerprint !== null) {
+            $this->saveToCache($fingerprint, $resolver);
         }
 
-        return null;
+        return $resolver;
+    }
+
+    private function getFingerprint(string $modulePath): ?BinaryFingerprint
+    {
+        $areas = $this->memoryMap->findByNameRegex(preg_quote($modulePath, '/'));
+        if ($areas === []) {
+            return null;
+        }
+        $area = $areas[0];
+        return new BinaryFingerprint(
+            join('_', [$area->device_id, $area->inode_num, $area->name])
+        );
+    }
+
+    private function loadFromCache(BinaryFingerprint $fingerprint): ?Elf64ReverseSymbolResolver
+    {
+        if ($this->binaryAnalysisCache === null) {
+            return null;
+        }
+        $cached = $this->binaryAnalysisCache->get($fingerprint, 'native_symbols');
+        if ($cached === null || !isset($cached['symbols']) || !is_array($cached['symbols'])) {
+            return null;
+        }
+        return Elf64ReverseSymbolResolver::fromArray($cached['symbols']);
+    }
+
+    private function saveToCache(BinaryFingerprint $fingerprint, Elf64ReverseSymbolResolver $resolver): void
+    {
+        if ($this->binaryAnalysisCache === null) {
+            return;
+        }
+        $this->binaryAnalysisCache->set($fingerprint, 'native_symbols', [
+            'symbols' => $resolver->toArray(),
+        ]);
     }
 
     private function resolvePath(string $path): string

--- a/src/Lib/Dwarf/NativeSymbolResolver.php
+++ b/src/Lib/Dwarf/NativeSymbolResolver.php
@@ -142,7 +142,9 @@ final class NativeSymbolResolver
         if ($cached === null || !isset($cached['symbols']) || !is_array($cached['symbols'])) {
             return null;
         }
-        return Elf64ReverseSymbolResolver::fromArray($cached['symbols']);
+        /** @var array<array{int, int, string}> $symbols */
+        $symbols = $cached['symbols'];
+        return Elf64ReverseSymbolResolver::fromArray($symbols);
     }
 
     private function saveToCache(BinaryFingerprint $fingerprint, Elf64ReverseSymbolResolver $resolver): void

--- a/src/Lib/Dwarf/NativeTraceCollector.php
+++ b/src/Lib/Dwarf/NativeTraceCollector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Dwarf;
 
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\File\NativeFileReader;
 use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
@@ -40,6 +41,7 @@ final class NativeTraceCollector
         private ProcessMemoryMapReader $memoryMapReader,
         private ProcessMemoryMapParser $memoryMapParser,
         private ?ProcessSymbolReaderInterface $phpSymbolReader = null,
+        private ?BinaryAnalysisCache $binaryAnalysisCache = null,
     ) {
     }
 
@@ -88,6 +90,8 @@ final class NativeTraceCollector
         $this->ehFrameCache = new ModuleEhFrameCache(
             processRoot: $process_root,
             fileReader: $file_reader,
+            binaryAnalysisCache: $this->binaryAnalysisCache,
+            memoryMap: $this->memoryMap,
         );
         $this->perfMapResolver = new PerfMapSymbolResolver($pid);
 
@@ -105,6 +109,7 @@ final class NativeTraceCollector
             perfMapResolver: $this->perfMapResolver,
             processRoot: $process_root,
             fileReader: $file_reader,
+            binaryAnalysisCache: $this->binaryAnalysisCache,
         );
         $this->cachedPid = $pid;
     }

--- a/src/Lib/Elf/Process/BinaryAnalysisCache.php
+++ b/src/Lib/Elf/Process/BinaryAnalysisCache.php
@@ -117,7 +117,11 @@ final class BinaryAnalysisCache
     private function saveIgbinary(BinaryFingerprint $fingerprint, string $namespace, array $data): void
     {
         $path = $this->getBasePath($fingerprint, $namespace) . '.igbinary';
-        $this->writeFile($path, igbinary_serialize($data));
+        $serialized = igbinary_serialize($data);
+        if ($serialized === false) {
+            return;
+        }
+        $this->writeFile($path, $serialized);
     }
 
     /** @param array<array-key, mixed> $data */

--- a/src/Lib/Elf/Process/BinaryAnalysisCache.php
+++ b/src/Lib/Elf/Process/BinaryAnalysisCache.php
@@ -18,10 +18,12 @@ use Reli\Lib\Directory\AppDirectory;
 final class BinaryAnalysisCache
 {
     private bool $enabled = true;
+    private bool $useIgbinary;
 
     public function __construct(
         private string $baseDirectory,
     ) {
+        $this->useIgbinary = extension_loaded('igbinary');
     }
 
     public function disable(): void
@@ -43,7 +45,56 @@ final class BinaryAnalysisCache
         if (!$this->enabled) {
             return null;
         }
-        $path = $this->getPath($fingerprint, $namespace);
+
+        // Try igbinary first, then JSON fallback
+        if ($this->useIgbinary) {
+            $data = $this->loadIgbinary($fingerprint, $namespace);
+            if ($data !== null) {
+                return $data;
+            }
+        }
+        return $this->loadJson($fingerprint, $namespace);
+    }
+
+    /** @param array<array-key, mixed> $data */
+    public function set(BinaryFingerprint $fingerprint, string $namespace, array $data): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+        if ($this->useIgbinary) {
+            $this->saveIgbinary($fingerprint, $namespace, $data);
+        } else {
+            $this->saveJson($fingerprint, $namespace, $data);
+        }
+    }
+
+    /** @return array<array-key, mixed>|null */
+    private function loadIgbinary(BinaryFingerprint $fingerprint, string $namespace): ?array
+    {
+        $path = $this->getBasePath($fingerprint, $namespace) . '.igbinary';
+        if (!is_file($path)) {
+            return null;
+        }
+        $content = @file_get_contents($path);
+        if ($content === false) {
+            return null;
+        }
+        try {
+            $data = igbinary_unserialize($content);
+        } catch (\Throwable) {
+            return null;
+        }
+        if (!is_array($data)) {
+            return null;
+        }
+        return $data;
+    }
+
+    /** @return array<array-key, mixed>|null */
+    private function loadJson(BinaryFingerprint $fingerprint, string $namespace): ?array
+    {
+        $path = $this->getBasePath($fingerprint, $namespace) . '.json';
         if (!is_file($path)) {
             return null;
         }
@@ -63,33 +114,41 @@ final class BinaryAnalysisCache
     }
 
     /** @param array<array-key, mixed> $data */
-    public function set(BinaryFingerprint $fingerprint, string $namespace, array $data): void
+    private function saveIgbinary(BinaryFingerprint $fingerprint, string $namespace, array $data): void
     {
-        if (!$this->enabled) {
-            return;
-        }
-        $path = $this->getPath($fingerprint, $namespace);
-        $dir = dirname($path);
-        AppDirectory::ensureDirectoryExists($dir);
+        $path = $this->getBasePath($fingerprint, $namespace) . '.igbinary';
+        $this->writeFile($path, igbinary_serialize($data));
+    }
 
-        $pid = getmypid();
-        $tmpPath = $path . '.tmp.' . ($pid !== false ? $pid : mt_rand());
+    /** @param array<array-key, mixed> $data */
+    private function saveJson(BinaryFingerprint $fingerprint, string $namespace, array $data): void
+    {
+        $path = $this->getBasePath($fingerprint, $namespace) . '.json';
         try {
-            $json = json_encode($data, JSON_THROW_ON_ERROR);
+            $encoded = json_encode($data, JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
             return;
         }
-        if (@file_put_contents($tmpPath, $json) === false) {
+        $this->writeFile($path, $encoded);
+    }
+
+    private function writeFile(string $path, string $content): void
+    {
+        $dir = dirname($path);
+        AppDirectory::ensureDirectoryExists($dir);
+        $pid = getmypid();
+        $tmpPath = $path . '.tmp.' . ($pid !== false ? $pid : mt_rand());
+        if (@file_put_contents($tmpPath, $content) === false) {
             return;
         }
         @rename($tmpPath, $path);
     }
 
-    private function getPath(BinaryFingerprint $fingerprint, string $namespace): string
+    private function getBasePath(BinaryFingerprint $fingerprint, string $namespace): string
     {
         return $this->baseDirectory
             . '/' . $fingerprint->getCacheKey()
-            . '/' . $namespace . '.json';
+            . '/' . $namespace;
     }
 
     private function removeDirectoryContents(string $dir): int

--- a/src/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolver.php
@@ -123,6 +123,20 @@ final class Elf64ReverseSymbolResolver
         }
     }
 
+    /** @return array<array{int, int, string}> */
+    public function toArray(): array
+    {
+        return $this->sortedSymbols;
+    }
+
+    /** @param array<array{int, int, string}> $symbols */
+    public static function fromArray(array $symbols): self
+    {
+        $resolver = new self();
+        $resolver->sortedSymbols = $symbols;
+        return $resolver;
+    }
+
     /**
      * @return array{string, int}|null [symbolName, offsetFromSymbolStart] or null
      */

--- a/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Dwarf;
+
+use PHPUnit\Framework\Attributes\Group;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\LinkMapLoader;
+use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\File\CatFileReader;
+use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\Libc\Errno\Errno;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
+use Reli\Lib\PhpInternals\Opcodes\OpcodeFactory;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
+use Reli\Lib\PhpProcessReader\CallTraceReader\TraceCache;
+use Reli\Lib\PhpProcessReader\CallTraceReader\TraceMerger;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapReader;
+use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
+use Reli\Lib\String\LineFetcher;
+use Reli\TargetPhpVmProvider;
+
+#[Group('frankenphp')]
+class FrankenPhpNativeTraceCollectorTest extends BaseTestCase
+{
+    /** @var resource|null */
+    private $child = null;
+
+    protected function tearDown(): void
+    {
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status)) {
+                if ($child_status['running']) {
+                    posix_kill($child_status['pid'], SIGKILL);
+                }
+            }
+        }
+    }
+
+    public function testNativeTraceCollectionFromFrankenPhp(): void
+    {
+        $docker_image_name = 'dunglas/frankenphp:php8.4';
+        $php_version = ZendTypeReader::V84;
+
+        $target_script =
+            <<<CODE
+            <?php
+            class A {
+                public function wait() {
+                    usleep(100000000);
+                }
+            }
+            \$object = new A;
+            fputs(STDOUT, "a\n");
+            \$object->wait();
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaFrankenPhpContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+        $child_status = proc_get_status($this->child);
+        $this->assertSame(true, $child_status['running']);
+
+        $target_php_settings = new TargetPhpSettings(
+            php_regex: '.*/libphp\.so$',
+            libpthread_regex: '.*/libc\.so.*',
+            php_version: $php_version,
+        );
+
+        // FrankenPHP runs PHP in a worker thread; try all threads to find
+        // the one with valid PHP executor globals
+        $tids = self::enumerateThreads($pid);
+        $this->assertNotEmpty($tids, 'Could not enumerate threads for the FrankenPHP process');
+
+        $php_tid = null;
+        $executor_globals_address = null;
+        $sapi_globals_address = null;
+        $last_error = '';
+
+        foreach ($tids as $tid) {
+            try {
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                );
+                $process_memory_map_creator = ProcessMemoryMapCreator::create();
+                $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+                    new ProcessModuleSymbolReaderCreator(
+                        new Elf64SymbolResolverCreator(
+                            new CatFileReader(),
+                            new Elf64Parser(
+                                new LittleEndianReader()
+                            )
+                        ),
+                        new MemoryReader(),
+                        new PerBinarySymbolCacheRetriever(),
+                        new LittleEndianReader(),
+                        new LinkMapLoader(
+                            new MemoryReader(),
+                            new LittleEndianReader()
+                        ),
+                        new ContainerAwarePathResolver(),
+                        $binary_analysis_cache,
+                    ),
+                    $process_memory_map_creator,
+                    $binary_analysis_cache,
+                );
+                $integer_reader = new LittleEndianReader();
+                $memory_reader_for_finder = new MemoryReader();
+                $tsrm_globals_resolver = new TsrmGlobalsResolver(
+                    $php_symbol_reader_creator,
+                    $integer_reader,
+                    $memory_reader_for_finder,
+                    $binary_analysis_cache,
+                    $process_memory_map_creator,
+                );
+                $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+                    $php_symbol_reader_creator,
+                    $tsrm_globals_resolver,
+                    $memory_reader_for_finder,
+                    $integer_reader,
+                    new Elf64Parser($integer_reader),
+                    new CatFileReader(),
+                    ProcessMemoryMapCreator::create(),
+                    new ContainerAwarePathResolver(),
+                    new ZendTypeReaderCreator(),
+                    $binary_analysis_cache,
+                );
+                $php_globals_finder = new PhpGlobalsFinder(
+                    $php_symbol_reader_creator,
+                    $integer_reader,
+                    $memory_reader_for_finder,
+                    $tsrm_ls_cache_finder,
+                    $tsrm_globals_resolver,
+                    $binary_analysis_cache,
+                    $process_memory_map_creator,
+                );
+
+                $eg_addr = $php_globals_finder->findExecutorGlobals(
+                    new ProcessSpecifier($tid),
+                    $target_php_settings,
+                );
+                $sg_addr = $php_globals_finder->findSAPIGlobals(
+                    new ProcessSpecifier($tid),
+                    $target_php_settings,
+                );
+
+                $php_tid = $tid;
+                $executor_globals_address = $eg_addr;
+                $sapi_globals_address = $sg_addr;
+                break;
+            } catch (\Throwable $e) {
+                $last_error = "TID {$tid}: " . get_class($e) . ': ' . $e->getMessage();
+                continue;
+            }
+        }
+
+        $this->assertNotNull(
+            $php_tid,
+            "Could not find a thread with valid PHP executor globals.\n"
+            . "pid={$pid}, tids=[" . implode(',', $tids) . "]\n"
+            . "last_error: {$last_error}"
+        );
+
+        // Stop the PHP worker thread for GETREGS
+        $ptrace = new PtraceX64();
+        $process_stopper = new ProcessStopper($ptrace, new Errno());
+        $this->assertTrue($process_stopper->stop($php_tid));
+
+        try {
+            // Collect native trace
+            $memory_reader = new MemoryReader();
+            $map_reader = new ProcessMemoryMapReader(
+                new CatFileReader()
+            );
+            $map_parser = new ProcessMemoryMapParser(
+                new LineFetcher()
+            );
+            $collector = new NativeTraceCollector(
+                $ptrace,
+                $memory_reader,
+                $map_reader,
+                $map_parser,
+            );
+            $collector->refreshMemoryMap($php_tid);
+            $native_trace = $collector->collect($php_tid);
+
+            // Native trace should be non-null
+            $this->assertNotNull(
+                $native_trace,
+                'Native trace should be collected from FrankenPHP worker thread'
+            );
+            $this->assertGreaterThan(
+                0,
+                count($native_trace->frames),
+                'Should have at least one native frame'
+            );
+
+            // Should contain at least one frame with a resolved symbol name
+            $symbol_names = array_filter(
+                array_map(
+                    fn(NativeFrame $f) => $f->symbolName,
+                    $native_trace->frames,
+                )
+            );
+            $this->assertNotEmpty(
+                $symbol_names,
+                'At least one frame should have a symbol name resolved'
+            );
+
+            // Log frame details for debugging
+            $frame_details = [];
+            foreach ($native_trace->frames as $i => $frame) {
+                $frame_details[] = sprintf(
+                    '#%d %s+0x%x (%s)',
+                    $i,
+                    $frame->symbolName ?? '??',
+                    $frame->offset,
+                    $frame->moduleName ?? '??',
+                );
+            }
+            fwrite(STDERR, "\n=== FrankenPHP Native Trace ===\n");
+            fwrite(STDERR, implode("\n", $frame_details) . "\n");
+            fwrite(STDERR, "=== End Native Trace ===\n\n");
+
+            // Also get PHP trace and test merge
+            $call_trace_reader = new CallTraceReader(
+                $memory_reader,
+                new ZendTypeReaderCreator(),
+                new OpcodeFactory()
+            );
+            $call_trace = $call_trace_reader->readCallTrace(
+                $php_tid,
+                $php_version,
+                $executor_globals_address,
+                $sapi_globals_address,
+                PHP_INT_MAX,
+                new TraceCache(),
+            );
+
+            if ($call_trace !== null) {
+                // Log PHP trace for debugging
+                $php_frames = [];
+                foreach ($call_trace->call_frames as $i => $frame) {
+                    $php_frames[] = sprintf(
+                        '#%d %s',
+                        $i,
+                        $frame->getFullyQualifiedFunctionName(),
+                    );
+                }
+                fwrite(STDERR, "\n=== FrankenPHP PHP Trace ===\n");
+                fwrite(STDERR, implode("\n", $php_frames) . "\n");
+                fwrite(STDERR, "=== End PHP Trace ===\n\n");
+
+                // Test merge
+                $merger = new TraceMerger();
+                $merged = $merger->merge($native_trace, $call_trace);
+                $this->assertGreaterThan(
+                    0,
+                    count($merged->frames),
+                    'Merged trace should have frames'
+                );
+
+                // Log merged trace
+                $merged_details = [];
+                foreach ($merged->frames as $i => $frame) {
+                    $merged_details[] = sprintf(
+                        '#%d [%s] %s',
+                        $i,
+                        $frame->isNative() ? 'native' : 'php',
+                        $frame->isNative()
+                            ? ($frame->nativeFrame->symbol_name ?? '??')
+                            : $frame->phpFrame->getFullyQualifiedFunctionName(),
+                    );
+                }
+                fwrite(STDERR, "\n=== FrankenPHP Merged Trace ===\n");
+                fwrite(STDERR, implode("\n", $merged_details) . "\n");
+                fwrite(STDERR, "=== End Merged Trace ===\n\n");
+            }
+        } finally {
+            $process_stopper->resume($php_tid);
+        }
+    }
+
+    /**
+     * Enumerate all thread IDs for the process group containing the given PID/TID.
+     * @return int[]
+     */
+    private static function enumerateThreads(int $pid): array
+    {
+        $tgid = self::findTgidFromTid($pid);
+        $task_dir = "/proc/{$tgid}/task";
+        if (!is_dir($task_dir)) {
+            return [];
+        }
+        $tids = scandir($task_dir);
+        if ($tids === false) {
+            return [];
+        }
+        $result = [];
+        foreach ($tids as $tid) {
+            if ($tid === '.' || $tid === '..') {
+                continue;
+            }
+            $result[] = (int)$tid;
+        }
+        return $result;
+    }
+
+    private static function findTgidFromTid(int $tid): int
+    {
+        $status = @file_get_contents("/proc/{$tid}/status");
+        if ($status !== false && preg_match('/^Tgid:\s+(\d+)/m', $status, $matches)) {
+            return (int)$matches[1];
+        }
+        return $tid;
+    }
+}

--- a/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
@@ -37,6 +37,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapReader;
@@ -139,12 +140,14 @@ class FrankenPhpNativeTraceCollectorTest extends BaseTestCase
                 );
                 $integer_reader = new LittleEndianReader();
                 $memory_reader_for_finder = new MemoryReader();
+                $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
                 $tsrm_globals_resolver = new TsrmGlobalsResolver(
                     $php_symbol_reader_creator,
                     $integer_reader,
                     $memory_reader_for_finder,
                     $binary_analysis_cache,
                     $process_memory_map_creator,
+                    $binary_fingerprint_creator,
                 );
                 $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
                     $php_symbol_reader_creator,
@@ -157,6 +160,7 @@ class FrankenPhpNativeTraceCollectorTest extends BaseTestCase
                     new ContainerAwarePathResolver(),
                     new ZendTypeReaderCreator(),
                     $binary_analysis_cache,
+                    $binary_fingerprint_creator,
                 );
                 $php_globals_finder = new PhpGlobalsFinder(
                     $php_symbol_reader_creator,
@@ -166,6 +170,7 @@ class FrankenPhpNativeTraceCollectorTest extends BaseTestCase
                     $tsrm_globals_resolver,
                     $binary_analysis_cache,
                     $process_memory_map_creator,
+                    $binary_fingerprint_creator,
                 );
 
                 $eg_addr = $php_globals_finder->findExecutorGlobals(

--- a/tests/Lib/Dwarf/ModuleEhFrameCacheTest.php
+++ b/tests/Lib/Dwarf/ModuleEhFrameCacheTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace Reli\Lib\Dwarf;
 
 use Reli\BaseTestCase;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 
 class ModuleEhFrameCacheTest extends BaseTestCase
 {
@@ -71,5 +75,129 @@ class ModuleEhFrameCacheTest extends BaseTestCase
 
         // Should return same array (cached)
         $this->assertSame($fdes1, $fdes2);
+    }
+
+    private function makeMemoryMapForPhpBinary(): ProcessMemoryMap
+    {
+        $maps_raw = file_get_contents('/proc/self/maps');
+        $parser = new \Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser(
+            new \Reli\Lib\String\LineFetcher()
+        );
+        return $parser->parse($maps_raw);
+    }
+
+    public function testDiskCacheRoundtrip(): void
+    {
+        $cache_dir = sys_get_temp_dir() . '/reli-test-ehframe-' . uniqid();
+        $memoryMap = $this->makeMemoryMapForPhpBinary();
+
+        try {
+            // Cold: parse from binary, write to disk cache
+            $binary_cache = new BinaryAnalysisCache($cache_dir);
+            $cache1 = new ModuleEhFrameCache(
+                binaryAnalysisCache: $binary_cache,
+                memoryMap: $memoryMap,
+            );
+            $fdes_original = $cache1->getFdesForModule(PHP_BINARY);
+            $this->assertNotNull($fdes_original);
+            $this->assertGreaterThan(100, count($fdes_original));
+
+            // Warm: load from disk cache (new instance, no in-memory cache)
+            $binary_cache2 = new BinaryAnalysisCache($cache_dir);
+            $cache2 = new ModuleEhFrameCache(
+                binaryAnalysisCache: $binary_cache2,
+                memoryMap: $memoryMap,
+            );
+            $fdes_cached = $cache2->getFdesForModule(PHP_BINARY);
+            $this->assertNotNull($fdes_cached);
+
+            // Same count
+            $this->assertCount(count($fdes_original), $fdes_cached);
+
+            // Spot-check: same initial locations and address ranges
+            for ($i = 0; $i < min(10, count($fdes_original)); $i++) {
+                $this->assertSame(
+                    $fdes_original[$i]->initialLocation,
+                    $fdes_cached[$i]->initialLocation,
+                    "FDE[$i] initialLocation mismatch"
+                );
+                $this->assertSame(
+                    $fdes_original[$i]->addressRange,
+                    $fdes_cached[$i]->addressRange,
+                    "FDE[$i] addressRange mismatch"
+                );
+                $this->assertSame(
+                    $fdes_original[$i]->instructions,
+                    $fdes_cached[$i]->instructions,
+                    "FDE[$i] instructions mismatch"
+                );
+                $this->assertSame(
+                    $fdes_original[$i]->cie->codeAlignmentFactor,
+                    $fdes_cached[$i]->cie->codeAlignmentFactor,
+                    "FDE[$i] CIE codeAlignmentFactor mismatch"
+                );
+                $this->assertSame(
+                    $fdes_original[$i]->cie->dataAlignmentFactor,
+                    $fdes_cached[$i]->cie->dataAlignmentFactor,
+                    "FDE[$i] CIE dataAlignmentFactor mismatch"
+                );
+            }
+
+            // FDE lookup should work the same
+            $target_addr = $fdes_original[5]->initialLocation + 1;
+            $found_original = $cache1->findFdeForAddress(PHP_BINARY, $target_addr);
+            $found_cached = $cache2->findFdeForAddress(PHP_BINARY, $target_addr);
+            $this->assertNotNull($found_original);
+            $this->assertNotNull($found_cached);
+            $this->assertSame($found_original->initialLocation, $found_cached->initialLocation);
+        } finally {
+            exec('rm -rf ' . escapeshellarg($cache_dir));
+        }
+    }
+
+    public function testCieSharing(): void
+    {
+        $cache_dir = sys_get_temp_dir() . '/reli-test-ehframe-cie-' . uniqid();
+        $memoryMap = $this->makeMemoryMapForPhpBinary();
+
+        try {
+            // Write to cache
+            $binary_cache = new BinaryAnalysisCache($cache_dir);
+            $cache1 = new ModuleEhFrameCache(
+                binaryAnalysisCache: $binary_cache,
+                memoryMap: $memoryMap,
+            );
+            $fdes_original = $cache1->getFdesForModule(PHP_BINARY);
+            $this->assertNotNull($fdes_original);
+
+            // After deserialization, FDEs sharing the same CIE should still share
+            $binary_cache2 = new BinaryAnalysisCache($cache_dir);
+            $cache2 = new ModuleEhFrameCache(
+                binaryAnalysisCache: $binary_cache2,
+                memoryMap: $memoryMap,
+            );
+            $fdes_cached = $cache2->getFdesForModule(PHP_BINARY);
+            $this->assertNotNull($fdes_cached);
+
+            // Find two FDEs that share the same CIE in the original
+            $shared_cie_fdes = [];
+            foreach ($fdes_original as $i => $fde) {
+                $cie_id = spl_object_id($fde->cie);
+                $shared_cie_fdes[$cie_id][] = $i;
+            }
+            foreach ($shared_cie_fdes as $indices) {
+                if (count($indices) >= 2) {
+                    // In the cached version, these should also share the same CIE instance
+                    $this->assertSame(
+                        spl_object_id($fdes_cached[$indices[0]]->cie),
+                        spl_object_id($fdes_cached[$indices[1]]->cie),
+                        'FDEs should share CIE instance after deserialization'
+                    );
+                    break;
+                }
+            }
+        } finally {
+            exec('rm -rf ' . escapeshellarg($cache_dir));
+        }
     }
 }

--- a/tests/Lib/Dwarf/NativeSymbolResolverTest.php
+++ b/tests/Lib/Dwarf/NativeSymbolResolverTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Dwarf;
 
 use Reli\BaseTestCase;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
@@ -115,5 +116,39 @@ class NativeSymbolResolverTest extends BaseTestCase
             $resolver->resolve($addr);
         }
         $this->assertTrue(true); // no crash
+    }
+
+    public function testDiskCacheRoundtrip(): void
+    {
+        $maps_raw = file_get_contents('/proc/self/maps');
+        $parser = new \Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser(
+            new \Reli\Lib\String\LineFetcher()
+        );
+        $map = $parser->parse($maps_raw);
+
+        $cache_dir = sys_get_temp_dir() . '/reli-test-natsym-' . uniqid();
+
+        try {
+            // Cold: resolve from binary, write to cache
+            $cache1 = new BinaryAnalysisCache($cache_dir);
+            $resolver1 = new NativeSymbolResolver($map, binaryAnalysisCache: $cache1);
+
+            $areas = $map->findByNameRegex('php');
+            if ($areas === []) {
+                $this->markTestSkipped('No php binary in memory map');
+            }
+            $addr = hexdec($areas[0]->begin) + 0x100;
+            $result1 = $resolver1->resolve($addr);
+
+            // Warm: new resolver, should load from disk cache
+            $cache2 = new BinaryAnalysisCache($cache_dir);
+            $resolver2 = new NativeSymbolResolver($map, binaryAnalysisCache: $cache2);
+            $result2 = $resolver2->resolve($addr);
+
+            // Same result
+            $this->assertSame($result1, $result2);
+        } finally {
+            exec('rm -rf ' . escapeshellarg($cache_dir));
+        }
     }
 }

--- a/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
+++ b/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
@@ -191,4 +191,35 @@ class Elf64ReverseSymbolResolverTest extends BaseTestCase
         $this->assertNotNull($result);
         $this->assertSame('my_func', $result[0]);
     }
+
+    public function testToArrayFromArrayRoundtrip(): void
+    {
+        $string_data = "\0alpha\0beta\0gamma\0";
+        $string_table = new Elf64StringTable($string_data);
+        $symbol_table = new Elf64SymbolTable(
+            $this->makeEntry(1, 0x3000, 0x50),     // alpha
+            $this->makeEntry(7, 0x1000, 0x200),     // beta
+            $this->makeEntry(12, 0x2000, 0x100),    // gamma
+        );
+
+        $original = Elf64ReverseSymbolResolver::fromSymbolTableAndStringTable($symbol_table, $string_table);
+
+        // Roundtrip
+        $array = $original->toArray();
+        $restored = Elf64ReverseSymbolResolver::fromArray($array);
+
+        // Same resolve results
+        $this->assertSame($original->resolve(0x1000), $restored->resolve(0x1000)); // beta exact
+        $this->assertSame($original->resolve(0x1100), $restored->resolve(0x1100)); // beta +0x100
+        $this->assertSame($original->resolve(0x2050), $restored->resolve(0x2050)); // gamma +0x50
+        $this->assertSame($original->resolve(0x3000), $restored->resolve(0x3000)); // alpha exact
+        $this->assertSame($original->resolve(0x500),  $restored->resolve(0x500));  // before all → null
+        $this->assertSame($original->resolve(0x1200), $restored->resolve(0x1200)); // past beta → null
+    }
+
+    public function testFromArrayEmpty(): void
+    {
+        $resolver = Elf64ReverseSymbolResolver::fromArray([]);
+        $this->assertNull($resolver->resolve(0x1000));
+    }
 }

--- a/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
+++ b/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
@@ -213,7 +213,7 @@ class Elf64ReverseSymbolResolverTest extends BaseTestCase
         $this->assertSame($original->resolve(0x1100), $restored->resolve(0x1100)); // beta +0x100
         $this->assertSame($original->resolve(0x2050), $restored->resolve(0x2050)); // gamma +0x50
         $this->assertSame($original->resolve(0x3000), $restored->resolve(0x3000)); // alpha exact
-        $this->assertSame($original->resolve(0x500),  $restored->resolve(0x500));  // before all → null
+        $this->assertSame($original->resolve(0x500), $restored->resolve(0x500));  // before all → null
         $this->assertSame($original->resolve(0x1200), $restored->resolve(0x1200)); // past beta → null
     }
 


### PR DESCRIPTION
## Summary
This PR adds persistent disk caching for expensive ELF symbol resolution and DWARF frame data parsing operations. The cache uses binary fingerprints (device ID, inode, and path) to identify binaries and supports both igbinary (if available) and JSON serialization formats for maximum compatibility.

## Key Changes

- **BinaryAnalysisCache enhancements**: Added `set()` method and dual serialization support (igbinary with JSON fallback) to improve performance and compatibility
  
- **ModuleEhFrameCache caching**: Integrated disk caching for parsed `.eh_frame` FDE (Frame Description Entry) data with proper CIE (Common Information Entry) sharing preservation during serialization/deserialization

- **NativeSymbolResolver caching**: Added disk caching for resolved native symbols from ELF symbol tables to avoid re-parsing on subsequent runs

- **Elf64ReverseSymbolResolver serialization**: Added `toArray()` and `fromArray()` methods to enable symbol table serialization for caching

- **NativeTraceCollector improvements**: Enhanced to support optional disk caching via BinaryAnalysisCache and ProcessMemoryMap parameters

- **Comprehensive test coverage**: Added tests for disk cache roundtrips, CIE sharing preservation, and symbol resolution caching

## Implementation Details

- Cache keys are based on binary fingerprints combining device ID, inode number, and file path to handle binary updates correctly
- Serialization preserves object identity relationships (e.g., multiple FDEs sharing the same CIE instance)
- Graceful fallback to JSON when igbinary extension is unavailable
- Atomic file writes using temporary files to prevent corruption
- All caching is optional and can be disabled without affecting functionality
- Added FrankenPHP integration test to validate native trace collection from multi-threaded PHP environments

https://claude.ai/code/session_01ATjT5ddDw9mvddUMG3NTVr