### PR TITLE
Fix -S flag parsing and add mod_php integration test

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run unit tests
         run: |
           mkdir -p build/logs
-          vendor/bin/phpunit --exclude-group target-version,frankenphp --coverage-clover build/logs/clover.xml
+          vendor/bin/phpunit --exclude-group target-version,frankenphp,mod_php --coverage-clover build/logs/clover.xml
 
       - name: Send to coveralls
         uses: coverallsapp/github-action@v2

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -238,6 +238,36 @@ Key observations:
 - `zend_function` and `zend_string` are stable during a request (not GC'd),
   so the inconsistency risk between Pass 1 and Pass 2 is negligible
 
+### Configuration Considerations
+
+The bulk copy approach should be opt-in or configurable, because:
+
+- **Large VM stacks**: deeply recursive code, heavily nested generators, or
+  frameworks with very deep call chains can push `vm_stack_usage` well beyond
+  the typical ~9KB. If the used portion spans many pages, the bulk copy cost
+  grows linearly (~430ns per page) and could exceed the benefit
+- **Multiple stack segments**: `ZendVmStack` segments are linked via `prev`.
+  Usually only the current segment matters, but edge cases may span multiple
+  segments
+- **Trade-off awareness**: the benefit (consistency without `-S`) vs cost
+  (extra memory copy per sample) is only meaningful at high sampling rates.
+  At the default 100Hz, even 174 individual readv calls fit within the 10ms
+  budget with room to spare
+
+Possible option design:
+
+```
+--bulk-stack-copy[=<max-size>]
+```
+
+- Not specified: current per-field behavior (safe default)
+- `--bulk-stack-copy`: enable with a sensible default max (e.g., 64KB)
+- `--bulk-stack-copy=256K`: enable with explicit max size; if actual usage
+  exceeds this, fall back to per-field reads
+
+This way advanced users who understand the consistency trade-offs can enable
+it, while the default behavior remains unchanged.
+
 ### Expected Impact
 
 - **Consistency**: window shrinks from ~3,480us to ~1-4us, potentially making

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -1,200 +1,211 @@
 # Trace Consistency and Sampling Bias Investigation
 
-`--stop-process` (`-S`) オプションの有無がトレースの整合性とサンプリング分布に与える影響の調査。
-reli on reli (自己プロファイリング) および phpspy との比較で得られた知見をまとめる。
+Investigation of how the `--stop-process` (`-S`) option affects trace consistency and
+sampling distribution. Findings obtained through reli-on-reli self-profiling and
+comparison with phpspy.
 
-## 背景
+## Background
 
-reli のサンプリングプロファイラには 2 つのモードがある:
+reli's sampling profiler has two modes:
 
-- **`-S` なし**: `process_vm_readv` でターゲットのメモリを直接読む (ターゲットは動き続ける)
-- **`-S` あり**: `PTRACE_ATTACH` (`SIGSTOP`) でターゲットを一時停止してからメモリを読む
+- **Without `-S`**: reads target memory via `process_vm_readv` while the target keeps running
+- **With `-S`**: pauses the target via `PTRACE_ATTACH` (`SIGSTOP`) before reading memory
 
-## 発見 1: `-S` フラグの VALUE_OPTIONAL バグ (修正済み)
+## Finding 1: `-S` Flag VALUE_OPTIONAL Bug (Fixed)
 
-`-S` を値なしで渡すと Symfony Console の `VALUE_OPTIONAL` が `null` を返し、
-コード上 `null` → `false` に変換されて **`-S` が無視されていた**。
+When `-S` was passed without an explicit value, Symfony Console's `VALUE_OPTIONAL`
+returned `null`, which the code converted to `false` — **silently ignoring the flag**.
 
 ```
--S       → false (バグ: 効かない)
--S=1     → true
+-S               → false (bug: no effect)
+-S=1             → true
 --stop-process=1 → true
-未指定    → false
+not specified    → false
 ```
 
-`hasParameterOption()` でフラグの存在を検出する形に修正。
-修正後、`-S` で truncated フレーム (internal 関数が 1 フレームだけ出る現象) が 0 になることを確認。
+Fixed by using `hasParameterOption()` to detect the flag's presence without a value.
+After the fix, `-S` eliminates truncated frames (internal functions appearing as
+single-frame samples) as expected.
 
-## 発見 2: PTRACE_ATTACH の SIGSTOP サンプリングバイアス
+## Finding 2: PTRACE_ATTACH SIGSTOP Sampling Bias
 
-### 現象
+### Observation
 
-reli on reli で inner reli を `-S` ありでプロファイルすると、
-`/proc/pid/stat` から計測した実際の user:sys 比率とサンプル分布が大きく乖離する。
+When profiling inner reli with `-S` enabled, the measured user:sys ratio from
+`/proc/pid/stat` and the sample distribution diverge significantly.
 
 ```
-実測 (bash time / /proc/pid/stat):
+Actual (bash time / /proc/pid/stat):
   user: 81%,  sys: 19%
 
-サンプル分布 (-S あり, PHP フレーム):
+Sample distribution (-S on, PHP frames):
   process_vm_readv (FFI/syscall): 68%
   PHP userland:                   30%
 
-サンプル分布 (-S あり, ネイティブフレーム):
+Sample distribution (-S on, native frames):
   libc::process_vm_readv:          92%
   PHP userland:                     6%
 ```
 
-### 原因
+### Cause
 
-`PTRACE_ATTACH` は `SIGSTOP` をターゲットに送るが、カーネルは `SIGSTOP` を
-**syscall 境界またはスケジューラの切り替え点** で配送する。
-ターゲットが user mode で PHP バイトコードを実行中は `SIGSTOP` の配送が遅延し、
-次の syscall (FFI 経由の `process_vm_readv` 等) に入った時点で停止する。
+`PTRACE_ATTACH` sends `SIGSTOP` to the target, but the kernel delivers `SIGSTOP`
+at **syscall boundaries or scheduler preemption points**. While the target is in
+user mode executing PHP bytecode, `SIGSTOP` delivery is deferred until the next
+syscall entry (e.g., FFI-based `process_vm_readv`).
 
-結果として **syscall 内で停止するサンプルが系統的に過大に出る**。
+This causes **systematic oversampling of syscall-internal states**.
 
-### phpspy での検証
+### Verification with phpspy
 
-phpspy の `-S` (pause-process) オプションでも同じ傾向を確認:
-
-```
-phpspy -S なし:  process_vm_readv = 12%,  PHP userland = 88%
-phpspy -S あり:  process_vm_readv = 92%,  PHP userland =  8%
-```
-
-`-S` を入れた瞬間に reli on reli と同じ傾向になる。
-`PTRACE_ATTACH` + `SIGSTOP` というメカニズム自体の制約。
-
-## 発見 3: `-S` なしの reli on reli では逆方向のバイアス
-
-### 現象
-
-reli on reli で `-S` なしにすると、`process_vm_readv` が frame 0 に **一切出ない**。
+phpspy's `-S` (pause-process) option exhibits the same bias:
 
 ```
-reli -S なし:
+phpspy without -S:  process_vm_readv = 12%,  PHP userland = 88%
+phpspy with -S:     process_vm_readv = 92%,  PHP userland =  8%
+```
+
+Enabling `-S` immediately shifts the distribution to match reli-on-reli results.
+This confirms the bias is inherent to the `PTRACE_ATTACH` + `SIGSTOP` mechanism,
+not specific to reli.
+
+## Finding 3: Without `-S`, reli-on-reli Shows Reverse Bias
+
+### Observation
+
+Profiling inner reli without `-S` causes `process_vm_readv` to **completely
+disappear** from frame 0.
+
+```
+reli without -S:
   process_vm_readv:   0%
   PHP userland:      61%
-  壊れ (<unknown>/<internal>/truncated): 23%
+  broken (<unknown>/<internal>/truncated): 23%
 ```
 
-### 原因
+### Cause
 
-inner reli が FFI 内 (C コード実行中) にいるとき、`current_execute_data` は
-FFI フレームを指している。しかし outer reli が PHP で遅い読み取りをしている間に
-inner は FFI から戻って `current_execute_data` が変わってしまう。
-結果として FFI フレームを整合的に読めず `<internal>` や `<unknown>` として壊れるか、
-FFI から戻った後の PHP フレームを読む。
+When inner reli is inside an FFI call (C code), `current_execute_data` points to
+the FFI call frame. However, outer reli's PHP-based memory reading is too slow —
+by the time it finishes reading, inner has already returned from FFI and
+`current_execute_data` has changed. The FFI frame is either read inconsistently
+(appearing as `<internal>` or `<unknown>`) or missed entirely.
 
-**読み取り速度が遅いと、速い処理 (syscall) のサンプルが系統的に欠落する。**
+**Slow reads cause fast operations (syscalls) to be systematically dropped.**
 
-## 発見 4: phpspy -S なしだけが両立
+## Finding 4: Only phpspy Without `-S` Achieves Both Accuracy and Consistency
 
 ```
-                    サンプル分布の正確さ    スタック整合性    壊れ率
-phpspy -S なし              正確               高           ~0%
-phpspy -S あり          syscall に偏る          高           ~0%
-reli -S あり            syscall に偏る          高           ~2%
-reli -S なし           userland に偏る          低          ~23%
+                    Distribution accuracy    Stack consistency    Broken rate
+phpspy without -S        Accurate                High               ~0%
+phpspy with -S        Biased to syscalls          High               ~0%
+reli with -S          Biased to syscalls          High               ~2%
+reli without -S       Biased to userland          Low               ~23%
 ```
 
-phpspy -S なしが唯一「分布が正確 + 整合性も OK」を両立できている理由は、
-C で高速にスタックを読み切れるため、ターゲットのスタックが変わる前にスナップショットが取れるから。
+phpspy without `-S` is the only configuration that achieves both accurate
+distribution and high consistency. This is because C-native reads complete fast
+enough to snapshot the stack before the target's state changes.
 
-## スループットとコスト比較
+## Throughput and Cost Comparison
 
-### スタック深さとスループット (sleep=0, -S なし)
+### Throughput by Stack Depth (sleep=0, no -S)
 
 ```
                     reli                    phpspy
-              readv/loop  loops/s     readv/loop  loops/s     倍率
+              readv/loop  loops/s     readv/loop  loops/s     ratio
 Shallow(3)          9       735            ~3    10,240       x14
 Deep(22)           37       225            ~4     6,947       x31
 Laravel(75)       174        53            ~5     1,892       x36
 ```
 
-readv の総呼び出し回数はほぼ同じ (~27,000-29,000/3s)。
-スループット差の本質は readv 間の PHP オーバーヘッド (FFI 呼び出し、Pointer 生成、型解決等)。
+Total readv call counts are similar (~27,000-29,000/3s).
+The throughput gap is dominated by PHP overhead between readv calls
+(FFI invocation, Pointer construction, type resolution, etc.).
 
-### 1 トレースあたりの CPU 時間 (Laravel 75 frames)
+### CPU Time per Trace (Laravel 75 frames)
 
 ```
               user/trace    sys/trace    total/trace    user:sys
-phpspy         0.19ms        0.30ms        0.50ms       0.65:1 (sys 支配)
-reli           0.81ms        0.15ms        0.96ms       5.3:1  (user 支配)
+phpspy         0.19ms        0.30ms        0.50ms       0.65:1 (sys-dominated)
+reli           0.81ms        0.15ms        0.96ms       5.3:1  (user-dominated)
 ```
 
-CPU/trace の差は約 2 倍。スループット差 (36x) に比べて小さい。
+CPU per trace differs by ~2x. Much smaller than the throughput gap (36x).
 
-### readv のサイズ別コスト
-
-```
-      8 bytes: 0.7 μs/call
-     64 bytes: 0.7 μs/call
-   4096 bytes: 0.8 μs/call
-  65536 bytes: 0.7 μs/call
- 262144 bytes: 0.8 μs/call
-```
-
-`process_vm_readv` はサイズにほぼ依存しない。
-
-## 改善案: VM スタック一括コピー
-
-### 現状の整合性ウィンドウ
+### readv Cost by Transfer Size
 
 ```
-reli (current):  最初の readv → 最後の readv = ~3,480 μs
-phpspy:          最初の readv → 最後の readv = ~500 μs
-1回の bulk readv: ~0.7 μs
+      8 bytes: 0.7 us/call
+     64 bytes: 0.7 us/call
+   4096 bytes: 0.8 us/call
+  65536 bytes: 0.7 us/call
+ 262144 bytes: 0.8 us/call
 ```
 
-### 2-pass scatter-gather 方式
+`process_vm_readv` cost is nearly independent of transfer size.
 
-1. **Pass 1**: VM スタックを 1 回の `process_vm_readv` で一括コピー (~64KB, ~0.7μs)
-   - ローカルで `execute_data` チェーンをパース
-   - `func`, `opline` 等のヒープ上ポインタを収集
-2. **Pass 2**: 収集したポインタを scatter-gather iovec で一括読み取り (~0.7μs)
-   - `IOV_MAX` = 1024、75 フレームで ~300-450 iovec なので収まる
+## Proposed Improvement: Bulk VM Stack Copy
 
-合計 2 syscall, 整合性ウィンドウ ~1.4μs + ローカル処理時間。
+### Current Consistency Windows
 
-### 実装の見通し
+```
+reli (current):   first readv to last readv = ~3,480 us
+phpspy:           first readv to last readv = ~500 us
+single bulk readv: ~0.7 us
+```
 
-`MemoryReaderInterface` がきれいに抽象化されているため、
-**バッファ付きデコレータを 1 クラス追加** するだけで実現可能な可能性がある。
+### 2-Pass Scatter-Gather Approach
+
+1. **Pass 1**: bulk-copy the VM stack in a single `process_vm_readv` (~64KB, ~0.7us)
+   - Parse `execute_data` chain locally
+   - Collect all heap pointers (`func`, `opline`, string addresses)
+2. **Pass 2**: scatter-gather read all heap data in a single `process_vm_readv` (~0.7us)
+   - `IOV_MAX` = 1024; 75 frames need ~300-450 iovecs, well within the limit
+
+Total: 2 syscalls, ~1.4us consistency window + local processing time.
+
+### Implementation Outlook
+
+`MemoryReaderInterface` is cleanly abstracted, so a **buffered decorator** may
+be sufficient with no changes to existing types:
 
 ```php
 class BufferedMemoryReader implements MemoryReaderInterface {
     public function prefetch(int $pid, int $address, int $size): void {
-        // VM スタックを一括コピー
+        // Bulk-copy VM stack in one process_vm_readv call
     }
 
     public function read(int $pid, int $address, int $size): CData {
-        if (/* address がバッファ範囲内 */) {
-            return /* ローカルバッファから返す */;
+        if (/* address falls within prefetched buffer */) {
+            return /* slice from local buffer */;
         }
         return $this->inner->read($pid, $address, $size);
     }
 }
 ```
 
-既存の `ZendExecuteData`, `FieldReader`, `Pointer`, `LazyDereferencer` 等は変更不要。
-アドレスベースで透過的にバッファから返すため、上位コードはリモートメモリかローカルバッファかを意識しない。
+Existing `ZendExecuteData`, `FieldReader`, `Pointer`, `LazyDereferencer`, etc.
+require no changes. The buffer is transparent — callers see the same
+`MemoryReaderInterface` regardless of whether data comes from local memory
+or a remote process.
 
-### 課題
+### Prerequisites
 
-- VM スタックの位置 (`EG(vm_stack)`) とサイズの取得が必要
-- VM スタック上の `execute_data` はカバーできるが、ヒープ上の `zend_function`,
-  `zend_string` (関数名/ファイル名/クラス名) は個別読み取りが残る
-  - ただし Pass 2 の scatter-gather でこれらも一括化できる見込み
-- `zend_function`, `zend_string` はリクエスト中に GC されないため、
-  Pass 1 → Pass 2 間 (~μs + ローカル処理) の不整合リスクは実質的に無視可能
+- Need to locate the VM stack: read `EG(vm_stack)` to get the current stack
+  segment's base address and size
+- VM stack covers `execute_data` frames; heap-resident data (`zend_function`,
+  `zend_string` for function/file/class names) still requires remote reads
+  - Pass 2 scatter-gather can batch these into a single syscall
+- `zend_function` and `zend_string` are stable during a request (not GC'd),
+  so the inconsistency risk between Pass 1 and Pass 2 is negligible
 
-### 期待される効果
+### Expected Impact
 
-- **整合性**: 3,480μs → ~1.4μs のウィンドウ縮小で `-S` なしでも壊れサンプルが激減する見込み
-- **スループット**: syscall 回数が 174 → 2 に減少。ただしボトルネックは PHP 側の処理なので
-  劇的な改善にはならない可能性。PHP 側の Pointer/FieldReader 処理の軽量化が別途必要
-- **サンプリングバイアス**: `-S` 不要になれば SIGSTOP バイアスを回避でき、
-  ネイティブトレースの分布も正確になる
+- **Consistency**: window shrinks from ~3,480us to ~1.4us, potentially making
+  `-S` unnecessary and eliminating broken samples without stopping the target
+- **Throughput**: syscall count drops from ~174 to 2 per trace. However, the
+  bottleneck is PHP-side processing, so the improvement may be modest unless
+  the Pointer/FieldReader layer is also optimized
+- **Sampling bias**: if `-S` becomes unnecessary, the SIGSTOP delivery bias
+  is avoided entirely, producing accurate native trace distributions

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -204,6 +204,14 @@ or a remote process.
 
 - Need to locate the VM stack: read `EG(vm_stack)` to get the current stack
   segment's base address and size
+  - reli already has this infrastructure: `ZendExecutorGlobals::$vm_stack`
+    → `ZendVmStack` with `$top`, `$end`, `$prev`, and `getSize()`
+  - The memory profiler (`inspector:memory`) already reads and analyzes
+    VM stack segments via `VmStackMemoryLocation`
+  - Prefetch range: from `ZendVmStack` header address to `$end` covers
+    all `execute_data` frames in the current segment
+  - Multiple segments (linked via `$prev`) may exist but the current
+    segment typically contains all active frames
 - VM stack covers `execute_data` frames; heap-resident data (`zend_function`,
   `zend_string` for function/file/class names) still requires remote reads
   - Pass 2 scatter-gather can batch these into a single syscall

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -1,0 +1,200 @@
+# Trace Consistency and Sampling Bias Investigation
+
+`--stop-process` (`-S`) オプションの有無がトレースの整合性とサンプリング分布に与える影響の調査。
+reli on reli (自己プロファイリング) および phpspy との比較で得られた知見をまとめる。
+
+## 背景
+
+reli のサンプリングプロファイラには 2 つのモードがある:
+
+- **`-S` なし**: `process_vm_readv` でターゲットのメモリを直接読む (ターゲットは動き続ける)
+- **`-S` あり**: `PTRACE_ATTACH` (`SIGSTOP`) でターゲットを一時停止してからメモリを読む
+
+## 発見 1: `-S` フラグの VALUE_OPTIONAL バグ (修正済み)
+
+`-S` を値なしで渡すと Symfony Console の `VALUE_OPTIONAL` が `null` を返し、
+コード上 `null` → `false` に変換されて **`-S` が無視されていた**。
+
+```
+-S       → false (バグ: 効かない)
+-S=1     → true
+--stop-process=1 → true
+未指定    → false
+```
+
+`hasParameterOption()` でフラグの存在を検出する形に修正。
+修正後、`-S` で truncated フレーム (internal 関数が 1 フレームだけ出る現象) が 0 になることを確認。
+
+## 発見 2: PTRACE_ATTACH の SIGSTOP サンプリングバイアス
+
+### 現象
+
+reli on reli で inner reli を `-S` ありでプロファイルすると、
+`/proc/pid/stat` から計測した実際の user:sys 比率とサンプル分布が大きく乖離する。
+
+```
+実測 (bash time / /proc/pid/stat):
+  user: 81%,  sys: 19%
+
+サンプル分布 (-S あり, PHP フレーム):
+  process_vm_readv (FFI/syscall): 68%
+  PHP userland:                   30%
+
+サンプル分布 (-S あり, ネイティブフレーム):
+  libc::process_vm_readv:          92%
+  PHP userland:                     6%
+```
+
+### 原因
+
+`PTRACE_ATTACH` は `SIGSTOP` をターゲットに送るが、カーネルは `SIGSTOP` を
+**syscall 境界またはスケジューラの切り替え点** で配送する。
+ターゲットが user mode で PHP バイトコードを実行中は `SIGSTOP` の配送が遅延し、
+次の syscall (FFI 経由の `process_vm_readv` 等) に入った時点で停止する。
+
+結果として **syscall 内で停止するサンプルが系統的に過大に出る**。
+
+### phpspy での検証
+
+phpspy の `-S` (pause-process) オプションでも同じ傾向を確認:
+
+```
+phpspy -S なし:  process_vm_readv = 12%,  PHP userland = 88%
+phpspy -S あり:  process_vm_readv = 92%,  PHP userland =  8%
+```
+
+`-S` を入れた瞬間に reli on reli と同じ傾向になる。
+`PTRACE_ATTACH` + `SIGSTOP` というメカニズム自体の制約。
+
+## 発見 3: `-S` なしの reli on reli では逆方向のバイアス
+
+### 現象
+
+reli on reli で `-S` なしにすると、`process_vm_readv` が frame 0 に **一切出ない**。
+
+```
+reli -S なし:
+  process_vm_readv:   0%
+  PHP userland:      61%
+  壊れ (<unknown>/<internal>/truncated): 23%
+```
+
+### 原因
+
+inner reli が FFI 内 (C コード実行中) にいるとき、`current_execute_data` は
+FFI フレームを指している。しかし outer reli が PHP で遅い読み取りをしている間に
+inner は FFI から戻って `current_execute_data` が変わってしまう。
+結果として FFI フレームを整合的に読めず `<internal>` や `<unknown>` として壊れるか、
+FFI から戻った後の PHP フレームを読む。
+
+**読み取り速度が遅いと、速い処理 (syscall) のサンプルが系統的に欠落する。**
+
+## 発見 4: phpspy -S なしだけが両立
+
+```
+                    サンプル分布の正確さ    スタック整合性    壊れ率
+phpspy -S なし              正確               高           ~0%
+phpspy -S あり          syscall に偏る          高           ~0%
+reli -S あり            syscall に偏る          高           ~2%
+reli -S なし           userland に偏る          低          ~23%
+```
+
+phpspy -S なしが唯一「分布が正確 + 整合性も OK」を両立できている理由は、
+C で高速にスタックを読み切れるため、ターゲットのスタックが変わる前にスナップショットが取れるから。
+
+## スループットとコスト比較
+
+### スタック深さとスループット (sleep=0, -S なし)
+
+```
+                    reli                    phpspy
+              readv/loop  loops/s     readv/loop  loops/s     倍率
+Shallow(3)          9       735            ~3    10,240       x14
+Deep(22)           37       225            ~4     6,947       x31
+Laravel(75)       174        53            ~5     1,892       x36
+```
+
+readv の総呼び出し回数はほぼ同じ (~27,000-29,000/3s)。
+スループット差の本質は readv 間の PHP オーバーヘッド (FFI 呼び出し、Pointer 生成、型解決等)。
+
+### 1 トレースあたりの CPU 時間 (Laravel 75 frames)
+
+```
+              user/trace    sys/trace    total/trace    user:sys
+phpspy         0.19ms        0.30ms        0.50ms       0.65:1 (sys 支配)
+reli           0.81ms        0.15ms        0.96ms       5.3:1  (user 支配)
+```
+
+CPU/trace の差は約 2 倍。スループット差 (36x) に比べて小さい。
+
+### readv のサイズ別コスト
+
+```
+      8 bytes: 0.7 μs/call
+     64 bytes: 0.7 μs/call
+   4096 bytes: 0.8 μs/call
+  65536 bytes: 0.7 μs/call
+ 262144 bytes: 0.8 μs/call
+```
+
+`process_vm_readv` はサイズにほぼ依存しない。
+
+## 改善案: VM スタック一括コピー
+
+### 現状の整合性ウィンドウ
+
+```
+reli (current):  最初の readv → 最後の readv = ~3,480 μs
+phpspy:          最初の readv → 最後の readv = ~500 μs
+1回の bulk readv: ~0.7 μs
+```
+
+### 2-pass scatter-gather 方式
+
+1. **Pass 1**: VM スタックを 1 回の `process_vm_readv` で一括コピー (~64KB, ~0.7μs)
+   - ローカルで `execute_data` チェーンをパース
+   - `func`, `opline` 等のヒープ上ポインタを収集
+2. **Pass 2**: 収集したポインタを scatter-gather iovec で一括読み取り (~0.7μs)
+   - `IOV_MAX` = 1024、75 フレームで ~300-450 iovec なので収まる
+
+合計 2 syscall, 整合性ウィンドウ ~1.4μs + ローカル処理時間。
+
+### 実装の見通し
+
+`MemoryReaderInterface` がきれいに抽象化されているため、
+**バッファ付きデコレータを 1 クラス追加** するだけで実現可能な可能性がある。
+
+```php
+class BufferedMemoryReader implements MemoryReaderInterface {
+    public function prefetch(int $pid, int $address, int $size): void {
+        // VM スタックを一括コピー
+    }
+
+    public function read(int $pid, int $address, int $size): CData {
+        if (/* address がバッファ範囲内 */) {
+            return /* ローカルバッファから返す */;
+        }
+        return $this->inner->read($pid, $address, $size);
+    }
+}
+```
+
+既存の `ZendExecuteData`, `FieldReader`, `Pointer`, `LazyDereferencer` 等は変更不要。
+アドレスベースで透過的にバッファから返すため、上位コードはリモートメモリかローカルバッファかを意識しない。
+
+### 課題
+
+- VM スタックの位置 (`EG(vm_stack)`) とサイズの取得が必要
+- VM スタック上の `execute_data` はカバーできるが、ヒープ上の `zend_function`,
+  `zend_string` (関数名/ファイル名/クラス名) は個別読み取りが残る
+  - ただし Pass 2 の scatter-gather でこれらも一括化できる見込み
+- `zend_function`, `zend_string` はリクエスト中に GC されないため、
+  Pass 1 → Pass 2 間 (~μs + ローカル処理) の不整合リスクは実質的に無視可能
+
+### 期待される効果
+
+- **整合性**: 3,480μs → ~1.4μs のウィンドウ縮小で `-S` なしでも壊れサンプルが激減する見込み
+- **スループット**: syscall 回数が 174 → 2 に減少。ただしボトルネックは PHP 側の処理なので
+  劇的な改善にはならない可能性。PHP 側の Pointer/FieldReader 処理の軽量化が別途必要
+- **サンプリングバイアス**: `-S` 不要になれば SIGSTOP バイアスを回避でき、
+  ネイティブトレースの分布も正確になる

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -200,6 +200,26 @@ require no changes. The buffer is transparent — callers see the same
 `MemoryReaderInterface` regardless of whether data comes from local memory
 or a remote process.
 
+### VM Stack Size Measurements
+
+Measured via `inspector:memory --pretty-print` on PHP 7.4 mod_php workers:
+
+```
+                    vm_stack_usage    vm_stack_total    readv cost (bulk)
+Shallow (3 frames):      448 bytes      262,144 bytes     ~430 ns (< 1 page)
+Deep (22 frames):      1,912 bytes      262,144 bytes     ~430 ns (< 1 page)
+Laravel (75 frames):   9,232 bytes      262,144 bytes     ~460 ns (~2 pages)
+Inner reli itself:    12,128 bytes      262,144 bytes     ~460 ns (~3 pages)
+```
+
+Key observations:
+- `vm_stack_total` is always 256KB (pre-allocated), but `vm_stack_usage` is tiny
+- 75 frames = ~9KB. Per frame ~120 bytes (9232 / 76 call frame headers)
+- **Only the used portion needs to be copied** (`top` to current stack position),
+  not the entire 256KB allocation
+- At ~9KB, the bulk copy fits in 2-3 pages → ~460ns, versus the current
+  174 individual readv calls via FFI
+
 ### Prerequisites
 
 - Need to locate the VM stack: read `EG(vm_stack)` to get the current stack

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -133,17 +133,22 @@ reli           0.81ms        0.15ms        0.96ms       5.3:1  (user-dominated)
 
 CPU per trace differs by ~2x. Much smaller than the throughput gap (36x).
 
-### readv Cost by Transfer Size
+### readv Cost by Transfer Size (C benchmark, 100K iterations)
 
 ```
-      8 bytes: 0.7 us/call
-     64 bytes: 0.7 us/call
-   4096 bytes: 0.8 us/call
-  65536 bytes: 0.7 us/call
- 262144 bytes: 0.8 us/call
+      8 bytes:     423 ns
+     64 bytes:     424 ns
+    256 bytes:     425 ns
+   1024 bytes:     445 ns
+   4096 bytes:     460 ns  (1 page)
+  16384 bytes:   1,000 ns  (4 pages)
+  65536 bytes:   3,721 ns  (16 pages)
+ 262144 bytes:  14,044 ns  (64 pages)
+1048576 bytes:  94,695 ns  (256 pages)
 ```
 
-`process_vm_readv` cost is nearly independent of transfer size.
+`process_vm_readv` cost is nearly constant below one page (~430ns), then
+scales roughly linearly with the number of pages crossed (page table walk cost).
 
 ## Proposed Improvement: Bulk VM Stack Copy
 
@@ -152,18 +157,23 @@ CPU per trace differs by ~2x. Much smaller than the throughput gap (36x).
 ```
 reli (current):   first readv to last readv = ~3,480 us
 phpspy:           first readv to last readv = ~500 us
-single bulk readv: ~0.7 us
+single bulk readv (64KB): ~3.7 us
+single bulk readv (16KB): ~1.0 us
 ```
 
 ### 2-Pass Scatter-Gather Approach
 
-1. **Pass 1**: bulk-copy the VM stack in a single `process_vm_readv` (~64KB, ~0.7us)
+1. **Pass 1**: bulk-copy the VM stack in a single `process_vm_readv`
+   - Actual stack usage is typically a few KB to tens of KB
+   - ~1-4us depending on size (16KB = ~1us, 64KB = ~3.7us)
    - Parse `execute_data` chain locally
    - Collect all heap pointers (`func`, `opline`, string addresses)
-2. **Pass 2**: scatter-gather read all heap data in a single `process_vm_readv` (~0.7us)
+2. **Pass 2**: scatter-gather read all heap data in a single `process_vm_readv`
    - `IOV_MAX` = 1024; 75 frames need ~300-450 iovecs, well within the limit
+   - Scattered across many pages, so cost depends on the number of distinct pages touched
 
-Total: 2 syscalls, ~1.4us consistency window + local processing time.
+Total: 2 syscalls, consistency window = ~1-4us for stack snapshot + local processing
+before Pass 2. Much smaller than the current ~3,480us window.
 
 ### Implementation Outlook
 
@@ -202,7 +212,7 @@ or a remote process.
 
 ### Expected Impact
 
-- **Consistency**: window shrinks from ~3,480us to ~1.4us, potentially making
+- **Consistency**: window shrinks from ~3,480us to ~1-4us, potentially making
   `-S` unnecessary and eliminating broken samples without stopping the target
 - **Throughput**: syscall count drops from ~174 to 2 per trace. However, the
   bottleneck is PHP-side processing, so the improvement may be modest unless

--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
@@ -80,6 +80,7 @@ final class TraceLoopSettingsFromConsoleInput
             );
         }
 
+        /** @var string|bool|int|float|list<string>|null $stop_process_raw */
         $stop_process_raw = $input->getOption('stop-process');
         if ($stop_process_raw === null) {
             // -S was not passed at all, or passed without a value (VALUE_OPTIONAL).

--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInput.php
@@ -80,15 +80,22 @@ final class TraceLoopSettingsFromConsoleInput
             );
         }
 
-        $stop_process = NullableCast::toString($input->getOption('stop-process'));
-        if (is_null($stop_process)) {
-            $stop_process = false;
-        }
-        $stop_process = filter_var($stop_process, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-        if ($stop_process === null) {
-            throw TraceLoopSettingsException::create(
-                TraceLoopSettingsException::STOP_PROCESS_IS_NOT_BOOLEAN
+        $stop_process_raw = $input->getOption('stop-process');
+        if ($stop_process_raw === null) {
+            // -S was not passed at all, or passed without a value (VALUE_OPTIONAL).
+            // Distinguish via hasParameterOption: if the flag is present, treat as true.
+            $stop_process = $input->hasParameterOption(['-S', '--stop-process']);
+        } else {
+            $stop_process = filter_var(
+                NullableCast::toString($stop_process_raw),
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
             );
+            if ($stop_process === null) {
+                throw TraceLoopSettingsException::create(
+                    TraceLoopSettingsException::STOP_PROCESS_IS_NOT_BOOLEAN
+                );
+            }
         }
 
         return new TraceLoopSettings(

--- a/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsFromConsoleInputTest.php
@@ -40,7 +40,20 @@ class TraceLoopSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('sleep-ns')->andReturns(null);
         $input->expects()->getOption('max-retries')->andReturns(null);
         $input->expects()->getOption('stop-process')->andReturns(null);
-        (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        $input->expects()->hasParameterOption(['-S', '--stop-process'])->andReturns(false);
+        $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        $this->assertSame(false, $settings->stop_process);
+    }
+
+    public function testFromConsoleInputStopProcessFlagWithoutValue(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('sleep-ns')->andReturns(null);
+        $input->expects()->getOption('max-retries')->andReturns(null);
+        $input->expects()->getOption('stop-process')->andReturns(null);
+        $input->expects()->hasParameterOption(['-S', '--stop-process'])->andReturns(true);
+        $settings = (new TraceLoopSettingsFromConsoleInput())->createSettings($input);
+        $this->assertSame(true, $settings->stop_process);
     }
 
     public function testFromConsoleInputSleepNsNotInteger(): void

--- a/tests/Lib/PhpProcessReader/CallTraceReader/ModPhpCallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/ModPhpCallTraceReaderTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\CallTraceReader;
+
+use PHPUnit\Framework\Attributes\Group;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\LinkMapLoader;
+use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\File\CatFileReader;
+use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\Opcodes\OpcodeFactory;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\Process\ProcessSpecifier;
+use Reli\TargetPhpVmProvider;
+
+#[Group('mod_php')]
+class ModPhpCallTraceReaderTest extends BaseTestCase
+{
+    /** @var resource|null */
+    private $child = null;
+
+    protected function tearDown(): void
+    {
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status)) {
+                if ($child_status['running']) {
+                    posix_kill($child_status['pid'], SIGKILL);
+                }
+            }
+        }
+    }
+
+    public function testReadCallTraceFromModPhpPrefork(): void
+    {
+        $docker_image_name = 'php:8.3-apache';
+        $php_version = ZendTypeReader::V83;
+
+        $memory_reader = new MemoryReader();
+        $executor_globals_reader = new CallTraceReader(
+            $memory_reader,
+            new ZendTypeReaderCreator(),
+            new OpcodeFactory()
+        );
+
+        // This script blocks on fgets(STDIN) which will never receive input
+        // under mod_php, keeping the Apache worker process alive and traceable.
+        $target_script =
+            <<<'CODE'
+            <?php
+            class A {
+                public function wait() {
+                    sleep(120);
+                }
+            }
+            $object = new A;
+            $object->wait();
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaModPhpContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+
+        $this->assertGreaterThan(0, $pid, 'Failed to get PID of mod_php worker process');
+
+        $child_status = proc_get_status($this->child);
+        $this->assertSame(true, $child_status['running']);
+
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $binary_analysis_cache = new BinaryAnalysisCache(
+            sys_get_temp_dir() . '/reli-test-' . uniqid()
+        );
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache,
+            ),
+            $process_memory_map_creator,
+            $binary_analysis_cache,
+        );
+        $integer_reader = new LittleEndianReader();
+        $memory_reader_for_finder = new MemoryReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            $target_php_settings,
+        );
+        $sapi_globals_address = $php_globals_finder->findSAPIGlobals(
+            new ProcessSpecifier($pid),
+            $target_php_settings,
+        );
+
+        $call_trace = $executor_globals_reader->readCallTrace(
+            $pid,
+            $php_version,
+            $executor_globals_address,
+            $sapi_globals_address,
+            PHP_INT_MAX,
+            new TraceCache(),
+        );
+        $this->assertNotEmpty($call_trace->call_frames);
+
+        // Find the wait() call in the trace
+        $function_names = array_map(
+            fn ($frame) => $frame->getFullyQualifiedFunctionName(),
+            $call_trace->call_frames,
+        );
+        $this->assertContains(
+            'A::wait',
+            $function_names,
+            'Expected to find A::wait in call trace, got: ' . implode(' -> ', $function_names)
+        );
+    }
+}

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -201,6 +201,97 @@ class TargetPhpVmProvider
         return [$proc_handle, $pid];
     }
 
+    /**
+     * Run a PHP script via Apache mod_php in a Docker container.
+     *
+     * The script is placed as /var/www/html/index.php inside a php:*-apache container.
+     * Apache is started in foreground, then a request is made to trigger the script.
+     * The script writes its PID via a shared file so the profiler can attach.
+     *
+     * @return array{0: resource, 1: int} [proc_handle, pid]
+     */
+    public static function runScriptViaModPhpContainer(
+        string $docker_image_name,
+        string $script,
+        array &$pipes,
+    ) {
+        $tmp_dir = '/tmp/reli-test/modphp-' . uniqid();
+        mkdir($tmp_dir, 0777, true);
+
+        $script_file = $tmp_dir . '/index.php';
+        $pid_file = $tmp_dir . '/target-pid';
+
+        touch($pid_file);
+        chmod($pid_file, 0666);
+
+        // Prepend PID writing logic to the script
+        $pid_writer_code = <<<'PIDCODE'
+        file_put_contents('/tmp/modphp-workdir/target-pid', (string)getmypid());
+        PIDCODE;
+
+        $modified_script = preg_replace(
+            '/^<\?php\s*/s',
+            "<?php\n" . $pid_writer_code . "\n",
+            $script
+        );
+        file_put_contents($script_file, $modified_script);
+        chmod($script_file, 0666);
+
+        // Start Apache in foreground, then trigger the PHP script.
+        // The php:*-apache images have Apache pre-configured with mod_php.
+        // The target script blocks (sleep), so wget must run in background.
+        // We poll the PID file to know when the PHP worker has started.
+        $shell_script = 'apache2-foreground &'
+            . ' sleep 2'
+            . ' && (wget -q -T 300 -O /dev/null http://127.0.0.1:80/index.php &) 2>/dev/null'
+            . ' ; wait_count=0'
+            . ' ; while [ ! -s /tmp/modphp-workdir/target-pid ] && [ $wait_count -lt 30 ]; do'
+            . '   sleep 1; wait_count=$((wait_count+1))'
+            . ' ; done'
+            . ' && echo "pid_ready"'
+            . ' && sleep infinity';
+
+        $docker_command = [
+            'docker',
+            'run',
+            '--rm',
+            '--pid', 'host',
+            '-i',
+            '-v', "$script_file:/var/www/html/index.php:ro",
+            '-v', "$tmp_dir:/tmp/modphp-workdir:rw",
+            '-v', '/tmp/reli-test:/tmp/reli-test:rw',
+            '--entrypoint', 'sh',
+            $docker_image_name,
+            '-c',
+            $shell_script,
+        ];
+
+        $proc_handle = proc_open(
+            $docker_command,
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w']
+            ],
+            $pipes
+        );
+
+        // Wait for the request to complete and PID to be written
+        $timeout = 60;
+        $start = time();
+        while (time() - $start < $timeout) {
+            $content = @file_get_contents($pid_file);
+            if ($content !== false && $content !== '' && (int)$content > 0) {
+                break;
+            }
+            usleep(500000); // 500ms
+        }
+
+        $pid = (int)file_get_contents($pid_file);
+
+        return [$proc_handle, $pid];
+    }
+
     public static function procOpenViaDocker(
         string $docker_image_name,
         string $command,


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `--stop-process` (`-S`) flag parsing and adds comprehensive documentation and testing for trace consistency investigation.

## Key Changes

### Bug Fix: `-S` Flag VALUE_OPTIONAL Parsing
- **Issue**: When `-S` was passed without an explicit value, Symfony Console's `VALUE_OPTIONAL` returned `null`, which was silently converted to `false`, causing the flag to have no effect
- **Fix**: Updated `TraceLoopSettingsFromConsoleInput` to use `hasParameterOption()` to detect flag presence, distinguishing between:
  - `-S` (no value) → `true` ✓
  - `-S=1` → `true` ✓
  - `--stop-process=1` → `true` ✓
  - Not specified → `false` ✓

### New Test: mod_php Integration
- Added `ModPhpCallTraceReaderTest` to verify call trace reading from Apache mod_php workers
- Test runs a PHP script in a `php:*-apache` Docker container, triggers it via HTTP, and validates that the profiler can read the call stack (specifically verifying the `A::wait` method appears in the trace)
- Added helper method `TargetPhpVmProvider::runScriptViaModPhpContainer()` to manage Docker container lifecycle and PID discovery

### Documentation: Trace Consistency Investigation
- Added comprehensive investigation document (`trace-consistency-investigation.md`) covering:
  - The `-S` flag bug and its fix
  - PTRACE_ATTACH SIGSTOP sampling bias (confirmed via phpspy comparison)
  - Reverse bias observed without `-S` due to slow PHP-based memory reads
  - Throughput and cost analysis comparing reli vs phpspy
  - Proposed improvement: bulk VM stack copy via scatter-gather `process_vm_readv` to reduce consistency window from ~3,480µs to ~1-4µs
  - Implementation outlook using a buffered decorator pattern with `MemoryReaderInterface`
  - VM stack size measurements and configuration considerations

## Implementation Details

The `-S` flag fix is minimal and surgical:
- Checks `hasParameterOption()` when `getOption()` returns `null` (the VALUE_OPTIONAL case)
- Falls back to explicit boolean parsing when a value is provided
- Maintains backward compatibility with existing `--stop-process=1` usage

The mod_php test uses a shared temporary directory and PID file to coordinate between the Docker container and the test process, polling for the PID to be written before proceeding with trace reading.

https://claude.ai/code/session_01AhhkCMCiDtfFk9fosTX6SH