### PR TITLE
Add scatter-gather VM stack prefetch with BufferedMemoryReader

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -45,6 +45,7 @@ use Reli\Lib\Log\StateCollector\StateCollector;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
+use Reli\Lib\Process\MemoryReader\BufferedMemoryReader;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Search\ProcessSearcher;
@@ -54,7 +55,9 @@ use Psr\Log\LoggerInterface;
 use function DI\autowire;
 
 return [
-    MemoryReaderInterface::class => autowire(MemoryReader::class),
+    MemoryReaderInterface::class => function () {
+        return new BufferedMemoryReader(new MemoryReader());
+    },
     ProcessMemoryMapCreatorInterface::class => autowire(ProcessMemoryMapCreator::class),
     ProcessModuleSymbolReaderCreatorInterface::class => autowire(ProcessModuleSymbolReaderCreator::class),
     ProcessPathResolver::class => autowire(ContainerAwarePathResolver::class),

--- a/docs/trace-consistency-investigation.md
+++ b/docs/trace-consistency-investigation.md
@@ -277,3 +277,107 @@ it, while the default behavior remains unchanged.
   the Pointer/FieldReader layer is also optimized
 - **Sampling bias**: if `-S` becomes unnecessary, the SIGSTOP delivery bias
   is avoided entirely, producing accurate native trace distributions
+
+## Implementation Results
+
+The `--bulk-stack-copy` option has been implemented with scatter-gather readv,
+along with several hot-path optimizations. Below are the measured results.
+
+### Architecture
+
+```
+Step 1: Read EG(vm_stack), EG(vm_stack_top), EG(vm_stack_end) individually
+        → determine prefetch range (vm_stack to vm_stack_top + 16KB margin)
+Step 2: Scatter-gather process_vm_readv in ONE syscall:
+          iov[0] = EG(current_execute_data)   — 8 bytes
+          iov[1] = VM stack with margin        — ~10-25 KB
+Step 3: Walk execute_data chain from local buffer (readRawInt64 + unpack)
+Step 4: Resolve function names from TraceCache (heap reads cached across traces)
+```
+
+Key components:
+- `BufferedMemoryReader`: decorator with scatter-gather readv and two fixed
+  buffer slots. `readRawInt64()` bypasses FFI entirely using `unpack('P', ...)`
+- `CallTraceReader`: pre-computed field offsets, direct buffer reads for chain
+  walk and frame field access (func, opline), func=NULL frame skip, partial
+  trace on read failure instead of full retry
+
+### Finding 5: func=NULL Frames at Stack Top
+
+Debug analysis revealed that the `<unknown>` frames (previously ~30% in
+reli-on-reli without `-S`) are caused by **partially-initialized execute_data
+frames** on the VM stack, not by heap read failures.
+
+```
+func=NULL: ced=0x7f2a686188c0 in_buf=Y func=0x0 prev=0x7f2a64201690
+```
+
+The VM stack snapshot captures a frame mid-push where `func` has not yet been
+written. The `prev_execute_data` pointer is always valid. Skipping the
+func=NULL frame and using `prev_execute_data` as the effective stack top
+eliminates `<unknown>` entirely — the prev frame is the function that was
+actually executing when the call was initiated.
+
+### Reli-on-Reli Benchmark (inner reli profiling FFI target)
+
+```
+Actual CPU ratio: user=81%, sys=18%
+
+                       user/tr  sys/tr  total/tr  traces/s
+reli normal (before)    0.83ms   5.92ms   6.75ms       147
+reli --bulk-stack-copy  0.12ms   0.23ms   0.35ms     2,841
+reli -S                 0.22ms   0.04ms   0.26ms     3,415
+reli --bulk + -S        0.09ms   0.02ms   0.12ms     7,946
+phpspy (no -S)          0.01ms   0.08ms   0.09ms     6,053
+phpspy -S               0.01ms   0.09ms   0.12ms     5,258
+```
+
+### Optimization Progression (reli --bulk + -S, reli-on-reli)
+
+```
+                            user/tr  total/tr  traces/s  vs phpspy-S
+bulk-stack-copy only         0.15ms    0.18ms    4,960      -6%
++ unpack fast path           0.12ms    0.14ms    5,940     +12%
++ fast chain walk            0.11ms    0.13ms    6,367     +21%
++ inline field reads         0.09ms    0.12ms    7,013     +33%
+```
+
+### Per-Trace CPU Comparison
+
+```
+              user     sys      total    traces/s   strategy
+reli bulk+-S   0.09    0.02     0.12      7,946     scatter-gather + TraceCache
+phpspy -S      0.01    0.10     0.12      5,258     per-field readv (C native)
+```
+
+reli and phpspy arrive at the same total cost (0.12ms/trace) via opposite
+strategies: reli's user cost is higher (PHP overhead) but sys cost is 5x
+lower (one scatter-gather readv + TraceCache eliminates most syscalls).
+phpspy's C-native user cost is negligible but it issues more readv calls
+per trace.
+
+### Why `-S` + bulk Outperforms phpspy
+
+1. **Scatter-gather readv**: one syscall reads `current_execute_data` + the
+   entire VM stack, vs phpspy's ~5 individual readv calls per trace
+2. **TraceCache**: `zend_function` / `zend_string` are immutable during a
+   request. After the first trace, heap reads drop to near zero. phpspy
+   re-reads function names every trace
+3. **Fewer kernel entries**: ~5,000 syscalls/s for reli vs ~20,000 for phpspy,
+   reducing kernel-side overhead (page table walks, context switches)
+
+### Remaining Limitations
+
+- **Without `-S`**: reli 2,841/s vs phpspy 6,053/s. PHP-side processing
+  takes long enough that the target's state changes between reads, causing
+  partial traces and wasted work. C-native phpspy completes reads before
+  the target moves
+- **CPU saturation**: without `-S`, three processes (target + inner reli +
+  outer reli) compete for CPU. With `-S`, the target is paused, leaving
+  more CPU for the profiler
+- **JIT**: PHP 8.4 tracing JIT provides only ~6% improvement. The remaining
+  PHP overhead (method dispatch, object creation, array operations) is not
+  amenable to JIT optimization
+- **Further optimization**: would require either a C extension for the core
+  readCallTrace loop, or a C extension wrapping the FFI syscall layer
+  (process_vm_readv, ptrace) to eliminate per-call FFI overhead

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -120,6 +120,10 @@ final class GetTraceCommand extends Command
             );
         }
 
+        if ($get_trace_settings->bulk_stack_copy_max_size !== null) {
+            $this->executor_globals_reader->enableBulkStackCopy($get_trace_settings->bulk_stack_copy_max_size);
+        }
+
         $process_specifier = $this->target_process_resolver->resolve($target_process_settings);
 
         $target_php_settings = $this->php_version_detector->decidePhpVersion(

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
@@ -15,10 +15,16 @@ namespace Reli\Inspector\Settings\GetTraceSettings;
 
 final class GetTraceSettings
 {
+    public const BULK_STACK_COPY_DEFAULT_MAX_SIZE = 65536;
+
+    /**
+     * @param int|null $bulk_stack_copy_max_size null = disabled, int = max bytes to prefetch
+     */
     public function __construct(
         public int $depth,
         public bool $with_native_trace = false,
         public bool $native_trace_anytime = false,
+        public ?int $bulk_stack_copy_max_size = null,
     ) {
     }
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
@@ -22,6 +22,7 @@ final class GetTraceSettingsException extends InspectorSettingsException
 
     protected const ERRORS = [
         self::DEPTH_IS_NOT_INTEGER => 'depth is not integer',
-        self::BULK_STACK_COPY_IS_NOT_VALID_SIZE => 'bulk-stack-copy value must be an integer with optional K/M suffix (e.g. 65536, 64K, 1M)',
+        self::BULK_STACK_COPY_IS_NOT_VALID_SIZE =>
+            'bulk-stack-copy value must be an integer with optional K/M suffix (e.g. 65536, 64K, 1M)',
     ];
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
@@ -18,8 +18,10 @@ use Reli\Inspector\Settings\InspectorSettingsException;
 final class GetTraceSettingsException extends InspectorSettingsException
 {
     public const DEPTH_IS_NOT_INTEGER = 1;
+    public const BULK_STACK_COPY_IS_NOT_VALID_SIZE = 2;
 
     protected const ERRORS = [
         self::DEPTH_IS_NOT_INTEGER => 'depth is not integer',
+        self::BULK_STACK_COPY_IS_NOT_VALID_SIZE => 'bulk-stack-copy value must be an integer with optional K/M suffix (e.g. 65536, 64K, 1M)',
     ];
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
@@ -48,7 +48,41 @@ final class GetTraceSettingsFromConsoleInput
                 InputOption::VALUE_NONE,
                 'collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)'
             )
+            ->addOption(
+                'bulk-stack-copy',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'bulk-copy VM stack per sample for consistency (default max: 64K). '
+                . 'Accepts optional max size in bytes (e.g. 65536, 16K, 256K)'
+            )
         ;
+    }
+
+    private function parseBulkStackCopy(InputInterface $input): ?int
+    {
+        /** @var string|bool|int|float|list<string>|null $raw */
+        $raw = $input->getOption('bulk-stack-copy');
+        if ($raw === null) {
+            if (!$input->hasParameterOption(['--bulk-stack-copy'])) {
+                return null;
+            }
+            return GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE;
+        }
+        $value = NullableCast::toString($raw);
+        if ($value === null) {
+            return GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE;
+        }
+        // Support K/M suffixes (e.g. "64K", "1M")
+        if (preg_match('/^(\d+)\s*([kKmM])?$/', $value, $m)) {
+            $num = (int)$m[1];
+            $suffix = strtoupper($m[2] ?? '');
+            return match ($suffix) {
+                'K' => $num * 1024,
+                'M' => $num * 1024 * 1024,
+                default => $num,
+            };
+        }
+        throw GetTraceSettingsException::create(GetTraceSettingsException::BULK_STACK_COPY_IS_NOT_VALID_SIZE);
     }
 
     /**
@@ -69,6 +103,9 @@ final class GetTraceSettingsFromConsoleInput
         if ($native_trace_anytime) {
             $with_native_trace = true;
         }
-        return new GetTraceSettings($depth, $with_native_trace, $native_trace_anytime);
+
+        $bulk_stack_copy_max_size = $this->parseBulkStackCopy($input);
+
+        return new GetTraceSettings($depth, $with_native_trace, $native_trace_anytime, $bulk_stack_copy_max_size);
     }
 }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -142,8 +142,12 @@ final class CallTraceReader
 
     /**
      * Prefetch the used portion of the VM stack into the BufferedMemoryReader's
-     * local buffer. This reads EG(vm_stack) and EG(vm_stack_top) to determine
-     * the range, then issues a single bulk process_vm_readv.
+     * local buffer. Reads EG(vm_stack) and EG(vm_stack_top) individually to
+     * determine the range, then issues a single bulk process_vm_readv.
+     *
+     * current_execute_data is intentionally read AFTER the prefetch (in
+     * getCurrentExecuteDataPointer) so that it is as close in time as possible
+     * to the VM stack snapshot contents.
      *
      * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      */

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -141,62 +141,92 @@ final class CallTraceReader
     }
 
     /**
-     * Prefetch the used portion of the VM stack into the BufferedMemoryReader's
-     * local buffer. Reads EG(vm_stack) and EG(vm_stack_top) individually to
-     * determine the range, then issues a single bulk process_vm_readv.
+     * Prefetch EG(current_execute_data) and the VM stack in a single
+     * process_vm_readv scatter-gather call.
      *
-     * current_execute_data is intentionally read AFTER the prefetch (in
-     * getCurrentExecuteDataPointer) so that it is as close in time as possible
-     * to the VM stack snapshot contents.
+     * Step 1: Read EG(vm_stack) and EG(vm_stack_top) individually to
+     *         determine the VM stack range. These change infrequently
+     *         relative to the stack contents, so slight staleness is OK.
+     * Step 2: Scatter-gather read in ONE syscall:
+     *           iov[0] = EG(current_execute_data) — 8 bytes
+     *           iov[1] = VM stack used portion      — ~1-10 KB
+     *         This ensures current_execute_data and the VM stack snapshot
+     *         are from the same kernel entry, minimizing the consistency
+     *         window to sub-microsecond kernel page-walk time.
      *
      * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     * @return Pointer<ZendExecuteData>|null current_execute_data from the scatter-gather snapshot
      */
-    private function prefetchVmStack(
+    private function prefetchVmStackScatterGather(
         int $pid,
         string $php_version,
         int $eg_address,
         Dereferencer $dereferencer,
-    ): void {
+    ): ?Pointer {
         assert($this->memory_reader instanceof BufferedMemoryReader);
 
         $this->memory_reader->clearBuffer();
 
         $zend_type_reader = $this->getTypeReader($php_version);
 
-        // Read EG(vm_stack) pointer to get the current stack segment address
-        [$offset, $size] = $zend_type_reader->getOffsetAndSizeOfMember(
+        // Step 1: Read EG(vm_stack) and EG(vm_stack_top) to determine range
+        [$vm_stack_offset, $ptr_size] = $zend_type_reader->getOffsetAndSizeOfMember(
             'zend_executor_globals',
             'vm_stack'
         );
         $vm_stack_raw = $dereferencer->deref(new Pointer(
             RawInt64::class,
-            $eg_address + $offset,
-            $size,
+            $eg_address + $vm_stack_offset,
+            $ptr_size,
         ));
         if ($vm_stack_raw->value === 0) {
-            return;
+            return null;
         }
         $vm_stack_address = $vm_stack_raw->value;
 
-        // Read EG(vm_stack_top) pointer to know the end of the used area
-        [$offset, $size] = $zend_type_reader->getOffsetAndSizeOfMember(
+        [$vm_stack_top_offset,] = $zend_type_reader->getOffsetAndSizeOfMember(
             'zend_executor_globals',
             'vm_stack_top'
         );
         $vm_stack_top_raw = $dereferencer->deref(new Pointer(
             RawInt64::class,
-            $eg_address + $offset,
-            $size,
+            $eg_address + $vm_stack_top_offset,
+            $ptr_size,
         ));
         if ($vm_stack_top_raw->value === 0) {
-            return;
+            return null;
         }
 
-        // Prefetch from the stack segment header to the current top (used area)
-        $prefetch_size = $vm_stack_top_raw->value - $vm_stack_address;
-        if ($prefetch_size > 0 && $prefetch_size <= $this->memory_reader->getMaxPrefetchSize()) {
-            $this->memory_reader->prefetch($pid, $vm_stack_address, $prefetch_size);
+        $stack_size = $vm_stack_top_raw->value - $vm_stack_address;
+        if ($stack_size <= 0 || $stack_size > $this->memory_reader->getMaxPrefetchSize()) {
+            return null;
         }
+
+        // Step 2: Scatter-gather read current_execute_data + VM stack in one syscall
+        [$ced_offset,] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_executor_globals',
+            'current_execute_data'
+        );
+
+        $this->memory_reader->prefetchScatterGather($pid, [
+            ['address' => $eg_address + $ced_offset, 'size' => $ptr_size],
+            ['address' => $vm_stack_address, 'size' => $stack_size],
+        ]);
+
+        // Read current_execute_data from the scatter-gather buffer
+        $ced_cdata = $this->memory_reader->read($pid, $eg_address + $ced_offset, $ptr_size);
+        /** @var \FFI\CInteger $cast */
+        $cast = \FFI::cast('long', $ced_cdata);
+        $ced_address = $cast->cdata;
+        if ($ced_address === 0) {
+            return null;
+        }
+
+        return new Pointer(
+            ZendExecuteData::class,
+            $ced_address,
+            $zend_type_reader->sizeOf('zend_execute_data'),
+        );
     }
 
     /**
@@ -213,15 +243,20 @@ final class CallTraceReader
     ): ?CallTrace {
         $dereferencer = $this->getDereferencer($pid, $php_version);
 
+        $current_execute_data_pointer = null;
         if ($this->bulk_stack_copy_enabled && $this->memory_reader instanceof BufferedMemoryReader) {
-            $this->prefetchVmStack($pid, $php_version, $executor_globals_address, $dereferencer);
+            $current_execute_data_pointer = $this->prefetchVmStackScatterGather(
+                $pid, $php_version, $executor_globals_address, $dereferencer,
+            );
         }
 
-        $current_execute_data_pointer = $this->getCurrentExecuteDataPointer(
-            $executor_globals_address,
-            $php_version,
-            $dereferencer,
-        );
+        if ($current_execute_data_pointer === null) {
+            $current_execute_data_pointer = $this->getCurrentExecuteDataPointer(
+                $executor_globals_address,
+                $php_version,
+                $dereferencer,
+            );
+        }
         if (is_null($current_execute_data_pointer)) {
             return null;
         }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -23,6 +23,7 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendOp;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\Process\MemoryReader\BufferedMemoryReader;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -35,12 +36,21 @@ use Reli\Lib\Process\ProcessSpecifier;
 final class CallTraceReader
 {
     private ?ZendTypeReader $zend_type_reader = null;
+    private bool $bulk_stack_copy_enabled = false;
 
     public function __construct(
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private OpcodeFactory $opcode_factory,
     ) {
+    }
+
+    public function enableBulkStackCopy(?int $max_prefetch_size = null): void
+    {
+        $this->bulk_stack_copy_enabled = true;
+        if ($max_prefetch_size !== null && $this->memory_reader instanceof BufferedMemoryReader) {
+            $this->memory_reader->setMaxPrefetchSize($max_prefetch_size);
+        }
     }
 
     /**
@@ -131,6 +141,61 @@ final class CallTraceReader
     }
 
     /**
+     * Prefetch the used portion of the VM stack into the BufferedMemoryReader's
+     * local buffer. This reads EG(vm_stack) and EG(vm_stack_top) to determine
+     * the range, then issues a single bulk process_vm_readv.
+     *
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     */
+    private function prefetchVmStack(
+        int $pid,
+        string $php_version,
+        int $eg_address,
+        Dereferencer $dereferencer,
+    ): void {
+        assert($this->memory_reader instanceof BufferedMemoryReader);
+
+        $this->memory_reader->clearBuffer();
+
+        $zend_type_reader = $this->getTypeReader($php_version);
+
+        // Read EG(vm_stack) pointer to get the current stack segment address
+        [$offset, $size] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_executor_globals',
+            'vm_stack'
+        );
+        $vm_stack_raw = $dereferencer->deref(new Pointer(
+            RawInt64::class,
+            $eg_address + $offset,
+            $size,
+        ));
+        if ($vm_stack_raw->value === 0) {
+            return;
+        }
+        $vm_stack_address = $vm_stack_raw->value;
+
+        // Read EG(vm_stack_top) pointer to know the end of the used area
+        [$offset, $size] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_executor_globals',
+            'vm_stack_top'
+        );
+        $vm_stack_top_raw = $dereferencer->deref(new Pointer(
+            RawInt64::class,
+            $eg_address + $offset,
+            $size,
+        ));
+        if ($vm_stack_top_raw->value === 0) {
+            return;
+        }
+
+        // Prefetch from the stack segment header to the current top (used area)
+        $prefetch_size = $vm_stack_top_raw->value - $vm_stack_address;
+        if ($prefetch_size > 0 && $prefetch_size <= $this->memory_reader->getMaxPrefetchSize()) {
+            $this->memory_reader->prefetch($pid, $vm_stack_address, $prefetch_size);
+        }
+    }
+
+    /**
      * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      * @throws MemoryReaderException
      */
@@ -143,6 +208,11 @@ final class CallTraceReader
         TraceCache $trace_cache,
     ): ?CallTrace {
         $dereferencer = $this->getDereferencer($pid, $php_version);
+
+        if ($this->bulk_stack_copy_enabled && $this->memory_reader instanceof BufferedMemoryReader) {
+            $this->prefetchVmStack($pid, $php_version, $executor_globals_address, $dereferencer);
+        }
+
         $current_execute_data_pointer = $this->getCurrentExecuteDataPointer(
             $executor_globals_address,
             $php_version,

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -420,8 +420,10 @@ final class CallTraceReader
                     $file_name,
                     $opline
                 );
-            } catch (MemoryReaderException) {
-                // Frame resolution failed — stop here, return what we have
+            } catch (MemoryReaderException | \TypeError) {
+                // Frame resolution failed — stop here, return what we have.
+                // TypeError can occur when FFI CData contains unexpected types
+                // (e.g. corrupt frame data from a running target).
                 break;
             }
         }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -19,6 +19,7 @@ use Reli\Lib\PhpInternals\Types\C\RawInt64;
 use Reli\Lib\PhpInternals\Types\Zend\Opline;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecuteData;
+use Reli\Lib\PhpInternals\Types\Zend\ZendFunction;
 use Reli\Lib\PhpInternals\Types\Zend\ZendOp;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
@@ -288,9 +289,12 @@ final class CallTraceReader
         $zend_type_reader = $this->getTypeReader($php_version);
         $ed_size = $zend_type_reader->sizeOf('zend_execute_data');
 
-        // Pre-compute offsets for the hot chain walk (avoids repeated getOffsetAndSizeOfMember)
+        // Pre-compute offsets for hot paths (avoids repeated getOffsetAndSizeOfMember)
         [$func_offset,] = $zend_type_reader->getOffsetAndSizeOfMember('zend_execute_data', 'func');
         [$prev_offset,] = $zend_type_reader->getOffsetAndSizeOfMember('zend_execute_data', 'prev_execute_data');
+        [$opline_offset,] = $zend_type_reader->getOffsetAndSizeOfMember('zend_execute_data', 'opline');
+        $func_size = $zend_type_reader->sizeOf('zend_function');
+        $opline_size = $zend_type_reader->sizeOf('zend_op');
 
         // Fast chain walk: collect frame addresses using raw int64 reads,
         // bypassing LazyDereferencer/FieldReader/Pointer per-frame overhead.
@@ -348,14 +352,31 @@ final class CallTraceReader
         }
 
         $result = [];
-        foreach ($stack as $current_execute_data) {
+        foreach ($frame_addresses as $idx => $frame_addr) {
             try {
+                $current_execute_data = $stack[$idx];
+
+                // Read func and opline pointers directly from buffer,
+                // bypassing __get → getFieldLazy → FieldReader → getOffsetAndSizeOfMember
+                $func_ptr = null;
+                $opline_ptr = null;
+                $func_addr_raw = $buffered?->readRawInt64($pid, $frame_addr + $func_offset);
+                if ($func_addr_raw !== null) {
+                    $func_ptr = $func_addr_raw !== 0
+                        ? new Pointer(ZendFunction::class, $func_addr_raw, $func_size)
+                        : null;
+                    // Pre-populate the lazy property to avoid __get on subsequent access
+                    $current_execute_data->func = $func_ptr;
+                } else {
+                    $func_ptr = $current_execute_data->func;
+                }
+
                 $function_name = $current_execute_data->getFunctionName(
                     $cached_dereferencer,
-                    $this->getTypeReader($php_version),
+                    $zend_type_reader,
                 );
 
-                if (is_null($current_execute_data->func)) {
+                if ($func_ptr === null) {
                     $result[] = new CallFrame(
                         '',
                         $function_name,
@@ -364,7 +385,7 @@ final class CallTraceReader
                     );
                     continue;
                 }
-                $current_function = $cached_dereferencer->deref($current_execute_data->func);
+                $current_function = $cached_dereferencer->deref($func_ptr);
 
                 $class_name = $current_function->getClassName($cached_dereferencer) ?? '';
                 $file_name = $current_function->getFileName($cached_dereferencer) ?? '<unknown>';
@@ -373,12 +394,21 @@ final class CallTraceReader
                 if (
                     $file_name !== '<internal>'
                     and $file_name !== '<unknown>'
-                    and !is_null($current_execute_data->opline)
                 ) {
-                    $opline = $this->readOpline(
-                        $php_version,
-                        $cached_dereferencer->deref($current_execute_data->opline)
-                    );
+                    $opline_addr_raw = $buffered?->readRawInt64($pid, $frame_addr + $opline_offset);
+                    if ($opline_addr_raw !== null) {
+                        $opline_ptr = $opline_addr_raw !== 0
+                            ? new Pointer(ZendOp::class, $opline_addr_raw, $opline_size)
+                            : null;
+                    } else {
+                        $opline_ptr = $current_execute_data->opline;
+                    }
+                    if ($opline_ptr !== null) {
+                        $opline = $this->readOpline(
+                            $php_version,
+                            $cached_dereferencer->deref($opline_ptr)
+                        );
+                    }
                 }
 
                 $result[] = new CallFrame(

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -287,6 +287,13 @@ final class CallTraceReader
 
         $current_execute_data = $dereferencer->deref($current_execute_data_pointer);
 
+        // If the top frame has func=NULL, it is being initialized (the call
+        // hasn't started executing yet). Skip it and use prev_execute_data
+        // as the effective top — that is the frame that was actually running.
+        if (is_null($current_execute_data->func) && !is_null($current_execute_data->prev_execute_data)) {
+            $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
+        }
+
         $stack = [];
         $stack[] = $current_execute_data;
         for ($i = 0; $i < $depth; $i++) {

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -285,30 +285,66 @@ final class CallTraceReader
         $trace_cache->updateCacheKey($this->getGlobalRequestTime($sapi_globals_address, $php_version, $dereferencer));
         $cached_dereferencer = $trace_cache->getDereferencer($dereferencer);
 
-        $current_execute_data = $dereferencer->deref($current_execute_data_pointer);
+        $zend_type_reader = $this->getTypeReader($php_version);
+        $ed_size = $zend_type_reader->sizeOf('zend_execute_data');
 
-        // If the top frame has func=NULL, it is being initialized (the call
-        // hasn't started executing yet). Skip it and use prev_execute_data
-        // as the effective top — that is the frame that was actually running.
-        if (is_null($current_execute_data->func) && !is_null($current_execute_data->prev_execute_data)) {
-            $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
+        // Pre-compute offsets for the hot chain walk (avoids repeated getOffsetAndSizeOfMember)
+        [$func_offset,] = $zend_type_reader->getOffsetAndSizeOfMember('zend_execute_data', 'func');
+        [$prev_offset,] = $zend_type_reader->getOffsetAndSizeOfMember('zend_execute_data', 'prev_execute_data');
+
+        // Fast chain walk: collect frame addresses using raw int64 reads,
+        // bypassing LazyDereferencer/FieldReader/Pointer per-frame overhead.
+        $buffered = ($this->bulk_stack_copy_enabled && $this->memory_reader instanceof BufferedMemoryReader)
+            ? $this->memory_reader
+            : null;
+
+        $frame_addresses = [];
+        $addr = $current_execute_data_pointer->address;
+
+        // If the top frame has func=NULL, it is being initialized.
+        // Skip it and use prev_execute_data as the effective top.
+        if ($buffered !== null) {
+            $func_val = $buffered->readRawInt64($pid, $addr + $func_offset);
+            if ($func_val === 0) {
+                $prev_val = $buffered->readRawInt64($pid, $addr + $prev_offset);
+                if ($prev_val !== null && $prev_val !== 0) {
+                    $addr = $prev_val;
+                }
+            }
         }
 
-        // Walk the execute_data chain. If a read fails mid-chain (e.g. stale
-        // pointer from a running target), keep the frames collected so far
-        // rather than discarding the entire trace and retrying.
-        $stack = [];
-        $stack[] = $current_execute_data;
-        try {
-            for ($i = 0; $i < $depth; $i++) {
-                if (is_null($current_execute_data->prev_execute_data)) {
+        $frame_addresses[] = $addr;
+
+        for ($i = 0; $i < $depth; $i++) {
+            $prev_addr = $buffered?->readRawInt64($pid, $addr + $prev_offset);
+            if ($prev_addr === null) {
+                // Buffer miss — fall back to FieldReader for remaining frames
+                try {
+                    $pointer = new Pointer(ZendExecuteData::class, $addr, $ed_size);
+                    $ed = $dereferencer->deref($pointer);
+                    if (is_null($ed->prev_execute_data)) {
+                        break;
+                    }
+                    $addr = $ed->prev_execute_data->address;
+                    $frame_addresses[] = $addr;
+                    // Continue with buffer reads from new address
+                    continue;
+                } catch (MemoryReaderException) {
                     break;
                 }
-                $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
-                $stack[] = $current_execute_data;
             }
-        } catch (MemoryReaderException) {
-            // Chain walk hit a bad address — use frames collected so far
+            if ($prev_addr === 0) {
+                break;
+            }
+            $addr = $prev_addr;
+            $frame_addresses[] = $addr;
+        }
+
+        // Build lazy ZendExecuteData objects from collected addresses
+        $stack = [];
+        foreach ($frame_addresses as $frame_addr) {
+            $pointer = new Pointer(ZendExecuteData::class, $frame_addr, $ed_size);
+            $stack[] = $dereferencer->deref($pointer);
         }
 
         $result = [];

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -294,58 +294,70 @@ final class CallTraceReader
             $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
         }
 
+        // Walk the execute_data chain. If a read fails mid-chain (e.g. stale
+        // pointer from a running target), keep the frames collected so far
+        // rather than discarding the entire trace and retrying.
         $stack = [];
         $stack[] = $current_execute_data;
-        for ($i = 0; $i < $depth; $i++) {
-            if (is_null($current_execute_data->prev_execute_data)) {
-                break;
+        try {
+            for ($i = 0; $i < $depth; $i++) {
+                if (is_null($current_execute_data->prev_execute_data)) {
+                    break;
+                }
+                $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
+                $stack[] = $current_execute_data;
             }
-            $current_execute_data = $dereferencer->deref($current_execute_data->prev_execute_data);
-            $stack[] = $current_execute_data;
+        } catch (MemoryReaderException) {
+            // Chain walk hit a bad address — use frames collected so far
         }
 
         $result = [];
         foreach ($stack as $current_execute_data) {
-            $function_name = $current_execute_data->getFunctionName(
-                $cached_dereferencer,
-                $this->getTypeReader($php_version),
-            );
+            try {
+                $function_name = $current_execute_data->getFunctionName(
+                    $cached_dereferencer,
+                    $this->getTypeReader($php_version),
+                );
 
-            if (is_null($current_execute_data->func)) {
+                if (is_null($current_execute_data->func)) {
+                    $result[] = new CallFrame(
+                        '',
+                        $function_name,
+                        '<unknown>',
+                        null
+                    );
+                    continue;
+                }
+                $current_function = $cached_dereferencer->deref($current_execute_data->func);
+
+                $class_name = $current_function->getClassName($cached_dereferencer) ?? '';
+                $file_name = $current_function->getFileName($cached_dereferencer) ?? '<unknown>';
+
+                $opline = null;
+                if (
+                    $file_name !== '<internal>'
+                    and $file_name !== '<unknown>'
+                    and !is_null($current_execute_data->opline)
+                ) {
+                    $opline = $this->readOpline(
+                        $php_version,
+                        $cached_dereferencer->deref($current_execute_data->opline)
+                    );
+                }
+
                 $result[] = new CallFrame(
-                    '',
+                    $class_name,
                     $function_name,
-                    '<unknown>',
-                    null
+                    $file_name,
+                    $opline
                 );
-                continue;
+            } catch (MemoryReaderException) {
+                // Frame resolution failed — stop here, return what we have
+                break;
             }
-            $current_function = $cached_dereferencer->deref($current_execute_data->func);
-
-            $class_name = $current_function->getClassName($cached_dereferencer) ?? '';
-            $file_name = $current_function->getFileName($cached_dereferencer) ?? '<unknown>';
-
-            $opline = null;
-            if (
-                $file_name !== '<internal>'
-                and $file_name !== '<unknown>'
-                and !is_null($current_execute_data->opline)
-            ) {
-                $opline = $this->readOpline(
-                    $php_version,
-                    $cached_dereferencer->deref($current_execute_data->opline)
-                );
-            }
-
-            $result[] = new CallFrame(
-                $class_name,
-                $function_name,
-                $file_name,
-                $opline
-            );
         }
 
-        return new CallTrace(...$result);
+        return $result !== [] ? new CallTrace(...$result) : null;
     }
 
     /**

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -144,12 +144,13 @@ final class CallTraceReader
      * Prefetch EG(current_execute_data) and the VM stack in a single
      * process_vm_readv scatter-gather call.
      *
-     * Step 1: Read EG(vm_stack) and EG(vm_stack_top) individually to
-     *         determine the VM stack range. These change infrequently
-     *         relative to the stack contents, so slight staleness is OK.
+     * Step 1: Read EG(vm_stack), EG(vm_stack_top), and EG(vm_stack_end)
+     *         to determine the VM stack range. We prefetch from vm_stack
+     *         to min(vm_stack_top + margin, vm_stack_end). The margin
+     *         covers frames that may be pushed between Step 1 and Step 2.
      * Step 2: Scatter-gather read in ONE syscall:
      *           iov[0] = EG(current_execute_data) — 8 bytes
-     *           iov[1] = VM stack used portion      — ~1-10 KB
+     *           iov[1] = VM stack with margin      — typically ~10-25 KB
      *         This ensures current_execute_data and the VM stack snapshot
      *         are from the same kernel entry, minimizing the consistency
      *         window to sub-microsecond kernel page-walk time.
@@ -169,7 +170,7 @@ final class CallTraceReader
 
         $zend_type_reader = $this->getTypeReader($php_version);
 
-        // Step 1: Read EG(vm_stack) and EG(vm_stack_top) to determine range
+        // Step 1: Read EG(vm_stack), EG(vm_stack_top), and EG(vm_stack_end)
         [$vm_stack_offset, $ptr_size] = $zend_type_reader->getOffsetAndSizeOfMember(
             'zend_executor_globals',
             'vm_stack'
@@ -197,7 +198,27 @@ final class CallTraceReader
             return null;
         }
 
-        $stack_size = $vm_stack_top_raw->value - $vm_stack_address;
+        [$vm_stack_end_offset,] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_executor_globals',
+            'vm_stack_end'
+        );
+        $vm_stack_end_raw = $dereferencer->deref(new Pointer(
+            RawInt64::class,
+            $eg_address + $vm_stack_end_offset,
+            $ptr_size,
+        ));
+        if ($vm_stack_end_raw->value === 0) {
+            return null;
+        }
+
+        // Prefetch up to vm_stack_top + 16KB margin, capped at vm_stack_end.
+        // The margin covers frames that may be pushed between Step 1 and Step 2.
+        $margin = 16384; // 16KB ≈ ~130 extra frames of headroom
+        $prefetch_end = min(
+            $vm_stack_top_raw->value + $margin,
+            $vm_stack_end_raw->value,
+        );
+        $stack_size = $prefetch_end - $vm_stack_address;
         if ($stack_size <= 0 || $stack_size > $this->memory_reader->getMaxPrefetchSize()) {
             return null;
         }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -268,7 +268,10 @@ final class CallTraceReader
         $current_execute_data_pointer = null;
         if ($this->bulk_stack_copy_enabled && $this->memory_reader instanceof BufferedMemoryReader) {
             $current_execute_data_pointer = $this->prefetchVmStackScatterGather(
-                $pid, $php_version, $executor_globals_address, $dereferencer,
+                $pid,
+                $php_version,
+                $executor_globals_address,
+                $dereferencer,
             );
         }
 

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -57,7 +57,7 @@ final class BufferedMemoryReader implements MemoryReaderInterface
 
     public function __construct(
         private MemoryReaderInterface $inner,
-        private int $max_prefetch_size = 65536,
+        private int $max_prefetch_size = 65536, // 64KB: typical VM stack usage + margin
     ) {
         $n = self::MAX_SCATTER_GATHER_REGIONS;
         $this->ffi = FFI::cdef('

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -16,36 +16,82 @@ namespace Reli\Lib\Process\MemoryReader;
 use FFI;
 use FFI\CData;
 use Reli\Lib\FFI\CannotAllocateBufferException;
+use Reli\Lib\Libc\Errno\Errno;
+use Reli\Lib\Process\ProcessNotFoundException;
 
 /**
- * A decorator that can prefetch a contiguous memory region (e.g. the VM stack)
- * in a single process_vm_readv call and serve subsequent reads from the local
- * buffer when the requested address falls within the prefetched range.
+ * A decorator that can prefetch memory regions from a target process and serve
+ * subsequent reads from local buffers.
  *
- * This shrinks the consistency window from thousands of microseconds (many
- * individual readv calls) down to a few microseconds (one bulk read), making
- * it possible to obtain consistent stack snapshots without stopping the target
- * process via PTRACE_ATTACH.
+ * Supports two prefetch modes:
+ * - Single-region prefetch via {@see prefetch()}
+ * - Scatter-gather prefetch via {@see prefetchScatterGather()} which reads
+ *   multiple non-contiguous regions in a single process_vm_readv syscall,
+ *   minimizing the consistency window between them.
  */
 final class BufferedMemoryReader implements MemoryReaderInterface
 {
+    private const MAX_SCATTER_GATHER_REGIONS = 2;
+
     private FFI $ffi;
-    private ?int $buffer_pid = null;
-    private int $buffer_address = 0;
-    private int $buffer_size = 0;
-    private string $buffer_data = '';
+
+    // Two fixed buffer slots instead of an array — avoids per-read foreach/hash overhead
+    private ?int $buf0_pid = null;
+    private int $buf0_address = 0;
+    private int $buf0_size = 0;
+    private string $buf0_data = '';
+
+    private ?int $buf1_pid = null;
+    private int $buf1_address = 0;
+    private int $buf1_size = 0;
+    private string $buf1_data = '';
+
+    // Pre-allocated scatter-gather infrastructure (reused across calls)
+    private CData $sg_local_iovs;
+    private CData $sg_remote_iovs;
+    /** @var list<CData> */
+    private array $sg_remote_bases;
+    private CData $sg_small_buf;
+    private ?CData $sg_large_buf = null;
+    private int $sg_large_buf_size = 0;
 
     public function __construct(
         private MemoryReaderInterface $inner,
         private int $max_prefetch_size = 65536,
     ) {
-        $this->ffi = FFI::cdef('');
+        $n = self::MAX_SCATTER_GATHER_REGIONS;
+        $this->ffi = FFI::cdef('
+            typedef int pid_t;
+            struct iovec {
+                void  *iov_base;
+                size_t iov_len;
+            };
+            int errno;
+            ssize_t process_vm_readv(pid_t pid,
+                             const struct iovec *local_iov,
+                             unsigned long liovcnt,
+                             const struct iovec *remote_iov,
+                             unsigned long riovcnt,
+                             unsigned long flags);
+        ', 'libc.so.6');
+
+        $this->sg_local_iovs = $this->ffi->new("struct iovec[{$n}]")
+            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
+        $this->sg_remote_iovs = $this->ffi->new("struct iovec[{$n}]")
+            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
+        $this->sg_remote_bases = [];
+        for ($i = 0; $i < $n; $i++) {
+            $this->sg_remote_bases[] = $this->ffi->new('long')
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+        }
+        // Small buffer for region 0 (typically 8 bytes for a pointer)
+        $this->sg_small_buf = $this->ffi->new('unsigned char[64]')
+            ?? throw new CannotAllocateBufferException('cannot allocate buffer');
     }
 
     /**
-     * Bulk-copy a contiguous region from the target process into a local buffer.
-     * Subsequent read() calls for addresses within this region will be served
-     * from the buffer without issuing a syscall.
+     * Bulk-copy a single contiguous region from the target process.
+     * Replaces any previously prefetched buffers.
      */
     public function prefetch(int $pid, int $address, int $size): void
     {
@@ -54,18 +100,120 @@ final class BufferedMemoryReader implements MemoryReaderInterface
             return;
         }
         $cdata = $this->inner->read($pid, $address, $size);
-        $this->buffer_pid = $pid;
-        $this->buffer_address = $address;
-        $this->buffer_size = $size;
-        $this->buffer_data = FFI::string($cdata, $size);
+        $this->buf0_pid = $pid;
+        $this->buf0_address = $address;
+        $this->buf0_size = $size;
+        $this->buf0_data = FFI::string($cdata, $size);
+        $this->buf1_pid = null;
+    }
+
+    /**
+     * Read multiple non-contiguous regions in a single process_vm_readv syscall.
+     *
+     * All regions are read in one kernel entry, so the consistency window
+     * between them is limited to kernel-side page-table walk time (typically
+     * sub-microsecond) rather than the round-trip through PHP userspace.
+     *
+     * Uses pre-allocated iovec arrays and buffers to avoid per-call FFI
+     * allocation overhead. Region 0 uses a fixed 64-byte buffer (sufficient
+     * for pointer-sized fields). Region 1's buffer is allocated once and
+     * reused if the size doesn't grow.
+     *
+     * @param list<array{address: int, size: int}> $regions max 2 regions
+     * @throws MemoryReaderException
+     */
+    public function prefetchScatterGather(int $pid, array $regions): void
+    {
+        $this->buffers = [];
+
+        $count = count($regions);
+        if ($count === 0 || $count > self::MAX_SCATTER_GATHER_REGIONS) {
+            return;
+        }
+
+        $total_size = 0;
+        foreach ($regions as $r) {
+            $total_size += $r['size'];
+        }
+        if ($total_size > $this->max_prefetch_size) {
+            return;
+        }
+
+        // Set up iovecs using pre-allocated structures
+        /** @var list<CData> $local_buffers */
+        $local_buffers = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $size = $regions[$i]['size'];
+            $address = $regions[$i]['address'];
+
+            // Pick the right pre-allocated buffer
+            if ($i === 0 && $size <= 64) {
+                $buf = $this->sg_small_buf;
+            } else {
+                // Region 1 (VM stack): reuse large buffer if big enough
+                if ($this->sg_large_buf === null || $this->sg_large_buf_size < $size) {
+                    $this->sg_large_buf = $this->ffi->new("unsigned char[{$size}]")
+                        ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+                    $this->sg_large_buf_size = $size;
+                }
+                $buf = $this->sg_large_buf;
+            }
+            $local_buffers[] = $buf;
+
+            /** @var \FFI\CInteger $this->sg_remote_bases[$i] */
+            $this->sg_remote_bases[$i]->cdata = $address;
+
+            /** @psalm-suppress PropertyTypeCoercion */
+            $this->sg_local_iovs[$i]->iov_base = FFI::addr($buf);
+            $this->sg_local_iovs[$i]->iov_len = $size;
+
+            $this->sg_remote_iovs[$i]->iov_len = $size;
+            /** @psalm-suppress PropertyTypeCoercion */
+            $this->sg_remote_iovs[$i]->iov_base = FFI::cast('void *', $this->sg_remote_bases[$i]);
+        }
+
+        $read = $this->ffi->process_vm_readv(
+            $pid,
+            FFI::addr($this->sg_local_iovs[0]),
+            $count,
+            FFI::addr($this->sg_remote_iovs[0]),
+            $count,
+            0
+        );
+
+        if ($read === -1) {
+            /** @var int $errno */
+            $errno = $this->ffi->errno;
+            if ($errno === Errno::ESRCH) {
+                throw new ProcessNotFoundException("process not found. pid={$pid}");
+            }
+            throw new MemoryReaderException(
+                "scatter-gather prefetch failed. pid={$pid}, regions={$count}, errno={$errno}",
+                $errno
+            );
+        }
+
+        // Store regions in fixed slots
+        $this->buf0_pid = $pid;
+        $this->buf0_address = $regions[0]['address'];
+        $this->buf0_size = $regions[0]['size'];
+        $this->buf0_data = FFI::string($local_buffers[0], $regions[0]['size']);
+
+        if ($count > 1) {
+            $this->buf1_pid = $pid;
+            $this->buf1_address = $regions[1]['address'];
+            $this->buf1_size = $regions[1]['size'];
+            $this->buf1_data = FFI::string($local_buffers[1], $regions[1]['size']);
+        } else {
+            $this->buf1_pid = null;
+        }
     }
 
     public function clearBuffer(): void
     {
-        $this->buffer_pid = null;
-        $this->buffer_address = 0;
-        $this->buffer_size = 0;
-        $this->buffer_data = '';
+        $this->buf0_pid = null;
+        $this->buf1_pid = null;
     }
 
     public function getMaxPrefetchSize(): int
@@ -85,15 +233,29 @@ final class BufferedMemoryReader implements MemoryReaderInterface
     #[\Override]
     public function read(int $pid, int $remote_address, int $size): CData
     {
+        // Check slot 1 first (VM stack — most reads hit here)
         if (
-            $this->buffer_pid === $pid
-            && $remote_address >= $this->buffer_address
-            && ($remote_address + $size) <= ($this->buffer_address + $this->buffer_size)
+            $this->buf1_pid === $pid
+            && $remote_address >= $this->buf1_address
+            && ($remote_address + $size) <= ($this->buf1_address + $this->buf1_size)
         ) {
-            $offset = $remote_address - $this->buffer_address;
+            $offset = $remote_address - $this->buf1_address;
             $buffer = $this->ffi->new("unsigned char[{$size}]")
                 ?? throw new CannotAllocateBufferException('cannot allocate buffer');
-            FFI::memcpy($buffer, substr($this->buffer_data, $offset, $size), $size);
+            FFI::memcpy($buffer, substr($this->buf1_data, $offset, $size), $size);
+            /** @var \FFI\CArray<int> */
+            return $buffer;
+        }
+        // Check slot 0 (EG field / single prefetch)
+        if (
+            $this->buf0_pid === $pid
+            && $remote_address >= $this->buf0_address
+            && ($remote_address + $size) <= ($this->buf0_address + $this->buf0_size)
+        ) {
+            $offset = $remote_address - $this->buf0_address;
+            $buffer = $this->ffi->new("unsigned char[{$size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            FFI::memcpy($buffer, substr($this->buf0_data, $offset, $size), $size);
             /** @var \FFI\CArray<int> */
             return $buffer;
         }

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -227,6 +227,37 @@ final class BufferedMemoryReader implements MemoryReaderInterface
     }
 
     /**
+     * Fast path: read a 64-bit integer directly from the buffer without
+     * any FFI allocation or casting. Returns null on buffer miss.
+     */
+    public function readRawInt64(int $pid, int $remote_address): ?int
+    {
+        // Check slot 1 first (VM stack)
+        if (
+            $this->buf1_pid === $pid
+            && $remote_address >= $this->buf1_address
+            && ($remote_address + 8) <= ($this->buf1_address + $this->buf1_size)
+        ) {
+            $offset = $remote_address - $this->buf1_address;
+            /** @var array{1: int} $v */
+            $v = unpack('P', $this->buf1_data, $offset);
+            return $v[1];
+        }
+        // Check slot 0
+        if (
+            $this->buf0_pid === $pid
+            && $remote_address >= $this->buf0_address
+            && ($remote_address + 8) <= ($this->buf0_address + $this->buf0_size)
+        ) {
+            $offset = $remote_address - $this->buf0_address;
+            /** @var array{1: int} $v */
+            $v = unpack('P', $this->buf0_data, $offset);
+            return $v[1];
+        }
+        return null;
+    }
+
+    /**
      * @return \FFI\CArray<int>
      * @throws MemoryReaderException
      */

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\MemoryReader;
+
+use FFI;
+use FFI\CData;
+use Reli\Lib\FFI\CannotAllocateBufferException;
+
+/**
+ * A decorator that can prefetch a contiguous memory region (e.g. the VM stack)
+ * in a single process_vm_readv call and serve subsequent reads from the local
+ * buffer when the requested address falls within the prefetched range.
+ *
+ * This shrinks the consistency window from thousands of microseconds (many
+ * individual readv calls) down to a few microseconds (one bulk read), making
+ * it possible to obtain consistent stack snapshots without stopping the target
+ * process via PTRACE_ATTACH.
+ */
+final class BufferedMemoryReader implements MemoryReaderInterface
+{
+    private FFI $ffi;
+    private ?int $buffer_pid = null;
+    private int $buffer_address = 0;
+    private int $buffer_size = 0;
+    private string $buffer_data = '';
+
+    public function __construct(
+        private MemoryReaderInterface $inner,
+        private int $max_prefetch_size = 65536,
+    ) {
+        $this->ffi = FFI::cdef('');
+    }
+
+    /**
+     * Bulk-copy a contiguous region from the target process into a local buffer.
+     * Subsequent read() calls for addresses within this region will be served
+     * from the buffer without issuing a syscall.
+     */
+    public function prefetch(int $pid, int $address, int $size): void
+    {
+        if ($size <= 0 || $size > $this->max_prefetch_size) {
+            $this->clearBuffer();
+            return;
+        }
+        $cdata = $this->inner->read($pid, $address, $size);
+        $this->buffer_pid = $pid;
+        $this->buffer_address = $address;
+        $this->buffer_size = $size;
+        $this->buffer_data = FFI::string($cdata, $size);
+    }
+
+    public function clearBuffer(): void
+    {
+        $this->buffer_pid = null;
+        $this->buffer_address = 0;
+        $this->buffer_size = 0;
+        $this->buffer_data = '';
+    }
+
+    public function getMaxPrefetchSize(): int
+    {
+        return $this->max_prefetch_size;
+    }
+
+    public function setMaxPrefetchSize(int $max_prefetch_size): void
+    {
+        $this->max_prefetch_size = $max_prefetch_size;
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     * @throws MemoryReaderException
+     */
+    #[\Override]
+    public function read(int $pid, int $remote_address, int $size): CData
+    {
+        if (
+            $this->buffer_pid === $pid
+            && $remote_address >= $this->buffer_address
+            && ($remote_address + $size) <= ($this->buffer_address + $this->buffer_size)
+        ) {
+            $offset = $remote_address - $this->buffer_address;
+            $buffer = $this->ffi->new("unsigned char[{$size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            FFI::memcpy($buffer, substr($this->buffer_data, $offset, $size), $size);
+            /** @var \FFI\CArray<int> */
+            return $buffer;
+        }
+        return $this->inner->read($pid, $remote_address, $size);
+    }
+}

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -124,7 +124,7 @@ final class BufferedMemoryReader implements MemoryReaderInterface
      */
     public function prefetchScatterGather(int $pid, array $regions): void
     {
-        $this->buffers = [];
+        $this->clearBuffer();
 
         $count = count($regions);
         if ($count === 0 || $count > self::MAX_SCATTER_GATHER_REGIONS) {
@@ -164,15 +164,34 @@ final class BufferedMemoryReader implements MemoryReaderInterface
             /** @var \FFI\CInteger $this->sg_remote_bases[$i] */
             $this->sg_remote_bases[$i]->cdata = $address;
 
+            /**
+             * @var FFI\Libc\iovec $local_iov
+             * @psalm-suppress InaccessibleMethod
+             * @psalm-suppress PossiblyInvalidPropertyAssignment
+             * @psalm-suppress PropertyTypeCoercion
+             */
+            $local_iov = $this->sg_local_iovs[$i];
             /** @psalm-suppress PropertyTypeCoercion */
-            $this->sg_local_iovs[$i]->iov_base = FFI::addr($buf);
-            $this->sg_local_iovs[$i]->iov_len = $size;
+            $local_iov->iov_base = FFI::addr($buf);
+            $local_iov->iov_len = $size;
 
-            $this->sg_remote_iovs[$i]->iov_len = $size;
+            /**
+             * @var FFI\Libc\iovec $remote_iov
+             * @psalm-suppress InaccessibleMethod
+             * @psalm-suppress PossiblyInvalidPropertyAssignment
+             */
+            $remote_iov = $this->sg_remote_iovs[$i];
+            $remote_iov->iov_len = $size;
             /** @psalm-suppress PropertyTypeCoercion */
-            $this->sg_remote_iovs[$i]->iov_base = FFI::cast('void *', $this->sg_remote_bases[$i]);
+            $remote_iov->iov_base = FFI::cast('void *', $this->sg_remote_bases[$i]);
         }
 
+        /**
+         * @var FFI\Libc\process_vm_readv_ffi $this->ffi
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidArgument
+         * @psalm-suppress MixedAssignment
+         */
         $read = $this->ffi->process_vm_readv(
             $pid,
             FFI::addr($this->sg_local_iovs[0]),

--- a/src/Lib/Process/Pointer/FieldReader.php
+++ b/src/Lib/Process/Pointer/FieldReader.php
@@ -17,6 +17,7 @@ use FFI;
 use FFI\CData;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\MemoryReader\BufferedMemoryReader;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\ProcessSpecifier;
 
@@ -47,9 +48,26 @@ final class FieldReader
             $struct_type,
             $field_name,
         );
+        $address = $struct_pointer->address + $offset;
+
+        // Fast path: read pointer value directly from buffer via unpack, no FFI
+        if ($size === 8 && $this->memory_reader instanceof BufferedMemoryReader) {
+            $addr = $this->memory_reader->readRawInt64($this->process_specifier->pid, $address);
+            if ($addr !== null) {
+                if ($addr === 0) {
+                    return null;
+                }
+                return new Pointer(
+                    $pointed_type,
+                    $addr,
+                    $this->type_reader->sizeOf($pointed_type::getCTypeName()),
+                );
+            }
+        }
+
         $buffer = $this->memory_reader->read(
             $this->process_specifier->pid,
-            $struct_pointer->address + $offset,
+            $address,
             $size,
         );
         /** @var \FFI\CInteger $addr_cdata */
@@ -78,9 +96,23 @@ final class FieldReader
             $struct_type,
             $field_name,
         );
+        $address = $struct_pointer->address + $offset;
+
+        // Fast path: read directly from buffer via unpack, no FFI
+        if ($this->memory_reader instanceof BufferedMemoryReader) {
+            $val = $this->memory_reader->readRawInt64($this->process_specifier->pid, $address);
+            if ($val !== null) {
+                return match ($size) {
+                    1 => $val & 0xFF,
+                    4 => $val & 0xFFFFFFFF,
+                    default => $val,
+                };
+            }
+        }
+
         $buffer = $this->memory_reader->read(
             $this->process_specifier->pid,
-            $struct_pointer->address + $offset,
+            $address,
             $size,
         );
         /** @var \FFI\CInteger $casted */

--- a/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
@@ -25,11 +25,14 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('depth')->andReturns(10);
         $input->expects()->getOption('with-native-trace')->andReturns(false);
         $input->expects()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
 
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
 
         $this->assertSame(10, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
+        $this->assertNull($settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputDefault(): void
@@ -38,9 +41,12 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('depth')->andReturns(null);
         $input->expects()->getOption('with-native-trace')->andReturns(false);
         $input->expects()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
         $this->assertSame(PHP_INT_MAX, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
+        $this->assertNull($settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputDepthNotInteger(): void
@@ -49,6 +55,8 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('depth')->andReturns('abc');
         $input->allows()->getOption('with-native-trace')->andReturns(false);
         $input->allows()->getOption('native-trace-anytime')->andReturns(false);
+        $input->allows()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
         $this->expectException(GetTraceSettingsException::class);
         (new GetTraceSettingsFromConsoleInput())->createSettings($input);
     }
@@ -59,9 +67,12 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('depth')->andReturns(null);
         $input->expects()->getOption('with-native-trace')->andReturns(true);
         $input->expects()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
         $this->assertTrue($settings->with_native_trace);
         $this->assertFalse($settings->native_trace_anytime);
+        $this->assertNull($settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputNativeTraceAnytime(): void
@@ -70,8 +81,45 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('depth')->andReturns(null);
         $input->expects()->getOption('with-native-trace')->andReturns(false);
         $input->expects()->getOption('native-trace-anytime')->andReturns(true);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
         $this->assertTrue($settings->with_native_trace); // implied by anytime
         $this->assertTrue($settings->native_trace_anytime);
+        $this->assertNull($settings->bulk_stack_copy_max_size);
+    }
+
+    public function testFromConsoleInputBulkStackCopyFlag(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('depth')->andReturns(null);
+        $input->expects()->getOption('with-native-trace')->andReturns(false);
+        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(true);
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+        $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
+    }
+
+    public function testFromConsoleInputBulkStackCopyWithSize(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('depth')->andReturns(null);
+        $input->expects()->getOption('with-native-trace')->andReturns(false);
+        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns('128K');
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+        $this->assertSame(128 * 1024, $settings->bulk_stack_copy_max_size);
+    }
+
+    public function testFromConsoleInputBulkStackCopyInvalidSize(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('depth')->andReturns(null);
+        $input->allows()->getOption('with-native-trace')->andReturns(false);
+        $input->allows()->getOption('native-trace-anytime')->andReturns(false);
+        $input->expects()->getOption('bulk-stack-copy')->andReturns('abc');
+        $this->expectException(GetTraceSettingsException::class);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
     }
 }

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -172,6 +172,78 @@ class BufferedMemoryReaderTest extends TestCase
         $buffered->setMaxPrefetchSize(200);
         $this->assertSame(200, $buffered->getMaxPrefetchSize());
     }
+
+    #[Test]
+    public function testScatterGatherReadsOwnProcessMemory(): void
+    {
+        $mock = $this->createMockReader();
+        $buffered = new BufferedMemoryReader($mock);
+
+        $pid = getmypid();
+
+        // Allocate two separate C buffers to scatter-gather read
+        $ffi = FFI::cdef('');
+        $region1 = $ffi->new('unsigned char[8]');
+        $region2 = $ffi->new('unsigned char[8]');
+        assert($region1 !== null && $region2 !== null);
+        FFI::memcpy($region1, 'AAAABBBB', 8);
+        FFI::memcpy($region2, 'CCCCDDDD', 8);
+
+        $addr1 = FFI::cast('long', FFI::addr($region1))->cdata;
+        $addr2 = FFI::cast('long', FFI::addr($region2))->cdata;
+
+        // Scatter-gather: read both regions in one syscall
+        $buffered->prefetchScatterGather($pid, [
+            ['address' => $addr1, 'size' => 8],
+            ['address' => $addr2, 'size' => 8],
+        ]);
+
+        // Read from region 1 buffer
+        $result = $buffered->read($pid, $addr1, 4);
+        $this->assertSame('AAAA', FFI::string($result, 4));
+
+        // Read from region 1 buffer (offset)
+        $result = $buffered->read($pid, $addr1 + 4, 4);
+        $this->assertSame('BBBB', FFI::string($result, 4));
+
+        // Read from region 2 buffer
+        $result = $buffered->read($pid, $addr2, 8);
+        $this->assertSame('CCCCDDDD', FFI::string($result, 8));
+
+        // Inner reader should not have been called
+        $this->assertSame(0, $mock->readCount);
+    }
+
+    #[Test]
+    public function testScatterGatherClearsOldBuffers(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x9000, 'OLD_DATA');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x9000, 8);
+        $mock->readCount = 0;
+
+        // Scatter-gather should clear old buffers
+        $pid = getmypid();
+        $ffi = FFI::cdef('');
+        $region = $ffi->new('unsigned char[4]');
+        assert($region !== null);
+        FFI::memcpy($region, 'NEW!', 4);
+        $addr = FFI::cast('long', FFI::addr($region))->cdata;
+
+        $buffered->prefetchScatterGather($pid, [
+            ['address' => $addr, 'size' => 4],
+        ]);
+
+        // Old buffer should be gone - falls through to inner
+        $result = $buffered->read(1, 0x9000, 8);
+        $this->assertSame(1, $mock->readCount);
+
+        // New scatter-gather buffer should work
+        $result = $buffered->read($pid, $addr, 4);
+        $this->assertSame('NEW!', FFI::string($result, 4));
+    }
 }
 
 /**

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\MemoryReader;
+
+use FFI;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class BufferedMemoryReaderTest extends TestCase
+{
+    private function createMockReader(): MemoryReaderInterface&MockMemoryReader
+    {
+        return new MockMemoryReader();
+    }
+
+    #[Test]
+    public function testDelegatesToInnerWhenNoBuffer(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'HELLO');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $result = $buffered->read(1, 0x1000, 5);
+
+        $this->assertSame('HELLO', FFI::string($result, 5));
+        $this->assertSame(1, $mock->readCount);
+    }
+
+    #[Test]
+    public function testServesFromBufferAfterPrefetch(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGHIJKLMNOP');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 16);
+
+        // This read falls within the prefetched range - should NOT call inner
+        $mock->readCount = 0;
+        $result = $buffered->read(1, 0x1004, 4);
+
+        $this->assertSame('EFGH', FFI::string($result, 4));
+        $this->assertSame(0, $mock->readCount);
+    }
+
+    #[Test]
+    public function testServesFromBufferAtBoundaries(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGH');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 8);
+        $mock->readCount = 0;
+
+        // Read at start
+        $result = $buffered->read(1, 0x1000, 2);
+        $this->assertSame('AB', FFI::string($result, 2));
+
+        // Read at end
+        $result = $buffered->read(1, 0x1006, 2);
+        $this->assertSame('GH', FFI::string($result, 2));
+
+        // Read entire range
+        $result = $buffered->read(1, 0x1000, 8);
+        $this->assertSame('ABCDEFGH', FFI::string($result, 8));
+
+        $this->assertSame(0, $mock->readCount);
+    }
+
+    #[Test]
+    public function testFallsThroughForOutOfRangeReads(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGH');
+        $mock->preload(0x2000, 'REMOTE');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 8);
+        $mock->readCount = 0;
+
+        // Read outside buffer range
+        $result = $buffered->read(1, 0x2000, 6);
+        $this->assertSame('REMOTE', FFI::string($result, 6));
+        $this->assertSame(1, $mock->readCount);
+    }
+
+    #[Test]
+    public function testFallsThroughForPartialOverlap(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGH');
+        $mock->preload(0x1006, 'GHIJKL');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 8);
+        $mock->readCount = 0;
+
+        // This read extends past the buffer - should fall through
+        $result = $buffered->read(1, 0x1006, 6);
+        $this->assertSame('GHIJKL', FFI::string($result, 6));
+        $this->assertSame(1, $mock->readCount);
+    }
+
+    #[Test]
+    public function testFallsThroughForDifferentPid(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGH');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 8);
+        $mock->readCount = 0;
+
+        // Different PID - should fall through
+        $result = $buffered->read(2, 0x1000, 8);
+        $this->assertSame('ABCDEFGH', FFI::string($result, 8));
+        $this->assertSame(1, $mock->readCount);
+    }
+
+    #[Test]
+    public function testClearBufferForcesRemoteRead(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, 'ABCDEFGH');
+
+        $buffered = new BufferedMemoryReader($mock);
+        $buffered->prefetch(1, 0x1000, 8);
+        $mock->readCount = 0;
+
+        $buffered->clearBuffer();
+
+        $result = $buffered->read(1, 0x1000, 8);
+        $this->assertSame('ABCDEFGH', FFI::string($result, 8));
+        $this->assertSame(1, $mock->readCount);
+    }
+
+    #[Test]
+    public function testPrefetchRejectsOversizedRegion(): void
+    {
+        $mock = $this->createMockReader();
+        $mock->preload(0x1000, str_repeat('A', 100));
+
+        $buffered = new BufferedMemoryReader($mock, max_prefetch_size: 50);
+        $buffered->prefetch(1, 0x1000, 100);
+
+        // Buffer should be cleared, so this falls through
+        $result = $buffered->read(1, 0x1000, 100);
+        $this->assertSame(str_repeat('A', 100), FFI::string($result, 100));
+    }
+
+    #[Test]
+    public function testSetMaxPrefetchSize(): void
+    {
+        $mock = $this->createMockReader();
+        $buffered = new BufferedMemoryReader($mock, max_prefetch_size: 50);
+
+        $this->assertSame(50, $buffered->getMaxPrefetchSize());
+
+        $buffered->setMaxPrefetchSize(200);
+        $this->assertSame(200, $buffered->getMaxPrefetchSize());
+    }
+}
+
+/**
+ * @internal test helper
+ */
+class MockMemoryReader implements MemoryReaderInterface
+{
+    /** @var array<string, string> */
+    public array $data = [];
+    public int $readCount = 0;
+
+    public function preload(int $address, string $bytes): void
+    {
+        $this->data[$address . ':' . strlen($bytes)] = $bytes;
+    }
+
+    #[\Override]
+    public function read(int $pid, int $remote_address, int $size): FFI\CData
+    {
+        $this->readCount++;
+        $key = $remote_address . ':' . $size;
+        $bytes = $this->data[$key] ?? str_repeat("\0", $size);
+        $buf = FFI::new("char[$size]");
+        assert($buf !== null);
+        FFI::memcpy($buf, $bytes, $size);
+        /** @var \FFI\CArray<int> */
+        return $buf;
+    }
+}

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -146,6 +146,7 @@ class BufferedMemoryReaderTest extends TestCase
         $this->assertSame(1, $mock->readCount);
     }
 
+
     #[Test]
     public function testPrefetchRejectsOversizedRegion(): void
     {

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -245,31 +245,3 @@ class BufferedMemoryReaderTest extends TestCase
         $this->assertSame('NEW!', FFI::string($result, 4));
     }
 }
-
-/**
- * @internal test helper
- */
-class MockMemoryReader implements MemoryReaderInterface
-{
-    /** @var array<string, string> */
-    public array $data = [];
-    public int $readCount = 0;
-
-    public function preload(int $address, string $bytes): void
-    {
-        $this->data[$address . ':' . strlen($bytes)] = $bytes;
-    }
-
-    #[\Override]
-    public function read(int $pid, int $remote_address, int $size): FFI\CData
-    {
-        $this->readCount++;
-        $key = $remote_address . ':' . $size;
-        $bytes = $this->data[$key] ?? str_repeat("\0", $size);
-        $buf = FFI::new("char[$size]");
-        assert($buf !== null);
-        FFI::memcpy($buf, $bytes, $size);
-        /** @var \FFI\CArray<int> */
-        return $buf;
-    }
-}

--- a/tests/Lib/Process/MemoryReader/MockMemoryReader.php
+++ b/tests/Lib/Process/MemoryReader/MockMemoryReader.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\MemoryReader;
+
+use FFI;
+
+/**
+ * @internal test helper
+ */
+class MockMemoryReader implements MemoryReaderInterface
+{
+    /** @var array<string, string> */
+    public array $data = [];
+    public int $readCount = 0;
+
+    public function preload(int $address, string $bytes): void
+    {
+        $this->data[$address . ':' . strlen($bytes)] = $bytes;
+    }
+
+    #[\Override]
+    public function read(int $pid, int $remote_address, int $size): FFI\CData
+    {
+        $this->readCount++;
+        $key = $remote_address . ':' . $size;
+        $bytes = $this->data[$key] ?? str_repeat("\0", $size);
+        $buf = FFI::new("char[$size]");
+        assert($buf !== null);
+        FFI::memcpy($buf, $bytes, $size);
+        /** @var \FFI\CArray<int> */
+        return $buf;
+    }
+}


### PR DESCRIPTION
## Summary

Implements `--bulk-stack-copy` option to improve trace consistency and performance by prefetching the VM stack and `current_execute_data` in a single `process_vm_readv` scatter-gather syscall, along with hot-path optimizations in the call trace reader.

## Key Changes

- **New `BufferedMemoryReader` class**: A decorator that implements two-slot buffering with scatter-gather support
  - `prefetch()`: single-region prefetch via inner reader
  - `prefetchScatterGather()`: reads multiple non-contiguous regions in one syscall using pre-allocated iovec structures
  - `readRawInt64()`: fast-path pointer reads using `unpack('P', ...)` to bypass FFI overhead
  - Reuses fixed 64-byte buffer for region 0 and dynamically-sized buffer for region 1

- **Enhanced `CallTraceReader`**:
  - New `enableBulkStackCopy()` method to activate scatter-gather mode
  - `prefetchVmStackScatterGather()`: reads EG(vm_stack) metadata, then scatter-gathers `current_execute_data` + VM stack in one syscall
  - Optimized frame chain walk using `readRawInt64()` for pointer reads, bypassing LazyDereferencer overhead
  - Pre-computed field offsets to avoid repeated `getOffsetAndSizeOfMember()` calls
  - Skips func=NULL frames (partially-initialized execute_data) by using `prev_execute_data` as effective stack top
  - Partial trace fallback on read failures instead of full retry

- **Console integration**:
  - New `--bulk-stack-copy` option with optional max size parameter (supports K/M suffixes, default 64KB)
  - Settings plumbing through `GetTraceSettings` and `GetTraceSettingsFromConsoleInput`
  - DI container configuration to wrap memory reader with `BufferedMemoryReader`

- **Performance optimizations in `FieldReader`**:
  - Fast path for 8-byte pointer reads using `readRawInt64()` when available
  - Avoids FFI allocation and casting for hot-path field access

## Implementation Details

- Scatter-gather uses pre-allocated iovec arrays to avoid per-call FFI allocation overhead
- Region 0 (EG field) uses fixed 64-byte buffer; Region 1 (VM stack) reuses large buffer if size doesn't grow
- Frame chain walk collects addresses first, then builds lazy Pointer objects to defer dereferencing
- Includes comprehensive test coverage for buffer hits, misses, boundaries, and scatter-gather operations
- Documentation updated with benchmark results showing 7,946 traces/s with `--bulk-stack-copy -S` vs 147 traces/s baseline

https://claude.ai/code/session_01S9yRj81wnzddh1g8PMpZnq