### PR TITLE
Add AArch64 architecture support for profiling

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Run unit tests
         run: |
           mkdir -p build/logs
-          vendor/bin/phpunit --exclude-group target-version,frankenphp --coverage-clover build/logs/clover.xml
+          vendor/bin/phpunit --exclude-group target-version,frankenphp,mod_php --coverage-clover build/logs/clover.xml
 
       - name: Send to coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -243,6 +243,25 @@ jobs:
           mkdir -p /tmp/reli-test
           docker compose run reli-test-for-ci vendor/bin/phpunit --group frankenphp --no-coverage
 
+  build-dev-image-arm64:
+    name: Build dev image (ARM64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build dev image
+        run: docker build -f Dockerfile-dev -t reli-dev .
+
+      - name: Save dev image
+        run: docker save reli-dev | gzip > /tmp/reli-dev-arm64.tar.gz
+
+      - name: Upload dev image
+        uses: actions/upload-artifact@v4
+        with:
+          name: reli-dev-arm64
+          path: /tmp/reli-dev-arm64.tar.gz
+          retention-days: 1
+
   phpunit-unit-arm64:
     name: phpunit (unit, ARM64)
     runs-on: ubuntu-24.04-arm
@@ -283,9 +302,77 @@ jobs:
           flag-name: unit-arm64
           parallel: true
 
+  phpunit-target-version-arm64:
+    name: phpunit (${{ matrix.name }}, ARM64)
+    needs: build-dev-image-arm64
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "PHP 7.4"
+            targets: "v74"
+          - name: "PHP 8.2"
+            targets: "v82"
+          - name: "PHP 8.4"
+            targets: "v84"
+          - name: "PHP 8.4 ZTS"
+            targets: "v84_zts"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download dev image
+        uses: actions/download-artifact@v4
+        with:
+          name: reli-dev-arm64
+          path: /tmp
+
+      - name: Load dev image
+        run: docker load < /tmp/reli-dev-arm64.tar.gz
+
+      - name: Restore target Docker image cache
+        id: target-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/target-image.tar.gz
+          key: docker-target-arm64-${{ matrix.targets }}
+
+      - name: Load cached target Docker image
+        if: steps.target-cache.outputs.cache-hit == 'true'
+        run: docker load < /tmp/target-image.tar.gz
+
+      - name: Install dependencies
+        run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run target version tests
+        env:
+          RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
+        run: |
+          mkdir -p build/logs
+          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
+
+      - name: Fix coverage paths from Docker container
+        run: sed -i 's|/app/|${{ github.workspace }}/|g' build/logs/clover.xml
+
+      - name: Send to coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/logs/clover.xml
+          flag-name: ${{ matrix.targets }}-arm64
+          parallel: true
+
+      - name: Save target Docker image for cache
+        if: steps.target-cache.outputs.cache-hit != 'true'
+        run: |
+          TARGET_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^php:' | head -1)
+          if [ -n "$TARGET_IMAGE" ]; then
+            docker save "$TARGET_IMAGE" | gzip > /tmp/target-image.tar.gz
+          fi
+
   coveralls-finish:
     name: Coveralls finish
-    needs: [phpunit-unit, phpunit-unit-arm64, phpunit-target-version]
+    needs: [phpunit-unit, phpunit-unit-arm64, phpunit-target-version, phpunit-target-version-arm64]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -243,9 +243,49 @@ jobs:
           mkdir -p /tmp/reli-test
           docker compose run reli-test-for-ci vendor/bin/phpunit --group frankenphp --no-coverage
 
+  phpunit-unit-arm64:
+    name: phpunit (unit, ARM64)
+    runs-on: ubuntu-24.04-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: ffi, dom, mbstring
+          coverage: pcov
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ runner.arch }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run unit tests
+        run: |
+          mkdir -p build/logs
+          vendor/bin/phpunit --exclude-group target-version,frankenphp --coverage-clover build/logs/clover.xml
+
+      - name: Send to coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/logs/clover.xml
+          flag-name: unit-arm64
+          parallel: true
+
   coveralls-finish:
     name: Coveralls finish
-    needs: [phpunit-unit, phpunit-target-version]
+    needs: [phpunit-unit, phpunit-unit-arm64, phpunit-target-version]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -245,7 +245,7 @@ jobs:
 
   phpunit-unit-arm64:
     name: phpunit (unit, ARM64)
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -246,21 +246,51 @@ jobs:
   build-dev-image-arm64:
     name: Build dev image (ARM64)
     runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}/dev
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build dev image
-        run: docker build -f Dockerfile-dev -t reli-dev .
+      - name: Compute Dockerfile hash
+        id: hash
+        run: echo "tag=sha-$(sha256sum Dockerfile-dev | cut -c1-16)-arm64" >> "$GITHUB_OUTPUT"
 
-      - name: Save dev image
-        run: docker save reli-dev | gzip > /tmp/reli-dev-arm64.tar.gz
-
-      - name: Upload dev image
-        uses: actions/upload-artifact@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
-          name: reli-dev-arm64
-          path: /tmp/reli-dev-arm64.tar.gz
-          retention-days: 1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image already exists
+        id: check
+        run: |
+          if docker manifest inspect "${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push dev image
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile-dev
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
+            ${{ env.IMAGE }}:latest-arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+    outputs:
+      image: ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
 
   phpunit-unit-arm64:
     name: phpunit (unit, ARM64)
@@ -306,6 +336,8 @@ jobs:
     name: phpunit (${{ matrix.name }}, ARM64)
     needs: build-dev-image-arm64
     runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -321,14 +353,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dev image
-        uses: actions/download-artifact@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
-          name: reli-dev-arm64
-          path: /tmp
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load dev image
-        run: docker load < /tmp/reli-dev-arm64.tar.gz
+      - name: Pull dev image
+        run: |
+          docker pull ${{ needs.build-dev-image-arm64.outputs.image }}
+          docker tag ${{ needs.build-dev-image-arm64.outputs.image }} reli-dev
 
       - name: Restore target Docker image cache
         id: target-cache

--- a/README.md
+++ b/README.md
@@ -85,12 +85,7 @@ Much of what can be done with phpspy will be done with reli in the future.
 On targeting ZTS, reli finds EG from the TLS. Stripped binaries are supported (TLS segments are scanned via brute force). On glibc 2.34+, where libpthread is merged into libc, reli automatically falls back to libc.so, so no extra options are needed in most cases.
 
 ### AArch64 (ARM64) support
-AArch64 Linux support is experimental. It enables profiling on ARM-based servers (e.g., AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets are supported.
-
-Key implementation differences from x86_64:
-- Uses `PTRACE_GETREGSET` instead of `PTRACE_GETREGS`/`PTRACE_PEEKUSER` (not available on AArch64)
-- Reads the thread pointer via `NT_ARM_TLS` (`TPIDR_EL0` register) instead of `FS_BASE`
-- Uses TLS Variant I (AArch64) DTV lookup instead of Variant II (x86_64)
+AArch64 Linux support is experimental. It enables profiling on ARM-based servers (e.g., AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets are supported. See [docs/aarch64-support.md](docs/aarch64-support.md) for technical details.
 
 ## Installation
 ### From Composer

--- a/README.md
+++ b/README.md
@@ -73,14 +73,24 @@ Much of what can be done with phpspy will be done with reli in the future.
 #### Execution
 - PHP 8.1+ (NTS / ZTS)
 - 64bit Linux x86_64
+- 64bit Linux AArch64 (experimental)
 - FFI extension must be enabled.
 - PCNTL extension must be enabled.
 
 #### Target
 - PHP 7.0+ (NTS / ZTS)
 - 64bit Linux x86_64
+- 64bit Linux AArch64 (experimental)
 
 On targeting ZTS, reli finds EG from the TLS. Stripped binaries are supported (TLS segments are scanned via brute force). On glibc 2.34+, where libpthread is merged into libc, reli automatically falls back to libc.so, so no extra options are needed in most cases.
+
+### AArch64 (ARM64) support
+AArch64 Linux support is experimental. It enables profiling on ARM-based servers (e.g., AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets are supported.
+
+Key implementation differences from x86_64:
+- Uses `PTRACE_GETREGSET` instead of `PTRACE_GETREGS`/`PTRACE_PEEKUSER` (not available on AArch64)
+- Reads the thread pointer via `NT_ARM_TLS` (`TPIDR_EL0` register) instead of `FS_BASE`
+- Uses TLS Variant I (AArch64) DTV lookup instead of Variant II (x86_64)
 
 ## Installation
 ### From Composer

--- a/config/di.php
+++ b/config/di.php
@@ -37,7 +37,9 @@ use Reli\Lib\File\PathResolver\ProcessPathResolver;
 use Reli\Lib\Directory\AppDirectory;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceAarch64;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
+use Reli\Lib\System\Architecture;
 use Reli\Lib\Log\StateCollector\CallerStateCollector;
 use Reli\Lib\Log\StateCollector\GroupedStateCollector;
 use Reli\Lib\Log\StateCollector\ProcessStateCollector;
@@ -100,7 +102,12 @@ return [
     BinaryAnalysisCache::class => fn () => new BinaryAnalysisCache(
         AppDirectory::getCacheDir() . '/binary-analysis'
     ),
-    Ptrace::class => autowire(PtraceX64::class),
+    Ptrace::class => function () {
+        return match (Architecture::detect()) {
+            Architecture::X86_64 => new PtraceX64(),
+            Architecture::AARCH64 => new PtraceAarch64(),
+        };
+    },
     Reli\Lib\Dwarf\NativeTraceCollector::class => autowire(),
     Reli\Command\Inspector\GetTraceCommand::class => autowire()
         ->constructorParameter(

--- a/docs/aarch64-support.md
+++ b/docs/aarch64-support.md
@@ -1,0 +1,48 @@
+# AArch64 (ARM64) Support
+
+## Overview
+
+Reli supports AArch64 Linux as an experimental platform. This enables profiling on ARM-based servers (e.g., AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets are supported.
+
+## Implementation differences from x86_64
+
+### ptrace register access
+
+AArch64 Linux does not support `PTRACE_GETREGS` or `PTRACE_PEEKUSER`. Instead, reli uses `PTRACE_GETREGSET` with an `iovec` structure to read registers:
+
+- **General-purpose registers**: `PTRACE_GETREGSET` with `NT_PRSTATUS` reads the `user_pt_regs` struct (X0-X30, SP, PC, PSTATE).
+- **Thread pointer (TLS)**: `PTRACE_GETREGSET` with `NT_ARM_TLS` (0x401) reads the `TPIDR_EL0` register, which is the AArch64 equivalent of x86_64's `FS_BASE`.
+
+### DWARF register numbering
+
+The DWARF register numbers differ between architectures:
+
+| Role | x86_64 | AArch64 |
+|------|--------|---------|
+| Instruction pointer | 16 (RIP) | 32 (PC) |
+| Stack pointer | 7 (RSP) | 31 (SP) |
+| Frame pointer | 6 (RBP) | 29 (X29/FP) |
+| Return address | 16 (RIP) | 30 (X30/LR) |
+| Callee-saved | RBX, RBP, R12-R15 | X19-X30 |
+
+### TLS Variant I vs Variant II
+
+This is the most significant architectural difference for ZTS support.
+
+- **x86_64 (TLS Variant II)**: `FS_BASE` points directly to `struct pthread`. The `_thread_db_pthread_dtvp` offset (from libpthread debug symbols) gives the position of the DTV pointer within the struct. So `DTV = *(FS_BASE + dtvp_offset)`.
+
+- **AArch64 (TLS Variant I)**: `TPIDR_EL0` points to `tcbhead_t`, which is located **after** `struct pthread` in memory (glibc defines `THREAD_SELF` as `(struct pthread *)tp - 1`). The DTV pointer is the first field of `tcbhead_t` at offset 0. So `DTV = *(TPIDR_EL0 + 0)`.
+
+The `_thread_db_pthread_dtvp` offset cannot be used directly with `TPIDR_EL0` on AArch64 because it's an offset within `struct pthread`, not from the thread pointer.
+
+### .eh_frame differences
+
+AArch64 ELF binaries use different CIE (Common Information Entry) defaults:
+
+| Field | x86_64 | AArch64 |
+|-------|--------|---------|
+| Code alignment factor | 1 | 4 |
+| Data alignment factor | -8 | -8 |
+| Return address register | 16 (RIP) | 30 (LR) |
+
+The frame pointer unwinding layout is identical on both architectures: `[FP+0]` = saved FP, `[FP+8]` = return address.

--- a/src/Lib/Dwarf/DwarfArchitecture.php
+++ b/src/Lib/Dwarf/DwarfArchitecture.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Dwarf;
+
+use Reli\Lib\System\Architecture;
+
+enum DwarfArchitecture
+{
+    case X86_64;
+    case AARCH64;
+
+    public static function fromArchitecture(Architecture $arch): self
+    {
+        return match ($arch) {
+            Architecture::X86_64 => self::X86_64,
+            Architecture::AARCH64 => self::AARCH64,
+        };
+    }
+
+    public static function detect(): self
+    {
+        return self::fromArchitecture(Architecture::detect());
+    }
+
+    /** DWARF register number for instruction pointer (RIP / PC) */
+    public function ipRegister(): int
+    {
+        return match ($this) {
+            self::X86_64 => 16,
+            self::AARCH64 => 32,
+        };
+    }
+
+    /** DWARF register number for stack pointer (RSP / SP) */
+    public function spRegister(): int
+    {
+        return match ($this) {
+            self::X86_64 => 7,
+            self::AARCH64 => 31,
+        };
+    }
+
+    /** DWARF register number for frame pointer (RBP / X29) */
+    public function fpRegister(): int
+    {
+        return match ($this) {
+            self::X86_64 => 6,
+            self::AARCH64 => 29,
+        };
+    }
+
+    /**
+     * DWARF register numbers for callee-saved registers that should be restored during unwinding.
+     * @return int[]
+     */
+    public function calleeSavedRegisters(): array
+    {
+        return match ($this) {
+            self::X86_64 => [3, 6, 12, 13, 14, 15], // RBX, RBP, R12-R15
+            self::AARCH64 => [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], // x19-x30
+        };
+    }
+}

--- a/src/Lib/Dwarf/NativeStackUnwinder.php
+++ b/src/Lib/Dwarf/NativeStackUnwinder.php
@@ -186,8 +186,9 @@ final class NativeStackUnwinder
             }
 
             // Create new register state
-            $new_registers = new RegisterState();
-            $new_registers->set(RegisterState::RSP, $cfa);
+            $arch = $registers->getArchitecture();
+            $new_registers = new RegisterState($arch);
+            $new_registers->set($arch->spRegister(), $cfa);
 
             // Restore return address register
             $ra_register = $fde->cie->returnAddressRegister;
@@ -196,13 +197,10 @@ final class NativeStackUnwinder
             if ($ra === null) {
                 return null;
             }
-            $new_registers->set(RegisterState::RIP, $ra);
+            $new_registers->set($arch->ipRegister(), $ra);
 
             // Restore callee-saved registers
-            foreach (
-                [RegisterState::RBP, RegisterState::RBX, RegisterState::R12,
-                       RegisterState::R13, RegisterState::R14, RegisterState::R15] as $reg
-            ) {
+            foreach ($arch->calleeSavedRegisters() as $reg) {
                 $rule = $row->getRegisterRule($reg);
                 $value = $this->applyRegisterRule($rule, $cfa, $registers, $pid);
                 if ($value !== null) {
@@ -330,29 +328,31 @@ final class NativeStackUnwinder
 
     private function framePointerUnwind(int $pid, RegisterState $registers): ?RegisterState
     {
-        $rbp = $registers->getRbp();
-        if ($rbp === 0) {
+        $fp = $registers->getRbp();
+        if ($fp === 0) {
             return null;
         }
 
         try {
-            // Standard frame pointer chain: [rbp] = saved rbp, [rbp+8] = return address
-            $saved_rbp = $this->readMemoryInt64($pid, $rbp);
-            $return_address = $this->readMemoryInt64($pid, $rbp + 8);
+            // Frame pointer chain: [fp] = saved fp, [fp+8] = return address
+            // This layout is identical on both x86_64 and AArch64
+            $saved_fp = $this->readMemoryInt64($pid, $fp);
+            $return_address = $this->readMemoryInt64($pid, $fp + 8);
 
-            if ($saved_rbp === null || $return_address === null || $return_address === 0) {
+            if ($saved_fp === null || $return_address === null || $return_address === 0) {
                 return null;
             }
 
-            // Sanity: saved RBP should be higher than current (stack grows down)
-            if ($saved_rbp !== 0 && $saved_rbp <= $rbp) {
+            // Sanity: saved FP should be higher than current (stack grows down)
+            if ($saved_fp !== 0 && $saved_fp <= $fp) {
                 return null;
             }
 
-            $new_registers = new RegisterState();
-            $new_registers->set(RegisterState::RIP, $return_address);
-            $new_registers->set(RegisterState::RSP, $rbp + 16);
-            $new_registers->set(RegisterState::RBP, $saved_rbp);
+            $arch = $registers->getArchitecture();
+            $new_registers = new RegisterState($arch);
+            $new_registers->set($arch->ipRegister(), $return_address);
+            $new_registers->set($arch->spRegister(), $fp + 16);
+            $new_registers->set($arch->fpRegister(), $saved_fp);
             return $new_registers;
         } catch (\Throwable) {
             return null;

--- a/src/Lib/Dwarf/NativeTraceCollector.php
+++ b/src/Lib/Dwarf/NativeTraceCollector.php
@@ -22,6 +22,7 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapReader;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\System\Architecture;
 
 final class NativeTraceCollector
 {
@@ -142,7 +143,25 @@ final class NativeTraceCollector
 
     private function ensureRegsFfi(): void
     {
-        if ($this->regsFfi === null) {
+        if ($this->regsFfi !== null) {
+            return;
+        }
+
+        if (Architecture::detect() === Architecture::AARCH64) {
+            $this->regsFfi = \FFI::cdef('
+                struct user_pt_regs {
+                    unsigned long long regs[31];
+                    unsigned long long sp;
+                    unsigned long long pc;
+                    unsigned long long pstate;
+                };
+                struct iovec {
+                    void  *iov_base;
+                    unsigned long iov_len;
+                };
+            ');
+            $this->regsBuffer = $this->regsFfi->new('struct user_pt_regs');
+        } else {
             $this->regsFfi = \FFI::cdef('
                 struct user_regs_struct {
                     unsigned long r15;
@@ -187,6 +206,10 @@ final class NativeTraceCollector
                 return null;
             }
 
+            if (Architecture::detect() === Architecture::AARCH64) {
+                return $this->readRegistersAarch64($pid, $regs);
+            }
+
             $result = $this->ptrace->ptrace(
                 PtraceRequest::PTRACE_GETREGS,
                 $pid,
@@ -202,5 +225,32 @@ final class NativeTraceCollector
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    /** @psalm-suppress UndefinedPropertyAssignment */
+    private function readRegistersAarch64(int $pid, \FFI\CData $regs): ?RegisterState
+    {
+        assert($this->regsFfi !== null);
+
+        $iov = $this->regsFfi->new('struct iovec');
+        if ($iov === null) {
+            return null;
+        }
+        $iov->iov_base = \FFI::addr($regs);
+        $iov->iov_len = \FFI::sizeof($regs);
+
+        // NT_PRSTATUS = 1
+        $result = $this->ptrace->ptrace(
+            PtraceRequest::PTRACE_GETREGSET,
+            $pid,
+            1,
+            \FFI::addr($iov),
+        );
+
+        if ($result === -1) {
+            return null;
+        }
+
+        return RegisterState::fromAarch64PtraceRegs($regs);
     }
 }

--- a/src/Lib/Dwarf/RegisterState.php
+++ b/src/Lib/Dwarf/RegisterState.php
@@ -14,15 +14,19 @@ declare(strict_types=1);
 namespace Reli\Lib\Dwarf;
 
 /**
- * x86_64 register state with DWARF register number mapping.
+ * Architecture-aware register state with DWARF register number mapping.
  *
  * DWARF register numbers for x86_64 (System V ABI):
  *  0: RAX,  1: RDX,  2: RCX,  3: RBX,  4: RSI,  5: RDI,
  *  6: RBP,  7: RSP,  8: R8,   9: R9,  10: R10, 11: R11,
  * 12: R12, 13: R13, 14: R14, 15: R15, 16: RIP (Return Address)
+ *
+ * DWARF register numbers for AArch64:
+ *  0-30: X0-X30,  31: SP,  32: PC
  */
 final class RegisterState
 {
+    // x86_64 DWARF register numbers
     public const RAX = 0;
     public const RDX = 1;
     public const RCX = 2;
@@ -44,6 +48,16 @@ final class RegisterState
     /** @var array<int, int> DWARF register number => value */
     private array $registers = [];
 
+    public function __construct(
+        private DwarfArchitecture $architecture = DwarfArchitecture::X86_64,
+    ) {
+    }
+
+    public function getArchitecture(): DwarfArchitecture
+    {
+        return $this->architecture;
+    }
+
     public function get(int $dwarfRegNum): int
     {
         return $this->registers[$dwarfRegNum] ?? 0;
@@ -56,17 +70,17 @@ final class RegisterState
 
     public function getRip(): int
     {
-        return $this->get(self::RIP);
+        return $this->get($this->architecture->ipRegister());
     }
 
     public function getRsp(): int
     {
-        return $this->get(self::RSP);
+        return $this->get($this->architecture->spRegister());
     }
 
     public function getRbp(): int
     {
-        return $this->get(self::RBP);
+        return $this->get($this->architecture->fpRegister());
     }
 
     /**
@@ -78,14 +92,13 @@ final class RegisterState
     }
 
     /**
-     * Create from ptrace user_regs_struct FFI data.
-     * The struct layout matches PtraceX64.php's definition.
+     * Create from x86_64 ptrace user_regs_struct FFI data.
      *
      * @psalm-suppress UndefinedPropertyFetch
      */
     public static function fromPtraceRegs(\FFI\CData $regs): self
     {
-        $state = new self();
+        $state = new self(DwarfArchitecture::X86_64);
         $state->set(self::R15, (int)$regs->r15);
         $state->set(self::R14, (int)$regs->r14);
         $state->set(self::R13, (int)$regs->r13);
@@ -103,6 +116,23 @@ final class RegisterState
         $state->set(self::RDI, (int)$regs->di);
         $state->set(self::RIP, (int)$regs->ip);
         $state->set(self::RSP, (int)$regs->sp);
+        return $state;
+    }
+
+    /**
+     * Create from AArch64 ptrace user_pt_regs FFI data.
+     *
+     * @psalm-suppress UndefinedPropertyFetch
+     * @psalm-suppress MixedArrayAccess
+     */
+    public static function fromAarch64PtraceRegs(\FFI\CData $regs): self
+    {
+        $state = new self(DwarfArchitecture::AARCH64);
+        for ($i = 0; $i <= 30; $i++) {
+            $state->set($i, (int)$regs->regs[$i]);
+        }
+        $state->set(31, (int)$regs->sp);
+        $state->set(32, (int)$regs->pc);
         return $state;
     }
 }

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -101,7 +101,8 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                     $root_link_map_address,
                 );
                 $tls_block_address = $tls_finder->findTlsBlock($pid, $link_map?->this_address);
-            } catch (TlsFinderException $e) {
+            } catch (TlsFinderException) {
+            } catch (\Reli\Lib\Process\MemoryReader\MemoryReaderException) {
             }
         }
 

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -101,8 +101,16 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                     $root_link_map_address,
                 );
                 $tls_block_address = $tls_finder->findTlsBlock($pid, $link_map?->this_address);
-            } catch (TlsFinderException) {
-            } catch (\Reli\Lib\Process\MemoryReader\MemoryReaderException) {
+            } catch (TlsFinderException $e) {
+                // TODO: remove diagnostic after ARM64 TLS investigation
+                fwrite(STDERR, "[TLS diag] TlsFinderException: {$e->getMessage()}\n");
+                $prev = $e->getPrevious();
+                if ($prev !== null) {
+                    fwrite(STDERR, "[TLS diag]   caused by: {$prev->getMessage()}\n");
+                }
+            } catch (\Reli\Lib\Process\MemoryReader\MemoryReaderException $e) {
+                // TODO: remove diagnostic after ARM64 TLS investigation
+                fwrite(STDERR, "[TLS diag] MemoryReaderException: {$e->getMessage()}\n");
             }
         }
 

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -101,16 +101,8 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                     $root_link_map_address,
                 );
                 $tls_block_address = $tls_finder->findTlsBlock($pid, $link_map?->this_address);
-            } catch (TlsFinderException $e) {
-                // TODO: remove diagnostic after ARM64 TLS investigation
-                fwrite(STDERR, "[TLS diag] TlsFinderException: {$e->getMessage()}\n");
-                $prev = $e->getPrevious();
-                if ($prev !== null) {
-                    fwrite(STDERR, "[TLS diag]   caused by: {$prev->getMessage()}\n");
-                }
-            } catch (\Reli\Lib\Process\MemoryReader\MemoryReaderException $e) {
-                // TODO: remove diagnostic after ARM64 TLS investigation
-                fwrite(STDERR, "[TLS diag] MemoryReaderException: {$e->getMessage()}\n");
+            } catch (TlsFinderException) {
+            } catch (\Reli\Lib\Process\MemoryReader\MemoryReaderException) {
             }
         }
 

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -17,9 +17,11 @@ use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\SymbolResolver\Elf64CachedSymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\SymbolResolverCreatorInterface;
+use Reli\Lib\Elf\Tls\Aarch64LinuxThreadPointerRetriever;
 use Reli\Lib\Elf\Tls\LibThreadDbTlsFinder;
 use Reli\Lib\Elf\Tls\TlsFinderException;
 use Reli\Lib\Elf\Tls\X64LinuxThreadPointerRetriever;
+use Reli\Lib\System\Architecture;
 use Reli\Lib\File\PathResolver\ProcessPathResolver;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
@@ -81,9 +83,13 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                         $libpthread_module_map
                     );
                 }
+                $thread_pointer_retriever = match (Architecture::detect()) {
+                    Architecture::X86_64 => X64LinuxThreadPointerRetriever::createDefault(),
+                    Architecture::AARCH64 => Aarch64LinuxThreadPointerRetriever::createDefault(),
+                };
                 $tls_finder = new LibThreadDbTlsFinder(
                     $libpthread_symbol_reader,
-                    X64LinuxThreadPointerRetriever::createDefault(),
+                    $thread_pointer_retriever,
                     $this->memory_reader,
                     $this->integer_reader,
                     $this->binary_analysis_cache,

--- a/src/Lib/Elf/Structure/Elf64/Elf64Header.php
+++ b/src/Lib/Elf/Structure/Elf64/Elf64Header.php
@@ -55,6 +55,7 @@ final class Elf64Header
     public const EM_NONE = 0;
     public const EM_386 = 3;
     public const EM_X86_64 = 62;
+    public const EM_AARCH64 = 183;
 
     public function __construct(
         public array $e_ident, // unsigned char[EI_NIDENT]

--- a/src/Lib/Elf/Tls/Aarch64LinuxThreadPointerRetriever.php
+++ b/src/Lib/Elf/Tls/Aarch64LinuxThreadPointerRetriever.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Tls;
 
-use FFI\CData;
-use Reli\Lib\FFI\CannotAllocateBufferException;
 use Reli\Lib\Libc\Errno\Errno;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceAarch64;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceRequest;
-use Reli\Lib\Process\RegisterReader\RegisterReaderException;
 
 /**
  * Retrieves the thread pointer (TPIDR_EL0) on AArch64 Linux
@@ -26,8 +23,6 @@ use Reli\Lib\Process\RegisterReader\RegisterReaderException;
  */
 final class Aarch64LinuxThreadPointerRetriever implements ThreadPointerRetrieverInterface
 {
-    private const NT_ARM_TLS = 0x401;
-
     public static function createDefault(): self
     {
         return new self(
@@ -69,7 +64,7 @@ final class Aarch64LinuxThreadPointerRetriever implements ThreadPointerRetriever
         }
 
         try {
-            $value = $this->readTpidrEl0($pid);
+            $value = $this->ptrace->readTlsRegister($pid);
         } catch (\Throwable $e) {
             if (!$already_attached) {
                 $this->ptrace->ptrace(PtraceRequest::PTRACE_DETACH, $pid, null, null);
@@ -82,42 +77,5 @@ final class Aarch64LinuxThreadPointerRetriever implements ThreadPointerRetriever
         }
 
         return $value;
-    }
-
-    /**
-     * Read TPIDR_EL0 via PTRACE_GETREGSET with NT_ARM_TLS (0x401).
-     * The kernel returns a single 64-bit value.
-     */
-    /** @psalm-suppress UndefinedPropertyAssignment */
-    private function readTpidrEl0(int $pid): int
-    {
-        /** @var \FFI $ffi */
-        $ffi = \FFI::cdef('
-            struct iovec {
-                void  *iov_base;
-                unsigned long iov_len;
-            };
-        ');
-
-        $buf = \FFI::new('unsigned long long')
-            ?? throw new CannotAllocateBufferException('cannot allocate tls buffer');
-        $iov = $ffi->new('struct iovec')
-            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
-
-        $iov->iov_base = \FFI::addr($buf);
-        $iov->iov_len = \FFI::sizeof($buf);
-
-        $result = $this->ptrace->ptrace(
-            PtraceRequest::PTRACE_GETREGSET,
-            $pid,
-            self::NT_ARM_TLS,
-            \FFI::addr($iov),
-        );
-
-        if ($result === -1) {
-            throw new TlsFinderException('PTRACE_GETREGSET NT_ARM_TLS failed');
-        }
-
-        return (int)$buf->cdata;
     }
 }

--- a/src/Lib/Elf/Tls/Aarch64LinuxThreadPointerRetriever.php
+++ b/src/Lib/Elf/Tls/Aarch64LinuxThreadPointerRetriever.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Tls;
+
+use FFI\CData;
+use Reli\Lib\FFI\CannotAllocateBufferException;
+use Reli\Lib\Libc\Errno\Errno;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceAarch64;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceRequest;
+use Reli\Lib\Process\RegisterReader\RegisterReaderException;
+
+/**
+ * Retrieves the thread pointer (TPIDR_EL0) on AArch64 Linux
+ * using PTRACE_GETREGSET with NT_ARM_TLS.
+ */
+final class Aarch64LinuxThreadPointerRetriever implements ThreadPointerRetrieverInterface
+{
+    private const NT_ARM_TLS = 0x401;
+
+    public static function createDefault(): self
+    {
+        return new self(
+            new PtraceAarch64(),
+            new Errno(),
+        );
+    }
+
+    public function __construct(
+        private PtraceAarch64 $ptrace,
+        private Errno $errno,
+    ) {
+    }
+
+    #[\Override]
+    public function getThreadPointer(int $pid): int
+    {
+        $already_attached = false;
+        $attach = $this->ptrace->ptrace(
+            PtraceRequest::PTRACE_ATTACH,
+            $pid,
+            null,
+            null
+        );
+        if ($attach === -1) {
+            $errno = $this->errno->get();
+            if ($errno) {
+                if ($errno === 1) {
+                    $already_attached = true;
+                } else {
+                    throw new TlsFinderException(
+                        "cannot attach to read thread pointer errno={$errno}"
+                    );
+                }
+            }
+        }
+        if (!$already_attached) {
+            pcntl_waitpid($pid, $status, \WUNTRACED);
+        }
+
+        try {
+            $value = $this->readTpidrEl0($pid);
+        } catch (\Throwable $e) {
+            if (!$already_attached) {
+                $this->ptrace->ptrace(PtraceRequest::PTRACE_DETACH, $pid, null, null);
+            }
+            throw new TlsFinderException('cannot find thread pointer', 0, $e);
+        }
+
+        if (!$already_attached) {
+            $this->ptrace->ptrace(PtraceRequest::PTRACE_DETACH, $pid, null, null);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Read TPIDR_EL0 via PTRACE_GETREGSET with NT_ARM_TLS (0x401).
+     * The kernel returns a single 64-bit value.
+     */
+    /** @psalm-suppress UndefinedPropertyAssignment */
+    private function readTpidrEl0(int $pid): int
+    {
+        /** @var \FFI $ffi */
+        $ffi = \FFI::cdef('
+            struct iovec {
+                void  *iov_base;
+                unsigned long iov_len;
+            };
+        ');
+
+        $buf = \FFI::new('unsigned long long')
+            ?? throw new CannotAllocateBufferException('cannot allocate tls buffer');
+        $iov = $ffi->new('struct iovec')
+            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
+
+        $iov->iov_base = \FFI::addr($buf);
+        $iov->iov_len = \FFI::sizeof($buf);
+
+        $result = $this->ptrace->ptrace(
+            PtraceRequest::PTRACE_GETREGSET,
+            $pid,
+            self::NT_ARM_TLS,
+            \FFI::addr($iov),
+        );
+
+        if ($result === -1) {
+            throw new TlsFinderException('PTRACE_GETREGSET NT_ARM_TLS failed');
+        }
+
+        return (int)$buf->cdata;
+    }
+}

--- a/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
+++ b/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
@@ -21,6 +21,7 @@ use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\System\Architecture;
 
 /**
  * This class uses some debugging symbols from libpthread.so,
@@ -48,25 +49,16 @@ final class LibThreadDbTlsFinder implements TlsFinderInterface
     {
         $thread_pointer = $this->thread_pointer_retriever->getThreadPointer($pid);
 
-        // TODO: remove diagnostic after ARM64 TLS investigation
-        fwrite(STDERR, sprintf(
-            "[TLS diag] thread_pointer=0x%x for pid=%d\n",
-            $thread_pointer,
-            $pid,
-        ));
-
         $descriptors = $this->resolveDescriptors();
 
-        // TODO: remove diagnostic after ARM64 TLS investigation
-        fwrite(STDERR, sprintf(
-            "[TLS diag] descriptors: dtvp_offset=%d, dtv_size=%d, pointer_val_offset=%d, modid_offset=%d\n",
-            $descriptors['pthread_dtvp_offset'],
-            $descriptors['dtv_dtv_size'],
-            $descriptors['dtv_t_pointer_val_offset'],
-            $descriptors['link_map_l_tls_modid_offset'],
-        ));
-
-        $dtv_pointer_address = $thread_pointer + $descriptors['pthread_dtvp_offset'];
+        // On AArch64 (TLS Variant I), TPIDR_EL0 points to tcbhead_t, where
+        // dtv is the first field (offset 0). On x86_64 (TLS Variant II),
+        // FS_BASE points to struct pthread, so _thread_db_pthread_dtvp gives
+        // the correct offset to the DTV pointer within the struct.
+        $dtv_pointer_address = match (Architecture::detect()) {
+            Architecture::AARCH64 => $thread_pointer,
+            Architecture::X86_64 => $thread_pointer + $descriptors['pthread_dtvp_offset'],
+        };
         $dtv_pointer_cdata = $this->memory_reader->read($pid, $dtv_pointer_address, 8);
         $dtv_pointer = $this->integer_reader->read64(new CDataByteReader($dtv_pointer_cdata), 0)->toInt();
 

--- a/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
+++ b/src/Lib/Elf/Tls/LibThreadDbTlsFinder.php
@@ -48,7 +48,23 @@ final class LibThreadDbTlsFinder implements TlsFinderInterface
     {
         $thread_pointer = $this->thread_pointer_retriever->getThreadPointer($pid);
 
+        // TODO: remove diagnostic after ARM64 TLS investigation
+        fwrite(STDERR, sprintf(
+            "[TLS diag] thread_pointer=0x%x for pid=%d\n",
+            $thread_pointer,
+            $pid,
+        ));
+
         $descriptors = $this->resolveDescriptors();
+
+        // TODO: remove diagnostic after ARM64 TLS investigation
+        fwrite(STDERR, sprintf(
+            "[TLS diag] descriptors: dtvp_offset=%d, dtv_size=%d, pointer_val_offset=%d, modid_offset=%d\n",
+            $descriptors['pthread_dtvp_offset'],
+            $descriptors['dtv_dtv_size'],
+            $descriptors['dtv_t_pointer_val_offset'],
+            $descriptors['link_map_l_tls_modid_offset'],
+        ));
 
         $dtv_pointer_address = $thread_pointer + $descriptors['pthread_dtvp_offset'];
         $dtv_pointer_cdata = $this->memory_reader->read($pid, $dtv_pointer_address, 8);

--- a/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
+++ b/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Libc\Sys\Ptrace;
+
+use FFI\CData;
+use FFI\CInteger;
+use Reli\Lib\FFI\CannotAllocateBufferException;
+use Reli\Lib\FFI\CannotCastCDataException;
+use Reli\Lib\Libc\Addressable;
+
+final class PtraceAarch64 implements Ptrace
+{
+    /** @var \FFI */
+    private \FFI $ffi;
+
+    public function __construct()
+    {
+        $this->ffi = \FFI::cdef('
+           struct user_pt_regs {
+               unsigned long long regs[31];
+               unsigned long long sp;
+               unsigned long long pc;
+               unsigned long long pstate;
+           };
+           struct iovec {
+               void  *iov_base;
+               unsigned long iov_len;
+           };
+           typedef int pid_t;
+           enum __ptrace_request
+           {
+               PTRACE_TRACEME = 0,
+               PTRACE_PEEKTEXT = 1,
+               PTRACE_PEEKDATA = 2,
+               PTRACE_POKETEXT = 4,
+               PTRACE_POKEDATA = 5,
+               PTRACE_CONT = 7,
+               PTRACE_KILL = 8,
+               PTRACE_SINGLESTEP = 9,
+               PTRACE_ATTACH = 16,
+               PTRACE_DETACH = 17,
+               PTRACE_SYSCALL = 24,
+               PTRACE_SETOPTIONS = 0x4200,
+               PTRACE_GETEVENTMSG = 0x4201,
+               PTRACE_GETSIGINFO = 0x4202,
+               PTRACE_SETSIGINFO = 0x4203,
+               PTRACE_GETREGSET = 0x4204,
+               PTRACE_SETREGSET = 0x4205
+           };
+           long ptrace(enum __ptrace_request request, pid_t pid, void *addr, void *data);
+           int errno;
+       ', 'libc.so.6');
+    }
+
+    #[\Override]
+    public function ptrace(
+        PtraceRequest $request,
+        int $pid,
+        Addressable|CData|null|int $addr,
+        Addressable|CData|null|int $data,
+    ): int {
+        if (is_null($addr) or is_int($addr)) {
+            /** @var CInteger */
+            $addr_holder = \FFI::new('long')
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $addr_holder->cdata = (int)$addr;
+            $addr = \FFI::cast('void *', $addr_holder)
+                ?? throw new CannotCastCDataException('cannot cast buffer');
+        }
+        if (is_null($data) or is_int($data)) {
+            /** @var CInteger */
+            $data_holder = \FFI::new('long')
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $data_holder->cdata = (int)$data;
+            $data = \FFI::cast('void *', $data_holder)
+                ?? throw new CannotCastCDataException('cannot cast buffer');
+        }
+
+        $addr_pointer = $addr instanceof Addressable ? $addr->toVoidPointer() : $addr;
+        $data_pointer = $data instanceof Addressable ? $data->toVoidPointer() : $data;
+
+        /** @var int */
+        return $this->ffi->ptrace(
+            $request->value,
+            $pid,
+            $addr_pointer,
+            $data_pointer,
+        );
+    }
+
+    /**
+     * Read all general-purpose registers via PTRACE_GETREGSET + NT_PRSTATUS.
+     *
+     * @return CData user_pt_regs struct
+     * @psalm-suppress UndefinedPropertyAssignment
+     */
+    public function getRegisters(int $pid): CData
+    {
+        $regs = $this->ffi->new('struct user_pt_regs')
+            ?? throw new CannotAllocateBufferException('cannot allocate user_pt_regs');
+        $iov = $this->ffi->new('struct iovec')
+            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
+
+        $iov->iov_base = \FFI::addr($regs);
+        $iov->iov_len = \FFI::sizeof($regs);
+
+        // NT_PRSTATUS = 1
+        $result = $this->ptrace(
+            PtraceRequest::PTRACE_GETREGSET,
+            $pid,
+            1,
+            \FFI::addr($iov),
+        );
+
+        if ($result === -1) {
+            throw new \RuntimeException('PTRACE_GETREGSET failed');
+        }
+
+        return $regs;
+    }
+}

--- a/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
+++ b/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
@@ -129,4 +129,39 @@ final class PtraceAarch64 implements Ptrace
 
         return $regs;
     }
+
+    /**
+     * Read TPIDR_EL0 (thread pointer) via PTRACE_GETREGSET + NT_ARM_TLS.
+     * All buffers are allocated from the same FFI context to avoid cross-context issues.
+     *
+     * @psalm-suppress UndefinedPropertyAssignment
+     * @psalm-suppress UndefinedPropertyFetch
+     * @psalm-suppress InvalidCast
+     */
+    public function readTlsRegister(int $pid): int
+    {
+        $buf = $this->ffi->new('unsigned long long')
+            ?? throw new CannotAllocateBufferException('cannot allocate tls buffer');
+        $iov = $this->ffi->new('struct iovec')
+            ?? throw new CannotAllocateBufferException('cannot allocate iovec');
+
+        $iov->iov_base = \FFI::addr($buf);
+        $iov->iov_len = \FFI::sizeof($buf);
+
+        // NT_ARM_TLS = 0x401
+        $result = $this->ptrace(
+            PtraceRequest::PTRACE_GETREGSET,
+            $pid,
+            0x401,
+            \FFI::addr($iov),
+        );
+
+        if ($result === -1) {
+            throw new \RuntimeException(
+                'PTRACE_GETREGSET NT_ARM_TLS failed, errno=' . ((int)$this->ffi->errno)
+            );
+        }
+
+        return (int)$buf->cdata;
+    }
 }

--- a/src/Lib/Libc/Sys/Ptrace/PtraceRequest.php
+++ b/src/Lib/Libc/Sys/Ptrace/PtraceRequest.php
@@ -38,4 +38,5 @@ enum PtraceRequest: int
     case PTRACE_GETEVENTMSG = 0x4201;
     case PTRACE_GETSIGINFO = 0x4202;
     case PTRACE_SETSIGINFO = 0x4203;
+    case PTRACE_GETREGSET = 0x4204;
 }

--- a/src/Lib/Process/ProcessStopper/ProcessStopper.php
+++ b/src/Lib/Process/ProcessStopper/ProcessStopper.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Process\ProcessStopper;
 
-use FFI\CInteger;
 use Reli\Lib\Libc\Errno\Errno;
+use Reli\Lib\Libc\Sys\Ptrace\Ptrace;
 use Reli\Lib\Libc\Sys\Ptrace\PtraceRequest;
-use Reli\Lib\Libc\Sys\Ptrace\PtraceX64;
 
 final class ProcessStopper
 {
     public function __construct(
-        private PtraceX64 $ptrace,
+        private Ptrace $ptrace,
         private Errno $errno,
     ) {
     }

--- a/src/Lib/Process/RegisterReader/Aarch64RegisterReader.php
+++ b/src/Lib/Process/RegisterReader/Aarch64RegisterReader.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\RegisterReader;
+
+use Reli\Lib\Libc\Errno\Errno;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceAarch64;
+use Reli\Lib\Libc\Sys\Ptrace\PtraceRequest;
+
+final class Aarch64RegisterReader
+{
+    /** Register index constants for user_pt_regs */
+    public const X0 = 0;
+    public const X1 = 1;
+    public const X2 = 2;
+    public const X3 = 3;
+    public const X4 = 4;
+    public const X5 = 5;
+    public const X6 = 6;
+    public const X7 = 7;
+    public const X8 = 8;
+    public const X9 = 9;
+    public const X10 = 10;
+    public const X11 = 11;
+    public const X12 = 12;
+    public const X13 = 13;
+    public const X14 = 14;
+    public const X15 = 15;
+    public const X16 = 16;
+    public const X17 = 17;
+    public const X18 = 18;
+    public const X19 = 19;
+    public const X20 = 20;
+    public const X21 = 21;
+    public const X22 = 22;
+    public const X23 = 23;
+    public const X24 = 24;
+    public const X25 = 25;
+    public const X26 = 26;
+    public const X27 = 27;
+    public const X28 = 28;
+    public const X29 = 29; // FP (frame pointer)
+    public const X30 = 30; // LR (link register)
+    public const SP = 31;
+    public const PC = 32;
+
+    public function __construct(
+        private PtraceAarch64 $ptrace,
+        private Errno $errno,
+    ) {
+    }
+
+    /**
+     * Attach to a process, read a single register value, and detach.
+     *
+     * @param int $register One of the register index constants (X0-X30, SP, PC)
+     * @throws RegisterReaderException
+     */
+    public function attachAndReadOne(int $pid, int $register): int
+    {
+        $already_attached = false;
+        $attach = $this->ptrace->ptrace(
+            PtraceRequest::PTRACE_ATTACH,
+            $pid,
+            null,
+            null
+        );
+        if ($attach === -1) {
+            $errno = $this->errno->get();
+            if ($errno) {
+                if ($errno === 1) {
+                    $already_attached = true;
+                } else {
+                    throw new RegisterReaderException(
+                        "failed to attach process errno={$errno}",
+                        $errno
+                    );
+                }
+            }
+        }
+        if (!$already_attached) {
+            pcntl_waitpid($pid, $status, \WUNTRACED);
+        }
+
+        try {
+            $regs = $this->ptrace->getRegisters($pid);
+        } catch (\Throwable $e) {
+            if (!$already_attached) {
+                $this->ptrace->ptrace(PtraceRequest::PTRACE_DETACH, $pid, null, null);
+            }
+            throw new RegisterReaderException(
+                "failed to read registers: {$e->getMessage()}",
+                0,
+                $e
+            );
+        }
+
+        /**
+         * @var int $value
+         * @psalm-suppress UndefinedPropertyFetch
+         * @psalm-suppress MixedArrayAccess
+         */
+        $value = match ($register) {
+            self::SP => (int)$regs->sp,
+            self::PC => (int)$regs->pc,
+            default => (int)$regs->regs[$register],
+        };
+
+        if (!$already_attached) {
+            $detach = $this->ptrace->ptrace(
+                PtraceRequest::PTRACE_DETACH,
+                $pid,
+                null,
+                null
+            );
+            if ($detach === -1) {
+                $errno = $this->errno->get();
+                if ($errno) {
+                    throw new RegisterReaderException(
+                        "failed to detach process errno={$errno}",
+                        $errno
+                    );
+                }
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Lib/System/Architecture.php
+++ b/src/Lib/System/Architecture.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\System;
+
+enum Architecture: string
+{
+    case X86_64 = 'x86_64';
+    case AARCH64 = 'aarch64';
+
+    public static function detect(): self
+    {
+        $machine = php_uname('m');
+        return self::from($machine);
+    }
+}

--- a/tests/Lib/Dwarf/DwarfArchitectureTest.php
+++ b/tests/Lib/Dwarf/DwarfArchitectureTest.php
@@ -18,7 +18,8 @@ use Reli\Lib\System\Architecture;
 
 class DwarfArchitectureTest extends BaseTestCase
 {
-    public function testX86RegisterNumbers(): void
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function testX86_64RegisterNumbers(): void
     {
         $arch = DwarfArchitecture::X86_64;
         $this->assertSame(16, $arch->ipRegister());

--- a/tests/Lib/Dwarf/DwarfArchitectureTest.php
+++ b/tests/Lib/Dwarf/DwarfArchitectureTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Dwarf;
+
+use Reli\BaseTestCase;
+use Reli\Lib\System\Architecture;
+
+class DwarfArchitectureTest extends BaseTestCase
+{
+    public function testX86_64RegisterNumbers(): void
+    {
+        $arch = DwarfArchitecture::X86_64;
+        $this->assertSame(16, $arch->ipRegister());
+        $this->assertSame(7, $arch->spRegister());
+        $this->assertSame(6, $arch->fpRegister());
+        $this->assertSame([3, 6, 12, 13, 14, 15], $arch->calleeSavedRegisters());
+    }
+
+    public function testAarch64RegisterNumbers(): void
+    {
+        $arch = DwarfArchitecture::AARCH64;
+        $this->assertSame(32, $arch->ipRegister());
+        $this->assertSame(31, $arch->spRegister());
+        $this->assertSame(29, $arch->fpRegister());
+        $this->assertSame(
+            [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+            $arch->calleeSavedRegisters()
+        );
+    }
+
+    public function testFromArchitecture(): void
+    {
+        $this->assertSame(
+            DwarfArchitecture::X86_64,
+            DwarfArchitecture::fromArchitecture(Architecture::X86_64)
+        );
+        $this->assertSame(
+            DwarfArchitecture::AARCH64,
+            DwarfArchitecture::fromArchitecture(Architecture::AARCH64)
+        );
+    }
+}

--- a/tests/Lib/Dwarf/DwarfArchitectureTest.php
+++ b/tests/Lib/Dwarf/DwarfArchitectureTest.php
@@ -18,7 +18,7 @@ use Reli\Lib\System\Architecture;
 
 class DwarfArchitectureTest extends BaseTestCase
 {
-    public function testX86_64RegisterNumbers(): void
+    public function testX8664RegisterNumbers(): void
     {
         $arch = DwarfArchitecture::X86_64;
         $this->assertSame(16, $arch->ipRegister());

--- a/tests/Lib/Dwarf/DwarfArchitectureTest.php
+++ b/tests/Lib/Dwarf/DwarfArchitectureTest.php
@@ -18,7 +18,7 @@ use Reli\Lib\System\Architecture;
 
 class DwarfArchitectureTest extends BaseTestCase
 {
-    public function testX8664RegisterNumbers(): void
+    public function testX86RegisterNumbers(): void
     {
         $arch = DwarfArchitecture::X86_64;
         $this->assertSame(16, $arch->ipRegister());

--- a/tests/Lib/Dwarf/EhFrameParserTest.php
+++ b/tests/Lib/Dwarf/EhFrameParserTest.php
@@ -17,6 +17,7 @@ use Reli\BaseTestCase;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\System\Architecture;
 
 class EhFrameParserTest extends BaseTestCase
 {
@@ -95,12 +96,20 @@ class EhFrameParserTest extends BaseTestCase
         );
 
         // All FDEs should have valid CIE references
+        $is_aarch64 = Architecture::detect() === Architecture::AARCH64;
         foreach (array_slice($fdes, 0, 50) as $fde) {
             $this->assertNotNull($fde->cie);
-            // x86_64 standard: code_alignment=1, data_alignment=-8, return_address=16
-            $this->assertSame(1, $fde->cie->codeAlignmentFactor);
-            $this->assertSame(-8, $fde->cie->dataAlignmentFactor);
-            $this->assertSame(16, $fde->cie->returnAddressRegister);
+            if ($is_aarch64) {
+                // AArch64 standard: code_alignment=4, data_alignment=-8, return_address=30 (LR)
+                $this->assertSame(4, $fde->cie->codeAlignmentFactor);
+                $this->assertSame(-8, $fde->cie->dataAlignmentFactor);
+                $this->assertSame(30, $fde->cie->returnAddressRegister);
+            } else {
+                // x86_64 standard: code_alignment=1, data_alignment=-8, return_address=16 (RIP)
+                $this->assertSame(1, $fde->cie->codeAlignmentFactor);
+                $this->assertSame(-8, $fde->cie->dataAlignmentFactor);
+                $this->assertSame(16, $fde->cie->returnAddressRegister);
+            }
         }
     }
 

--- a/tests/Lib/Dwarf/RegisterStateTest.php
+++ b/tests/Lib/Dwarf/RegisterStateTest.php
@@ -67,7 +67,7 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(16, RegisterState::RIP);
     }
 
-    public function testDefaultArchitectureIsX8664(): void
+    public function testDefaultArchitectureIsX86(): void
     {
         $state = new RegisterState();
         $this->assertSame(DwarfArchitecture::X86_64, $state->getArchitecture());
@@ -92,7 +92,7 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(0x7fff0010, $state->getRbp());
     }
 
-    public function testX8664ConvenienceMethodsUnchanged(): void
+    public function testX86ConvenienceMethodsUnchanged(): void
     {
         // Ensure x86_64 convenience methods still use the correct registers
         $state = new RegisterState(DwarfArchitecture::X86_64);

--- a/tests/Lib/Dwarf/RegisterStateTest.php
+++ b/tests/Lib/Dwarf/RegisterStateTest.php
@@ -66,4 +66,42 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(7, RegisterState::RSP);
         $this->assertSame(16, RegisterState::RIP);
     }
+
+    public function testDefaultArchitectureIsX86_64(): void
+    {
+        $state = new RegisterState();
+        $this->assertSame(DwarfArchitecture::X86_64, $state->getArchitecture());
+    }
+
+    public function testAarch64Architecture(): void
+    {
+        $state = new RegisterState(DwarfArchitecture::AARCH64);
+        $this->assertSame(DwarfArchitecture::AARCH64, $state->getArchitecture());
+    }
+
+    public function testAarch64ConvenienceMethods(): void
+    {
+        $state = new RegisterState(DwarfArchitecture::AARCH64);
+        // AArch64 DWARF: PC=32, SP=31, FP(X29)=29
+        $state->set(32, 0x400000);  // PC
+        $state->set(31, 0x7fff0000);  // SP
+        $state->set(29, 0x7fff0010);  // FP (X29)
+
+        $this->assertSame(0x400000, $state->getRip());
+        $this->assertSame(0x7fff0000, $state->getRsp());
+        $this->assertSame(0x7fff0010, $state->getRbp());
+    }
+
+    public function testX86_64ConvenienceMethodsUnchanged(): void
+    {
+        // Ensure x86_64 convenience methods still use the correct registers
+        $state = new RegisterState(DwarfArchitecture::X86_64);
+        $state->set(16, 0x400000);  // RIP
+        $state->set(7, 0x7fff0000);  // RSP
+        $state->set(6, 0x7fff0010);  // RBP
+
+        $this->assertSame(0x400000, $state->getRip());
+        $this->assertSame(0x7fff0000, $state->getRsp());
+        $this->assertSame(0x7fff0010, $state->getRbp());
+    }
 }

--- a/tests/Lib/Dwarf/RegisterStateTest.php
+++ b/tests/Lib/Dwarf/RegisterStateTest.php
@@ -67,7 +67,8 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(16, RegisterState::RIP);
     }
 
-    public function testDefaultArchitectureIsX86(): void
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function testDefaultArchitectureIsX86_64(): void
     {
         $state = new RegisterState();
         $this->assertSame(DwarfArchitecture::X86_64, $state->getArchitecture());
@@ -92,7 +93,8 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(0x7fff0010, $state->getRbp());
     }
 
-    public function testX86ConvenienceMethodsUnchanged(): void
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function testX86_64ConvenienceMethodsUnchanged(): void
     {
         // Ensure x86_64 convenience methods still use the correct registers
         $state = new RegisterState(DwarfArchitecture::X86_64);

--- a/tests/Lib/Dwarf/RegisterStateTest.php
+++ b/tests/Lib/Dwarf/RegisterStateTest.php
@@ -67,7 +67,7 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(16, RegisterState::RIP);
     }
 
-    public function testDefaultArchitectureIsX86_64(): void
+    public function testDefaultArchitectureIsX8664(): void
     {
         $state = new RegisterState();
         $this->assertSame(DwarfArchitecture::X86_64, $state->getArchitecture());
@@ -92,7 +92,7 @@ class RegisterStateTest extends BaseTestCase
         $this->assertSame(0x7fff0010, $state->getRbp());
     }
 
-    public function testX86_64ConvenienceMethodsUnchanged(): void
+    public function testX8664ConvenienceMethodsUnchanged(): void
     {
         // Ensure x86_64 convenience methods still use the correct registers
         $state = new RegisterState(DwarfArchitecture::X86_64);

--- a/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
+++ b/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
@@ -19,6 +19,7 @@ use Reli\BaseTestCase;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\System\Architecture;
 
 class LibThreadDbTlsFinderTest extends BaseTestCase
 {
@@ -58,7 +59,13 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
         $module_id[0] = 1;
 
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
-        $memory_reader->expects()->read(1, 0x10008, 8)->andReturns($dtv_address);
+        // On AArch64 (TLS Variant I), DTV is read from thread_pointer + 0;
+        // on x86_64 (TLS Variant II), from thread_pointer + dtvp_offset (8).
+        $dtv_read_address = match (Architecture::detect()) {
+            Architecture::AARCH64 => 0x10000,
+            Architecture::X86_64 => 0x10008,
+        };
+        $memory_reader->expects()->read(1, $dtv_read_address, 8)->andReturns($dtv_address);
         $memory_reader->expects()->read(1, 0x20008, 8)->andReturns($tls_block_address);
         $memory_reader->expects()->read(1, 0x40080, 4)->andReturns($module_id);
 

--- a/tests/Lib/System/ArchitectureTest.php
+++ b/tests/Lib/System/ArchitectureTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\System;
+
+use Reli\BaseTestCase;
+
+class ArchitectureTest extends BaseTestCase
+{
+    public function testFromX86_64(): void
+    {
+        $this->assertSame(Architecture::X86_64, Architecture::from('x86_64'));
+    }
+
+    public function testFromAarch64(): void
+    {
+        $this->assertSame(Architecture::AARCH64, Architecture::from('aarch64'));
+    }
+
+    public function testFromInvalidThrows(): void
+    {
+        $this->expectException(\ValueError::class);
+        Architecture::from('mips');
+    }
+
+    public function testDetectReturnsValidArchitecture(): void
+    {
+        $arch = Architecture::detect();
+        $this->assertContains($arch, [Architecture::X86_64, Architecture::AARCH64]);
+    }
+}

--- a/tests/Lib/System/ArchitectureTest.php
+++ b/tests/Lib/System/ArchitectureTest.php
@@ -17,7 +17,8 @@ use Reli\BaseTestCase;
 
 class ArchitectureTest extends BaseTestCase
 {
-    public function testFromX86(): void
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function testFromX86_64(): void
     {
         $this->assertSame(Architecture::X86_64, Architecture::from('x86_64'));
     }

--- a/tests/Lib/System/ArchitectureTest.php
+++ b/tests/Lib/System/ArchitectureTest.php
@@ -17,7 +17,7 @@ use Reli\BaseTestCase;
 
 class ArchitectureTest extends BaseTestCase
 {
-    public function testFromX86_64(): void
+    public function testFromX86(): void
     {
         $this->assertSame(Architecture::X86_64, Architecture::from('x86_64'));
     }


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for ARM64 (AArch64) architecture to the profiler, enabling stack unwinding, register reading, and thread pointer retrieval on AArch64 Linux systems.

## Key Changes

### New Architecture Support
- **Architecture Detection**: Added `Architecture` enum to detect and represent x86_64 and AArch64 architectures
- **DWARF Architecture Mapping**: Created `DwarfArchitecture` enum to map architecture-specific DWARF register numbers and provide architecture-aware register utilities

### AArch64-Specific Components
- **PtraceAarch64**: New ptrace implementation for AArch64 using `PTRACE_GETREGSET` with `NT_PRSTATUS` to read general-purpose registers via the `user_pt_regs` structure
- **Aarch64RegisterReader**: Register reader for AArch64 with support for all 31 general-purpose registers plus SP and PC
- **Aarch64LinuxThreadPointerRetriever**: Thread pointer (TPIDR_EL0) retrieval using `PTRACE_GETREGSET` with `NT_ARM_TLS` (0x401)

### Register State Enhancements
- **RegisterState**: Made architecture-aware with constructor parameter and methods to get architecture-specific register numbers (IP, SP, FP)
- Added `fromAarch64PtraceRegs()` factory method to create register state from AArch64 ptrace data
- Updated `getRip()`, `getRsp()`, and `getRbp()` to use architecture-specific DWARF register numbers

### Stack Unwinding Updates
- **NativeStackUnwinder**: Updated to use architecture-specific register numbers and callee-saved register lists
- **NativeTraceCollector**: Added AArch64 register reading support using `PTRACE_GETREGSET`
- **FramePointerUnwind**: Made architecture-agnostic by using generic frame pointer terminology

### Infrastructure
- Updated DI container to select appropriate Ptrace implementation based on detected architecture
- Added AArch64 ELF machine type constant (`EM_AARCH64 = 183`)
- Added `PTRACE_GETREGSET` to PtraceRequest enum
- Added ARM64 CI workflow for unit tests on ARM64 runners

### Compatibility
- Maintained backward compatibility with x86_64 architecture
- All x86_64-specific code paths remain unchanged
- Architecture detection is automatic based on system uname

https://claude.ai/code/session_01MFZ1B6XqFWfC32QrJAQhDF