### PR TITLE
Fix native/PHP trace merging: frame direction, placement, and zend_execute boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ $ sudo php ./reli i:trace --with-native-trace -p <pid>
 2 libc.so.6::usleep+0x4c [native]:0
 3 php8.4::zif_usleep+0x42 [native]:0
 4 usleep <internal>:-1
-5 php8.4::execute_ex+0x4dfa [native]:0
-6 <main> /app/test.php:15
+5 <main> /app/test.php:15
+6 php8.4::execute_ex+0x4dfa [native]:0
 7 php8.4::zend_execute+0x141 [native]:0
 8 php8.4::zend_execute_script+0x56 [native]:0
 9 php8.4::php_execute_script_ex+0x278 [native]:0
@@ -517,7 +517,7 @@ $ sudo php ./reli i:trace --with-native-trace -p <pid>
 11 php8.4::_start+0x25 [native]:0
 ```
 
-Native frames are labeled with `[native]:0` and show `module::symbol+offset`. PHP frames are interleaved just before their VM execution boundaries (`execute_ex`, `zend_execute`), reflecting the correct caller-callee relationship: the VM boundary dispatches/runs the PHP function.
+Native frames are labeled with `[native]:0` and show `module::symbol+offset`. PHP frames are placed on the callee side of `execute_ex`, reflecting that all PHP execution happens inside the VM's opcode dispatcher.
 
 The output is phpspy-compatible, so it can be directly converted to flamegraphs or speedscope profiles:
 ```bash

--- a/README.md
+++ b/README.md
@@ -507,17 +507,17 @@ $ sudo php ./reli i:trace --with-native-trace -p <pid>
 1 libc.so.6::__nanosleep+0x17 [native]:0
 2 libc.so.6::usleep+0x4c [native]:0
 3 php8.4::zif_usleep+0x42 [native]:0
-4 php8.4::execute_ex+0x4dfa [native]:0
-5 usleep <internal>:-1
-6 php8.4::zend_execute+0x141 [native]:0
-7 <main> /app/test.php:15
+4 usleep <internal>:-1
+5 php8.4::execute_ex+0x4dfa [native]:0
+6 <main> /app/test.php:15
+7 php8.4::zend_execute+0x141 [native]:0
 8 php8.4::zend_execute_script+0x56 [native]:0
 9 php8.4::php_execute_script_ex+0x278 [native]:0
 10 libc.so.6::__libc_start_main+0x8b [native]:0
 11 php8.4::_start+0x25 [native]:0
 ```
 
-Native frames are labeled with `[native]:0` and show `module::symbol+offset`. PHP frames are interleaved at the VM execution boundaries (`execute_ex`, `zend_execute`).
+Native frames are labeled with `[native]:0` and show `module::symbol+offset`. PHP frames are interleaved just before their VM execution boundaries (`execute_ex`, `zend_execute`), reflecting the correct caller-callee relationship: the VM boundary dispatches/runs the PHP function.
 
 The output is phpspy-compatible, so it can be directly converted to flamegraphs or speedscope profiles:
 ```bash

--- a/README.md
+++ b/README.md
@@ -508,9 +508,9 @@ $ sudo php ./reli i:trace --with-native-trace -p <pid>
 2 libc.so.6::usleep+0x4c [native]:0
 3 php8.4::zif_usleep+0x42 [native]:0
 4 php8.4::execute_ex+0x4dfa [native]:0
-5 <main> /app/test.php:15
+5 usleep <internal>:-1
 6 php8.4::zend_execute+0x141 [native]:0
-7 usleep <internal>:-1
+7 <main> /app/test.php:15
 8 php8.4::zend_execute_script+0x56 [native]:0
 9 php8.4::php_execute_script_ex+0x278 [native]:0
 10 libc.so.6::__libc_start_main+0x8b [native]:0

--- a/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
@@ -53,6 +53,15 @@ final class TraceMerger
             $native_frame = $native_frames[$i];
             $symbol_name = $native_frame->symbolName ?? '';
 
+            // If this is a PHP VM execution function, insert the PHP frame BEFORE it.
+            // The VM boundary (execute_ex, zend_execute, etc.) is the caller that
+            // dispatches/runs the PHP function, so the PHP frame belongs on the
+            // inner (callee) side of the boundary.
+            if ($this->isPhpVmFunction($symbol_name) && $php_frame_index < $php_frame_count) {
+                $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
+                $php_frame_index++;
+            }
+
             // Add native frame
             $merged[] = MergedCallFrame::fromNative(
                 new NativeCallFrame(
@@ -62,12 +71,6 @@ final class TraceMerger
                     $native_frame->ip,
                 )
             );
-
-            // If this is a PHP VM execution function, insert the corresponding PHP frame
-            if ($this->isPhpVmFunction($symbol_name) && $php_frame_index < $php_frame_count) {
-                $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
-                $php_frame_index++;
-            }
         }
 
         // Add remaining PHP frames that weren't matched

--- a/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
@@ -18,12 +18,21 @@ use Reli\Lib\Dwarf\NativeTrace;
 final class TraceMerger
 {
     /**
-     * PHP VM execution function names that indicate a PHP frame boundary.
-     * When we see these in the native trace, the next PHP frame corresponds.
+     * PHP VM boundary functions where PHP frames should be inserted.
+     *
+     * execute_ex: the opcode dispatcher — each call runs one PHP function's opcodes.
+     * ZEND_DO_*CALL handlers: opcode handlers that invoke PHP functions.
+     *   - ICALL: calls internal (C) functions like strlen, usleep
+     *   - UCALL: calls user functions (triggers another execute_ex)
+     *   - FCALL: general function call
+     *   - INCLUDE_OR_EVAL: include/require/eval (triggers another execute_ex)
+     *
+     * zend_execute is intentionally excluded — it's just a thin wrapper that
+     * calls execute_ex for the top-level script. All PHP execution happens
+     * inside execute_ex, so zend_execute doesn't correspond to a PHP frame.
      */
     private const PHP_VM_FUNCTIONS = [
         'execute_ex',
-        'zend_execute',
         'ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER',
         'ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER',
         'ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER',
@@ -40,29 +49,51 @@ final class TraceMerger
     public function merge(NativeTrace $nativeTrace, CallTrace $phpTrace): MergedCallTrace
     {
         $merged = [];
-        $php_frame_index = 0; // start from innermost (current) frame
+        $php_frame_index = 0;
         $php_frame_count = count($phpTrace->call_frames);
 
-        // Native frames are ordered top-to-bottom (innermost/current first)
-        // PHP call_frames are also ordered innermost first
-        // Match them in the same direction: inner to outer
         $native_frames = $nativeTrace->frames;
         $native_count = count($native_frames);
+
+        // Count total VM boundaries in native trace to determine how many
+        // PHP frames each boundary should consume.
+        $total_boundaries = 0;
+        for ($i = 0; $i < $native_count; $i++) {
+            if ($this->isPhpVmFunction($native_frames[$i]->symbolName ?? '')) {
+                $total_boundaries++;
+            }
+        }
+
+        $first_boundary = true;
+        $remaining_boundaries = $total_boundaries;
 
         for ($i = 0; $i < $native_count; $i++) {
             $native_frame = $native_frames[$i];
             $symbol_name = $native_frame->symbolName ?? '';
 
-            // If this is a PHP VM execution function, insert the PHP frame BEFORE it.
-            // The VM boundary (execute_ex, zend_execute, etc.) is the caller that
-            // dispatches/runs the PHP function, so the PHP frame belongs on the
-            // inner (callee) side of the boundary.
             if ($this->isPhpVmFunction($symbol_name) && $php_frame_index < $php_frame_count) {
-                $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
-                $php_frame_index++;
+                if ($first_boundary) {
+                    // At the first (innermost) VM boundary, consume any "excess"
+                    // PHP frames that lack their own boundary. This handles
+                    // internal function calls (ICALL) whose opcode handlers were
+                    // inlined into execute_ex and don't appear in the native trace.
+                    // e.g., <main> calls usleep(): 2 PHP frames but only 1 execute_ex
+                    //   → consume usleep (excess) + <main> (this boundary's frame)
+                    $excess = $php_frame_count - $remaining_boundaries;
+                    for ($j = 0; $j < $excess; $j++) {
+                        $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
+                        $php_frame_index++;
+                    }
+                    $first_boundary = false;
+                }
+                // Consume one PHP frame for this VM boundary
+                if ($php_frame_index < $php_frame_count) {
+                    $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
+                    $php_frame_index++;
+                }
+                $remaining_boundaries--;
             }
 
-            // Add native frame
             $merged[] = MergedCallFrame::fromNative(
                 new NativeCallFrame(
                     $native_frame->symbolName ?? sprintf('0x%x', $native_frame->ip),
@@ -84,12 +115,10 @@ final class TraceMerger
 
     private function isPhpVmFunction(string $symbolName): bool
     {
-        // Exact match for known functions
         if (in_array($symbolName, self::PHP_VM_FUNCTIONS, true)) {
             return true;
         }
 
-        // Pattern match for ZEND_DO_*CALL* handler variants
         if (str_starts_with($symbolName, 'ZEND_DO_') && str_contains($symbolName, 'CALL')) {
             return true;
         }

--- a/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/TraceMerger.php
@@ -40,14 +40,15 @@ final class TraceMerger
     public function merge(NativeTrace $nativeTrace, CallTrace $phpTrace): MergedCallTrace
     {
         $merged = [];
-        $php_frame_index = count($phpTrace->call_frames) - 1; // start from deepest
+        $php_frame_index = 0; // start from innermost (current) frame
+        $php_frame_count = count($phpTrace->call_frames);
 
-        // Walk native frames from bottom (main) to top (current)
-        // Native frames are ordered top-to-bottom, so reverse iterate
+        // Native frames are ordered top-to-bottom (innermost/current first)
+        // PHP call_frames are also ordered innermost first
+        // Match them in the same direction: inner to outer
         $native_frames = $nativeTrace->frames;
         $native_count = count($native_frames);
 
-        // Process native frames top-to-bottom (as they come from unwinder)
         for ($i = 0; $i < $native_count; $i++) {
             $native_frame = $native_frames[$i];
             $symbol_name = $native_frame->symbolName ?? '';
@@ -63,16 +64,16 @@ final class TraceMerger
             );
 
             // If this is a PHP VM execution function, insert the corresponding PHP frame
-            if ($this->isPhpVmFunction($symbol_name) && $php_frame_index >= 0) {
+            if ($this->isPhpVmFunction($symbol_name) && $php_frame_index < $php_frame_count) {
                 $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
-                $php_frame_index--;
+                $php_frame_index++;
             }
         }
 
         // Add remaining PHP frames that weren't matched
-        while ($php_frame_index >= 0) {
+        while ($php_frame_index < $php_frame_count) {
             $merged[] = MergedCallFrame::fromPhp($phpTrace->call_frames[$php_frame_index]);
-            $php_frame_index--;
+            $php_frame_index++;
         }
 
         return new MergedCallTrace(...$merged);

--- a/tests/Lib/Dwarf/TraceMergerTest.php
+++ b/tests/Lib/Dwarf/TraceMergerTest.php
@@ -54,14 +54,15 @@ class TraceMergerTest extends BaseTestCase
 
         $merged = $this->merger->merge($native, $php);
 
-        // Should have: some_internal [native], execute_ex [native], myFunction [php], zend_execute_script [native]
+        // Should have: some_internal [native], myFunction [php], execute_ex [native], zend_execute_script [native]
+        // PHP frame is placed BEFORE its VM boundary (execute_ex dispatches/runs myFunction)
         $this->assertCount(4, $merged->frames);
         $this->assertTrue($merged->frames[0]->isNative());
         $this->assertSame('some_internal', $merged->frames[0]->nativeFrame->symbol_name);
-        $this->assertTrue($merged->frames[1]->isNative());
-        $this->assertSame('execute_ex', $merged->frames[1]->nativeFrame->symbol_name);
-        $this->assertTrue($merged->frames[2]->isPhp());
-        $this->assertSame('myFunction', $merged->frames[2]->phpFrame->function_name);
+        $this->assertTrue($merged->frames[1]->isPhp());
+        $this->assertSame('myFunction', $merged->frames[1]->phpFrame->function_name);
+        $this->assertTrue($merged->frames[2]->isNative());
+        $this->assertSame('execute_ex', $merged->frames[2]->nativeFrame->symbol_name);
         $this->assertTrue($merged->frames[3]->isNative());
     }
 
@@ -80,14 +81,14 @@ class TraceMergerTest extends BaseTestCase
 
         $merged = $this->merger->merge($native, $php);
 
-        // execute_ex (inner VM boundary) should get sleep_wrapper (innermost PHP frame)
-        // zend_execute (outer VM boundary) should get main (outermost PHP frame)
+        // PHP frames are placed BEFORE their VM boundaries (inner side):
+        // zif_sleep [native], sleep_wrapper [php], execute_ex [native], main [php], zend_execute [native]
         $this->assertCount(5, $merged->frames);
         $this->assertSame('zif_sleep', $merged->frames[0]->nativeFrame->symbol_name);
-        $this->assertSame('execute_ex', $merged->frames[1]->nativeFrame->symbol_name);
-        $this->assertSame('sleep_wrapper', $merged->frames[2]->phpFrame->function_name);
-        $this->assertSame('zend_execute', $merged->frames[3]->nativeFrame->symbol_name);
-        $this->assertSame('main', $merged->frames[4]->phpFrame->function_name);
+        $this->assertSame('sleep_wrapper', $merged->frames[1]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[2]->nativeFrame->symbol_name);
+        $this->assertSame('main', $merged->frames[3]->phpFrame->function_name);
+        $this->assertSame('zend_execute', $merged->frames[4]->nativeFrame->symbol_name);
     }
 
     public function testMergeEmptyNative(): void

--- a/tests/Lib/Dwarf/TraceMergerTest.php
+++ b/tests/Lib/Dwarf/TraceMergerTest.php
@@ -72,7 +72,7 @@ class TraceMergerTest extends BaseTestCase
             new NativeFrame(0x2000, 'execute_ex', 'php', 0),
             new NativeFrame(0x3000, 'zend_execute', 'php', 0),
         );
-        // PHP frames: deepest first in call_frames
+        // PHP frames: innermost (current) first in call_frames
         $php = new CallTrace(
             new CallFrame('', 'sleep_wrapper', '/app/test.php', null),
             new CallFrame('', 'main', '/app/test.php', null),
@@ -80,10 +80,14 @@ class TraceMergerTest extends BaseTestCase
 
         $merged = $this->merger->merge($native, $php);
 
-        // execute_ex should get the first PHP frame (main - deepest, consumed from end)
-        // zend_execute should get sleep_wrapper
-        $php_frames = array_filter($merged->frames, fn($f) => $f->isPhp());
-        $this->assertCount(2, $php_frames);
+        // execute_ex (inner VM boundary) should get sleep_wrapper (innermost PHP frame)
+        // zend_execute (outer VM boundary) should get main (outermost PHP frame)
+        $this->assertCount(5, $merged->frames);
+        $this->assertSame('zif_sleep', $merged->frames[0]->nativeFrame->symbol_name);
+        $this->assertSame('execute_ex', $merged->frames[1]->nativeFrame->symbol_name);
+        $this->assertSame('sleep_wrapper', $merged->frames[2]->phpFrame->function_name);
+        $this->assertSame('zend_execute', $merged->frames[3]->nativeFrame->symbol_name);
+        $this->assertSame('main', $merged->frames[4]->phpFrame->function_name);
     }
 
     public function testMergeEmptyNative(): void

--- a/tests/Lib/Dwarf/TraceMergerTest.php
+++ b/tests/Lib/Dwarf/TraceMergerTest.php
@@ -109,7 +109,7 @@ class TraceMergerTest extends BaseTestCase
 
         $merged = $this->merger->merge($native, $php);
 
-        // zif_sleep [native], sleep_wrapper [php], ICALL [native], main [php], execute_ex [native], zend_execute [native]
+        // zif_sleep, sleep_wrapper [php], ICALL, main [php], execute_ex, zend_execute
         $this->assertCount(6, $merged->frames);
         $this->assertSame('zif_sleep', $merged->frames[0]->nativeFrame->symbol_name);
         $this->assertSame('sleep_wrapper', $merged->frames[1]->phpFrame->function_name);

--- a/tests/Lib/Dwarf/TraceMergerTest.php
+++ b/tests/Lib/Dwarf/TraceMergerTest.php
@@ -66,14 +66,16 @@ class TraceMergerTest extends BaseTestCase
         $this->assertTrue($merged->frames[3]->isNative());
     }
 
-    public function testMergeMultiplePhpFrames(): void
+    public function testMergeMultiplePhpFramesIcallInlined(): void
     {
+        // <main> calls sleep_wrapper (internal), ICALL handler inlined into execute_ex.
+        // Only 1 VM boundary (execute_ex), but 2 PHP frames.
+        // Both PHP frames should be placed before execute_ex.
         $native = new NativeTrace(
             new NativeFrame(0x1000, 'zif_sleep', 'php', 0),
             new NativeFrame(0x2000, 'execute_ex', 'php', 0),
             new NativeFrame(0x3000, 'zend_execute', 'php', 0),
         );
-        // PHP frames: innermost (current) first in call_frames
         $php = new CallTrace(
             new CallFrame('', 'sleep_wrapper', '/app/test.php', null),
             new CallFrame('', 'main', '/app/test.php', null),
@@ -81,14 +83,73 @@ class TraceMergerTest extends BaseTestCase
 
         $merged = $this->merger->merge($native, $php);
 
-        // PHP frames are placed BEFORE their VM boundaries (inner side):
-        // zif_sleep [native], sleep_wrapper [php], execute_ex [native], main [php], zend_execute [native]
+        // zif_sleep [native], sleep_wrapper [php], main [php], execute_ex [native], zend_execute [native]
         $this->assertCount(5, $merged->frames);
         $this->assertSame('zif_sleep', $merged->frames[0]->nativeFrame->symbol_name);
         $this->assertSame('sleep_wrapper', $merged->frames[1]->phpFrame->function_name);
-        $this->assertSame('execute_ex', $merged->frames[2]->nativeFrame->symbol_name);
-        $this->assertSame('main', $merged->frames[3]->phpFrame->function_name);
+        $this->assertSame('main', $merged->frames[2]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[3]->nativeFrame->symbol_name);
         $this->assertSame('zend_execute', $merged->frames[4]->nativeFrame->symbol_name);
+    }
+
+    public function testMergeMultiplePhpFramesIcallVisible(): void
+    {
+        // <main> calls sleep_wrapper (internal), ICALL handler visible in native trace.
+        // 2 VM boundaries (ICALL + execute_ex), 2 PHP frames → 1:1 match.
+        $native = new NativeTrace(
+            new NativeFrame(0x1000, 'zif_sleep', 'php', 0),
+            new NativeFrame(0x2000, 'ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER', 'php', 0),
+            new NativeFrame(0x3000, 'execute_ex', 'php', 0),
+            new NativeFrame(0x4000, 'zend_execute', 'php', 0),
+        );
+        $php = new CallTrace(
+            new CallFrame('', 'sleep_wrapper', '/app/test.php', null),
+            new CallFrame('', 'main', '/app/test.php', null),
+        );
+
+        $merged = $this->merger->merge($native, $php);
+
+        // zif_sleep [native], sleep_wrapper [php], ICALL [native], main [php], execute_ex [native], zend_execute [native]
+        $this->assertCount(6, $merged->frames);
+        $this->assertSame('zif_sleep', $merged->frames[0]->nativeFrame->symbol_name);
+        $this->assertSame('sleep_wrapper', $merged->frames[1]->phpFrame->function_name);
+        $this->assertSame('ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER', $merged->frames[2]->nativeFrame->symbol_name);
+        $this->assertSame('main', $merged->frames[3]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[4]->nativeFrame->symbol_name);
+        $this->assertSame('zend_execute', $merged->frames[5]->nativeFrame->symbol_name);
+    }
+
+    public function testMergeDeepCallChain(): void
+    {
+        // <main> → foo() → bar() → strlen() (internal, handler inlined)
+        // 3 execute_ex in native, 4 PHP frames
+        $native = new NativeTrace(
+            new NativeFrame(0x1000, 'zif_strlen', 'php', 0),
+            new NativeFrame(0x2000, 'execute_ex', 'php', 0),  // bar
+            new NativeFrame(0x3000, 'execute_ex', 'php', 0),  // foo
+            new NativeFrame(0x4000, 'execute_ex', 'php', 0),  // main
+            new NativeFrame(0x5000, 'zend_execute', 'php', 0),
+        );
+        $php = new CallTrace(
+            new CallFrame('', 'strlen', '/app/test.php', null),
+            new CallFrame('', 'bar', '/app/test.php', null),
+            new CallFrame('', 'foo', '/app/test.php', null),
+            new CallFrame('', 'main', '/app/test.php', null),
+        );
+
+        $merged = $this->merger->merge($native, $php);
+
+        // strlen (excess) + bar before first execute_ex, then foo, main before subsequent ones
+        $this->assertCount(9, $merged->frames);
+        $this->assertSame('zif_strlen', $merged->frames[0]->nativeFrame->symbol_name);
+        $this->assertSame('strlen', $merged->frames[1]->phpFrame->function_name);
+        $this->assertSame('bar', $merged->frames[2]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[3]->nativeFrame->symbol_name);
+        $this->assertSame('foo', $merged->frames[4]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[5]->nativeFrame->symbol_name);
+        $this->assertSame('main', $merged->frames[6]->phpFrame->function_name);
+        $this->assertSame('execute_ex', $merged->frames[7]->nativeFrame->symbol_name);
+        $this->assertSame('zend_execute', $merged->frames[8]->nativeFrame->symbol_name);
     }
 
     public function testMergeEmptyNative(): void


### PR DESCRIPTION
## Summary
- Fix PHP frame consumption direction (was outer→inner, now inner→outer)
- Place PHP frames on the callee side of VM boundaries, not the caller side
- Remove `zend_execute` from VM boundary list (it's just a thin wrapper around `execute_ex`)
- Handle excess PHP frames when ICALL handlers are inlined into `execute_ex`

## Problem

TraceMerger had three issues:

### 1. PHP frame consumption direction was reversed
Native frames were walked inner→outer (from index 0), but PHP frames were consumed outer→inner (from the end). This caused the innermost `execute_ex` to pair with the outermost PHP frame (`main`).

### 2. PHP frames were placed on the caller side of VM boundaries
VM boundary functions (`execute_ex`, etc.) **call/dispatch** PHP functions, so PHP frames belong on the inner (callee) side. Placing them on the outer side implied "usleep called execute_ex", which is backwards.

### 3. `zend_execute` was treated as a VM boundary
`zend_execute` is just an entry wrapper that calls `execute_ex`. It doesn't correspond to any PHP frame. Treating it as a boundary caused it to consume one PHP frame, pushing `<main>` outside of `execute_ex` — but `<main>` executes inside `execute_ex`.

## After

```
0 libc.so.6::clock_nanosleep+0x5a [native]:0
1 libc.so.6::__nanosleep+0x17 [native]:0
2 libc.so.6::usleep+0x4c [native]:0
3 php8.4::zif_usleep+0x42 [native]:0
4 usleep <internal>:-1                        ← PHP frame
5 <main> /app/test.php:15                     ← PHP frame
6 php8.4::execute_ex+0x4dfa [native]:0        ← VM (both PHP frames live inside this)
7 php8.4::zend_execute+0x141 [native]:0       ← entry wrapper (not a boundary)
```

When ICALL handler is not inlined, frames match 1:1:
```
3 php8.4::zif_usleep+0x42 [native]:0
4 usleep <internal>:-1                        ← matched to ICALL boundary
5 php8.4::ZEND_DO_ICALL_... [native]:0
6 <main> /app/test.php:15                     ← matched to execute_ex boundary
7 php8.4::execute_ex+0x4dfa [native]:0
```

## Test plan
- [x] TraceMergerTest: all 7 tests pass (native only, interleaved, ICALL inlined, ICALL visible, deep chain, empty native, PHP-only extraction)
- [x] phpcs passes

https://claude.ai/code/session_01QhbNCUKD6yyZ1bsxRs58iW