### PR TITLE
Organize app state directories and resolve output paths

### DIFF
--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -33,6 +33,7 @@ use Reli\Inspector\Settings\WatchSettings\WatchSettingsFromConsoleInput;
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Inspector\TraceLoopProvider;
 use Reli\Lib\Console\EchoBackCanceller;
+use Reli\Lib\Directory\AppDirectory;
 use Reli\Lib\Log\Log;
 use Revolt\EventLoop;
 use Reli\Inspector\Watch\Action\ActionInterface;
@@ -190,6 +191,9 @@ final class WatchCommand extends Command
             $output,
             $output_settings,
         );
+        // Ensure output directory exists
+        AppDirectory::ensureDirectoryExists($watch_settings->action_output_dir);
+
         // Build rate limiters (need disk_tracker before actions)
         $disk_tracker = new DiskUsageTracker(
             $watch_settings->max_dump_size_bytes,
@@ -463,6 +467,7 @@ final class WatchCommand extends Command
         }
 
         // Build actions for daemon mode
+        AppDirectory::ensureDirectoryExists($watch_settings->action_output_dir);
         $output_settings = $this->output_settings_from_console_input->createSettings($input);
         $trace_output = $this->trace_output_factory->fromSettingsAndConsoleOutput($output, $output_settings);
         $disk_tracker = new DiskUsageTracker(

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Settings\WatchSettings;
 use PhpCast\NullableCast;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\Trigger\MemoryGrowthRateTrigger;
+use Reli\Lib\Directory\AppDirectory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -84,7 +85,6 @@ final class WatchSettingsFromConsoleInput
                 null,
                 InputOption::VALUE_REQUIRED,
                 'output directory for dump and log files',
-                '.',
             )
             ->addOption(
                 'log-file',
@@ -219,7 +219,9 @@ final class WatchSettingsFromConsoleInput
                 $input->getOption('backoff-max')
                 ?? WatchSettings::BACKOFF_MAX_SECONDS_DEFAULT
             ),
-            action_output_dir: (string)($input->getOption('action-output-dir') ?? '.'),
+            action_output_dir: self::resolveOutputDir(
+                NullableCast::toString($input->getOption('action-output-dir'))
+            ),
             status_interval_seconds: (int)(
                 $input->getOption('status-interval')
                 ?? WatchSettings::STATUS_INTERVAL_SECONDS_DEFAULT
@@ -240,9 +242,39 @@ final class WatchSettingsFromConsoleInput
             )),
             actions: $actions,
             action_exec_command: NullableCast::toString($input->getOption('action-exec-command')),
-            log_file: NullableCast::toString($input->getOption('log-file')),
+            log_file: self::resolveAbsolutePathOrNull(
+                NullableCast::toString($input->getOption('log-file'))
+            ),
             memory_output_format: NullableCast::toString($input->getOption('memory-output-format')),
             include_binary: (bool)$input->getOption('include-binary'),
         );
+    }
+
+    private static function resolveOutputDir(?string $path): string
+    {
+        if ($path === null || $path === '') {
+            return AppDirectory::getWatchDumpDir();
+        }
+        return self::resolveAbsolutePath($path);
+    }
+
+    private static function resolveAbsolutePath(string $path): string
+    {
+        if ($path[0] === '/') {
+            return $path;
+        }
+        $cwd = getcwd();
+        if ($cwd === false) {
+            throw new \RuntimeException('Failed to get current working directory');
+        }
+        return $cwd . '/' . $path;
+    }
+
+    private static function resolveAbsolutePathOrNull(?string $path): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+        return self::resolveAbsolutePath($path);
     }
 }

--- a/src/Lib/Directory/AppDirectory.php
+++ b/src/Lib/Directory/AppDirectory.php
@@ -77,11 +77,27 @@ final class AppDirectory
     }
 
     /**
+     * Log directory. Falls back to temp directory.
+     */
+    public static function getLogDir(): string
+    {
+        return self::getStateDir() . '/logs';
+    }
+
+    /**
+     * Watch dump directory. Falls back to temp directory.
+     */
+    public static function getWatchDumpDir(): string
+    {
+        return self::getStateDir() . '/watch-dumps';
+    }
+
+    /**
      * Log file path.
      */
     public static function getLogPath(): string
     {
-        return self::getStateDir() . '/reli.log';
+        return self::getLogDir() . '/reli.log';
     }
 
     /**

--- a/tests/Command/Inspector/WatchCommandTest.php
+++ b/tests/Command/Inspector/WatchCommandTest.php
@@ -101,7 +101,7 @@ class WatchCommandTest extends TestCase
         $this->assertSame(['memory-dump'], $action_opt->getDefault());
 
         $output_dir = $def->getOption('action-output-dir');
-        $this->assertSame('.', $output_dir->getDefault());
+        $this->assertNull($output_dir->getDefault());
 
         $format = $def->getOption('memory-output-format');
         $this->assertSame('json', $format->getDefault());

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -15,6 +15,7 @@ namespace Reli\Inspector\Settings\WatchSettings;
 
 use Mockery;
 use Reli\BaseTestCase;
+use Reli\Lib\Directory\AppDirectory;
 use Symfony\Component\Console\Input\InputInterface;
 
 class WatchSettingsFromConsoleInputTest extends BaseTestCase
@@ -30,7 +31,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'watch-var' => [],
             'action' => ['memory-dump'],
             'action-exec-command' => null,
-            'action-output-dir' => '.',
+            'action-output-dir' => null,
             'log-file' => null,
             'memory-output-format' => 'json',
             'poll-interval' => null,
@@ -73,6 +74,37 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertNull($settings->memory_growth_rate);
         $this->assertFalse($settings->memory_peak_watch);
         $this->assertFalse($settings->include_binary);
+        $this->assertSame(AppDirectory::getWatchDumpDir(), $settings->action_output_dir);
+    }
+
+    public function testActionOutputDirAbsolutePath(): void
+    {
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'action-output-dir' => '/tmp/my-dumps',
+            ]));
+
+        $this->assertSame('/tmp/my-dumps', $settings->action_output_dir);
+    }
+
+    public function testActionOutputDirRelativePathResolvesToAbsolute(): void
+    {
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'action-output-dir' => 'my-dumps',
+            ]));
+
+        $this->assertSame(getcwd() . '/my-dumps', $settings->action_output_dir);
+    }
+
+    public function testLogFileRelativePathResolvesToAbsolute(): void
+    {
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'log-file' => 'watch.log',
+            ]));
+
+        $this->assertSame(getcwd() . '/watch.log', $settings->log_file);
     }
 
     public function testMemoryLimit(): void

--- a/tests/Lib/Directory/AppDirectoryTest.php
+++ b/tests/Lib/Directory/AppDirectoryTest.php
@@ -128,11 +128,49 @@ class AppDirectoryTest extends BaseTestCase
 
     // --- Log path ---
 
+    // --- Log directory ---
+
+    public function testGetLogDirWithHome(): void
+    {
+        putenv('XDG_STATE_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.local/state/reli/logs', AppDirectory::getLogDir());
+    }
+
+    public function testGetLogDirWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_STATE_HOME');
+        $result = AppDirectory::getLogDir();
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringEndsWith('/logs', $result);
+    }
+
+    // --- Watch dump directory ---
+
+    public function testGetWatchDumpDirWithHome(): void
+    {
+        putenv('XDG_STATE_HOME');
+        putenv('HOME=/tmp/app-test-home');
+        $this->assertSame('/tmp/app-test-home/.local/state/reli/watch-dumps', AppDirectory::getWatchDumpDir());
+    }
+
+    public function testGetWatchDumpDirWithoutHomeReturnsAbsolutePath(): void
+    {
+        putenv('HOME');
+        putenv('XDG_STATE_HOME');
+        $result = AppDirectory::getWatchDumpDir();
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringEndsWith('/watch-dumps', $result);
+    }
+
+    // --- Log path ---
+
     public function testGetLogPathWithHome(): void
     {
         putenv('XDG_STATE_HOME');
         putenv('HOME=/tmp/app-test-home');
-        $this->assertSame('/tmp/app-test-home/.local/state/reli/reli.log', AppDirectory::getLogPath());
+        $this->assertSame('/tmp/app-test-home/.local/state/reli/logs/reli.log', AppDirectory::getLogPath());
     }
 
     public function testGetLogPathWithoutHomeReturnsAbsolutePath(): void
@@ -141,7 +179,7 @@ class AppDirectoryTest extends BaseTestCase
         putenv('XDG_STATE_HOME');
         $result = AppDirectory::getLogPath();
         $this->assertStringStartsWith('/', $result);
-        $this->assertStringEndsWith('/reli.log', $result);
+        $this->assertStringEndsWith('/logs/reli.log', $result);
     }
 
     // --- ensureDirectoryExists delegates ---


### PR DESCRIPTION
## Summary
This PR refactors the application directory structure to better organize state files and improves path resolution for user-provided output directories.

## Key Changes

- **New directory structure**: Added dedicated subdirectories under the state directory:
  - `getLogDir()`: Returns `~/.local/state/reli/logs` for log files
  - `getWatchDumpDir()`: Returns `~/.local/state/reli/watch-dumps` for watch dump files
  - Updated `getLogPath()` to use the new log directory

- **Improved path resolution**: Enhanced `WatchSettingsFromConsoleInput` to properly handle user-provided paths:
  - `action-output-dir` now defaults to `AppDirectory::getWatchDumpDir()` instead of current directory
  - Added `resolveOutputDir()` to handle null/empty values by using the watch dump directory
  - Added `resolveAbsolutePath()` to convert relative paths to absolute paths based on current working directory
  - Added `resolveAbsolutePathOrNull()` for optional path parameters like `log-file`

- **Directory creation**: Updated `WatchCommand` to ensure output directories exist before use in both normal and daemon modes

- **Test coverage**: Added comprehensive tests for:
  - New `getLogDir()` and `getWatchDumpDir()` methods
  - Path resolution behavior for absolute and relative paths
  - Default behavior using app directories

## Implementation Details

The path resolution logic ensures that:
- Absolute paths (starting with `/`) are used as-is
- Relative paths are resolved relative to the current working directory
- Null/empty values for `action-output-dir` default to the application's watch dump directory
- All output directories are created before use to prevent runtime errors

https://claude.ai/code/session_014SnLnqWx47wWEg45muPNVS