### PR TITLE
Add include-binary flag to memory dump actions

### DIFF
--- a/src/Inspector/Settings/WatchSettings/WatchSettings.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettings.php
@@ -49,6 +49,7 @@ final class WatchSettings
         public ?string $action_exec_command,
         public ?string $log_file,
         public ?string $memory_output_format,
+        public bool $include_binary = false,
     ) {
     }
 }

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -156,6 +156,12 @@ final class WatchSettingsFromConsoleInput
                 'status summary interval in seconds for daemon mode (default: 60)',
             )
             ->addOption(
+                'include-binary',
+                null,
+                InputOption::VALUE_NONE,
+                'include read-only binary segments in memory dumps',
+            )
+            ->addOption(
                 'quiet-watch',
                 null,
                 InputOption::VALUE_NONE,
@@ -236,6 +242,7 @@ final class WatchSettingsFromConsoleInput
             action_exec_command: NullableCast::toString($input->getOption('action-exec-command')),
             log_file: NullableCast::toString($input->getOption('log-file')),
             memory_output_format: NullableCast::toString($input->getOption('memory-output-format')),
+            include_binary: (bool)$input->getOption('include-binary'),
         );
     }
 }

--- a/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
@@ -33,6 +33,7 @@ final class DaemonMemoryDumpAction implements ActionInterface
         private MemoryDumper $memory_dumper,
         private string $output_dir,
         private DiskUsageTracker $disk_tracker,
+        private bool $include_binary = false,
     ) {
     }
 
@@ -83,6 +84,7 @@ final class DaemonMemoryDumpAction implements ActionInterface
                 $eg,
                 $cg,
                 $output_path,
+                $this->include_binary,
             );
             $this->disk_tracker->recordFile($output_path);
             Log::info('memory-dump saved', [

--- a/src/Inspector/Watch/Action/MemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/MemoryDumpAction.php
@@ -37,6 +37,7 @@ final class MemoryDumpAction implements ActionInterface
         private int $cg_address,
         private string $output_dir,
         private DiskUsageTracker $disk_tracker,
+        private bool $include_binary = false,
     ) {
     }
 
@@ -71,6 +72,7 @@ final class MemoryDumpAction implements ActionInterface
                 $this->eg_address,
                 $this->cg_address,
                 $output_path,
+                $this->include_binary,
             );
 
             $this->disk_tracker->recordFile($output_path);

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -83,6 +83,7 @@ final class ActionFactory
                 $cg_address,
                 $settings->action_output_dir,
                 $disk_tracker,
+                $settings->include_binary,
             );
         }
 
@@ -123,6 +124,7 @@ final class ActionFactory
                         $this->memory_dumper,
                         $settings->action_output_dir,
                         $disk_tracker,
+                        $settings->include_binary,
                     );
                     break;
             }
@@ -173,6 +175,7 @@ final class ActionFactory
                 $cg_address,
                 $settings->action_output_dir,
                 $disk_tracker,
+                $settings->include_binary,
             ),
             'exec' => $settings->action_exec_command !== null
                 ? new ExecAction($settings->action_exec_command)

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -43,6 +43,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'backoff-max' => null,
             'status-interval' => null,
             'quiet-watch' => false,
+            'include-binary' => false,
         ];
         $merged = array_merge($defaults, $overrides);
         $input = Mockery::mock(InputInterface::class);
@@ -71,6 +72,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertNull($settings->memory_usage_bytes);
         $this->assertNull($settings->memory_growth_rate);
         $this->assertFalse($settings->memory_peak_watch);
+        $this->assertFalse($settings->include_binary);
     }
 
     public function testMemoryLimit(): void
@@ -155,6 +157,16 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             2 * 1024 * 1024 * 1024,
             $settings->max_dump_size_bytes,
         );
+    }
+
+    public function testIncludeBinary(): void
+    {
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'include-binary' => true,
+            ]));
+
+        $this->assertTrue($settings->include_binary);
     }
 
     public function testAllTriggerFlags(): void

--- a/tests/Inspector/Watch/Action/DaemonMemoryDumpActionTest.php
+++ b/tests/Inspector/Watch/Action/DaemonMemoryDumpActionTest.php
@@ -111,6 +111,40 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
         );
     }
 
+    public function testPassesIncludeBinaryFlag(): void
+    {
+        $result = new MemoryDumpResult('/tmp/test.dump', 5, 1024);
+        $dumper = Mockery::mock(
+            'overload:' . MemoryDumper::class,
+        );
+        $dumper->shouldReceive('dump')
+            ->once()
+            ->withArgs(function (
+                ProcessSpecifier $ps,
+                $tps,
+                int $eg,
+                int $cg,
+                string $path,
+                bool $include_binary,
+            ): bool {
+                return $include_binary === true;
+            })
+            ->andReturn($result);
+
+        $action = new DaemonMemoryDumpAction(
+            $dumper,
+            sys_get_temp_dir(),
+            new DiskUsageTracker(1024 * 1024),
+            true,
+        );
+
+        $action->execute(
+            new TriggerEvent('mem', 'desc', 100.0),
+            new ProcessSpecifier(42),
+            $this->makeContext(0x1000, 0x2000, 'v84'),
+        );
+    }
+
     private function makeContext(
         int $eg = 0,
         int $cg = 0,

--- a/tests/Inspector/Watch/Action/MemoryDumpActionTest.php
+++ b/tests/Inspector/Watch/Action/MemoryDumpActionTest.php
@@ -100,6 +100,43 @@ class MemoryDumpActionTest extends BaseTestCase
         );
     }
 
+    public function testPassesIncludeBinaryFlag(): void
+    {
+        $result = new MemoryDumpResult('/tmp/test.dump', 5, 1024);
+        $dumper = Mockery::mock(
+            'overload:' . MemoryDumper::class,
+        );
+        $dumper->shouldReceive('dump')
+            ->once()
+            ->withArgs(function (
+                ProcessSpecifier $ps,
+                TargetPhpSettings $tps,
+                int $eg,
+                int $cg,
+                string $path,
+                bool $include_binary,
+            ): bool {
+                return $include_binary === true;
+            })
+            ->andReturn($result);
+
+        $action = new MemoryDumpAction(
+            $dumper,
+            new TargetPhpSettings(php_version: 'v84'),
+            0x1000,
+            0x2000,
+            sys_get_temp_dir(),
+            new DiskUsageTracker(1024 * 1024),
+            true,
+        );
+
+        $action->execute(
+            new TriggerEvent('mem', 'desc', 100.0),
+            new ProcessSpecifier(42),
+            $this->makeContext(),
+        );
+    }
+
     public function testHandlesDumpException(): void
     {
         $dumper = Mockery::mock(


### PR DESCRIPTION
## Summary
This PR adds support for an `--include-binary` command-line flag that allows users to include read-only binary segments in memory dumps. The flag is threaded through the watch settings, action factory, and memory dump action classes.

## Key Changes
- Added `--include-binary` command-line option to `WatchSettingsFromConsoleInput` that accepts a boolean flag
- Added `include_binary` property to `WatchSettings` class (defaults to `false`)
- Updated `MemoryDumpAction` and `DaemonMemoryDumpAction` to accept and pass the `include_binary` flag to the `MemoryDumper::dump()` method
- Modified `ActionFactory` to pass the `include_binary` setting when constructing memory dump actions
- Added comprehensive test coverage in both `MemoryDumpActionTest` and `DaemonMemoryDumpActionTest` to verify the flag is correctly passed through to the dumper

## Implementation Details
- The flag defaults to `false` to maintain backward compatibility
- The flag is passed as the final parameter to `MemoryDumper::dump()` in both action classes
- The option is properly integrated into the command-line interface with a descriptive help message

https://claude.ai/code/session_014QV2HyWhgfeStnQRmeBhiX