### PR TITLE
Fix root path mapping in MappedPathResolver

### DIFF
--- a/src/Lib/File/PathResolver/MappedPathResolver.php
+++ b/src/Lib/File/PathResolver/MappedPathResolver.php
@@ -38,12 +38,15 @@ final class MappedPathResolver implements ProcessPathResolver
         $original_path = $path;
         while ($path !== '/') {
             $path = $this->getDirectory($path);
+            if ($path === '/' ) {
+                break;
+            }
             if (isset($this->path_map[$path])) {
                 return $this->path_map[$path] . \substr($original_path, \strlen($path));
             }
         }
         if (isset($this->path_map['/'])) {
-            return $this->path_map['/'] . \substr($original_path, \strlen($path));
+            return $this->path_map['/'] . $original_path;
         }
         return $original_path;
     }

--- a/src/Lib/File/PathResolver/MappedPathResolver.php
+++ b/src/Lib/File/PathResolver/MappedPathResolver.php
@@ -38,7 +38,7 @@ final class MappedPathResolver implements ProcessPathResolver
         $original_path = $path;
         while ($path !== '/') {
             $path = $this->getDirectory($path);
-            if ($path === '/' ) {
+            if ($path === '/') {
                 break;
             }
             if (isset($this->path_map[$path])) {

--- a/tests/Command/CommandEnumeratorTestData/Lib/File/PathResolver/MappedPathResolverTest.php
+++ b/tests/Command/CommandEnumeratorTestData/Lib/File/PathResolver/MappedPathResolverTest.php
@@ -75,6 +75,19 @@ class MappedPathResolverTest extends TestCase
                     '/proc/1/1',
                 ],
             ],
+            'map root to directory' => [
+                'expects' => [
+                    '/mnt/target/usr/lib/php.so',
+                    '/mnt/target/usr/bin/php',
+                ],
+                'path_map' => [
+                    '/' => '/mnt/target',
+                ],
+                'paths' => [
+                    '/usr/lib/php.so',
+                    '/usr/bin/php',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
Fixed a bug in the `MappedPathResolver` where mapping the root path (`/`) to a target directory was not working correctly. The resolver now properly handles root path mappings and includes a test case to prevent regression.

## Key Changes
- **Fixed root path mapping logic**: Modified the path resolution loop to break when reaching the root directory, preventing incorrect substring calculations
- **Corrected substring calculation**: Changed from `substr($original_path, strlen($path))` to `$original_path` when applying root path mappings, since the root path is already `/`
- **Added test coverage**: Added a new test case `'map root to directory'` that verifies mapping `/` to `/mnt/target` correctly resolves paths like `/usr/lib/php.so` to `/mnt/target/usr/lib/php.so`

## Implementation Details
The issue was in the path resolution algorithm: when no intermediate path matched in the map, the code would fall back to checking for a root (`/`) mapping. However, the substring calculation was incorrect because `$path` would be `/` at that point, making `substr($original_path, 1)` instead of using the full `$original_path`. The fix simplifies this by directly concatenating the mapped root with the original path.

https://claude.ai/code/session_014AqrkYhoGdCiEBujc6sxJA