### PR TITLE
Add anonymous mmap region dumping and improve error handling

### DIFF
--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -180,6 +180,43 @@ final class MemoryDumper
             }
         }
 
+        // Anonymous writable mmap regions.
+        // glibc's malloc uses mmap for large allocations
+        // (> M_MMAP_THRESHOLD, typically 128KB). Persistent PHP
+        // data such as EG(function_table)->arData and interned
+        // strings can end up here. Use pagemap to skip
+        // non-resident pages.
+        $anon_areas = $memory_map->findByNameRegex('^$');
+        foreach ($anon_areas as $area) {
+            if (
+                $area->inode_num === 0
+                && $area->attribute->read
+                && $area->attribute->write
+                && !$area->attribute->execute
+            ) {
+                $addr = (int)hexdec($area->begin);
+                $size = (int)hexdec($area->end) - $addr;
+                if ($size <= 0) {
+                    continue;
+                }
+                $resident_runs = $this->findResidentRuns(
+                    $pid,
+                    $addr,
+                    $size,
+                );
+                if ($resident_runs !== null && $resident_runs !== []) {
+                    foreach ($resident_runs as $run) {
+                        $read_list[] = $run;
+                    }
+                } else {
+                    $read_list[] = [
+                        'address' => $addr,
+                        'size' => $size,
+                    ];
+                }
+            }
+        }
+
         // PHP binary's writable data/BSS segments
         $php_rw_areas = $memory_map->findByNameRegex(
             $target_php_settings->php_regex,

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -250,15 +250,19 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
                 }
             }
         } else {
-            $func = $dereferencer->deref($this->func);
-            $function_name = $func->getFunctionName($dereferencer, $zend_type_reader);
-            $func = $dereferencer->deref($this->func);
-            if (is_null($function_name)) {
-                if ($this->isFunctionlessCall($zend_type_reader)) {
-                    $function_name = '<main>';
-                } elseif (!$func->isUserFunction()) {
-                    $function_name = '<internal>';
+            try {
+                $func = $dereferencer->deref($this->func);
+                $function_name = $func->getFunctionName($dereferencer, $zend_type_reader);
+                $func = $dereferencer->deref($this->func);
+                if (is_null($function_name)) {
+                    if ($this->isFunctionlessCall($zend_type_reader)) {
+                        $function_name = '<main>';
+                    } elseif (!$func->isUserFunction()) {
+                        $function_name = '<internal>';
+                    }
                 }
+            } catch (\RuntimeException) {
+                $function_name = '<unknown>';
             }
         }
         if ($function_name === '' or is_null($function_name)) {
@@ -273,8 +277,12 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         if (is_null($this->func)) {
             return '';
         }
-        $func = $dereferencer->deref($this->func);
-        return $func->getClassName($dereferencer) ?? '';
+        try {
+            $func = $dereferencer->deref($this->func);
+            return $func->getClassName($dereferencer) ?? '';
+        } catch (\RuntimeException) {
+            return '';
+        }
     }
 
     public function getFullyQualifiedFunctionName(


### PR DESCRIPTION
## Summary
This PR enhances memory dumping capabilities and improves robustness when dealing with corrupted or inaccessible function metadata.

## Key Changes

- **Anonymous mmap region dumping**: Added support for dumping anonymous writable memory regions (inode 0) that are commonly used by glibc's malloc for large allocations. These regions often contain persistent PHP data structures like function tables and interned strings. The implementation uses pagemap to efficiently skip non-resident pages.

- **Error handling in ZendExecuteData**: Wrapped function metadata retrieval in try-catch blocks to gracefully handle `RuntimeException` when dereferencing corrupted or inaccessible function pointers:
  - `getFunctionName()`: Returns `'<unknown>'` on error instead of crashing
  - `getFunctionClassName()`: Returns empty string on error instead of crashing

## Implementation Details

The anonymous mmap region dumping filters for memory areas that:
- Have empty names (regex `^$`)
- Have inode number 0 (indicating anonymous memory)
- Are readable and writable but not executable
- Contain actual resident pages (using `findResidentRuns()` to optimize memory reads)

The error handling improvements make the memory inspector more resilient when encountering corrupted process memory or invalid function references, which can occur in production debugging scenarios.

https://claude.ai/code/session_01JTBFhUkCakxhGhbPobMe3B