### PR TITLE
Prevent infinite loops in ZendMmChunk iteration

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendMmChunk.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmChunk.php
@@ -144,9 +144,14 @@ final class ZendMmChunk implements CDataDereferencable
      */
     public function iterateChunks(Dereferencer $dereferencer): iterable
     {
+        $visited = [$this->getPointer()->address => true];
         yield $this;
         $chunk = $this;
         while (!is_null($chunk->next) and $chunk->next->address !== $this->getPointer()->address) {
+            if (isset($visited[$chunk->next->address])) {
+                break;
+            }
+            $visited[$chunk->next->address] = true;
             $chunk = $dereferencer->deref($chunk->next);
             yield $chunk;
         }


### PR DESCRIPTION
## Summary
Added cycle detection to the `iterateChunks()` method in `ZendMmChunk` to prevent infinite loops when traversing the chunk linked list.

## Key Changes
- Introduced a `$visited` array to track already-visited chunk addresses
- Added a check to break out of the iteration loop if a previously visited chunk address is encountered
- This prevents infinite loops in cases where the chunk linked list contains cycles

## Implementation Details
The fix maintains a set of visited chunk addresses using an associative array for O(1) lookup performance. Before dereferencing the next chunk pointer, the code now verifies that the target address hasn't been visited before. If a cycle is detected, the iteration terminates gracefully rather than looping indefinitely.

https://claude.ai/code/session_01SbxanBVJgEM6HJaYP2MQNw