### PR TITLE
Add memory dump file inspector command

### DIFF
--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class MemoryDumpInspectCommand extends Command
+{
+    private const MAGIC = "RELIMEM\0";
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('inspector:memory:dump:inspect')
+            ->setDescription('[experimental] inspect a memory dump file header, memory map, and regions')
+        ;
+        $this->addArgument(
+            'dump-file',
+            InputArgument::REQUIRED,
+            'path to the memory dump file'
+        );
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $dump_file */
+        $dump_file = $input->getArgument('dump-file');
+
+        $fp = fopen($dump_file, 'rb');
+        if ($fp === false) {
+            throw new \RuntimeException("failed to open file: {$dump_file}");
+        }
+        try {
+            $this->inspect($fp, $output);
+        } finally {
+            fclose($fp);
+        }
+
+        return 0;
+    }
+
+    /** @param resource $fp */
+    private function inspect($fp, OutputInterface $output): void
+    {
+        // === Header ===
+        $magic = fread($fp, 8);
+        if ($magic !== self::MAGIC) {
+            throw new \RuntimeException("invalid dump file: bad magic");
+        }
+        $format_version = $this->readUint32($fp);
+        if ($format_version !== 1) {
+            throw new \RuntimeException("unsupported dump format version: {$format_version}");
+        }
+        $php_version = $this->readString($fp);
+        $pid = $this->readInt64($fp);
+        $eg_address = $this->readInt64($fp);
+        $cg_address = $this->readInt64($fp);
+        $memory_map_count = $this->readUint32($fp);
+        $region_count = $this->readUint32($fp);
+
+        $output->writeln('<info>=== Header ===</info>');
+        $output->writeln("  Magic:            RELIMEM");
+        $output->writeln("  Format Version:   {$format_version}");
+        $output->writeln("  PHP Version:      {$php_version}");
+        $output->writeln("  PID:              {$pid}");
+        $output->writeln("  EG Address:       0x" . dechex($eg_address));
+        $output->writeln("  CG Address:       0x" . dechex($cg_address));
+        $output->writeln("  Memory Map Count: {$memory_map_count}");
+        $output->writeln("  Region Count:     {$region_count}");
+        $output->writeln('');
+
+        // === Memory Map ===
+        $output->writeln('<info>=== Memory Map ===</info>');
+        for ($i = 0; $i < $memory_map_count; $i++) {
+            $begin = $this->readString($fp);
+            $end = $this->readString($fp);
+            $file_offset = $this->readString($fp);
+            $attrs = fread($fp, 4);
+            if ($attrs === false || strlen($attrs) !== 4) {
+                throw new \RuntimeException("failed to read memory area attributes");
+            }
+            $attribute = new ProcessMemoryAttribute(
+                ord($attrs[0]) !== 0,
+                ord($attrs[1]) !== 0,
+                ord($attrs[2]) !== 0,
+                ord($attrs[3]) !== 0,
+            );
+            $device_id = $this->readString($fp);
+            $inode = $this->readInt64($fp);
+            $name = $this->readString($fp);
+
+            $perms = ($attribute->read ? 'r' : '-')
+                . ($attribute->write ? 'w' : '-')
+                . ($attribute->execute ? 'x' : '-')
+                . ($attribute->protected ? 'p' : '-');
+
+            $output->writeln(sprintf(
+                '  %s-%s %s %s %s %d %s',
+                $begin,
+                $end,
+                $perms,
+                $file_offset,
+                $device_id,
+                $inode,
+                $name,
+            ));
+        }
+        $output->writeln('');
+
+        // === Regions ===
+        $output->writeln('<info>=== Regions ===</info>');
+        $total_bytes = 0;
+        for ($i = 0; $i < $region_count; $i++) {
+            $address = $this->readInt64($fp);
+            $size = $this->readInt64($fp);
+            // skip region data without loading into memory
+            fseek($fp, $size, SEEK_CUR);
+            $total_bytes += $size;
+
+            $output->writeln(sprintf(
+                '  #%d  0x%s - 0x%s  (%s)',
+                $i,
+                dechex($address),
+                dechex($address + $size),
+                $this->formatSize($size),
+            ));
+        }
+        $output->writeln('');
+        $output->writeln(sprintf(
+            '<info>Total: %d regions, %s</info>',
+            $region_count,
+            $this->formatSize($total_bytes),
+        ));
+    }
+
+    private function formatSize(int $bytes): string
+    {
+        if ($bytes >= 1024 * 1024) {
+            return sprintf('%.1f MiB', (float)$bytes / 1024.0 / 1024.0);
+        }
+        if ($bytes >= 1024) {
+            return sprintf('%.1f KiB', (float)$bytes / 1024.0);
+        }
+        return sprintf('%d B', $bytes);
+    }
+
+    /** @param resource $fp */
+    private function readUint32($fp): int
+    {
+        $data = fread($fp, 4);
+        if ($data === false || strlen($data) !== 4) {
+            throw new \RuntimeException("failed to read uint32");
+        }
+        /** @var array{val: int} */
+        $result = unpack('Vval', $data);
+        return $result['val'];
+    }
+
+    /** @param resource $fp */
+    private function readInt64($fp): int
+    {
+        $data = fread($fp, 8);
+        if ($data === false || strlen($data) !== 8) {
+            throw new \RuntimeException("failed to read int64");
+        }
+        /** @var array{val: int} */
+        $result = unpack('Pval', $data);
+        return $result['val'];
+    }
+
+    /** @param resource $fp */
+    private function readString($fp): string
+    {
+        $len = $this->readUint32($fp);
+        if ($len === 0) {
+            return '';
+        }
+        $data = fread($fp, $len);
+        if ($data === false || strlen($data) !== $len) {
+            throw new \RuntimeException("failed to read string of length {$len}");
+        }
+        return $data;
+    }
+}

--- a/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\MemoryDump\MemoryDumpWriter;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class MemoryDumpInspectCommandTest extends TestCase
+{
+    private string $tmp_file;
+
+    protected function setUp(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'reli_inspect_test_');
+        if ($tmp === false) {
+            $this->fail('failed to create temp file');
+        }
+        $this->tmp_file = $tmp;
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tmp_file)) {
+            unlink($this->tmp_file);
+        }
+    }
+
+    private function createDumpFile(
+        int $pid = 1234,
+        string $php_version = 'v84',
+        int $eg_address = 0x7f00deadbeef,
+        int $cg_address = 0x7f00cafebabe,
+        array $memory_areas = [],
+        array $regions = [],
+    ): void {
+        $writer = new MemoryDumpWriter();
+        $writer->write(
+            $this->tmp_file,
+            $pid,
+            $php_version,
+            $eg_address,
+            $cg_address,
+            $memory_areas,
+            $regions,
+        );
+    }
+
+    #[Test]
+    public function testHeaderOutput(): void
+    {
+        $this->createDumpFile(
+            pid: 9999,
+            php_version: 'v84',
+            eg_address: 0x7f0000001000,
+            cg_address: 0x7f0000002000,
+        );
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $result = $command->run($input, $output);
+        $this->assertSame(0, $result);
+
+        $display = $output->fetch();
+        $this->assertStringContainsString('=== Header ===', $display);
+        $this->assertStringContainsString('Format Version:   1', $display);
+        $this->assertStringContainsString('PHP Version:      v84', $display);
+        $this->assertStringContainsString('PID:              9999', $display);
+        $this->assertStringContainsString('EG Address:       0x7f0000001000', $display);
+        $this->assertStringContainsString('CG Address:       0x7f0000002000', $display);
+        $this->assertStringContainsString('Memory Map Count: 0', $display);
+        $this->assertStringContainsString('Region Count:     0', $display);
+    }
+
+    #[Test]
+    public function testMemoryMapOutput(): void
+    {
+        $memory_areas = [
+            new ProcessMemoryArea(
+                '7f0000000000',
+                '7f0000200000',
+                '0',
+                new ProcessMemoryAttribute(true, true, false, true),
+                '00:00',
+                0,
+                '[heap]',
+            ),
+            new ProcessMemoryArea(
+                '7f0001000000',
+                '7f0001100000',
+                '1000',
+                new ProcessMemoryAttribute(true, false, true, false),
+                'fd:01',
+                12345,
+                '/usr/bin/php',
+            ),
+        ];
+
+        $this->createDumpFile(memory_areas: $memory_areas);
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $command->run($input, $output);
+        $display = $output->fetch();
+
+        $this->assertStringContainsString('=== Memory Map ===', $display);
+        $this->assertStringContainsString('Memory Map Count: 2', $display);
+        $this->assertStringContainsString('7f0000000000-7f0000200000 rw-p', $display);
+        $this->assertStringContainsString('[heap]', $display);
+        $this->assertStringContainsString('7f0001000000-7f0001100000 r-x-', $display);
+        $this->assertStringContainsString('/usr/bin/php', $display);
+    }
+
+    #[Test]
+    public function testRegionsOutput(): void
+    {
+        $regions = [
+            ['address' => 0x7f0000000000, 'size' => 64, 'data' => str_repeat("\x42", 64)],
+            ['address' => 0x7f0001000000, 'size' => 2 * 1024 * 1024, 'data' => str_repeat("\xAB", 2 * 1024 * 1024)],
+        ];
+
+        $this->createDumpFile(regions: $regions);
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $command->run($input, $output);
+        $display = $output->fetch();
+
+        $this->assertStringContainsString('=== Regions ===', $display);
+        $this->assertStringContainsString('Region Count:     2', $display);
+        $this->assertStringContainsString('#0  0x7f0000000000 - 0x7f0000000040', $display);
+        $this->assertStringContainsString('64 B', $display);
+        $this->assertStringContainsString('#1  0x7f0001000000 - 0x7f0001200000', $display);
+        $this->assertStringContainsString('2.0 MiB', $display);
+        $this->assertStringContainsString('Total: 2 regions', $display);
+    }
+
+    #[Test]
+    public function testMemoryMapPermissionFlags(): void
+    {
+        $memory_areas = [
+            new ProcessMemoryArea(
+                '1000',
+                '2000',
+                '0',
+                new ProcessMemoryAttribute(false, false, false, false),
+                '00:00',
+                0,
+                '',
+            ),
+            new ProcessMemoryArea(
+                '3000',
+                '4000',
+                '0',
+                new ProcessMemoryAttribute(true, true, true, true),
+                '00:00',
+                0,
+                '',
+            ),
+        ];
+
+        $this->createDumpFile(memory_areas: $memory_areas);
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $command->run($input, $output);
+        $display = $output->fetch();
+
+        $this->assertStringContainsString('1000-2000 ----', $display);
+        $this->assertStringContainsString('3000-4000 rwxp', $display);
+    }
+
+    #[Test]
+    public function testInvalidMagicThrowsException(): void
+    {
+        file_put_contents($this->tmp_file, 'NOTVALID');
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('invalid dump file: bad magic');
+        $command->run($input, $output);
+    }
+
+    #[Test]
+    public function testNonExistentFileThrowsException(): void
+    {
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => '/tmp/nonexistent_reli_dump_' . uniqid()]);
+        $output = new BufferedOutput();
+
+        $this->expectException(\RuntimeException::class);
+        $command->run($input, $output);
+    }
+
+    #[Test]
+    public function testEmptyDumpFile(): void
+    {
+        $this->createDumpFile();
+
+        $command = new MemoryDumpInspectCommand();
+        $input = new ArrayInput(['dump-file' => $this->tmp_file]);
+        $output = new BufferedOutput();
+
+        $result = $command->run($input, $output);
+        $this->assertSame(0, $result);
+
+        $display = $output->fetch();
+        $this->assertStringContainsString('Total: 0 regions, 0 B', $display);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a new console command `inspector:memory:dump:inspect` that allows users to inspect and analyze memory dump files created by the reli-prof profiler. The command reads and displays the dump file structure including header information, memory map details, and memory regions.

## Key Changes
- Added `MemoryDumpInspectCommand` class that extends Symfony's `Command`
- Implements parsing of the RELIMEM binary dump format (version 1)
- Displays dump file header with metadata (PHP version, PID, EG/CG addresses)
- Parses and displays memory map entries with permissions and file information
- Lists all memory regions with their addresses, sizes, and formatted byte counts
- Includes helper methods for reading binary data (uint32, int64, strings)
- Provides human-readable output with size formatting (B, KiB, MiB)

## Notable Implementation Details
- Uses magic number validation (`RELIMEM\0`) to ensure file integrity
- Supports format version checking for future compatibility
- Efficiently skips region data without loading into memory using `fseek()`
- Calculates and displays total memory dumped across all regions
- Properly handles file I/O errors with descriptive exception messages
- Uses Symfony Console styling for organized, colored output

https://claude.ai/code/session_01W68cc2aSwVXUMswZQ7Hjxv