### PR TITLE
Fix resolveMapPtr LSB masking for PHP 7.4 + add opcache tests

### DIFF
--- a/src/Lib/PhpInternals/ZendTypeReader.php
+++ b/src/Lib/PhpInternals/ZendTypeReader.php
@@ -181,18 +181,33 @@ final class ZendTypeReader
         Dereferencer $dereferencer,
     ): int {
         $address_candidate = $map_ptr;
+
+        if ($map_ptr & 1) {
+            // PHP 8.0+ has biased base (map_ptr_base = real_base - 1,
+            // commit 27815959 in php-src), so the LSB in the offset
+            // cancels out and no masking is needed.
+            // PHP 7.4 stores the raw base and encodes offsets with
+            // | 1 (ZEND_MAP_PTR_PTR2OFFSET), requiring - 1 (or & ~1)
+            // when resolving (ZEND_MAP_PTR_OFFSET2PTR = base+off-1).
+            // This applies even when map_ptr_base is 0:
+            //   PTR2OFFSET with base=0 gives (ptr-0)|1 = ptr|1
+            //   OFFSET2PTR gives 0 + (ptr|1) - 1 = ptr
+            $offset = $this->isPhpVersionLowerThan(ZendTypeReader::V80)
+                ? ($map_ptr & ~1)
+                : $map_ptr;
+            $pointer = new Pointer(
+                RawInt64::class,
+                $map_ptr_base + $offset,
+                8,
+            );
+            return $dereferencer->deref($pointer)->value;
+        }
+
         if ($map_ptr_base === 0) {
             return $map_ptr;
         }
 
-        if ($map_ptr & 1) {
-            $pointer = new Pointer(
-                RawInt64::class,
-                $map_ptr_base + $map_ptr,
-                8,
-            );
-            return $dereferencer->deref($pointer)->value;
-        } elseif ($this->isPhpVersionLowerThan(ZendTypeReader::V82)) {
+        if ($this->isPhpVersionLowerThan(ZendTypeReader::V82)) {
             $pointer = new Pointer(
                 RawInt64::class,
                 $address_candidate,

--- a/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
@@ -1,0 +1,490 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\MemoryDump;
+
+use DI\ContainerBuilder;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
+use Reli\Lib\Elf\Process\LinkMapLoader;
+use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\File\CatFileReader;
+use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
+use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\Process\ProcessSpecifier;
+use Reli\TargetPhpVmProvider;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[Group('target-version')]
+class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
+{
+    private const OPCACHE_INI = '-dzend_extension=opcache'
+        . ' -dopcache.enable_cli=1 -dopcache.enable=1';
+
+    /** @var resource|null */
+    private $child = null;
+
+    /** @var list<string> */
+    private array $temp_files = [];
+
+    protected function tearDown(): void
+    {
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status)) {
+                if ($child_status['running']) {
+                    posix_kill($child_status['pid'], SIGKILL);
+                }
+            }
+        }
+        foreach ($this->temp_files as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'opcacheSupported')]
+    public function testDumpWithOpcacheEnabled(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+
+        $target_script = <<<'CODE'
+            <?php
+            $tmpdir = '/tmp/opcache_test_' . getmypid();
+            @mkdir($tmpdir, 0777, true);
+            for ($i = 0; $i < 5; $i++) {
+                $f = $tmpdir . '/class_' . $i . '.php';
+                $code = '<?php class OpcacheClass' . $i
+                    . ' { public static array $data = [];'
+                    . ' public static function work(): int'
+                    . ' { self::$data = array_fill(0, 50, "v' . $i . '");'
+                    . ' return count(self::$data); } }';
+                file_put_contents($f, $code);
+                require $f;
+            }
+            OpcacheClass0::work();
+            OpcacheClass1::work();
+            OpcacheClass2::work();
+            if (function_exists('opcache_get_status')) {
+                $status = @opcache_get_status(false);
+                if ($status !== false && ($status['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+            self::OPCACHE_INI,
+        );
+
+        $this->waitForOpcacheReady($pipes[1], $docker_image_name);
+
+        $globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $process = new ProcessSpecifier($pid);
+        $settings = new TargetPhpSettings(php_version: $php_version);
+
+        $eg = $globals_finder->findExecutorGlobals($process, $settings);
+        $cg = $globals_finder->findCompilerGlobals($process, $settings);
+
+        $dumper = new MemoryDumper(
+            $memory_reader,
+            $zend_type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                $process_memory_map_creator,
+                $zend_type_reader_creator,
+            ),
+            $process_memory_map_creator,
+        );
+
+        $output_path = tempnam(sys_get_temp_dir(), 'reli-opcache-dump-');
+        $this->assertNotFalse($output_path);
+        $this->temp_files[] = $output_path;
+
+        $result = $dumper->dump(
+            $process,
+            $settings,
+            $eg,
+            $cg,
+            $output_path,
+        );
+
+        $this->assertFileExists($result->output_path);
+        $this->assertGreaterThan(0, $result->region_count);
+        $this->assertGreaterThan(
+            64 * 1024,
+            $result->total_bytes,
+            'Dump with opcache should contain meaningful data',
+        );
+
+        // Verify the dump file is valid by parsing the header
+        $fp = fopen($output_path, 'rb');
+        $this->assertNotFalse($fp);
+        $magic = fread($fp, 8);
+        $this->assertSame("RELIMEM\0", $magic);
+        fclose($fp);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'opcacheSupported')]
+    public function testDumpRoundtripWithOpcache(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+
+        $target_script = <<<'CODE'
+            <?php
+            $tmpdir = '/tmp/opcache_rt_' . getmypid();
+            @mkdir($tmpdir, 0777, true);
+            $f = $tmpdir . '/Cached.php';
+            $code = '<?php class CachedClass {'
+                . ' public static function run(): string'
+                . ' { return str_repeat("x", 1024); } }';
+            file_put_contents($f, $code);
+            require $f;
+            $val = CachedClass::run();
+            if (function_exists('opcache_get_status')) {
+                $status = @opcache_get_status(false);
+                if ($status !== false && ($status['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+            self::OPCACHE_INI,
+        );
+
+        $this->waitForOpcacheReady($pipes[1], $docker_image_name);
+
+        $globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $process = new ProcessSpecifier($pid);
+        $settings = new TargetPhpSettings(php_version: $php_version);
+
+        $eg = $globals_finder->findExecutorGlobals($process, $settings);
+        $cg = $globals_finder->findCompilerGlobals($process, $settings);
+
+        $dumper = new MemoryDumper(
+            $memory_reader,
+            $zend_type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                $process_memory_map_creator,
+                $zend_type_reader_creator,
+            ),
+            $process_memory_map_creator,
+        );
+
+        $output_path = tempnam(sys_get_temp_dir(), 'reli-opcache-rt-');
+        $this->assertNotFalse($output_path);
+        $this->temp_files[] = $output_path;
+
+        $result = $dumper->dump(
+            $process,
+            $settings,
+            $eg,
+            $cg,
+            $output_path,
+        );
+
+        $this->assertFileExists($result->output_path);
+        $this->assertGreaterThan(0, $result->region_count);
+
+        // Read back the dump file via MemoryDumpReaderFactory
+        $factory = new MemoryDumpReaderFactory(new ContainerBuilder());
+        $reader = $factory->createFromPath($output_path, []);
+        $this->assertInstanceOf(MemoryDumpReader::class, $reader);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'opcacheSupported')]
+    public function testLightweightDumpSmallerThanFullShm(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+
+        // opcache.memory_consumption defaults to 128MB; the actual
+        // resident pages should be a small fraction of that.
+        $target_script = <<<'CODE'
+            <?php
+            $tmpdir = '/tmp/opcache_lw_' . getmypid();
+            @mkdir($tmpdir, 0777, true);
+            $f = $tmpdir . '/Small.php';
+            file_put_contents($f, '<?php class SmallClass { public static function id(): int { return 1; } }');
+            require $f;
+            SmallClass::id();
+            if (function_exists('opcache_get_status')) {
+                $status = @opcache_get_status(false);
+                if ($status !== false && ($status['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, (string)($status['memory_usage']['used_memory'] ?? 0) . "\n");
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "0\n");
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "0\n");
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+            self::OPCACHE_INI,
+        );
+
+        $opcache_used_str = $this->waitForOpcacheReadyWithUsage(
+            $pipes[1],
+            $docker_image_name,
+        );
+        $opcache_used = (int)trim($opcache_used_str);
+
+        $globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $process = new ProcessSpecifier($pid);
+        $settings = new TargetPhpSettings(php_version: $php_version);
+
+        $eg = $globals_finder->findExecutorGlobals($process, $settings);
+        $cg = $globals_finder->findCompilerGlobals($process, $settings);
+
+        $dumper = new MemoryDumper(
+            $memory_reader,
+            $zend_type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                $process_memory_map_creator,
+                $zend_type_reader_creator,
+            ),
+            $process_memory_map_creator,
+        );
+
+        $output_path = tempnam(sys_get_temp_dir(), 'reli-opcache-lw-');
+        $this->assertNotFalse($output_path);
+        $this->temp_files[] = $output_path;
+
+        $result = $dumper->dump(
+            $process,
+            $settings,
+            $eg,
+            $cg,
+            $output_path,
+        );
+
+        $this->assertGreaterThan(0, $result->region_count);
+
+        // The default opcache.memory_consumption is 128MB.
+        // With pagemap-based resident page filtering, the dump should
+        // be much smaller than the full SHM region size.
+        // A tiny script should use only a few MB of opcache at most.
+        $shm_total = 128 * 1024 * 1024; // default opcache SHM size
+        $this->assertLessThan(
+            $shm_total,
+            $result->total_bytes,
+            'Lightweight dump should be smaller than full SHM region ('
+            . $shm_total . ' bytes)',
+        );
+
+        // The dump size should be reasonably proportional to actual usage
+        if ($opcache_used > 0) {
+            // Allow generous headroom: dump includes ZendMM chunks,
+            // heap, binary segments, etc. in addition to opcache SHM.
+            // But the total should still be well under 128MB.
+            $this->assertLessThan(
+                64 * 1024 * 1024,
+                $result->total_bytes,
+                'Dump for a tiny script should be well under 64MB',
+            );
+        }
+
+        unlink($output_path);
+    }
+
+    /**
+     * Read lines from stdout until "ready" or "opcache_disabled".
+     * Skips warning lines (e.g. failed extension loading).
+     * @param resource $stdout
+     */
+    private function waitForOpcacheReady(
+        $stdout,
+        string $docker_image_name,
+    ): void {
+        for ($i = 0; $i < 20; $i++) {
+            $line = fgets($stdout);
+            if ($line === false) {
+                $this->fail(
+                    'unexpected EOF from container '
+                    . $docker_image_name,
+                );
+            }
+            if ($line === "ready\n") {
+                return;
+            }
+            if ($line === "opcache_disabled\n") {
+                $this->markTestSkipped(
+                    'opcache not available in '
+                    . $docker_image_name,
+                );
+            }
+            // skip warning/notice lines
+        }
+        $this->fail('did not receive ready signal');
+    }
+
+    /**
+     * Like waitForOpcacheReady but also captures the used_memory
+     * line emitted before "ready".
+     * @param resource $stdout
+     */
+    private function waitForOpcacheReadyWithUsage(
+        $stdout,
+        string $docker_image_name,
+    ): string {
+        $last_numeric = '0';
+        for ($i = 0; $i < 20; $i++) {
+            $line = fgets($stdout);
+            if ($line === false) {
+                $this->fail(
+                    'unexpected EOF from container '
+                    . $docker_image_name,
+                );
+            }
+            if ($line === "ready\n") {
+                return $last_numeric;
+            }
+            if ($line === "opcache_disabled\n") {
+                $this->markTestSkipped(
+                    'opcache not available in '
+                    . $docker_image_name,
+                );
+            }
+            if (is_numeric(trim($line))) {
+                $last_numeric = $line;
+            }
+        }
+        $this->fail('did not receive ready signal');
+    }
+
+    private function createGlobalsFinder(
+        MemoryReader $memory_reader,
+        ZendTypeReaderCreator $zend_type_reader_creator,
+    ): PhpGlobalsFinder {
+        $integer_reader = new LittleEndianReader();
+        $binary_analysis_cache = new BinaryAnalysisCache(
+            sys_get_temp_dir() . '/reli-test-' . uniqid(),
+        );
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator(
+            $memory_reader,
+        );
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser($integer_reader),
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                $integer_reader,
+                new LinkMapLoader($memory_reader, $integer_reader),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache,
+            ),
+            $process_memory_map_creator,
+            $binary_analysis_cache,
+        );
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        return new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader,
+            new PhpTsrmLsCacheFinder(
+                $php_symbol_reader_creator,
+                $tsrm_globals_resolver,
+                $memory_reader,
+                $integer_reader,
+                new Elf64Parser($integer_reader),
+                new CatFileReader(),
+                ProcessMemoryMapCreator::create(),
+                new ContainerAwarePathResolver(),
+                $zend_type_reader_creator,
+                $binary_analysis_cache,
+                $binary_fingerprint_creator,
+            ),
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+    }
+}

--- a/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
@@ -46,8 +46,20 @@ use Reli\TargetPhpVmProvider;
 #[Group('target-version')]
 class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
 {
-    private const OPCACHE_INI = '-dzend_extension=opcache'
-        . ' -dopcache.enable_cli=1 -dopcache.enable=1';
+    private const OPCACHE_INI = '-dopcache.enable_cli=1'
+        . ' -dopcache.enable=1';
+
+    private static function opcacheIniFor(string $php_version): string
+    {
+        // PHP 8.5+ ships opcache as a built-in Zend extension.
+        // Older versions need explicit loading via zend_extension.
+        $load = version_compare(
+            ltrim($php_version, 'v'),
+            '85',
+            '<',
+        ) ? '-dzend_extension=opcache ' : '';
+        return $load . self::OPCACHE_INI;
+    }
 
     /** @var resource|null */
     private $child = null;
@@ -77,6 +89,9 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
         string $php_version,
         string $docker_image_name,
     ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no matching target');
+        }
         $memory_reader = new MemoryReader();
         $zend_type_reader_creator = new ZendTypeReaderCreator();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
@@ -116,7 +131,7 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
             $docker_image_name,
             $target_script,
             $pipes,
-            self::OPCACHE_INI,
+            self::opcacheIniFor($php_version),
         );
 
         $this->waitForOpcacheReady($pipes[1], $docker_image_name);
@@ -174,6 +189,9 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
         string $php_version,
         string $docker_image_name,
     ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no matching target');
+        }
         $memory_reader = new MemoryReader();
         $zend_type_reader_creator = new ZendTypeReaderCreator();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
@@ -207,7 +225,7 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
             $docker_image_name,
             $target_script,
             $pipes,
-            self::OPCACHE_INI,
+            self::opcacheIniFor($php_version),
         );
 
         $this->waitForOpcacheReady($pipes[1], $docker_image_name);
@@ -258,6 +276,9 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
         string $php_version,
         string $docker_image_name,
     ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no matching target');
+        }
         $memory_reader = new MemoryReader();
         $zend_type_reader_creator = new ZendTypeReaderCreator();
         $process_memory_map_creator = ProcessMemoryMapCreator::create();
@@ -293,7 +314,7 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
             $docker_image_name,
             $target_script,
             $pipes,
-            self::OPCACHE_INI,
+            self::opcacheIniFor($php_version),
         );
 
         $opcache_used_str = $this->waitForOpcacheReadyWithUsage(

--- a/tests/Inspector/Watch/VariableReaderIntegrationTest.php
+++ b/tests/Inspector/Watch/VariableReaderIntegrationTest.php
@@ -608,6 +608,517 @@ class VariableReaderIntegrationTest extends BaseTestCase
         $this->assertSame(2, $results[$key3]->array_count);
     }
 
+    /**
+     * Read static properties from an opcache-enabled target.
+     *
+     * When opcache is active on PHP 8.2+, static_members_table is
+     * stored as a MAP_PTR offset with the LSB set to 1.
+     * resolveMapPtr must mask the flag bit before calculating the
+     * real address, otherwise the dereference reads from addr+1
+     * and returns garbage.
+     */
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'opcacheSupported')]
+    public function testReadStaticPropertyWithOpcache(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no matching target');
+        }
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script = <<<'CODE'
+            <?php
+            $tmpdir = '/tmp/opcache_static_' . getmypid();
+            @mkdir($tmpdir, 0777, true);
+            $f = $tmpdir . '/StaticTarget.php';
+            $code = '<?php class StaticTarget {'
+                . ' public static $count = 77;'
+                . ' public static $label = "opcache_test";'
+                . ' public static $items = array(10, 20, 30, 40);'
+                . ' }';
+            file_put_contents($f, $code);
+            require $f;
+            StaticTarget::$count;
+            if (function_exists('opcache_get_status')) {
+                $status = @opcache_get_status(false);
+                if ($status !== false && ($status['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+            $this->opcacheIniFor($php_version),
+        );
+
+        $s = $this->readOpcacheReadySignal($pipes[1]);
+        if ($s === "opcache_disabled\n") {
+            $this->markTestSkipped(
+                'opcache not available in '
+                . $docker_image_name,
+            );
+        }
+        $this->assertSame("ready\n", $s);
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $cg_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $variable_reader = new VariableReader(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+
+        $triggers = [
+            new VariableValueTrigger(
+                'static::StaticTarget::$count:gt:0',
+            ),
+            new VariableValueTrigger(
+                'static::StaticTarget::$label:eq:opcache_test',
+            ),
+            new VariableValueTrigger(
+                'static::StaticTarget::$items:count_gt:1',
+            ),
+        ];
+        $results = $variable_reader->readVariables(
+            $triggers,
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+            $cg_address,
+        );
+
+        $key_count = 'static::StaticTarget::$count';
+        $this->assertArrayHasKey($key_count, $results);
+        $this->assertSame(
+            VariableValue::TYPE_LONG,
+            $results[$key_count]->type,
+        );
+        $this->assertSame(77, $results[$key_count]->scalar_value);
+
+        $key_label = 'static::StaticTarget::$label';
+        $this->assertArrayHasKey($key_label, $results);
+        $this->assertSame(
+            VariableValue::TYPE_STRING,
+            $results[$key_label]->type,
+        );
+        $this->assertSame(
+            'opcache_test',
+            $results[$key_label]->scalar_value,
+        );
+
+        $key_items = 'static::StaticTarget::$items';
+        $this->assertArrayHasKey($key_items, $results);
+        $this->assertSame(
+            VariableValue::TYPE_ARRAY,
+            $results[$key_items]->type,
+        );
+        $this->assertSame(4, $results[$key_items]->array_count);
+    }
+
+    /**
+     * Verify resolveMapPtr LSB masking for PHP 7.4 with opcache.
+     *
+     * Background (why PEAR.php?):
+     *   In Docker's overlayfs, opcache only caches files that reside
+     *   in the image's lower layer — bind-mounted or dynamically
+     *   created files live on a different device and are silently
+     *   skipped.  PEAR.php ships with the official php:7.4-cli
+     *   image AND declares a static property ($bivalentMethods),
+     *   making it the only readily-available file that satisfies
+     *   both conditions.
+     *
+     * What this tests:
+     *   When opcache caches a script in PHP 7.4 CLI, classes with
+     *   static properties are persisted as IMMUTABLE in SHM.
+     *   zend_persist_class_entry() calls ZEND_MAP_PTR_NEW(), which
+     *   in ZEND_MAP_PTR_KIND_PTR_OR_OFFSET mode returns
+     *   PTR2OFFSET(ptr) = (ptr - base) | 1, storing the value with
+     *   LSB=1 in static_members_table__ptr.
+     *
+     *   PHP 7.4's map_ptr_base is the raw (unbiased) base, so
+     *   resolveMapPtr must strip the LSB before adding to the base
+     *   (matching ZEND_MAP_PTR_OFFSET2PTR = base + offset - 1).
+     *   PHP 8.0+ biases the base by -1 (commit 27815959 in
+     *   php-src), making the explicit mask unnecessary.
+     *
+     *   Without the & ~1 mask on PHP 7.4, the resolved address is
+     *   off by 1 byte, producing a garbage pointer that makes the
+     *   static property unreadable.
+     */
+    #[Group('target-version')]
+    public function testReadStaticPropertyWithOpcacheImmutableClass(): void
+    {
+        $php_version = 'v74';
+        $docker_image_name = TargetPhpVmProvider::dockerImageNameFromTarget(
+            $php_version,
+        );
+
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        // PEAR.php is in the image's base layer so opcache caches
+        // it; it declares PEAR::$bivalentMethods (a static prop).
+        // We must access the static property to trigger
+        // zend_class_init_statics(), which populates the MAP_PTR
+        // slot (initially NULL for immutable classes).
+        $target_script = <<<'CODE'
+            <?php
+            require "/usr/local/lib/php/PEAR.php";
+            // Force static member initialization via Reflection.
+            // PEAR::$bivalentMethods is protected and only accessed
+            // in __call/__callStatic, so normal usage does not
+            // trigger ZEND_FETCH_STATIC_PROP / zend_class_init_statics.
+            $r = new ReflectionProperty('PEAR', 'bivalentMethods');
+            $r->setAccessible(true);
+            $r->getValue();
+            if (function_exists('opcache_get_status')) {
+                $s = @opcache_get_status(false);
+                if ($s && ($s['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+            '-dzend_extension=opcache'
+            . ' -dopcache.enable_cli=1'
+            . ' -dopcache.enable=1',
+        );
+
+        $s = $this->readOpcacheReadySignal($pipes[1]);
+        if ($s !== "ready\n") {
+            $this->markTestSkipped(
+                'opcache not available in '
+                . $docker_image_name,
+            );
+        }
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $cg_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $zend_type_reader = $zend_type_reader_creator->create(
+            $php_version,
+        );
+        $dereferencer = new \Reli\Lib\Process\Pointer\RemoteProcessDereferencer(
+            $memory_reader,
+            $process_specifier,
+            new \Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider(
+                $zend_type_reader,
+            ),
+            new \Reli\Lib\PhpInternals\VersionedPointedTypeResolver(
+                $php_version,
+            ),
+        );
+
+        $eg = $dereferencer->deref(new \Reli\Lib\Process\Pointer\Pointer(
+            \Reli\Lib\PhpInternals\Types\Zend\ZendExecutorGlobals::class,
+            $eg_address,
+            $zend_type_reader->sizeOf('zend_executor_globals'),
+        ));
+        $class_table = $dereferencer->deref($eg->class_table);
+
+        $bucket = $class_table->findByKey(
+            $dereferencer,
+            'pear',
+        );
+        $this->assertNotNull($bucket, 'PEAR class must exist');
+
+        $class_zval = $dereferencer->deref(
+            $bucket->val->getPointer(),
+        );
+        $ce = $dereferencer->deref($class_zval->value->ce);
+        $this->assertGreaterThan(
+            0,
+            $ce->default_static_members_count,
+            'PEAR must have static members',
+        );
+        $this->assertNotNull($ce->static_members_table);
+        $raw_ptr = $ce->static_members_table->address;
+
+        // Key assertion: on PHP 7.4 with opcache, the
+        // static_members_table__ptr is PTR2OFFSET encoded.
+        $this->assertSame(
+            1,
+            $raw_ptr & 1,
+            sprintf(
+                'static_members_table__ptr 0x%x should have'
+                . ' LSB=1 (PTR2OFFSET encoding)',
+                $raw_ptr,
+            ),
+        );
+
+        // resolveMapPtr must handle this correctly.
+        // Without the & ~1 fix this would read from an
+        // off-by-1 address and throw RuntimeException
+        // ("no memory region found" in dump analysis, or
+        // garbage pointer in live process).
+        $cg = $dereferencer->deref(
+            new \Reli\Lib\Process\Pointer\Pointer(
+                \Reli\Lib\PhpInternals\Types\Zend\ZendCompilerGlobals::class,
+                $cg_address,
+                $zend_type_reader->sizeOf('zend_compiler_globals'),
+            ),
+        );
+        $table_address = $zend_type_reader->resolveMapPtr(
+            $cg->map_ptr_base,
+            $raw_ptr,
+            $dereferencer,
+        );
+        // new PEAR() accesses self::$bivalentMethods, which
+        // triggers ZEND_FETCH_STATIC_PROP → zend_class_init_statics
+        // → the MAP_PTR slot is populated with the table pointer.
+        // Without the & ~1 fix, the resolved address is off by 1
+        // and reads garbage from the wrong slot, giving either 0
+        // or a wildly misaligned pointer.
+        $this->assertNotSame(
+            0,
+            $table_address,
+            'MAP_PTR slot should be non-zero after static init',
+        );
+        $this->assertSame(
+            0,
+            $table_address & 0xf,
+            sprintf(
+                'Resolved address 0x%x should be aligned',
+                $table_address,
+            ),
+        );
+    }
+
+    private function opcacheIniFor(string $php_version): string
+    {
+        $load = version_compare(
+            ltrim($php_version, 'v'),
+            '85',
+            '<',
+        ) ? '-dzend_extension=opcache ' : '';
+        return $load
+            . '-dopcache.enable_cli=1 -dopcache.enable=1';
+    }
+
+    /**
+     * Same MAP_PTR bug, but using opcache.preload to guarantee
+     * that statics are fully initialized (non-zero MAP_PTR slot).
+     * preload requires root, so this test uses a custom Docker
+     * command without -u uid:gid.
+     */
+    #[Group('target-version')]
+    public function testReadStaticPropertyWithOpcachePreload(): void
+    {
+        $php_version = 'v74';
+        $docker_image_name = TargetPhpVmProvider::dockerImageNameFromTarget(
+            $php_version,
+        );
+
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        $preload_file = tempnam('/tmp/reli-test', 'preload-');
+        $target_file = tempnam('/tmp/reli-test', 'target-');
+        $pid_writer = tempnam('/tmp/reli-test', 'pidwr-');
+        $pid_file = tempnam('/tmp/reli-test', 'pidf-');
+        chmod($preload_file, 0777);
+        chmod($target_file, 0777);
+        chmod($pid_writer, 0777);
+        chmod($pid_file, 0777);
+
+        file_put_contents($preload_file, <<<'PHP'
+            <?php
+            class PreloadedTarget {
+                public static $count = 77;
+                public static $label = "preloaded_test";
+                public static $items = [10, 20, 30, 40];
+            }
+            PHP);
+        file_put_contents($pid_writer, <<<'PHP'
+            <?php
+            file_put_contents('/target-pid', getmypid());
+            fputs(STDOUT, "pid written\n");
+            PHP);
+        file_put_contents($target_file, <<<'PHP'
+            <?php
+            PreloadedTarget::$count;
+            if (function_exists('opcache_get_status')) {
+                $s = @opcache_get_status(false);
+                if ($s && ($s['opcache_enabled'] ?? false)) {
+                    fputs(STDOUT, "ready\n");
+                } else {
+                    fputs(STDOUT, "opcache_disabled\n");
+                }
+            } else {
+                fputs(STDOUT, "opcache_disabled\n");
+            }
+            fgets(STDIN);
+            PHP);
+
+        $php_ini = '-dzend_extension=opcache'
+            . ' -dopcache.enable_cli=1'
+            . ' -dopcache.enable=1'
+            . ' -dopcache.preload=/preload.php'
+            . ' -dopcache.preload_user=root';
+
+        $this->child = proc_open(
+            [
+                'docker', 'run', '--rm', '--pid', 'host',
+                '-i', '--entrypoint', 'sh',
+                '-v', "$preload_file:/preload.php:ro",
+                '-v', "$target_file:/source:rw",
+                '-v', "$pid_writer:/pid-writer:rw",
+                '-v', "$pid_file:/target-pid:rw",
+                '-v', '/tmp/reli-test:/tmp/reli-test:rw',
+                $docker_image_name, '-c',
+                "php $php_ini"
+                . ' -dauto_prepend_file=/pid-writer'
+                . ' /source',
+            ],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+        );
+
+        $pid_msg = fgets($pipes[1]);
+        if ($pid_msg === false) {
+            $this->markTestSkipped('container failed to start');
+        }
+        $pid = (int)file_get_contents($pid_file);
+        if ($pid === 0) {
+            $this->markTestSkipped('failed to get target pid');
+        }
+
+        $s = $this->readOpcacheReadySignal($pipes[1]);
+        if ($s !== "ready\n") {
+            $this->markTestSkipped('opcache preload not available');
+        }
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $cg_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $variable_reader = new VariableReader(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+
+        $triggers = [
+            new VariableValueTrigger(
+                'static::PreloadedTarget::$count:gt:0',
+            ),
+            new VariableValueTrigger(
+                'static::PreloadedTarget::$label'
+                . ':eq:preloaded_test',
+            ),
+            new VariableValueTrigger(
+                'static::PreloadedTarget::$items:count_gt:1',
+            ),
+        ];
+        $results = $variable_reader->readVariables(
+            $triggers,
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+            $cg_address,
+        );
+
+        $key = 'static::PreloadedTarget::$count';
+        $this->assertArrayHasKey($key, $results);
+        $this->assertSame(77, $results[$key]->scalar_value);
+
+        $key_label = 'static::PreloadedTarget::$label';
+        $this->assertArrayHasKey($key_label, $results);
+        $this->assertSame(
+            'preloaded_test',
+            $results[$key_label]->scalar_value,
+        );
+
+        $key_items = 'static::PreloadedTarget::$items';
+        $this->assertArrayHasKey($key_items, $results);
+        $this->assertSame(4, $results[$key_items]->array_count);
+    }
+
+    /**
+     * Read lines from stdout, skipping extension load warnings.
+     * @param resource $stdout
+     */
+    private function readOpcacheReadySignal($stdout): string
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $line = fgets($stdout);
+            if ($line === false) {
+                return '';
+            }
+            if (
+                $line === "ready\n"
+                || $line === "opcache_disabled\n"
+            ) {
+                return $line;
+            }
+        }
+        return '';
+    }
+
     private function createGlobalsFinder(
         MemoryReader $memory_reader,
         ZendTypeReaderCreator $zend_type_reader_creator,

--- a/tests/Lib/PhpInternals/ResolveMapPtrTest.php
+++ b/tests/Lib/PhpInternals/ResolveMapPtrTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals;
+
+use PHPUnit\Framework\Attributes\Test;
+use Reli\BaseTestCase;
+use Reli\Lib\PhpInternals\Types\C\RawInt64;
+use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\Pointer;
+
+class ResolveMapPtrTest extends BaseTestCase
+{
+    /**
+     * PHP 7.4 has no ZEND_MAP_PTR_BIASED_BASE.
+     * map_ptr_base is the raw base address, so the LSB
+     * flag in the offset must be masked before adding.
+     */
+    #[Test]
+    public function testV74MasksLsbFromOffset(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V74);
+
+        $base = 0x7f0000100000;       // unbiased base
+        $real_offset = 0x200;          // true offset
+        $encoded = $real_offset | 1;   // MAP_PTR encoded (0x201)
+
+        $expected_address = $base + $real_offset; // 0x7f0000100200
+        $stored_value = 0xdeadbeef;
+
+        $dereferencer = $this->createStubDereferencer(
+            $expected_address,
+            $stored_value,
+        );
+
+        $result = $reader->resolveMapPtr(
+            $base,
+            $encoded,
+            $dereferencer,
+        );
+        $this->assertSame($stored_value, $result);
+    }
+
+    /**
+     * PHP 8.0 introduced biased base (commit 27815959 in php-src).
+     * map_ptr_base = real_base - 1, so no masking needed.
+     */
+    #[Test]
+    public function testV80UsesBiasedBaseWithoutMask(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V80);
+
+        $real_base = 0x7f0000100000;
+        $biased_base = $real_base - 1;
+        $real_offset = 0x400;
+        $encoded = $real_offset | 1;
+
+        $expected_address = $real_base + $real_offset;
+        $stored_value = 0xcafebabe;
+
+        $dereferencer = $this->createStubDereferencer(
+            $expected_address,
+            $stored_value,
+        );
+
+        $result = $reader->resolveMapPtr(
+            $biased_base,
+            $encoded,
+            $dereferencer,
+        );
+        $this->assertSame($stored_value, $result);
+    }
+
+    /**
+     * PHP 8.1+ uses ZEND_MAP_PTR_BIASED_BASE (map_ptr_base =
+     * real_base - 1), so LSB must NOT be masked — the -1 bias
+     * in the base cancels out the |1 in the offset.
+     */
+    #[Test]
+    public function testV81UsesBiasedBaseWithoutMask(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V81);
+
+        $real_base = 0x7f0000100000;
+        $biased_base = $real_base - 1;  // BIASED_BASE
+        $real_offset = 0x200;
+        $encoded = $real_offset | 1;    // 0x201
+
+        // biased_base + encoded = (real_base-1) + (offset|1)
+        //                       = real_base + offset
+        $expected_address = $real_base + $real_offset;
+        $stored_value = 0x12345678;
+
+        $dereferencer = $this->createStubDereferencer(
+            $expected_address,
+            $stored_value,
+        );
+
+        $result = $reader->resolveMapPtr(
+            $biased_base,
+            $encoded,
+            $dereferencer,
+        );
+        $this->assertSame($stored_value, $result);
+    }
+
+    #[Test]
+    public function testV84UsesBiasedBaseWithoutMask(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V84);
+
+        $real_base = 0x7f0000200000;
+        $biased_base = $real_base - 1;
+        $real_offset = 0x800;
+        $encoded = $real_offset | 1;
+
+        $expected_address = $real_base + $real_offset;
+        $stored_value = 0xaabbccdd;
+
+        $dereferencer = $this->createStubDereferencer(
+            $expected_address,
+            $stored_value,
+        );
+
+        $result = $reader->resolveMapPtr(
+            $biased_base,
+            $encoded,
+            $dereferencer,
+        );
+        $this->assertSame($stored_value, $result);
+    }
+
+    /**
+     * base=0, LSB=0: direct pointer, no resolution needed.
+     */
+    #[Test]
+    public function testBaseZeroLsbZeroReturnsDirectly(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V74);
+        $dereferencer = \Mockery::mock(Dereferencer::class);
+
+        $result = $reader->resolveMapPtr(
+            0,
+            0x12345678,
+            $dereferencer,
+        );
+        $this->assertSame(0x12345678, $result);
+    }
+
+    /**
+     * PHP 7.4 with base=0 and LSB=1.
+     * PTR2OFFSET with base=0: (ptr - 0) | 1 = ptr | 1
+     * OFFSET2PTR with base=0: 0 + (ptr|1) - 1 = ptr
+     * resolveMapPtr must NOT early-return for base=0 when LSB=1.
+     */
+    #[Test]
+    public function testV74BaseZeroLsbOneStillResolves(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V74);
+
+        $slot_addr = 0x55a000100200; // aligned MAP_PTR slot
+        $encoded = $slot_addr | 1;   // PTR2OFFSET(slot) with base=0
+        $stored_value = 0xdeadbeef;  // value stored at the slot
+
+        // base + (encoded & ~1) = 0 + slot_addr = slot_addr
+        $dereferencer = $this->createStubDereferencer(
+            $slot_addr,
+            $stored_value,
+        );
+
+        $result = $reader->resolveMapPtr(
+            0,
+            $encoded,
+            $dereferencer,
+        );
+        $this->assertSame($stored_value, $result);
+    }
+
+    #[Test]
+    public function testLsbZeroFallsThroughToDoubleDeref(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V80);
+
+        $direct_ptr = 0x7f0000300000; // LSB=0 (aligned)
+        $table_address = 0x7f0000400000;
+
+        $dereferencer = $this->createStubDereferencer(
+            $direct_ptr,
+            $table_address,
+        );
+
+        $result = $reader->resolveMapPtr(
+            0x7f0000100000, // non-zero base
+            $direct_ptr,
+            $dereferencer,
+        );
+        $this->assertSame($table_address, $result);
+    }
+
+    private function createStubDereferencer(
+        int $expected_address,
+        int $return_value,
+    ): Dereferencer {
+        $test = $this;
+        return new class (
+            $expected_address,
+            $return_value,
+            $test,
+        ) implements Dereferencer {
+            public function __construct(
+                private int $expected_address,
+                private int $return_value,
+                private ResolveMapPtrTest $test,
+            ) {
+            }
+
+            public function deref(Pointer $pointer): mixed
+            {
+                $this->test->assertSame(
+                    $this->expected_address,
+                    $pointer->address,
+                    sprintf(
+                        'Expected deref at 0x%x, got 0x%x',
+                        $this->expected_address,
+                        $pointer->address,
+                    ),
+                );
+                return new class ($this->return_value) {
+                    public int $value;
+                    public function __construct(int $v)
+                    {
+                        $this->value = $v;
+                    }
+                };
+            }
+        };
+    }
+}

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -108,10 +108,16 @@ class TargetPhpVmProvider
         };
     }
 
+    public static function opcacheSupported()
+    {
+        return self::from(ZendTypeReader::V74);
+    }
+
     public static function runScriptViaContainer(
         string $docker_image_name,
         string $script,
         array &$pipes,
+        string $extra_php_ini = '',
     ) {
         $tmp_file = tempnam('/tmp/reli-test', 'reli-prof-test');
         $pid_writer = tempnam('/tmp/reli-test', 'reli-prof-test-pid-writer');
@@ -134,9 +140,12 @@ class TargetPhpVmProvider
             $script
         );
 
+        $php_command = 'php'
+            . ($extra_php_ini !== '' ? ' ' . $extra_php_ini : '')
+            . ' -dauto_prepend_file=/pid-writer /source';
         $proc_handle = self::procOpenViaDocker(
             $docker_image_name,
-            'php -dauto_prepend_file=/pid-writer /source',
+            $php_command,
             [
                 ['pipe', 'r'],
                 ['pipe', 'w'],


### PR DESCRIPTION
## Summary

- Fix `resolveMapPtr` off-by-1 bug when reading MAP_PTR-encoded pointers on PHP 7.4
- Add opcache-enabled memory dump integration tests
- Add integration tests that detect the fix via live process memory scanning

## Background

PHP 7.4 uses `ZEND_MAP_PTR_KIND_PTR_OR_OFFSET` mode where `zend_map_ptr_new()` returns `PTR2OFFSET(ptr) = (ptr - base) | 1`. The resolution macro `ZEND_MAP_PTR_OFFSET2PTR` computes `base + offset - 1` to strip the flag bit.

PHP 8.0 ([php-src commit 27815959](https://github.com/php/php-src/commit/27815959e176fcdf30b54c5d9e2909f5f3e2b430)) moved the `- 1` into the base itself (`ZEND_MAP_PTR_BIASED_BASE: base = real_base - 1`), so `base + offset` gives the correct address without masking. The `map_ptr_real_base` field was later added in PHP 8.1 ([php-src commit 6434c93a](https://github.com/php/php-src/commit/6434c93a27fd23cb1b05f8ab092bb4a43df2e9d5)) as a refactor.

`resolveMapPtr` was doing `base + offset` unconditionally — correct for PHP 8.0+ but **off by 1 byte for PHP 7.4**. This caused garbage pointer reads for immutable opcache-cached classes whose `static_members_table__ptr` contains an LSB=1 encoded offset.

## Changes

### `src/Lib/PhpInternals/ZendTypeReader.php`
- Strip LSB (`& ~1`) before adding to base for PHP < 8.0
- Move the `$map_ptr & 1` check before the `$map_ptr_base === 0` early return (PHP 7.4 CLI with opcache can have `base=0` but `PTR2OFFSET` still encodes `| 1`)

### `tests/Lib/PhpInternals/ResolveMapPtrTest.php` (new)
7 unit tests covering all version branches:
- PHP 7.4: masks LSB from offset
- PHP 7.4 with base=0: still resolves correctly
- PHP 8.0-8.4: biased base, no masking needed
- base=0 + LSB=0: direct return
- LSB=0 with non-zero base: double-pointer deref fallback

### `tests/Inspector/Watch/VariableReaderIntegrationTest.php`
- `testReadStaticPropertyWithOpcacheImmutableClass`: Uses `PEAR.php` from the Docker image base layer (the only way opcache CLI caches files on overlayfs — bind-mounted files are on a different device and silently skipped). Confirms `static_members_table__ptr` has LSB=1 and that `resolveMapPtr` returns an aligned address. **Without the fix, returns `0x...01` (off-by-1 garbage).**
- `testReadStaticPropertyWithOpcachePreload`: Uses `opcache.preload` to fully initialize statics, verifies actual property values (`$count=77`, `$label`, `$items`).
- `testReadStaticPropertyWithOpcache`: General opcache flow test across PHP 7.4-8.4.

### `tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php` (new)
3 tests for memory dump with opcache-enabled targets:
- Dump from opcache-enabled process
- Dump write + read back roundtrip via `MemoryDumpReaderFactory`
- Pagemap-based lightweight dump is smaller than full 128MB SHM

### `tests/TargetPhpVmProvider.php`
- Add `$extra_php_ini` parameter to `runScriptViaContainer`
- Add `opcacheSupported()` data provider (PHP 7.4+)

## Known issue

`getStaticPropertyIterator` returns empty for PEAR's immutable class entry even though `resolveMapPtr` returns the correct address. The PEAR.php test works around this by verifying `resolveMapPtr` directly instead of going through `VariableReader`. The `reli inspector:watch` CLI tool reads the property successfully via the same code path, suggesting a DI/construction difference. This is a separate issue from the `resolveMapPtr` fix.

## Test plan

- [x] `ResolveMapPtrTest` — 7 unit tests, all pass
- [x] `testReadStaticPropertyWithOpcacheImmutableClass` — fix present: aligned address; fix absent: `0x...01` garbage
- [x] `testReadStaticPropertyWithOpcachePreload` — reads actual static property values
- [x] `testReadStaticPropertyWithOpcache` — PHP 7.4-8.4 NTS/ZTS
- [x] `MemoryDumpOpcacheIntegrationTest` — 3 tests, PHP 7.4-8.4
- [x] Existing `testReadStaticProperty` (without opcache) still passes

https://claude.ai/code/session_013L6KejqyndLjhZeWkg1BNA
