### PR TITLE
Add test for memory dump analysis with dependency-root

### DIFF
--- a/tests/Command/Inspector/MemoryDumpCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpCommandTest.php
@@ -362,6 +362,59 @@ class MemoryDumpCommandTest extends BaseTestCase
         $this->assertSame(0, $analyze_result);
     }
 
+    // dependency-root で /proc/<pid>/root を指定して
+    // include-binary なしのダンプを解析できることを確認
+    #[DataProvider('provideFromV72')]
+    public function testDumpAndAnalyzeWithDependencyRoot(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no target version');
+        }
+
+        $output_path = $this->createTmpFile();
+        $container = $this->createContainer();
+        [, $pid, ] = $this->startTargetProcess($docker_image_name);
+
+        // Dump WITHOUT --include-binary
+        /** @var MemoryDumpCommand $dump_command */
+        $dump_command = $container->make(MemoryDumpCommand::class);
+
+        $input = new ArrayInput([
+            '--pid' => (string)$pid,
+            '--output' => $output_path,
+        ]);
+        $input->setInteractive(false);
+        $result = $dump_command->run($input, new BufferedOutput());
+        $this->assertSame(0, $result);
+
+        // Analyze with --dependency-root pointing to the container's root
+        // via /proc/<pid>/root so that read-only binary segments can be
+        // resolved without --include-binary in the dump
+        /** @var MemoryAnalyzeCommand $analyze_command */
+        $analyze_command = $container->make(MemoryAnalyzeCommand::class);
+
+        $dependency_root = "/proc/{$pid}/root";
+        $analyze_input = new ArrayInput([
+            'dump-file' => $output_path,
+            '--dependency-root' => $dependency_root,
+        ]);
+        $analyze_input->setInteractive(false);
+        $analyze_output = new BufferedOutput();
+
+        ob_start();
+        try {
+            $analyze_result = $analyze_command->run(
+                $analyze_input,
+                $analyze_output,
+            );
+        } finally {
+            ob_end_clean();
+        }
+        $this->assertSame(0, $analyze_result);
+    }
+
     #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
     public function testDumpWithNoCache(
         string $php_version,


### PR DESCRIPTION
## Summary
Added a new test case to verify that memory dumps can be analyzed using the `--dependency-root` flag to resolve binary segments without requiring `--include-binary` in the dump itself.

## Key Changes
- Added `testDumpAndAnalyzeWithDependencyRoot()` test method that:
  - Creates a memory dump without the `--include-binary` flag
  - Analyzes the dump using `--dependency-root` pointing to `/proc/<pid>/root` (the container's root filesystem)
  - Verifies that read-only binary segments can be resolved through the dependency root path
  - Confirms the analysis completes successfully (exit code 0)

## Implementation Details
- Test is parameterized with `provideFromV72` data provider to run against multiple PHP versions
- Uses `ArrayInput` to construct command arguments for both dump and analyze operations
- Properly manages output buffering during analysis execution
- Validates that the `--dependency-root` feature enables analysis of dumps that lack binary data by leveraging the container's filesystem

https://claude.ai/code/session_01BcUybbxn3SMxCbaZsC1Zuw