### PR TITLE
Add process suspension during memory dumps

### DIFF
--- a/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
@@ -20,6 +20,7 @@ use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Log\Log;
 use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * Memory dump action for daemon mode.
@@ -31,6 +32,7 @@ final class DaemonMemoryDumpAction implements ActionInterface
 {
     public function __construct(
         private MemoryDumper $memory_dumper,
+        private ProcessStopper $process_stopper,
         private string $output_dir,
         private DiskUsageTracker $disk_tracker,
         private bool $include_binary = false,
@@ -72,6 +74,7 @@ final class DaemonMemoryDumpAction implements ActionInterface
             date('Ymd-His', (int)$event->timestamp),
         );
 
+        $stopped = $this->process_stopper->stop($process->pid);
         try {
             /** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
             $target_settings = new TargetPhpSettings(
@@ -96,6 +99,10 @@ final class DaemonMemoryDumpAction implements ActionInterface
                 'pid' => $process->pid,
                 'error' => $e->getMessage(),
             ]);
+        } finally {
+            if ($stopped) {
+                $this->process_stopper->resume($process->pid);
+            }
         }
     }
 }

--- a/src/Inspector/Watch/Action/MemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/MemoryDumpAction.php
@@ -20,6 +20,7 @@ use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Log\Log;
 use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * Fast binary memory dump action.
@@ -31,6 +32,7 @@ final class MemoryDumpAction implements ActionInterface
 {
     public function __construct(
         private MemoryDumper $memory_dumper,
+        private ProcessStopper $process_stopper,
         /** @var TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> */
         private TargetPhpSettings $target_php_settings,
         private int $eg_address,
@@ -65,6 +67,7 @@ final class MemoryDumpAction implements ActionInterface
             date('Ymd-His', (int)$event->timestamp),
         );
 
+        $stopped = $this->process_stopper->stop($process->pid);
         try {
             $result = $this->memory_dumper->dump(
                 $process,
@@ -86,6 +89,10 @@ final class MemoryDumpAction implements ActionInterface
                 'pid' => $process->pid,
                 'error' => $e->getMessage(),
             ]);
+        } finally {
+            if ($stopped) {
+                $this->process_stopper->resume($process->pid);
+            }
         }
     }
 }

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -24,12 +24,14 @@ use Reli\Inspector\Watch\Action\LogAction;
 use Reli\Inspector\Watch\Action\MemoryDumpAction;
 use Reli\Inspector\Watch\Action\TraceAction;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 final class ActionFactory
 {
     public function __construct(
         private CallTraceReader $call_trace_reader,
         private MemoryDumper $memory_dumper,
+        private ProcessStopper $process_stopper,
     ) {
     }
 
@@ -78,6 +80,7 @@ final class ActionFactory
             /** @psalm-suppress InvalidArgument */
             $actions[] = new MemoryDumpAction(
                 $this->memory_dumper,
+                $this->process_stopper,
                 $target_php_settings,
                 $eg_address,
                 $cg_address,
@@ -122,6 +125,7 @@ final class ActionFactory
                 case 'memory-dump':
                     $actions[] = new Action\DaemonMemoryDumpAction(
                         $this->memory_dumper,
+                        $this->process_stopper,
                         $settings->action_output_dir,
                         $disk_tracker,
                         $settings->include_binary,
@@ -170,6 +174,7 @@ final class ActionFactory
             /** @psalm-suppress InvalidArgument */
             'memory-dump' => new MemoryDumpAction(
                 $this->memory_dumper,
+                $this->process_stopper,
                 $target_php_settings,
                 $eg_address,
                 $cg_address,

--- a/tests/Inspector/Watch/Action/DaemonMemoryDumpActionTest.php
+++ b/tests/Inspector/Watch/Action/DaemonMemoryDumpActionTest.php
@@ -22,6 +22,7 @@ use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * @runTestsInSeparateProcesses
@@ -34,8 +35,10 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
         $dumper = Mockery::mock(
             'overload:' . MemoryDumper::class,
         );
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
         $action = new DaemonMemoryDumpAction(
             $dumper,
+            $stopper,
             '/tmp',
             new DiskUsageTracker(1024 * 1024),
         );
@@ -56,8 +59,10 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
         $tracker->recordFile($tmp);
         unlink($tmp);
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
         $action = new DaemonMemoryDumpAction(
             $dumper,
+            $stopper,
             '/tmp',
             $tracker,
         );
@@ -76,8 +81,10 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
         );
         $dumper->shouldNotReceive('dump');
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
         $action = new DaemonMemoryDumpAction(
             $dumper,
+            $stopper,
             '/tmp',
             new DiskUsageTracker(1024 * 1024),
         );
@@ -98,8 +105,13 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
         );
         $dumper->shouldReceive('dump')->once()->andReturn($result);
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
+        $stopper->shouldReceive('stop')->once()->andReturn(true);
+        $stopper->shouldReceive('resume')->once();
+
         $action = new DaemonMemoryDumpAction(
             $dumper,
+            $stopper,
             sys_get_temp_dir(),
             new DiskUsageTracker(1024 * 1024),
         );
@@ -131,8 +143,13 @@ class DaemonMemoryDumpActionTest extends BaseTestCase
             })
             ->andReturn($result);
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
+        $stopper->shouldReceive('stop')->once()->andReturn(true);
+        $stopper->shouldReceive('resume')->once();
+
         $action = new DaemonMemoryDumpAction(
             $dumper,
+            $stopper,
             sys_get_temp_dir(),
             new DiskUsageTracker(1024 * 1024),
             true,

--- a/tests/Inspector/Watch/Action/MemoryDumpActionTest.php
+++ b/tests/Inspector/Watch/Action/MemoryDumpActionTest.php
@@ -23,6 +23,7 @@ use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * @runTestsInSeparateProcesses
@@ -35,8 +36,10 @@ class MemoryDumpActionTest extends BaseTestCase
         $dumper = Mockery::mock(
             'overload:' . MemoryDumper::class,
         );
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
         $action = new MemoryDumpAction(
             $dumper,
+            $stopper,
             new TargetPhpSettings(php_version: 'v84'),
             0x1000,
             0x2000,
@@ -60,8 +63,10 @@ class MemoryDumpActionTest extends BaseTestCase
         $tracker->recordFile($tmp);
         unlink($tmp);
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
         $action = new MemoryDumpAction(
             $dumper,
+            $stopper,
             new TargetPhpSettings(php_version: 'v84'),
             0x1000,
             0x2000,
@@ -83,9 +88,13 @@ class MemoryDumpActionTest extends BaseTestCase
             'overload:' . MemoryDumper::class,
         );
         $dumper->shouldReceive('dump')->once()->andReturn($result);
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
+        $stopper->shouldReceive('stop')->once()->andReturn(true);
+        $stopper->shouldReceive('resume')->once();
 
         $action = new MemoryDumpAction(
             $dumper,
+            $stopper,
             new TargetPhpSettings(php_version: 'v84'),
             0x1000,
             0x2000,
@@ -120,8 +129,13 @@ class MemoryDumpActionTest extends BaseTestCase
             })
             ->andReturn($result);
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
+        $stopper->shouldReceive('stop')->once()->andReturn(true);
+        $stopper->shouldReceive('resume')->once();
+
         $action = new MemoryDumpAction(
             $dumper,
+            $stopper,
             new TargetPhpSettings(php_version: 'v84'),
             0x1000,
             0x2000,
@@ -146,8 +160,13 @@ class MemoryDumpActionTest extends BaseTestCase
             new \RuntimeException('chunk not found'),
         );
 
+        $stopper = Mockery::mock('overload:' . ProcessStopper::class);
+        $stopper->shouldReceive('stop')->once()->andReturn(true);
+        $stopper->shouldReceive('resume')->once();
+
         $action = new MemoryDumpAction(
             $dumper,
+            $stopper,
             new TargetPhpSettings(php_version: 'v84'),
             0x1000,
             0x2000,

--- a/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
+++ b/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
@@ -24,6 +24,7 @@ use Reli\Inspector\Watch\Action\ExecAction;
 use Reli\Inspector\Watch\Action\LogAction;
 use Reli\Inspector\Watch\Action\MemoryDumpAction;
 use Reli\Inspector\Watch\Action\TraceAction;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * @runTestsInSeparateProcesses
@@ -67,6 +68,7 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
             Mockery::mock(
                 'overload:' . MemoryDumper::class,
             ),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
     }
 

--- a/tests/Inspector/Watch/ActionFactoryTest.php
+++ b/tests/Inspector/Watch/ActionFactoryTest.php
@@ -21,6 +21,7 @@ use Reli\Inspector\Watch\Action\DaemonTraceAction;
 use Reli\Inspector\Watch\Action\ExecAction;
 use Reli\Inspector\Watch\Action\LogAction;
 use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 /**
  * @runTestsInSeparateProcesses
@@ -61,6 +62,7 @@ class ActionFactoryTest extends BaseTestCase
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
         $output = Mockery::mock(TraceOutput::class);
 
@@ -78,6 +80,7 @@ class ActionFactoryTest extends BaseTestCase
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
         $output = Mockery::mock(TraceOutput::class);
 
@@ -95,6 +98,7 @@ class ActionFactoryTest extends BaseTestCase
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
         $output = Mockery::mock(TraceOutput::class);
 
@@ -115,6 +119,7 @@ class ActionFactoryTest extends BaseTestCase
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
         $output = Mockery::mock(TraceOutput::class);
 
@@ -132,6 +137,7 @@ class ActionFactoryTest extends BaseTestCase
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
+            Mockery::mock('overload:' . ProcessStopper::class),
         );
         $output = Mockery::mock(TraceOutput::class);
 


### PR DESCRIPTION
## Summary
This change adds process suspension capability to memory dump operations. When performing memory dumps, the target process is now paused before dumping and resumed afterward, ensuring consistent memory snapshots and preventing potential issues from concurrent memory modifications.

## Key Changes
- Added `ProcessStopper` dependency injection to `MemoryDumpAction` and `DaemonMemoryDumpAction`
- Implemented process suspension before memory dump execution with guaranteed resumption via try-finally block
- Updated `ActionFactory` to inject `ProcessStopper` into memory dump action constructors
- Updated all related test mocks to include the new `ProcessStopper` dependency

## Implementation Details
- The process is stopped before the memory dump operation begins
- A try-finally block ensures the process is resumed only if it was successfully stopped, preventing accidental resumption of already-running processes
- The suspension/resumption logic is applied consistently across both standard and daemon memory dump actions
- All factory methods and tests have been updated to maintain compatibility with the new dependency

https://claude.ai/code/session_01DAbPZBqcdXSStDv7Z5rqWx