### PR TITLE
Add support for tracking call stacks in suspended Fibers

### DIFF
--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -712,7 +712,6 @@ The references in the objects_store don't add refcount to the objects.
 
 # Currently not yet supported
 - Variables captured in inactive Generators
-- Variables captured in suspended Fibers
 - TMP/VARs in PHP 7.0 target
 - internal classes other than `\Closure`
 - References to `\Closure`s in the engine, such as the callbacks of internal functions like `register_shutdown_function()` or `set_exception_handler()`

--- a/src/Lib/PhpInternals/Types/Zend/ZendFiber.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendFiber.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
+
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
+class ZendFiber implements PointedTypeResolverAware
+{
+    use InlineCDataCreatorTrait;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendObject $std;
+
+    /** @var Pointer<ZendExecuteData>|null */
+    public ?Pointer $execute_data;
+
+    /** @var Pointer<ZendExecuteData>|null */
+    public ?Pointer $stack_bottom;
+
+    /**
+     * @param CastedCData<\FFI\PhpInternals\zend_fiber> $casted_cdata
+     * @param Pointer<ZendFiber> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->std);
+        unset($this->execute_data);
+        unset($this->stack_bottom);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'std' => $this->std = new ZendObject(
+                new CastedCData(
+                    $this->casted_cdata->casted->std,
+                    $this->casted_cdata->casted->std,
+                ),
+                new Pointer(
+                    ZendObject::class,
+                    $this->pointer->address,
+                    FFI::typeof($this->casted_cdata->casted->std)->getSize(),
+                ),
+            ),
+            'execute_data' => $this->execute_data =
+                $this->casted_cdata->casted->execute_data !== null
+                ? Pointer::fromCData(
+                    ZendExecuteData::class,
+                    $this->casted_cdata->casted->execute_data,
+                )
+                : null
+            ,
+            'stack_bottom' => $this->stack_bottom =
+                $this->casted_cdata->casted->stack_bottom !== null
+                ? Pointer::fromCData(
+                    ZendExecuteData::class,
+                    $this->casted_cdata->casted->stack_bottom,
+                )
+                : null
+            ,
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'zend_fiber';
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_fiber> $casted_cdata
+         * @var Pointer<ZendFiber> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
+    }
+
+    /** @return Pointer<ZendFiber> */
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+
+    /**
+     * @param Pointer<ZendObject> $pointer
+     * @return Pointer<ZendFiber>
+     */
+    public static function getPointerFromZendObjectPointer(
+        Pointer $pointer,
+        ZendTypeReader $zend_type_reader,
+    ): Pointer {
+        return new Pointer(
+            ZendFiber::class,
+            $pointer->address,
+            $zend_type_reader->sizeOf('zend_fiber'),
+        );
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -23,6 +23,7 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendClassConstant;
 use Reli\Lib\PhpInternals\Types\Zend\ZendClassEntry;
 use Reli\Lib\PhpInternals\Types\Zend\ZendClosure;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCompilerGlobals;
+use Reli\Lib\PhpInternals\Types\Zend\ZendFiber;
 use Reli\Lib\PhpInternals\Types\Zend\ZendGenerator;
 use Reli\Lib\PhpInternals\Types\Zend\ZendConstant;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecuteData;
@@ -88,6 +89,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\DefinedClassesCon
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\DefinedFunctionsContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\DynamicFuncDefsContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\FunctionDefinitionContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\FiberContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\GeneratorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\GlobalConstantContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\GlobalConstantsContext;
@@ -1069,6 +1071,30 @@ final class MemoryLocationsCollector
             }
         }
 
+        if (
+            $class_entry->getClassName($dereferencer) === 'Fiber'
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V81)
+        ) {
+            try {
+                $fiber_context = $this->collectFiber(
+                    $dereferencer->deref(
+                        ZendFiber::getPointerFromZendObjectPointer(
+                            $object->getPointer(),
+                            $zend_type_reader,
+                        ),
+                    ),
+                    $map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+                $object_context->add('fiber', $fiber_context);
+            } catch (\Throwable) {
+            }
+        }
+
         return $object_context;
     }
 
@@ -1193,6 +1219,41 @@ final class MemoryLocationsCollector
         }
 
         return $generator_context;
+    }
+
+    public function collectFiber(
+        ZendFiber $zend_fiber,
+        int $map_ptr_base,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+        ContextPools $context_pools,
+        ?MemoryLimitErrorDetails $memory_limit_error_details,
+    ): FiberContext {
+        $fiber_context = new FiberContext();
+
+        try {
+            if ($zend_fiber->execute_data !== null) {
+                $execute_data = $dereferencer->deref($zend_fiber->execute_data);
+                $call_frames_context = new CallFramesContext();
+                foreach ($execute_data->iterateStackChain($dereferencer) as $key => $frame) {
+                    $call_frame_context = $this->collectCallFrame(
+                        $frame,
+                        $map_ptr_base,
+                        $dereferencer,
+                        $zend_type_reader,
+                        $memory_locations,
+                        $context_pools,
+                        $memory_limit_error_details,
+                    );
+                    $call_frames_context->add((string)$key, $call_frame_context);
+                }
+                $fiber_context->add('call_frames', $call_frames_context);
+            }
+        } catch (\Throwable) {
+        }
+
+        return $fiber_context;
     }
 
     public function collectFunctionTable(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/FiberContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/FiberContext.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+final class FiberContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -512,6 +512,161 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
     }
 
+    public static function provideFromV81()
+    {
+        yield from TargetPhpVmProvider::from(ZendTypeReader::V81);
+    }
+
+    #[DataProvider('provideFromV81')]
+    public function testFiberCallStackTracking(string $php_version, string $docker_image_name): void
+    {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            $fiber = new Fiber(function () {
+                $x = 1;
+                Fiber::suspend();
+                $x = 2;
+            });
+            $fiber->start();
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $context_analyzer = new ContextAnalyzer();
+        $sink = new ArrayContextTreeSink();
+        $context_analyzer->analyze(
+            $collected_memories->top_reference_context,
+            $sink,
+        );
+        $contexts_analyzed = $sink->getResult();
+
+        // Verify that a fiber with call_frames exists somewhere in the context tree
+        $found_fiber_with_frames = false;
+        $findFiber = function (array $tree) use (&$findFiber, &$found_fiber_with_frames): void {
+            foreach ($tree as $key => $value) {
+                if ($key === 'fiber' && is_array($value) && isset($value['call_frames'])) {
+                    $found_fiber_with_frames = true;
+                    return;
+                }
+                if (is_array($value) && $key !== '#locations') {
+                    $findFiber($value);
+                    if ($found_fiber_with_frames) {
+                        return;
+                    }
+                }
+            }
+        };
+        $findFiber($contexts_analyzed);
+        $this->assertTrue(
+            $found_fiber_with_frames,
+            'Should find at least one fiber with tracked call frames'
+        );
+    }
+
     #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
     public function testMemoryLimitViolation(string $php_version, string $docker_image_name)
     {

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -101,6 +101,9 @@ class zend_op extends CData
 
 class zend_fiber extends CData
 {
+    public zend_object $std;
+    public ?CPointer $execute_data;
+    public ?CPointer $stack_bottom;
 }
 
 class zend_fiber_context extends CData


### PR DESCRIPTION
## Summary
This PR adds support for collecting and analyzing call stack information from suspended PHP Fibers (introduced in PHP 8.1). Previously, variables captured in suspended Fibers were not tracked by the memory profiler.

## Key Changes
- **New `ZendFiber` type class** (`src/Lib/PhpInternals/Types/Zend/ZendFiber.php`): Represents the internal `zend_fiber` structure with access to the fiber's execute data and stack information
- **New `FiberContext` reference context** (`src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/FiberContext.php`): Provides a context container for fiber-related memory references
- **Enhanced `MemoryLocationsCollector`**: Added `collectFiber()` method to traverse and collect call frames from suspended fibers, integrated into the object collection pipeline
- **Updated FFI stubs** (`tools/stubs/ffi/php.php`): Added struct field definitions for `zend_fiber` (std, execute_data, stack_bottom)
- **Comprehensive test coverage** (`testFiberCallStackTracking`): New test that verifies fiber call stack tracking works correctly by:
  - Creating a fiber that suspends mid-execution
  - Collecting memory locations from the running process
  - Verifying that the fiber's call frames are properly tracked in the context tree

## Implementation Details
- Fiber support is gated to PHP 8.1+ using version checks
- Call frame collection from fibers reuses the existing `collectCallFrame()` infrastructure
- Error handling is defensive with try-catch blocks to gracefully handle edge cases
- The implementation follows the same pattern as existing Generator support for consistency

https://claude.ai/code/session_01UvbtaHduMXHgLqf3VBZU5X