### PR TITLE
Fix double-counting of generator memory during yield-from delegation

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -44,6 +44,8 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V71)
         ) {
             $size = $zend_type_reader->sizeOf('zend_closure');
+        } elseif ($class_name === \Generator::class) {
+            $size = $zend_type_reader->sizeOf('zend_generator');
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1150,7 +1150,13 @@ final class MemoryLocationsCollector
         $generator_context = new GeneratorContext();
 
         try {
-            if ($zend_generator->execute_data !== null) {
+            if (
+                $zend_generator->execute_data !== null
+                and !$this->isExecuteDataInsideGeneratorStruct(
+                    $zend_generator,
+                    $zend_type_reader,
+                )
+            ) {
                 $execute_data = $dereferencer->deref($zend_generator->execute_data);
                 $call_frames_context = new CallFramesContext();
                 foreach ($execute_data->iterateStackChain($dereferencer) as $key => $frame) {
@@ -1219,6 +1225,24 @@ final class MemoryLocationsCollector
         }
 
         return $generator_context;
+    }
+
+    /**
+     * Check if generator->execute_data points to the inline execute_fake field
+     * inside the zend_generator struct. This happens during yield-from delegation.
+     * Collecting call frames from execute_fake would double-count the generator's
+     * own ZendMM allocation, inflating analyzed_percentage above 100%.
+     */
+    private function isExecuteDataInsideGeneratorStruct(
+        ZendGenerator $zend_generator,
+        ZendTypeReader $zend_type_reader,
+    ): bool {
+        assert($zend_generator->execute_data !== null);
+        $execute_data_address = $zend_generator->execute_data->address;
+        $generator_address = $zend_generator->getPointer()->address;
+        $generator_size = $zend_type_reader->sizeOf('zend_generator');
+        return $execute_data_address >= $generator_address
+            && $execute_data_address < $generator_address + $generator_size;
     }
 
     public function collectFiber(


### PR DESCRIPTION
## Summary
This PR fixes a memory analysis bug where generator memory was being double-counted during yield-from delegation, causing the analyzed_percentage to exceed 100%.

## Key Changes
- **Added validation in `collectGenerator()`**: Before processing execute_data from a generator, check if it points to the inline `execute_fake` field within the zend_generator struct itself. This prevents double-counting the generator's own ZendMM allocation when yield-from delegation is active.

- **New helper method `isExecuteDataInsideGeneratorStruct()`**: Determines whether a generator's execute_data pointer references memory inside the generator struct by comparing the execute_data address against the generator's address range.

- **Fixed generator size calculation in `ZendObjectMemoryLocation`**: Added explicit size calculation for Generator objects using `zend_generator` struct size, ensuring accurate memory accounting for generator instances.

## Implementation Details
The fix addresses a specific edge case in PHP's generator implementation: during yield-from delegation, a generator's `execute_data` field can point to an inline `execute_fake` field within the zend_generator struct itself. Previously, the code would traverse call frames from this execute_data, inadvertently re-analyzing the generator's own memory allocation and inflating the total analyzed memory percentage.

The solution checks if the execute_data address falls within the generator struct's memory bounds before processing its call frames, preventing this double-counting while maintaining correct analysis for normal generator execution.

https://claude.ai/code/session_013hQG8YHY5zYk6vVHXoPZJU