### PR TITLE
Update memory profiler documentation for Fiber and Generator support

### DIFF
--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -738,6 +738,7 @@ The references in the objects_store don't add refcount to the objects.
 - internal classes other than `\Closure`, `\Fiber`, and `\Generator`
 - The contents of resources
 - Data that can only be reached from circular references that don't contain any objects
+- Support for the opcache SHM
 
 # Troubleshooting
 ## jq says "parse error: Exceeds depth limit for parsing at line 1"

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -734,12 +734,10 @@ The `objects_store` is an important table that holds references to all objects i
 The references in the objects_store don't add refcount to the objects.
 
 # Currently not yet supported
-- Variables captured in inactive Generators
 - TMP/VARs in PHP 7.0 target
-- internal classes other than `\Closure`
+- internal classes other than `\Closure`, `\Fiber`, and `\Generator`
 - The contents of resources
 - Data that can only be reached from circular references that don't contain any objects
-- Support for the opcache SHM
 
 # Troubleshooting
 ## jq says "parse error: Exceeds depth limit for parsing at line 1"


### PR DESCRIPTION
## Summary
Updated the memory profiler documentation to reflect current support status for internal classes and remove outdated limitations.

## Key Changes
- Removed "Variables captured in inactive Generators" from the unsupported features list, indicating this is now supported
- Updated the internal classes limitation to include `\Fiber` and `\Generator` alongside `\Closure`, clarifying which internal classes are now supported by the profiler

## Details
These documentation updates align the "Currently not yet supported" section with the actual capabilities of the memory profiler, removing a previously documented limitation and expanding the list of supported internal classes.

https://claude.ai/code/session_014zxzXZimH1xR4P546jutrq