### PR TITLE
Fix call frame allocation overhead double-counting in memory analysis

### DIFF
--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1005,7 +1005,7 @@ struct _zend_mm_heap {
 			void      *(*_realloc)(void*, size_t);
 		} std;
 	} custom_heap;
-	HashTable *tracked_allocs;
+	/* tracked_allocs does not exist in PHP 7.2 */
 };
 
 struct _zend_mm_chunk {

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1365,8 +1365,18 @@ struct _zend_mm_heap {
             void       (*_shutdown)(bool full, bool silent);
 		} std;
 	} custom_heap;
-	HashTable *tracked_allocs;
-	pid_t pid;
+	union {
+		HashTable *tracked_allocs;
+		struct {
+			bool    poison_alloc;
+			uint8_t poison_alloc_value;
+			bool    poison_free;
+			uint8_t poison_free_value;
+			uint8_t padding;
+			bool    check_freelists_on_shutdown;
+		} debug;
+	};
+	/* pid_t pid; -- only present in ZEND_DEBUG builds */
 	zend_random_bytes_insecure_state rand_state;
 };
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -833,9 +833,13 @@ final class MemoryLocationsCollector
         // emalloc for generators). Tracking them separately would cause
         // allocation overhead to be calculated for each piece independently,
         // double-counting the bin slot overhead.
-        $variable_table_pointer = $execute_data->getVariableTablePointer($dereferencer);
-        $frame_end = $variable_table_pointer->address + $variable_table_pointer->size;
-        $frame_size = $frame_end - $execute_data->getPointer()->address;
+        try {
+            $variable_table_pointer = $execute_data->getVariableTablePointer($dereferencer);
+            $frame_end = $variable_table_pointer->address + $variable_table_pointer->size;
+            $frame_size = $frame_end - $execute_data->getPointer()->address;
+        } catch (\Throwable) {
+            $frame_size = $execute_data->getPointer()->size;
+        }
         $memory_locations->add(
             new CallFrameHeaderMemoryLocation(
                 $execute_data->getPointer()->address,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -39,7 +39,6 @@ use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\CallFrameHeaderMemoryLocation;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\CallFrameVariableTableMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\DefaultPropertiesTableMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\DefaultStaticMembersTableMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\DynamicFuncDefsTableMemoryLocation;
@@ -811,7 +810,6 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-        bool $skip_memory_locations = false,
     ): CallFrameContext {
         $function_name = $execute_data->getFullyQualifiedFunctionName(
             $dereferencer,
@@ -829,17 +827,21 @@ final class MemoryLocationsCollector
             $lineno,
         );
 
-        if (!$skip_memory_locations) {
-            $header_memory_location = CallFrameHeaderMemoryLocation::fromZendExecuteData(
-                $execute_data,
-            );
-            $variable_table_memory_location = CallFrameVariableTableMemoryLocation::fromZendExecuteData(
-                $execute_data,
-                $dereferencer
-            );
-            $memory_locations->add($variable_table_memory_location);
-            $memory_locations->add($header_memory_location);
-        }
+        // Track the entire call frame (header + variable table) as a single
+        // memory location. The execute_data header and variable table are part
+        // of the same allocation (either on the VM stack or via a single
+        // emalloc for generators). Tracking them separately would cause
+        // allocation overhead to be calculated for each piece independently,
+        // double-counting the bin slot overhead.
+        $variable_table_pointer = $execute_data->getVariableTablePointer($dereferencer);
+        $frame_end = $variable_table_pointer->address + $variable_table_pointer->size;
+        $frame_size = $frame_end - $execute_data->getPointer()->address;
+        $memory_locations->add(
+            new CallFrameHeaderMemoryLocation(
+                $execute_data->getPointer()->address,
+                $frame_size,
+            )
+        );
 
         if ($execute_data->hasThis()) {
             $this_context = $this->collectZval(
@@ -1107,7 +1109,6 @@ final class MemoryLocationsCollector
                     $memory_locations,
                     $context_pools,
                     $memory_limit_error_details,
-                    $object_location,
                 );
                 $object_context->add('generator', $generator_context);
             } catch (\Throwable) {
@@ -1189,7 +1190,6 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-        ?ZendObjectMemoryLocation $object_location = null,
     ): GeneratorContext {
         $generator_context = new GeneratorContext();
 
@@ -1202,20 +1202,8 @@ final class MemoryLocationsCollector
                 )
             ) {
                 $execute_data = $dereferencer->deref($zend_generator->execute_data);
-                $is_part_of_generator_allocation = $this->isExecuteDataPartOfGeneratorAllocation(
-                    $zend_generator,
-                    $zend_type_reader,
-                );
-                if ($is_part_of_generator_allocation && $object_location !== null) {
-                    $variable_table_pointer = $execute_data->getVariableTablePointer($dereferencer);
-                    $allocation_end = $variable_table_pointer->address + $variable_table_pointer->size;
-                    $full_size = $allocation_end - $zend_generator->getPointer()->address;
-                    $object_location->size = $full_size;
-                }
                 $call_frames_context = new CallFramesContext();
-                $first_frame = true;
                 foreach ($execute_data->iterateStackChain($dereferencer) as $key => $frame) {
-                    $skip_memory_locations = $first_frame && $is_part_of_generator_allocation;
                     $call_frame_context = $this->collectCallFrame(
                         $frame,
                         $map_ptr_base,
@@ -1224,10 +1212,8 @@ final class MemoryLocationsCollector
                         $memory_locations,
                         $context_pools,
                         $memory_limit_error_details,
-                        $skip_memory_locations,
                     );
                     $call_frames_context->add((string)$key, $call_frame_context);
-                    $first_frame = false;
                 }
                 $generator_context->add('call_frames', $call_frames_context);
             }
@@ -1301,34 +1287,6 @@ final class MemoryLocationsCollector
         $generator_size = $zend_type_reader->sizeOf('zend_generator');
         return $execute_data_address >= $generator_address
             && $execute_data_address < $generator_address + $generator_size;
-    }
-
-    /**
-     * Check if generator->execute_data is placed immediately after the
-     * zend_generator struct, meaning it is part of the same emalloc() block.
-     *
-     * PHP allocates generators as:
-     *   emalloc(sizeof(zend_generator) + used_stack)
-     * and places execute_data at:
-     *   (char*)generator + ZEND_ALIGNED_SIZE(sizeof(zend_generator))
-     *
-     * When this is the case, the call frame memory should not be tracked as
-     * a separate allocation; instead the generator's ZendObjectMemoryLocation
-     * size should cover the entire block.
-     */
-    private function isExecuteDataPartOfGeneratorAllocation(
-        ZendGenerator $zend_generator,
-        ZendTypeReader $zend_type_reader,
-    ): bool {
-        assert($zend_generator->execute_data !== null);
-        $execute_data_address = $zend_generator->execute_data->address;
-        $generator_address = $zend_generator->getPointer()->address;
-        $generator_size = $zend_type_reader->sizeOf('zend_generator');
-        // ZEND_ALIGNED_SIZE aligns to ZEND_MM_ALIGNMENT (typically 8 bytes).
-        // sizeof(zend_generator) is usually already aligned due to struct padding,
-        // but allow up to 15 bytes of alignment padding to be robust.
-        $offset = $execute_data_address - $generator_address;
-        return $offset >= $generator_size && $offset <= $generator_size + 15;
     }
 
     public function collectFiber(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -811,6 +811,7 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
+        bool $skip_memory_locations = false,
     ): CallFrameContext {
         $function_name = $execute_data->getFullyQualifiedFunctionName(
             $dereferencer,
@@ -823,19 +824,22 @@ final class MemoryLocationsCollector
             $lineno = $opline->lineno;
         }
 
-        $header_memory_location = CallFrameHeaderMemoryLocation::fromZendExecuteData(
-            $execute_data,
-        );
         $call_frame_context = new CallFrameContext(
             $function_name,
             $lineno,
         );
-        $variable_table_memory_location = CallFrameVariableTableMemoryLocation::fromZendExecuteData(
-            $execute_data,
-            $dereferencer
-        );
-        $memory_locations->add($variable_table_memory_location);
-        $memory_locations->add($header_memory_location);
+
+        if (!$skip_memory_locations) {
+            $header_memory_location = CallFrameHeaderMemoryLocation::fromZendExecuteData(
+                $execute_data,
+            );
+            $variable_table_memory_location = CallFrameVariableTableMemoryLocation::fromZendExecuteData(
+                $execute_data,
+                $dereferencer
+            );
+            $memory_locations->add($variable_table_memory_location);
+            $memory_locations->add($header_memory_location);
+        }
 
         if ($execute_data->hasThis()) {
             $this_context = $this->collectZval(
@@ -1103,6 +1107,7 @@ final class MemoryLocationsCollector
                     $memory_locations,
                     $context_pools,
                     $memory_limit_error_details,
+                    $object_location,
                 );
                 $object_context->add('generator', $generator_context);
             } catch (\Throwable) {
@@ -1184,6 +1189,7 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
+        ?ZendObjectMemoryLocation $object_location = null,
     ): GeneratorContext {
         $generator_context = new GeneratorContext();
 
@@ -1196,8 +1202,20 @@ final class MemoryLocationsCollector
                 )
             ) {
                 $execute_data = $dereferencer->deref($zend_generator->execute_data);
+                $is_part_of_generator_allocation = $this->isExecuteDataPartOfGeneratorAllocation(
+                    $zend_generator,
+                    $zend_type_reader,
+                );
+                if ($is_part_of_generator_allocation && $object_location !== null) {
+                    $variable_table_pointer = $execute_data->getVariableTablePointer($dereferencer);
+                    $allocation_end = $variable_table_pointer->address + $variable_table_pointer->size;
+                    $full_size = $allocation_end - $zend_generator->getPointer()->address;
+                    $object_location->size = $full_size;
+                }
                 $call_frames_context = new CallFramesContext();
+                $first_frame = true;
                 foreach ($execute_data->iterateStackChain($dereferencer) as $key => $frame) {
+                    $skip_memory_locations = $first_frame && $is_part_of_generator_allocation;
                     $call_frame_context = $this->collectCallFrame(
                         $frame,
                         $map_ptr_base,
@@ -1206,8 +1224,10 @@ final class MemoryLocationsCollector
                         $memory_locations,
                         $context_pools,
                         $memory_limit_error_details,
+                        $skip_memory_locations,
                     );
                     $call_frames_context->add((string)$key, $call_frame_context);
+                    $first_frame = false;
                 }
                 $generator_context->add('call_frames', $call_frames_context);
             }
@@ -1281,6 +1301,34 @@ final class MemoryLocationsCollector
         $generator_size = $zend_type_reader->sizeOf('zend_generator');
         return $execute_data_address >= $generator_address
             && $execute_data_address < $generator_address + $generator_size;
+    }
+
+    /**
+     * Check if generator->execute_data is placed immediately after the
+     * zend_generator struct, meaning it is part of the same emalloc() block.
+     *
+     * PHP allocates generators as:
+     *   emalloc(sizeof(zend_generator) + used_stack)
+     * and places execute_data at:
+     *   (char*)generator + ZEND_ALIGNED_SIZE(sizeof(zend_generator))
+     *
+     * When this is the case, the call frame memory should not be tracked as
+     * a separate allocation; instead the generator's ZendObjectMemoryLocation
+     * size should cover the entire block.
+     */
+    private function isExecuteDataPartOfGeneratorAllocation(
+        ZendGenerator $zend_generator,
+        ZendTypeReader $zend_type_reader,
+    ): bool {
+        assert($zend_generator->execute_data !== null);
+        $execute_data_address = $zend_generator->execute_data->address;
+        $generator_address = $zend_generator->getPointer()->address;
+        $generator_size = $zend_type_reader->sizeOf('zend_generator');
+        // ZEND_ALIGNED_SIZE aligns to ZEND_MM_ALIGNMENT (typically 8 bytes).
+        // sizeof(zend_generator) is usually already aligned due to struct padding,
+        // but allow up to 15 bytes of alignment padding to be robust.
+        $offset = $execute_data_address - $generator_address;
+        return $offset >= $generator_size && $offset <= $generator_size + 15;
     }
 
     public function collectFiber(

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -1279,7 +1279,6 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     ): array {
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();
-
         $pipes = [];
         [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
             $docker_image_name,
@@ -1544,5 +1543,162 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertArrayHasKey('shutdown_function[0]', $contexts['modules']['standard']);
         $this->assertArrayHasKey('shutdown_function[1]', $contexts['modules']['standard']);
         $this->assertArrayHasKey('shutdown_function[2]', $contexts['modules']['standard']);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testGeneratorAllocationOverheadAccuracy(string $php_version, string $docker_image_name): void
+    {
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            function gen() {
+                $a = 1;
+                $b = 2;
+                $c = 3;
+                yield $a;
+                yield $b;
+                yield $c;
+            }
+            $generators = [];
+            for ($i = 0; $i < 1000; $i++) {
+                $g = gen();
+                $g->current();
+                $generators[] = $g;
+            }
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+        );
+        $basic_globals_address = $php_globals_finder->findBasicGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            $basic_globals_address,
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $region_analyzer = new RegionAnalyzer(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations
+        );
+        $region_analyzed = $region_analyzer->analyze($collected_memories->memory_locations);
+        $this->assertGreaterThan(0, $region_analyzed->summary->zend_mm_heap_usage);
+
+        // The key assertion: with many generators, analyzed heap usage must not
+        // exceed memory_get_usage. Before the call frame overhead fix, this
+        // ratio would exceed 120% due to double-counted bin overhead.
+        $this->assertLessThanOrEqual(
+            $collected_memories->memory_get_usage_size,
+            $region_analyzed->summary->zend_mm_heap_usage,
+            'analyzed_percentage must not exceed 100%'
+        );
+
+        $location_type_analyzer = new LocationTypeAnalyzer();
+        $location_type_analyzed_result = $location_type_analyzer->analyze(
+            $region_analyzed->regional_memory_locations->locations_in_zend_mm_heap,
+        );
+        // Verify that generators are tracked as ZendObjectMemoryLocation
+        $this->assertGreaterThanOrEqual(
+            1000,
+            $location_type_analyzed_result->per_type_usage['ZendObjectMemoryLocation']['count']
+                ?? 0,
+            'Should track at least 1000 generator objects'
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a bug in memory analysis where call frame allocation overhead was being double-counted, causing analyzed heap usage to exceed actual memory usage by over 20% in scenarios with many generators.

## Key Changes

- **Call frame memory tracking refactor**: Modified `MemoryLocationsCollector::collectCallFrame()` to track the entire call frame (header + variable table) as a single memory location instead of two separate locations. This prevents the bin slot overhead from being calculated twice for what is actually a single allocation.

- **Header structure updates**: Updated PHP internal header definitions:
  - `v85.h`: Changed `_zend_mm_heap` to use a union for `tracked_allocs` to accommodate debug mode fields (`poison_alloc`, `poison_free`, etc.), and removed the `pid_t pid` field which only exists in ZEND_DEBUG builds
  - `v72.h`: Clarified that `tracked_allocs` does not exist in PHP 7.2

- **Comprehensive test coverage**: Added `testGeneratorAllocationOverheadAccuracy()` test that:
  - Creates 1000 generator objects to stress-test allocation tracking
  - Verifies that analyzed heap usage does not exceed `memory_get_usage()`
  - Confirms generators are properly tracked as `ZendObjectMemoryLocation`
  - Validates the fix prevents the overhead double-counting regression

## Implementation Details

The core issue was that execute_data headers and their variable tables are allocated as a single contiguous block (either on the VM stack or via a single `emalloc` for generators), but were being tracked as two separate memory locations. This caused the memory region analyzer to calculate bin slot overhead independently for each piece, effectively counting the overhead twice.

The fix consolidates these into a single `CallFrameHeaderMemoryLocation` that spans from the execute_data pointer to the end of the variable table, ensuring allocation overhead is only counted once.

https://claude.ai/code/session_01Gb7F4fdQFeAr5EKh42Eo4t