### PR TITLE
Add support for tracking WeakReference and WeakMap objects

### DIFF
--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1113,8 +1113,8 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 // main/SAPI.h

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1111,6 +1111,12 @@ struct _zend_generator {
 	uint32_t gc_buffer_size;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
 // main/SAPI.h
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1132,6 +1132,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1134,13 +1134,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1305,13 +1305,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1303,6 +1303,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1343,13 +1343,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1341,6 +1341,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1383,6 +1383,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1385,13 +1385,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1464,13 +1464,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1462,6 +1462,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1480,6 +1480,17 @@ struct _zend_generator {
 	uint8_t flags;
 };
 
+/* zend_weakrefs.h */
+typedef struct _zend_weakref {
+	zend_object std;
+	zend_object *referent;
+} zend_weakref;
+
+typedef struct _zend_weakmap {
+	zend_object std;
+	HashTable ht;
+} zend_weakmap;
+
 /* main/SAPI.h */
 /*
    +----------------------------------------------------------------------+

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1482,13 +1482,13 @@ struct _zend_generator {
 
 /* zend_weakrefs.h */
 typedef struct _zend_weakref {
-	zend_object std;
 	zend_object *referent;
+	zend_object std;
 } zend_weakref;
 
 typedef struct _zend_weakmap {
-	zend_object std;
 	HashTable ht;
+	zend_object std;
 } zend_weakmap;
 
 /* main/SAPI.h */

--- a/src/Lib/PhpInternals/Types/Zend/ZendWeakMap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendWeakMap.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
+
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
+class ZendWeakMap implements PointedTypeResolverAware
+{
+    use InlineCDataCreatorTrait;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendObject $std;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendArray $ht;
+
+    /**
+     * @param CastedCData<\FFI\PhpInternals\zend_weakmap> $casted_cdata
+     * @param Pointer<ZendWeakMap> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->std);
+        unset($this->ht);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'std' => $this->std = new ZendObject(
+                new CastedCData(
+                    $this->casted_cdata->casted->std,
+                    $this->casted_cdata->casted->std,
+                ),
+                new Pointer(
+                    ZendObject::class,
+                    $this->pointer->address,
+                    FFI::typeof($this->casted_cdata->casted->std)->getSize(),
+                ),
+            ),
+            'ht' => $this->ht = $this->createInlineDereferencable('ht', ZendArray::class),
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'zend_weakmap';
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_weakmap> $casted_cdata
+         * @var Pointer<ZendWeakMap> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
+    }
+
+    /** @return Pointer<ZendWeakMap> */
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+
+    /**
+     * @param Pointer<ZendObject> $pointer
+     * @return Pointer<ZendWeakMap>
+     */
+    public static function getPointerFromZendObjectPointer(
+        Pointer $pointer,
+        ZendTypeReader $zend_type_reader,
+    ): Pointer {
+        return new Pointer(
+            ZendWeakMap::class,
+            $pointer->address,
+            $zend_type_reader->sizeOf('zend_weakmap'),
+        );
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendWeakMap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendWeakMap.php
@@ -21,6 +21,12 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 /**
+ * In PHP internals, the zend_weakmap struct has the layout:
+ *   { HashTable ht; zend_object std; }
+ * The custom field (ht) comes BEFORE the embedded zend_object.
+ * The object store pointer points to &wm->std, so we must subtract
+ * the offset of std to get the struct base.
+ *
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
  */
@@ -56,7 +62,9 @@ class ZendWeakMap implements PointedTypeResolverAware
                 ),
                 new Pointer(
                     ZendObject::class,
-                    $this->pointer->address,
+                    $this->pointer->address
+                    +
+                    FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('std'),
                     FFI::typeof($this->casted_cdata->casted->std)->getSize(),
                 ),
             ),
@@ -100,10 +108,12 @@ class ZendWeakMap implements PointedTypeResolverAware
         Pointer $pointer,
         ZendTypeReader $zend_type_reader,
     ): Pointer {
+        $struct_size = $zend_type_reader->sizeOf('zend_weakmap');
+        [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakmap', 'std');
         return new Pointer(
             ZendWeakMap::class,
-            $pointer->address,
-            $zend_type_reader->sizeOf('zend_weakmap'),
+            $pointer->address - $std_offset,
+            $struct_size,
         );
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendWeakReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendWeakReference.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
+
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
+class ZendWeakReference implements PointedTypeResolverAware
+{
+    use InlineCDataCreatorTrait;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendObject $std;
+
+    /** @var Pointer<ZendObject>|null */
+    public ?Pointer $referent;
+
+    /**
+     * @param CastedCData<\FFI\PhpInternals\zend_weakref> $casted_cdata
+     * @param Pointer<ZendWeakReference> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->std);
+        unset($this->referent);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'std' => $this->std = new ZendObject(
+                new CastedCData(
+                    $this->casted_cdata->casted->std,
+                    $this->casted_cdata->casted->std,
+                ),
+                new Pointer(
+                    ZendObject::class,
+                    $this->pointer->address,
+                    FFI::typeof($this->casted_cdata->casted->std)->getSize(),
+                ),
+            ),
+            'referent' => $this->referent =
+                $this->casted_cdata->casted->referent !== null
+                ? Pointer::fromCData(
+                    ZendObject::class,
+                    $this->casted_cdata->casted->referent,
+                )
+                : null
+            ,
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'zend_weakref';
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        /**
+         * @var CastedCData<\FFI\PhpInternals\zend_weakref> $casted_cdata
+         * @var Pointer<ZendWeakReference> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
+    }
+
+    /** @return Pointer<ZendWeakReference> */
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+
+    /**
+     * @param Pointer<ZendObject> $pointer
+     * @return Pointer<ZendWeakReference>
+     */
+    public static function getPointerFromZendObjectPointer(
+        Pointer $pointer,
+        ZendTypeReader $zend_type_reader,
+    ): Pointer {
+        return new Pointer(
+            ZendWeakReference::class,
+            $pointer->address,
+            $zend_type_reader->sizeOf('zend_weakref'),
+        );
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/ZendWeakReference.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendWeakReference.php
@@ -21,6 +21,12 @@ use Reli\Lib\Process\Pointer\PointedTypeResolver;
 use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
 
 /**
+ * In PHP internals, the zend_weakref struct has the layout:
+ *   { zend_object *referent; zend_object std; }
+ * The custom field (referent) comes BEFORE the embedded zend_object.
+ * The object store pointer points to &wr->std, so we must subtract
+ * the offset of std to get the struct base.
+ *
  * @psalm-consistent-constructor
  * @psalm-suppress ClassMustBeFinal
  */
@@ -56,7 +62,9 @@ class ZendWeakReference implements PointedTypeResolverAware
                 ),
                 new Pointer(
                     ZendObject::class,
-                    $this->pointer->address,
+                    $this->pointer->address
+                    +
+                    FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('std'),
                     FFI::typeof($this->casted_cdata->casted->std)->getSize(),
                 ),
             ),
@@ -107,10 +115,12 @@ class ZendWeakReference implements PointedTypeResolverAware
         Pointer $pointer,
         ZendTypeReader $zend_type_reader,
     ): Pointer {
+        $struct_size = $zend_type_reader->sizeOf('zend_weakref');
+        [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakref', 'std');
         return new Pointer(
             ZendWeakReference::class,
-            $pointer->address,
-            $zend_type_reader->sizeOf('zend_weakref'),
+            $pointer->address - $std_offset,
+            $struct_size,
         );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -47,6 +47,20 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             $size = $zend_type_reader->sizeOf('zend_closure');
         } elseif ($class_name === \Generator::class) {
             $size = $zend_type_reader->sizeOf('zend_generator');
+        } elseif (
+            $class_name === \WeakReference::class
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V74)
+        ) {
+            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakref', 'std');
+            $address -= $std_offset;
+            $size = $zend_object->getMemorySize($dereferencer) + $std_offset;
+        } elseif (
+            $class_name === \WeakMap::class
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V80)
+        ) {
+            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakmap', 'std');
+            $address -= $std_offset;
+            $size = $zend_object->getMemorySize($dereferencer) + $std_offset;
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -46,6 +46,16 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             $size = $zend_type_reader->sizeOf('zend_closure');
         } elseif ($class_name === \Generator::class) {
             $size = $zend_type_reader->sizeOf('zend_generator');
+        } elseif (
+            $class_name === \WeakReference::class
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V74)
+        ) {
+            $size = $zend_type_reader->sizeOf('zend_weakref');
+        } elseif (
+            $class_name === \WeakMap::class
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V80)
+        ) {
+            $size = $zend_type_reader->sizeOf('zend_weakmap');
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -37,6 +37,7 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
         assert($zend_object->ce !== null);
         $ce = $dereferencer->deref($zend_object->ce);
         $class_name = $ce->getClassName($dereferencer);
+        $address = $zend_object->getPointer()->address;
         if ($class_name === \Fiber::class) {
             $size = $zend_type_reader->sizeOf('zend_fiber');
         } elseif (
@@ -51,16 +52,20 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V74)
         ) {
             $size = $zend_type_reader->sizeOf('zend_weakref');
+            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakref', 'std');
+            $address -= $std_offset;
         } elseif (
             $class_name === \WeakMap::class
             and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V80)
         ) {
             $size = $zend_type_reader->sizeOf('zend_weakmap');
+            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakmap', 'std');
+            $address -= $std_offset;
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }
         return new self(
-            $zend_object->getPointer()->address,
+            $address,
             $size,
             $zend_object->zend_refcounted_h->refcount,
             $zend_object->zend_refcounted_h->type_info,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -47,20 +47,6 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             $size = $zend_type_reader->sizeOf('zend_closure');
         } elseif ($class_name === \Generator::class) {
             $size = $zend_type_reader->sizeOf('zend_generator');
-        } elseif (
-            $class_name === \WeakReference::class
-            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V74)
-        ) {
-            $size = $zend_type_reader->sizeOf('zend_weakref');
-            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakref', 'std');
-            $address -= $std_offset;
-        } elseif (
-            $class_name === \WeakMap::class
-            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V80)
-        ) {
-            $size = $zend_type_reader->sizeOf('zend_weakmap');
-            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('zend_weakmap', 'std');
-            $address -= $std_offset;
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1030,6 +1030,10 @@ final class MemoryLocationsCollector
             $zend_type_reader,
         );
         $memory_locations->add($object_location);
+        $zend_object_address = $object->getPointer()->address;
+        if ($object_location->address !== $zend_object_address) {
+            $memory_locations->memory_locations[$zend_object_address] = $object_location;
+        }
         $memory_locations->add($object_handlers_memory_location);
 
         $object_context = $context_pools

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -39,6 +39,8 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendObjectsStore;
 use Reli\Lib\PhpInternals\Types\Zend\ZendReference;
 use Reli\Lib\PhpInternals\Types\Zend\ZendResource;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
+use Reli\Lib\PhpInternals\Types\Zend\ZendWeakMap;
+use Reli\Lib\PhpInternals\Types\Zend\ZendWeakReference;
 use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
@@ -119,6 +121,8 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ScalarValueContex
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\TopReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\WeakMapContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\WeakReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -1152,6 +1156,54 @@ final class MemoryLocationsCollector
             }
         }
 
+        if (
+            $class_entry->getClassName($dereferencer) === 'WeakReference'
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V74)
+        ) {
+            try {
+                $weak_reference_context = $this->collectWeakReference(
+                    $dereferencer->deref(
+                        ZendWeakReference::getPointerFromZendObjectPointer(
+                            $object->getPointer(),
+                            $zend_type_reader,
+                        ),
+                    ),
+                    $map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+                $object_context->add('weak_reference', $weak_reference_context);
+            } catch (\Throwable) {
+            }
+        }
+
+        if (
+            $class_entry->getClassName($dereferencer) === 'WeakMap'
+            and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V80)
+        ) {
+            try {
+                $weak_map_context = $this->collectWeakMap(
+                    $dereferencer->deref(
+                        ZendWeakMap::getPointerFromZendObjectPointer(
+                            $object->getPointer(),
+                            $zend_type_reader,
+                        ),
+                    ),
+                    $map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+                $object_context->add('weak_map', $weak_map_context);
+            } catch (\Throwable) {
+            }
+        }
+
         return $object_context;
     }
 
@@ -1493,6 +1545,64 @@ final class MemoryLocationsCollector
                 continue;
             }
         }
+    }
+
+    public function collectWeakReference(
+        ZendWeakReference $zend_weak_reference,
+        int $map_ptr_base,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+        ContextPools $context_pools,
+        ?MemoryLimitErrorDetails $memory_limit_error_details,
+    ): WeakReferenceContext {
+        $weak_reference_context = new WeakReferenceContext();
+
+        if ($zend_weak_reference->referent !== null) {
+            try {
+                $referent_context = $this->collectZendObjectPointer(
+                    $zend_weak_reference->referent,
+                    $map_ptr_base,
+                    $memory_locations,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+                $weak_reference_context->add('referent', $referent_context);
+            } catch (\Throwable) {
+            }
+        }
+
+        return $weak_reference_context;
+    }
+
+    public function collectWeakMap(
+        ZendWeakMap $zend_weak_map,
+        int $map_ptr_base,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+        ContextPools $context_pools,
+        ?MemoryLimitErrorDetails $memory_limit_error_details,
+    ): WeakMapContext {
+        $weak_map_context = new WeakMapContext();
+
+        try {
+            $array_context = $this->collectZendArray(
+                $zend_weak_map->ht,
+                $map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
+            $weak_map_context->add('entries', $array_context);
+        } catch (\Throwable) {
+        }
+
+        return $weak_map_context;
     }
 
     public function collectFunctionTable(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/WeakMapContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/WeakMapContext.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+final class WeakMapContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/WeakReferenceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/WeakReferenceContext.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+final class WeakReferenceContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -1866,4 +1866,309 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             'analyzed_percentage must not exceed 100%'
         );
     }
+
+    public static function provideFromV74()
+    {
+        yield from TargetPhpVmProvider::from(ZendTypeReader::V74);
+    }
+
+    #[DataProvider('provideFromV74')]
+    public function testWeakReferenceReferentTracking(string $php_version, string $docker_image_name): void
+    {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            class MyTargetObject {
+                public int $value = 42;
+            }
+            $obj = new MyTargetObject();
+            $ref = WeakReference::create($obj);
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $context_analyzer = new ContextAnalyzer();
+        $sink = new ArrayContextTreeSink();
+        $context_analyzer->analyze(
+            $collected_memories->top_reference_context,
+            $sink,
+        );
+        $contexts_analyzed = $sink->getResult();
+
+        $found_weak_reference_with_referent = false;
+        $findWeakReference = function (array $tree) use (
+            &$findWeakReference,
+            &$found_weak_reference_with_referent,
+        ): void {
+            foreach ($tree as $key => $value) {
+                if ($key === 'weak_reference' && is_array($value) && isset($value['referent'])) {
+                    $found_weak_reference_with_referent = true;
+                    return;
+                }
+                if (is_array($value) && $key !== '#locations') {
+                    $findWeakReference($value);
+                    if ($found_weak_reference_with_referent) {
+                        return;
+                    }
+                }
+            }
+        };
+        $findWeakReference($contexts_analyzed);
+        $this->assertTrue(
+            $found_weak_reference_with_referent,
+            'Should find at least one WeakReference with a tracked referent'
+        );
+    }
+
+    #[DataProvider('provideFromV80')]
+    public function testWeakMapEntriesTracking(string $php_version, string $docker_image_name): void
+    {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            class KeyObject {}
+            $key1 = new KeyObject();
+            $key2 = new KeyObject();
+            $map = new WeakMap();
+            $map[$key1] = 'value_one';
+            $map[$key2] = 'value_two';
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $context_analyzer = new ContextAnalyzer();
+        $sink = new ArrayContextTreeSink();
+        $context_analyzer->analyze(
+            $collected_memories->top_reference_context,
+            $sink,
+        );
+        $contexts_analyzed = $sink->getResult();
+
+        $found_weak_map_with_entries = false;
+        $findWeakMap = function (array $tree) use (&$findWeakMap, &$found_weak_map_with_entries): void {
+            foreach ($tree as $key => $value) {
+                if ($key === 'weak_map' && is_array($value) && isset($value['entries'])) {
+                    $found_weak_map_with_entries = true;
+                    return;
+                }
+                if (is_array($value) && $key !== '#locations') {
+                    $findWeakMap($value);
+                    if ($found_weak_map_with_entries) {
+                        return;
+                    }
+                }
+            }
+        };
+        $findWeakMap($contexts_analyzed);
+        $this->assertTrue(
+            $found_weak_map_with_entries,
+            'Should find at least one WeakMap with tracked entries'
+        );
+    }
 }

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -68,14 +68,14 @@ class zend_generator extends CData
 
 class zend_weakref extends CData
 {
-    public zend_object $std;
     public ?CPointer $referent;
+    public zend_object $std;
 }
 
 class zend_weakmap extends CData
 {
-    public zend_object $std;
     public zend_array $ht;
+    public zend_object $std;
 }
 
 class zend_constants extends CData

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -66,6 +66,18 @@ class zend_generator extends CData
     public zval $retval;
 }
 
+class zend_weakref extends CData
+{
+    public zend_object $std;
+    public ?CPointer $referent;
+}
+
+class zend_weakmap extends CData
+{
+    public zend_object $std;
+    public zend_array $ht;
+}
+
 class zend_constants extends CData
 {
     public ?CPointer $name;


### PR DESCRIPTION
## Summary
This PR adds support for tracking PHP's `WeakReference` (PHP 7.4+) and `WeakMap` (PHP 8.0+) objects in memory analysis. These special object types are now properly recognized and their internal structures are traversed to collect referent and entry information.

## Key Changes

- **New Type Classes**: Added `ZendWeakReference` and `ZendWeakMap` classes to represent the internal PHP structures for weak references and weak maps, with proper pointer offset calculations to account for embedded `zend_object` structures.

- **Context Classes**: Introduced `WeakReferenceContext` and `WeakMapContext` to represent these objects in the reference context tree.

- **Memory Collection**: Extended `MemoryLocationsCollector` to detect and collect `WeakReference` and `WeakMap` objects:
  - For `WeakReference`: Tracks the referent object pointer
  - For `WeakMap`: Tracks the internal hash table containing key-value entries

- **Memory Location Tracking**: Updated `ZendObjectMemoryLocation` to correctly calculate memory sizes for weak reference and weak map structures based on their respective struct definitions.

- **FFI Stubs and Headers**: Added struct definitions for `zend_weakref` and `zend_weakmap` to all PHP version headers (7.4-8.5) and FFI stubs.

- **Integration Tests**: Added comprehensive integration tests (`testWeakReferenceReferentTracking` and `testWeakMapEntriesTracking`) that verify weak references and weak maps are properly tracked in the memory context tree.

## Implementation Details

The implementation handles the fact that both `zend_weakref` and `zend_weakmap` have custom fields that come before the embedded `zend_object` structure. The object store pointer points to the `std` field, so pointer calculations must subtract the offset of `std` to get the actual struct base address. This is handled by the `getPointerFromZendObjectPointer()` static methods in both classes.

https://claude.ai/code/session_015WXRJUFFgNiYWDEX8SUzod