### PR TITLE
Fix fiber VM stack detection logic for PHP 8.1+

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1347,12 +1347,16 @@ final class MemoryLocationsCollector
                     );
                 }
             } elseif (
-                $zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V82)
-                and !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V81)
+                !$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V81)
                 and $zend_fiber->execute_data !== null
                 and $this->fiber_vm_stack_memory_locations !== null
                 and $this->chunk_memory_locations !== null
             ) {
+                // fiber->vm_stack is only set when the fiber's callback returns
+                // (end of zend_fiber_execute). For suspended fibers, EG(vm_stack)
+                // is saved to a local zend_fiber_vm_state on the C stack via
+                // zend_fiber_capture_vm_state(), so we must scan the C stack to
+                // find it. This applies to all PHP versions with Fiber support.
                 $this->scanFiberCStackForVmStack(
                     $zend_fiber,
                     $dereferencer,
@@ -1366,10 +1370,11 @@ final class MemoryLocationsCollector
     }
 
     /**
-     * PHP 8.1's zend_fiber lacks the vm_stack field (added in 8.2).
-     * When a fiber suspends, EG(vm_stack) is saved to a local variable on the
-     * fiber's C stack by the context switch code, but there's no stable struct
-     * field to read it from.
+     * When a fiber suspends, zend_fiber_switch_context() saves EG(vm_stack) to
+     * a local zend_fiber_vm_state variable on the C stack via
+     * zend_fiber_capture_vm_state(). The fiber->vm_stack field is only set at
+     * the end of zend_fiber_execute() when the fiber's callback returns, so it
+     * is always NULL for suspended fibers regardless of PHP version.
      *
      * This method brute-force scans the fiber's C stack memory to locate the
      * saved vm_stack pointer. For each pointer-sized value on the C stack:


### PR DESCRIPTION
## Summary
Corrected the PHP version check and improved documentation for fiber VM stack detection. The logic now properly applies to all PHP versions with Fiber support (8.1+) rather than being incorrectly limited to PHP 8.1 only.

## Key Changes
- **Fixed version check**: Changed from checking `isPhpVersionLowerThan(V82) AND !isPhpVersionLowerThan(V81)` (PHP 8.1 only) to `!isPhpVersionLowerThan(V81)` (PHP 8.1+)
- **Improved documentation**: Updated comments to clarify that:
  - The `fiber->vm_stack` field is only set when a fiber's callback returns (end of execution)
  - For suspended fibers, `EG(vm_stack)` is saved to a local `zend_fiber_vm_state` on the C stack via `zend_fiber_capture_vm_state()`
  - This behavior applies to all PHP versions with Fiber support, not just 8.1
- **Enhanced method documentation**: Clarified that the C stack scanning approach is necessary because `fiber->vm_stack` is always NULL for suspended fibers regardless of PHP version

## Implementation Details
The change ensures that suspended fiber VM stack detection works correctly across all supported PHP versions (8.1+) by properly scanning the C stack for the saved `vm_stack` pointer, rather than relying on a version-specific struct field that may not be populated.

https://claude.ai/code/session_01Rt6UmaP8p5XXAyt9TJFhw6