### PR TITLE
Fix fiber C stack scanning to find VM stacks correctly

### DIFF
--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -929,6 +929,12 @@ typedef enum {
 	ZEND_FIBER_TRANSFER_FLAG_BAILOUT = 1 << 1
 } zend_fiber_transfer_flag;
 
+// Not exposed in PHP headers (forward-declared only). Defined in zend_fibers.c.
+// Using uintptr_t instead of void* to prevent FFI SEGV on pointer cast.
+struct _zend_fiber_stack {
+	uintptr_t pointer;
+	size_t size;
+};
 typedef struct _zend_fiber_stack zend_fiber_stack;
 
 /* Encapsulates data needed for a context switch. */

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -947,6 +947,12 @@ typedef enum {
 	ZEND_FIBER_TRANSFER_FLAG_BAILOUT = 1 << 1
 } zend_fiber_transfer_flag;
 
+// Not exposed in PHP headers (forward-declared only). Defined in zend_fibers.c.
+// Using uintptr_t instead of void* to prevent FFI SEGV on pointer cast.
+struct _zend_fiber_stack {
+	uintptr_t pointer;
+	size_t size;
+};
 typedef struct _zend_fiber_stack zend_fiber_stack;
 
 /* Encapsulates data needed for a context switch. */

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -994,6 +994,12 @@ typedef enum {
 	ZEND_FIBER_TRANSFER_FLAG_BAILOUT = 1 << 1
 } zend_fiber_transfer_flag;
 
+// Not exposed in PHP headers (forward-declared only). Defined in zend_fibers.c.
+// Using uintptr_t instead of void* to prevent FFI SEGV on pointer cast.
+struct _zend_fiber_stack {
+	uintptr_t pointer;
+	size_t size;
+};
 typedef struct _zend_fiber_stack zend_fiber_stack;
 
 /* Encapsulates data needed for a context switch. */

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1002,6 +1002,12 @@ typedef enum {
 	ZEND_FIBER_TRANSFER_FLAG_BAILOUT = 1 << 1
 } zend_fiber_transfer_flag;
 
+// Not exposed in PHP headers (forward-declared only). Defined in zend_fibers.c.
+// Using uintptr_t instead of void* to prevent FFI SEGV on pointer cast.
+struct _zend_fiber_stack {
+	uintptr_t pointer;
+	size_t size;
+};
 typedef struct _zend_fiber_stack zend_fiber_stack;
 
 /* Encapsulates data needed for a context switch. */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1460,20 +1460,25 @@ final class MemoryLocationsCollector
             return;
         }
 
-        // The C stack region starts with a guard page (PROT_NONE, typically 4KB).
-        // Reading it via process_vm_readv would fail, so skip it.
-        $guard_page_size = 4096;
-        $stack_start = $fiber_stack->pointer + $guard_page_size;
-        $usable_size = $fiber_stack->size - $guard_page_size;
+        // In php-src, zend_fiber_stack_allocate() sets:
+        //   stack->pointer = mmap_base + guard_pages (already past the guard page)
+        //   stack->size    = usable stack size (excludes guard pages)
+        // So pointer/size describe the usable region directly — no adjustment needed.
+        //
+        // The C stack grows downward (high→low on x86-64), so the saved
+        // zend_fiber_vm_state local variable is near the top (high address end).
+        // Scan from the top of the stack to maximise the chance of finding it.
+        $usable_size = $fiber_stack->size;
         if ($usable_size <= 0) {
             return;
         }
 
         $scan_size = min($usable_size, 256 * 1024);
+        $scan_start = $fiber_stack->pointer + $usable_size - $scan_size;
 
         $c_stack_pointer = new Pointer(
             PointerArray::class,
-            $stack_start,
+            $scan_start,
             $scan_size,
         );
         $c_stack = $dereferencer->deref($c_stack_pointer);

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -1865,6 +1865,18 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $region_analyzed->summary->zend_mm_heap_usage,
             'analyzed_percentage must not exceed 100%'
         );
+
+        // analyzed_percentage should not be extremely low — with 100 fibers
+        // having deep call stacks, the fiber VM stacks represent a significant
+        // portion of heap usage. If the C stack scanning fails to find them,
+        // analyzed_percentage drops well below 50%.
+        $analyzed_percentage = (float)$region_analyzed->summary->zend_mm_heap_usage
+            / (float)$collected_memories->memory_get_usage_size * 100.0;
+        $this->assertGreaterThan(
+            50.0,
+            $analyzed_percentage,
+            'analyzed_percentage should not be extremely low (fiber VM stacks should be found)'
+        );
     }
 
     public static function provideFromV74()


### PR DESCRIPTION
## Summary
This PR fixes the fiber C stack scanning logic to correctly locate `zend_fiber_vm_state` structures on the stack. The previous implementation incorrectly assumed the fiber stack pointer pointed to the start of a guard page, but in php-src the pointer already accounts for guard pages and points directly to the usable stack region.

## Key Changes

- **Fixed stack pointer calculation**: Removed the incorrect 4KB guard page offset. The `fiber_stack->pointer` already points past guard pages and `fiber_stack->size` represents only the usable region.

- **Corrected scan direction**: Changed to scan from the top (high address end) of the stack downward, since the C stack grows downward on x86-64 and the `zend_fiber_vm_state` local variable is typically near the top of the stack frame.

- **Added struct definition**: Defined `zend_fiber_stack` structure in PHP header files (v82-v85) with proper field types (`uintptr_t` for pointer to prevent FFI issues, `size_t` for size).

- **Added regression test**: Added assertion to verify that `analyzed_percentage` exceeds 50% when analyzing fiber stacks. This ensures the C stack scanning successfully finds VM stacks; if scanning fails, the percentage drops well below 50%.

## Implementation Details

The key insight is understanding how php-src's `zend_fiber_stack_allocate()` works:
- `stack->pointer` = mmap base + guard pages (already positioned past guard pages)
- `stack->size` = usable stack size (excludes guard pages)

Therefore, the usable region is directly described by pointer/size without adjustment. The scan now correctly starts at `pointer + size - scan_size` to scan the top 256KB of the usable stack region where the VM state is most likely to be found.

https://claude.ai/code/session_01GCG16x9hxLVfjorCR3ci1a