### PR TITLE
Add memory report user and internal documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Reli is a sampling profiler (or a VM state inspector) written in PHP. It can rea
 - Investigating the cause of a bug or performance failure
   - Even if a PHP script is in an unexplained unresponsive state, you can use this to find out what it is doing internally.
 - [Finding memory bottlenecks or memory leaks](https://github.com/reliforp/reli-prof/blob/0.11.x/docs/memory-profiler.md)
+- [Automatic memory analysis report](docs/memory-report.md): generate prioritized findings from a memory snapshot — dominant classes, cycles, choke points, blame allocation, and more
 - [Condition-based monitoring](docs/watch-command.md): automatically trigger memory dumps, trace captures, or alerts when memory thresholds, function calls, or variable conditions are met
 - [Variable inspection](docs/peek-var-command.md): read PHP variable values from a running process without modifying it
 
@@ -760,6 +761,23 @@ $ cat 2183131.memory_dump.json | jq 'path(..|objects|select(."#reference_node_id
 The refcount of the object recorded in the memory location is 6 in this example. Calling methods via `$obj->call()` adds refcount by 1, but `$this->call()` doesn't add refcount. References from objects_store don't add refcount too. So all 6 references are analyzed here.
 
 See [./docs/memory-profiler.md](https://github.com/reliforp/reli-prof/blob/0.11.x/docs/memory-profiler.md) for more info.
+
+### Automatic analysis report
+
+Instead of manually querying with `jq`, you can generate an automatic analysis report. First save to SQLite, then run the report:
+
+```bash
+$ sudo php ./reli i:m -p <pid> -f sqlite3 -o snapshot.db
+$ php ./reli inspector:memory:report snapshot.db
+```
+
+Or generate the report directly:
+
+```bash
+$ sudo php ./reli i:m -p <pid> -f report
+```
+
+The report identifies dominant classes, circular references, choke points, deduplication candidates, and more — with severity, hypothesis, and next steps for each finding. See [docs/memory-report.md](docs/memory-report.md) for details.
 
 ## Binary analysis cache
 Reli caches the results of expensive binary analysis operations (ELF symbol resolution, TLS brute force offsets, PHP version detection, etc.) to disk. This dramatically speeds up repeated profiling of the same PHP binary -- for example, ZTS target initialization drops from ~8 seconds to ~5 milliseconds on warm cache.

--- a/docs/internals/memory-report-architecture.md
+++ b/docs/internals/memory-report-architecture.md
@@ -1,0 +1,257 @@
+# Memory Analysis Report Architecture
+
+## Overview
+
+`inspector:memory:report` analyzes a memory snapshot SQLite database
+and produces structured findings. Not a dump of tables and numbers,
+but a prioritized list of actionable conclusions derived from the data.
+
+For user-facing documentation, see [memory-report.md](../memory-report.md).
+
+## Two Layers
+
+### Computation layer (internal): Passes
+
+Passes are internal computation steps. Each pass reads from the SQLite DB
+or shared in-memory structures and produces intermediate results.
+
+### Output layer (external): Findings
+
+Findings are the unit of output. Each finding has:
+
+```
+kind:               Identifier (e.g., "dominant_class", "cycle_cluster")
+severity:           high | medium | low | info | warning
+confidence:         high | medium | low
+summary:            One-line human description
+facts:              Observed data points (array<string, mixed>)
+hypothesis:         What this likely means
+next_checks:        What to investigate further
+impact_bytes:       Estimated recoverable memory
+evidence_node_ids:  Representative node IDs for drill-down
+representative_paths: Owner paths (3-hop or drill-down)
+replay_query:       SQL to reproduce this finding
+```
+
+Implementation: `Finding.php`, `FindingSeverity.php`, `FindingConfidence.php`.
+
+## Data Flow
+
+```
+MemoryReportCommand::execute()
+  ├── PDO("sqlite:snapshot.db")
+  └── ReportGenerator::generateFromDb($db, $run_id)
+        ├── loadMeta() → node_count, edge_count
+        ├── Phase 1: Summary passes (always)
+        │     ├── OverviewPass($summary)
+        │     ├── TypeBreakdownPass($location_types)
+        │     ├── ClassRankingPass($class_objects)
+        │     └── CompanionDetectionPass($class_objects)
+        ├── Phase 2: SQL passes (< 500K nodes)
+        │     ├── DynamicPropertiesPass($db)
+        │     ├── PerPropertyMemoryPass($db)
+        │     ├── TopArraysPass($db)
+        │     ├── TopStringsPass($db)
+        │     ├── NonTreeEdgePass($db)
+        │     └── StructuralDedupPass($db)
+        ├── Phase 3: Graph passes (< 500K edges)
+        │     ├── GraphSubstrate::loadFromDb($db)
+        │     │     ├── loadNodeSizes()
+        │     │     ├── loadEdges()
+        │     │     ├── computeSubtreeSizes() [post-order DFS]
+        │     │     └── computeScc() [Tarjan's algorithm]
+        │     ├── CycleClusterPass($substrate)
+        │     ├── DrillDownPass($substrate, $db)
+        │     ├── ChokePointPass($substrate, $db)
+        │     ├── BlameAllocationPass($substrate, $db)
+        │     └── RetainedSizeConfidencePass($substrate)
+        └── ReportResult($meta, $findings)
+              └── TextReportFormatter / JsonReportFormatter
+```
+
+## Inline Mode (via MemoryOutputFactory)
+
+When used with `inspector:memory -f report`, the pipeline is:
+
+```
+MemoryCommand::execute()
+  └── MemoryOutputFactory::create(settings)
+        └── ReportMemoryOutput
+              ├── Write to temp SQLite via PdoMemoryOutput
+              ├── ReportGenerator::generateFromDb(temp_db)
+              ├── Format output
+              └── Delete temp file
+```
+
+## GraphSubstrate
+
+Before graph analysis passes run, the substrate loads the full
+graph from SQLite into PHP arrays and computes reusable structures:
+
+**Graph load** (from SQLite):
+- `$node_sizes[node_id]`: shallow size per node
+- `$node_classes[node_id]`: class name per node
+- `$children[parent_id]`: int-only adjacency list (tree edges)
+- `$all_parents[child_id]`: reverse adjacency (all edges)
+- `$roots[]`: nodes with NULL parent
+
+**Post-order DFS**:
+- `$subtree_sizes[node_id]`: tree-based retained size
+
+**Tarjan SCC** (iterative, stack-based):
+- `$node_to_scc[node_id]`: SCC membership
+- `$scc_profiles[scc_id]`: node count, total size, external in/out edges,
+  class composition signature, single-owner likelihood
+
+All computed once, shared by CycleClusterPass, DrillDownPass,
+ChokePointPass, BlameAllocationPass, RetainedSizeConfidencePass.
+
+Measured performance:
+
+| Edges | Load | DFS | SCC | Total | Memory |
+|---|---|---|---|---|---|
+| 200K | 0.2s | 0.1s | 0.2s | **0.5s** | ~130 MB |
+| 1M | 1s | 0.6s | 0.8s | **2.4s** | ~300 MB |
+| 2.5M | 7s | 1.6s | - | **~10s** | ~1.2 GB |
+
+## Computation Passes
+
+### Phase 1: Summary-Based (always run)
+
+These passes use only data from the `summary`, `location_types_summary`,
+and `class_objects_summary` tables. Zero additional memory. Works for
+any target size.
+
+| Pass | Source | Emits |
+|---|---|---|
+| 1. OverviewPass | summary table | `overview`, `coverage_gap` |
+| 2. TypeBreakdownPass | location_types_summary | `dominant_type` |
+| 3. ClassRankingPass | class_objects_summary | `dominant_class` |
+| 4. CompanionDetectionPass | class_objects_summary | `companion_pair` |
+
+### Phase 2: SQL-Based (< 500K nodes)
+
+These passes run SQL queries against the full context tables.
+
+| Pass | Source | Emits |
+|---|---|---|
+| 5. DynamicPropertiesPass | context_edges (link_name = 'dynamic_properties') | `dynamic_properties_overhead` |
+| 6. PerPropertyMemoryPass | context_edges + context_node_locations | `expensive_property` |
+| 7. TopArraysPass | v_arrays + 3-hop ancestor | `large_array` |
+| 8. TopStringsPass | context_node_locations (ZendString) | `large_string` |
+| 9. NonTreeEdgePass | context_edges (is_tree = 0) | `shared_singleton`, `shared_fanin`, `dedup_candidate` |
+| 10. StructuralDedupPass | context_node_locations + context_edges (shape hash) | `structural_duplicate`, `empty_object` |
+
+### Phase 3: Graph-Based (< 500K edges)
+
+These passes use the in-memory GraphSubstrate.
+
+| Pass | Source | Emits |
+|---|---|---|
+| 11. CycleClusterPass | SCC profiles | `cycle_cluster`, `micro_cycle` |
+| 12. DrillDownPass | subtree_sizes + children | `bottleneck_path` |
+| 13. ChokePointPass | subtree_sizes + node_sizes | `choke_point` |
+| 14. BlameAllocationPass | node_sizes + tree/all edges | `root_blame` |
+| 15. RetainedSizeConfidencePass | SCC profiles | `retained_exact`, `retained_approximate` |
+
+## Adaptive Complexity
+
+The `ReportGenerator` checks `node_count` and `edge_count` from the
+database to decide which phases to run:
+
+| Target size | Phases | Strategy |
+|---|---|---|
+| < 500K nodes, < 500K edges | All 15 passes | Full analysis |
+| < 500K nodes, >= 500K edges | Phase 1 + 2 | SQL analysis, no graph |
+| >= 500K nodes | Phase 1 only | Summary + heuristics |
+
+This prevents out-of-memory errors when analyzing very large snapshots.
+
+## File Layout
+
+```
+src/Inspector/Output/MemoryOutput/Report/
+├── Finding.php                    # Value object
+├── FindingSeverity.php            # Enum: high|medium|low|info|warning
+├── FindingConfidence.php          # Enum: high|medium|low
+├── ReportGenerator.php            # Orchestrator
+├── ReportResult.php               # Meta + findings container
+├── Formatter/
+│   ├── ReportFormatterInterface.php
+│   ├── TextReportFormatter.php    # Human-readable text
+│   └── JsonReportFormatter.php    # Structured JSON
+├── Pass/
+│   ├── PassInterface.php          # Common interface
+│   ├── OverviewPass.php           # Pass 1
+│   ├── TypeBreakdownPass.php      # Pass 2
+│   ├── ClassRankingPass.php       # Pass 3
+│   ├── CompanionDetectionPass.php # Pass 4
+│   ├── DynamicPropertiesPass.php  # Pass 5
+│   ├── PerPropertyMemoryPass.php  # Pass 6
+│   ├── TopArraysPass.php         # Pass 7 (renumbered from design)
+│   ├── TopStringsPass.php        # Pass 8
+│   ├── NonTreeEdgePass.php       # Pass 9
+│   ├── StructuralDedupPass.php   # Pass 10
+│   ├── CycleClusterPass.php      # Pass 11
+│   ├── DrillDownPass.php         # Pass 12
+│   ├── ChokePointPass.php        # Pass 13
+│   ├── BlameAllocationPass.php   # Pass 14
+│   └── RetainedSizeConfidencePass.php  # Pass 15
+└── Substrate/
+    └── GraphSubstrate.php         # Graph load + DFS + Tarjan SCC
+
+src/Inspector/Output/MemoryOutput/
+├── ReportMemoryOutput.php         # MemoryOutputInterface for inline mode
+
+src/Command/Inspector/
+├── MemoryReportCommand.php        # inspector:memory:report command
+```
+
+## Design Principles
+
+1. **Graph algorithms in PHP, results in DB, queries in SQL.**
+   SCC/DFS/BFS are computed in PHP. Subsequent analysis uses SQL JOINs
+   and aggregations against the existing context tables.
+
+2. **Computation once, findings many.**
+   Graph load + DFS + SCC happen once via GraphSubstrate. All graph
+   passes share the same substrate instance.
+
+3. **Findings over numbers.**
+   Don't show "top 10 classes." Show "this class is 95% of objects,
+   which is abnormal, and here's the likely cause."
+
+4. **Confidence on everything.**
+   Every finding says how sure it is (`confidence`) and why it might
+   be wrong (shared memory fraction for blame, cycle count for
+   retained size).
+
+5. **Replay everything.**
+   Every finding includes `replay_query` — the SQL to reproduce it
+   directly against the SQLite database.
+
+## Finding Types Catalog
+
+| Kind | Severity | Source Pass | Validated On |
+|---|---|---|---|
+| `overview` | info | OverviewPass | All |
+| `coverage_gap` | warning | OverviewPass | Guzzle (8.6%), Fiber (pre-fix) |
+| `dominant_type` | high/medium | TypeBreakdownPass | smalot (arrays 86%), php-imap (strings 87%) |
+| `dominant_class` | high | ClassRankingPass | PrinsFrank (95.3%), PHPStan (213K) |
+| `companion_pair` | medium | CompanionDetectionPass | PhpSpreadsheet, CommonMark, PhpWord, Forms |
+| `dynamic_properties_overhead` | medium/low | DynamicPropertiesPass | Monolog (93K DateTimeImmutable) |
+| `expensive_property` | medium/low | PerPropertyMemoryPass | Monolog (message 11.5 MB) |
+| `large_array` | medium/low | TopArraysPass | smalot (uchrCache 2.6 MB) |
+| `large_string` | medium/low | TopStringsPass | php-imap (raw 210 KB x 200) |
+| `shared_singleton` | info | NonTreeEdgePass | Symfony Forms (formFactory) |
+| `shared_fanin` | medium | NonTreeEdgePass | php-imap (oMessage) |
+| `dedup_candidate` | low/info | NonTreeEdgePass | Symfony Forms (dispatcher 1,801x) |
+| `structural_duplicate` | medium/low | StructuralDedupPass | CommonMark (246K empty Data) |
+| `empty_object` | medium/low | StructuralDedupPass | CommonMark, Symfony Forms |
+| `cycle_cluster` | medium/low | CycleClusterPass | php-imap (201x), SimplePie (1x2K), Forms (1,802x) |
+| `micro_cycle` | low | CycleClusterPass | Symfony Forms (OptionsResolver <-> Closure) |
+| `bottleneck_path` | high | DrillDownPass | PHP-Parser ($ast 89 MB), CommonMark (71 MB) |
+| `choke_point` | high | ChokePointPass | Eloquent (Collection 72B -> 15 MB) |
+| `root_blame` | info | BlameAllocationPass | Eloquent (class_table 48%, call_frames 35%) |
+| `retained_exact` | info | RetainedSizeConfidencePass | Monolog (DAG, no cycles) |
+| `retained_approximate` | info | RetainedSizeConfidencePass | php-imap (201 cycles) |

--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -2,6 +2,8 @@
 
 The memory profiler supports outputting analysis results to a relational database instead of JSON. This is useful for analyzing large memory snapshots where the JSON output would be too large to handle with tools like `jq`, and enables powerful ad-hoc querying with SQL.
 
+> **Tip**: SQLite snapshots can also be used with `inspector:memory:report` to generate automatic analysis reports. See [memory-report.md](memory-report.md).
+
 Supported databases:
 - **SQLite** (`-f sqlite3`) — local file, no server needed
 - **MySQL** (`-f mysql`) — connect to an existing MySQL/MariaDB server

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -7,6 +7,8 @@ reli inspector:memory -p <pid_of_target_process>
 
 You can use this mode to analyze the memory usage of the target process, for finding out memory bottlenecks or memory leaks.
 
+> **Tip**: For automatic analysis of memory snapshots (dominant classes, cycles, choke points, etc.), see [memory-report.md](memory-report.md). For saving snapshots to a database for SQL querying, see [memory-profiler-database.md](memory-profiler-database.md).
+
 For example, you can see statistics such as whether strings, arrays or objects are particularly dominant in a script's memory usage, or contextual information such as where certain local variables in a given call frame are referenced from elsewhere, and the actual values held by certain memory areas.
 
 The functionality of this mode is similar to [php-meminfo](https://github.com/BitOne/php-meminfo), but works in the [phpspy](https://github.com/adsr/phpspy)-ish way.
@@ -411,6 +413,23 @@ The example of the output is like below.
   }
 }
 ```
+
+### Automatic analysis instead of manual jq
+
+If you prefer actionable findings over manual `jq` exploration, use the automatic report feature. Save to SQLite and generate a report:
+
+```bash
+sudo ./reli inspector:memory -p <pid> -f sqlite3 -o snapshot.db
+./reli inspector:memory:report snapshot.db
+```
+
+Or generate directly:
+
+```bash
+sudo ./reli inspector:memory -p <pid> -f report
+```
+
+See [memory-report.md](memory-report.md) for full documentation on the report format, finding types, and JSON output for programmatic use.
 
 ## Capturing the memory_limit violation
 

--- a/docs/memory-report.md
+++ b/docs/memory-report.md
@@ -1,0 +1,218 @@
+# Memory Analysis Report
+
+The memory profiler can automatically analyze a snapshot and produce a prioritized report of findings — not raw tables and numbers, but actionable conclusions about what is consuming memory, why, and what to investigate next.
+
+## Quick Start
+
+### From a SQLite snapshot (recommended)
+
+First capture a snapshot to SQLite, then generate the report:
+
+```bash
+sudo ./reli inspector:memory -p <pid> -f sqlite3 -o snapshot.db
+./reli inspector:memory:report snapshot.db
+```
+
+### Inline with live capture
+
+Generate the report directly from a live process (captures to a temp SQLite file internally):
+
+```bash
+sudo ./reli inspector:memory -p <pid> -f report
+```
+
+## Output Formats
+
+### Human-readable text (`report`)
+
+```bash
+./reli inspector:memory:report snapshot.db
+# or
+sudo ./reli inspector:memory -p <pid> -f report
+```
+
+Example output:
+
+```
+======================================================================
+ reli-prof Memory Analysis Report
+======================================================================
+
+=== Overview ===
+  Heap: 41.70 MB (99.5% analyzed), VM stack: 0.02 MB, Compiler arena: 0.01 MB
+
+=== Findings ===
+
+  [HIGH] dominant_class: CrossReferenceEntryInUseObject: 100,203 instances, 95.3% of object memory (6.88 MB)
+    Unbounded accumulation — likely a loop without limit
+    Next: Check if count scales with input size; Look for owner path to find the accumulating container
+
+  [HIGH] bottleneck_path: call_frames -> 1 -> local_variables -> $crossReferenceSections (41.50 MB)
+    Heaviest memory path — the primary chain of memory consumption
+    Next: Examine the leaf of this path for the actual data consuming memory
+
+  [MEDIUM] cycle_cluster: 201 identical cycles: Attachment:3, Message:1 (15 nodes each, 170.89 KB total)
+    Single entry point — breaking the owner reference likely frees this cycle
+    Next: Identify the back-reference causing the cycle; Consider using WeakReference or explicit cleanup
+
+  [LOW] dedup_candidate: dispatcher: 1,801 copies x 88B ALL SAME SIZE = 154.77 KB wasted
+    Multiple copies of same-size objects via shared references; may be shareable
+
+=== Root Blame Allocation ===
+
+  Root Branch                Exclusive    Shared     Total   % Heap
+  ----------------------------------------------------------------------
+  call_frames                  38.50M     1.20M    39.70M    95.2%
+  class_table                   1.80M     0.10M     1.90M     4.6%
+
+=== Additional Info ===
+  [retained_approximate] 201 cycles (3,015 nodes) — retained size is approximate; collapse to DAG for exact
+
+======================================================================
+```
+
+### Structured JSON (`report-json`)
+
+For programmatic consumption or AI-assisted analysis:
+
+```bash
+./reli inspector:memory:report snapshot.db -f report-json
+# or
+sudo ./reli inspector:memory -p <pid> -f report-json
+```
+
+Each finding includes machine-readable fields:
+
+```json
+{
+  "meta": {
+    "node_count": 137922,
+    "edge_count": 200709,
+    "php_version": "v84",
+    "heap_memory_analyzed_percentage": 99.52
+  },
+  "findings": [
+    {
+      "kind": "dominant_class",
+      "severity": "high",
+      "confidence": "high",
+      "summary": "CrossReferenceEntryInUseObject: 100,203 instances, 95.3% of object memory (6.88 MB)",
+      "facts": {
+        "class_name": "..\\CrossReferenceEntryInUseObject",
+        "count": 100203,
+        "memory_bytes": 7214612,
+        "percentage_of_object_memory": 95.3,
+        "avg_size": 72
+      },
+      "hypothesis": "Unbounded accumulation — likely a loop without limit",
+      "next_checks": [
+        "Check if count scales with input size",
+        "Look for owner path to find the accumulating container"
+      ],
+      "impact_bytes": 7214612,
+      "replay_query": "SELECT class_name, count, memory_usage FROM class_objects_summary ORDER BY memory_usage DESC LIMIT 1"
+    }
+  ]
+}
+```
+
+## Command Reference
+
+### `inspector:memory:report`
+
+Generate a report from an existing SQLite database:
+
+```
+Usage:
+  inspector:memory:report [options] <db-file>
+
+Arguments:
+  db-file                     Path to the SQLite database file
+
+Options:
+  -f, --output-format=FORMAT  Output format: report (text) or report-json [default: report]
+  -o, --output=PATH           Output file path (default: stdout)
+      --run-id=ID             Run ID to analyze [default: 1]
+      --pretty-print          Pretty print JSON output (default: on)
+```
+
+### `inspector:memory` with report format
+
+Generate a report directly from a live process:
+
+```bash
+sudo ./reli inspector:memory -p <pid> -f report         # text
+sudo ./reli inspector:memory -p <pid> -f report-json    # JSON
+sudo ./reli inspector:memory -p <pid> -f report -o report.txt  # to file
+```
+
+## Finding Types
+
+Each finding has a `kind`, `severity` (high/medium/low/info/warning), and `confidence` (high/medium/low).
+
+### High Severity
+
+| Kind | Description | Example |
+|---|---|---|
+| `dominant_class` | One class > 50% of object memory | "100,203 CrossReferenceEntryInUseObject = 95.3%" |
+| `dominant_type` | One memory type > 80% of heap | "ZendString accounts for 87% of heap" |
+| `bottleneck_path` | Heaviest memory path from root | "call_frames -> $users -> Collection -> items[] (16 MB)" |
+| `choke_point` | Small node retaining large subtree | "MarkdownParser (152B) holds 73 MB via closedBlockParsers" |
+
+### Medium Severity
+
+| Kind | Description | Example |
+|---|---|---|
+| `dominant_type` | One memory type > 50% of heap | "ZendObject accounts for 66% of heap" |
+| `companion_pair` | Two classes with matching instance counts | "Cell (200,020) always paired with IgnoredErrors (200,020)" |
+| `dynamic_properties_overhead` | Classes with dynamic property tables (> 1 MB) | "93,315 DateTimeImmutable with dynamic props = 5.1 MB" |
+| `expensive_property` | High-frequency property consuming memory (> 1 MB) | "message: 100K occurrences x 121B = 11.5 MB" |
+| `cycle_cluster` | Group of identical circular reference patterns | "201 identical Message <-> Attachment cycles" |
+| `shared_fanin` | Multiple references to shared objects | "oMessage: 603 refs -> 201 targets (3.0 each)" |
+| `structural_duplicate` | Objects with identical shape (class + size + properties) | "246K Data objects with NO properties = 13.4 MB" |
+| `empty_object` | Objects with no stored properties | "OrderedHashMap: 1,600 x 88B, no properties stored" |
+| `large_array` | Individual large arrays (> 1 MB) | "2.62 MB, 65K elements — Font -> uchrCache" |
+| `large_string` | Individual large strings (> 100 KB) | "210 KB — structure -> raw (email body)" |
+
+### Low Severity
+
+| Kind | Description | Example |
+|---|---|---|
+| `micro_cycle` | Two-node circular references | "1,802 OptionsResolver <-> Closure micro-cycles" |
+| `dedup_candidate` | Same-size objects that may be shareable | "dispatcher: 1,801 copies x 88B = 155 KB wasted" |
+
+### Info
+
+| Kind | Description |
+|---|---|
+| `overview` | Heap total/usage, VM stack, compiler arena, analyzed percentage |
+| `shared_singleton` | Many references to one target (normal singleton pattern) |
+| `root_blame` | Memory attributed to each root branch (call_frames, class_table, etc.) |
+| `retained_exact` | No cycles — retained size computation is exact |
+| `retained_approximate` | Cycles exist — retained size is approximate |
+
+### Warning
+
+| Kind | Description |
+|---|---|
+| `coverage_gap` | Less than 95% of heap analyzed — unaccounted memory |
+
+## Analysis Phases
+
+The report generator adapts its analysis depth based on snapshot size:
+
+| Snapshot size | Phases run | Strategy |
+|---|---|---|
+| Any size | Phase 1 (Passes 1-6) | Summary + SQL: overview, types, classes, companions, dynamic properties, per-property |
+| < 500K nodes | Phase 2 (Passes 7-11) | SQL-heavy: cycles (SCC), top arrays/strings, shared refs, structural dedup |
+| < 500K edges | Phase 3 (Passes 12-15) | Full graph: drill-down, choke points, blame allocation, retained size confidence |
+
+For very large snapshots (> 500K nodes), only the lightweight summary-based passes run, avoiding graph loading that would consume too much memory.
+
+## Tips
+
+- **Start with the SQLite workflow**: Capture once, analyze many times. The `inspector:memory:report` command is fast on an existing database.
+- **Use JSON for CI/automation**: The `report-json` format is designed for programmatic consumption — pipe it to `jq`, feed it to an LLM, or integrate into monitoring.
+- **Check `replay_query`**: Many findings include the SQL query that produced them. Run it directly on the SQLite database to explore further.
+- **Look at `impact_bytes`**: Findings are not all equal. Focus on findings with the largest `impact_bytes` for the biggest memory savings.
+- **Companion pairs**: When two classes have nearly identical instance counts, reducing one will likely reduce the other. Find the owner relationship to understand which one drives the allocation.


### PR DESCRIPTION
## Summary
- Add `docs/memory-report.md`: user-facing guide with quick start, command reference, output examples, finding types catalog, and usage tips
- Add `docs/internals/memory-report-architecture.md`: internal design doc covering data flow, GraphSubstrate, computation passes, adaptive complexity, file layout, and design principles

Follow-up to #556 which merged the implementation.

## Test plan
- [ ] Documentation only — no code changes
- [ ] Verify links between docs are correct

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf