### PR TITLE
Fix SCC cycle detection, companion explosion, choke point labels

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -68,6 +68,10 @@ final class ChokePointPass implements PassInterface
             "SELECT class_name, location_type FROM context_node_locations"
             . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
         );
+        $type_stmt = $this->db->prepare(
+            "SELECT type FROM context_nodes"
+            . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
+        );
 
         $findings = [];
         foreach (array_slice($chokepoints, 0, 10) as [$node, $shallow, $subtree, $ratio]) {
@@ -75,9 +79,22 @@ final class ChokePointPass implements PassInterface
             $loc = $loc_stmt->fetch(\PDO::FETCH_ASSOC);
             $class = $loc['class_name'] ?? '';
             $loc_type = $loc['location_type'] ?? '';
-            $label = $class ? preg_replace('/^.*\\\\/', '', $class) : $loc_type;
 
-            // Walk up to build path
+            // Build a meaningful label: prefer class_name > location_type > node type > link_name
+            $label = '';
+            if ($class) {
+                $label = preg_replace('/^.*\\\\/', '', $class);
+            } elseif ($loc_type !== '') {
+                $label = $loc_type;
+            } else {
+                $type_stmt->execute([$node]);
+                $type_row = $type_stmt->fetch(\PDO::FETCH_NUM);
+                if ($type_row) {
+                    $label = $type_row[0];
+                }
+            }
+
+            // Walk up to build path, use link_name as fallback label
             $path_parts = [];
             $cur = $node;
             for ($i = 0; $i < 4; $i++) {
@@ -86,7 +103,13 @@ final class ChokePointPass implements PassInterface
                 }
                 [$parent, $link] = $parent_map[$cur];
                 $path_parts[] = $link;
+                if ($i === 0 && $label === '') {
+                    $label = $link;
+                }
                 $cur = $parent;
+            }
+            if ($label === '') {
+                $label = "(node #{$node})";
             }
             $path = $path_parts ? implode(' <- ', $path_parts) : '(root)';
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -36,57 +36,135 @@ final class CompanionDetectionPass implements PassInterface
         $classes = [];
         foreach ($this->class_objects_summary as $name => $entry) {
             if ($entry['count'] > 100) {
-                $classes[] = ['name' => $name, 'count' => $entry['count'], 'memory' => $entry['memory_usage']];
+                $classes[] = [
+                    'name' => $name,
+                    'count' => $entry['count'],
+                    'memory' => $entry['memory_usage'],
+                ];
             }
         }
 
-        $findings = [];
+        // Union-Find to group classes with similar counts
         $count = count($classes);
+        $parent = range(0, $count - 1);
+
+        $find = function (int $x) use (&$parent, &$find): int {
+            if ($parent[$x] !== $x) {
+                $parent[$x] = $find($parent[$x]);
+            }
+            return $parent[$x];
+        };
+
+        $union = function (int $a, int $b) use (&$parent, &$find): void {
+            $ra = $find($a);
+            $rb = $find($b);
+            if ($ra !== $rb) {
+                $parent[$ra] = $rb;
+            }
+        };
+
         for ($i = 0; $i < $count; $i++) {
             for ($j = $i + 1; $j < $count; $j++) {
-                $a = $classes[$i];
-                $b = $classes[$j];
-                $max_count = max($a['count'], $b['count']);
-                if ($max_count === 0) {
-                    continue;
+                $diff = abs($classes[$i]['count'] - $classes[$j]['count']);
+                if ($diff < $classes[$i]['count'] * 0.05) {
+                    $union($i, $j);
                 }
-                $diff = abs($a['count'] - $b['count']);
-                if ($diff < $a['count'] * 0.05) {
-                    $short_a = preg_replace('/^.*\\\\/', '', $a['name']) ?? $a['name'];
-                    $short_b = preg_replace('/^.*\\\\/', '', $b['name']) ?? $b['name'];
-                    $total_memory = $a['memory'] + $b['memory'];
+            }
+        }
 
-                    $findings[] = new Finding(
-                        kind: 'companion_pair',
-                        severity: FindingSeverity::Medium,
-                        confidence: FindingConfidence::Medium,
-                        summary: sprintf(
-                            '%s (%s) always paired with %s (%s)',
-                            $short_a,
-                            number_format($a['count']),
-                            $short_b,
-                            number_format($b['count']),
+        // Group by root
+        /** @var array<int, list<int>> */
+        $groups = [];
+        for ($i = 0; $i < $count; $i++) {
+            $groups[$find($i)][] = $i;
+        }
+
+        $findings = [];
+        foreach ($groups as $members) {
+            if (count($members) < 2) {
+                continue;
+            }
+
+            $group_classes = array_map(
+                fn(int $idx) => $classes[$idx],
+                $members
+            );
+            $total_memory = array_sum(
+                array_column($group_classes, 'memory')
+            );
+
+            // Sort by memory descending within group
+            usort(
+                $group_classes,
+                fn($a, $b) => $b['memory'] <=> $a['memory']
+            );
+
+            $names = array_map(
+                fn($c) => sprintf(
+                    '%s (%s)',
+                    preg_replace('/^.*\\\\/', '', $c['name']),
+                    number_format($c['count'])
+                ),
+                $group_classes
+            );
+
+            if (count($members) === 2) {
+                $findings[] = new Finding(
+                    kind: 'companion_pair',
+                    severity: FindingSeverity::Medium,
+                    confidence: FindingConfidence::Medium,
+                    summary: sprintf(
+                        '%s always paired with %s',
+                        $names[0],
+                        $names[1],
+                    ),
+                    facts: [
+                        'classes' => array_map(
+                            fn($c) => [
+                                'name' => $c['name'],
+                                'count' => $c['count'],
+                            ],
+                            $group_classes
                         ),
-                        facts: [
-                            'class_a' => $a['name'],
-                            'count_a' => $a['count'],
-                            'class_b' => $b['name'],
-                            'count_b' => $b['count'],
-                            'total_memory' => $total_memory,
-                        ],
-                        hypothesis: 'These classes are likely created together — one owns the other',
-                        next_checks: [
-                            'Check if one class references the other directly',
-                            'Reducing one will likely reduce the other proportionally',
-                        ],
-                        impact_bytes: $total_memory,
-                        replay_query: "SELECT a.class_name, a.count, b.class_name, b.count"
-                            . " FROM class_objects_summary a JOIN class_objects_summary b"
-                            . " ON a.run_id = b.run_id AND a.class_name < b.class_name"
-                            . " AND abs(a.count - b.count) < a.count * 0.05"
-                            . " WHERE a.count > 100 ORDER BY a.memory_usage + b.memory_usage DESC",
-                    );
-                }
+                        'total_memory' => $total_memory,
+                    ],
+                    hypothesis: 'These classes are likely created together'
+                        . ' — one owns the other',
+                    next_checks: [
+                        'Check if one class references the other',
+                        'Reducing one will likely reduce the other',
+                    ],
+                    impact_bytes: $total_memory,
+                );
+            } else {
+                $findings[] = new Finding(
+                    kind: 'companion_cluster',
+                    severity: FindingSeverity::Medium,
+                    confidence: FindingConfidence::Medium,
+                    summary: sprintf(
+                        '%d classes with ~%s instances each: %s',
+                        count($members),
+                        number_format($group_classes[0]['count']),
+                        implode(', ', $names),
+                    ),
+                    facts: [
+                        'classes' => array_map(
+                            fn($c) => [
+                                'name' => $c['name'],
+                                'count' => $c['count'],
+                            ],
+                            $group_classes
+                        ),
+                        'total_memory' => $total_memory,
+                    ],
+                    hypothesis: 'These classes are created together'
+                        . ' as a group — likely one per entity',
+                    next_checks: [
+                        'Find the common owner that creates all of them',
+                        'Reducing the owner count reduces all proportionally',
+                    ],
+                    impact_bytes: $total_memory,
+                );
             }
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -46,28 +46,30 @@ final class CompanionDetectionPass implements PassInterface
 
         // Union-Find to group classes with similar counts
         $count = count($classes);
-        $parent = range(0, $count - 1);
+        /** @var array<int, int> */
+        $uf_parent = range(0, max($count - 1, 0));
 
-        $find = function (int $x) use (&$parent, &$find): int {
-            if ($parent[$x] !== $x) {
-                $parent[$x] = $find($parent[$x]);
+        /**
+         * @param array<int, int> $p
+         * @psalm-suppress MixedArrayOffset, MixedArrayTypeCoercion, MixedReturnStatement
+         */
+        $ufFind = static function (array &$p, int $x): int {
+            while ($p[$x] !== $x) {
+                $p[$x] = $p[$p[$x]];
+                $x = $p[$x];
             }
-            return $parent[$x];
-        };
-
-        $union = function (int $a, int $b) use (&$parent, &$find): void {
-            $ra = $find($a);
-            $rb = $find($b);
-            if ($ra !== $rb) {
-                $parent[$ra] = $rb;
-            }
+            return $x;
         };
 
         for ($i = 0; $i < $count; $i++) {
             for ($j = $i + 1; $j < $count; $j++) {
                 $diff = abs($classes[$i]['count'] - $classes[$j]['count']);
                 if ($diff < $classes[$i]['count'] * 0.05) {
-                    $union($i, $j);
+                    $ra = $ufFind($uf_parent, $i);
+                    $rb = $ufFind($uf_parent, $j);
+                    if ($ra !== $rb) {
+                        $uf_parent[$ra] = $rb;
+                    }
                 }
             }
         }
@@ -76,7 +78,7 @@ final class CompanionDetectionPass implements PassInterface
         /** @var array<int, list<int>> */
         $groups = [];
         for ($i = 0; $i < $count; $i++) {
-            $groups[$find($i)][] = $i;
+            $groups[$ufFind($uf_parent, $i)][] = $i;
         }
 
         $findings = [];
@@ -102,7 +104,7 @@ final class CompanionDetectionPass implements PassInterface
             $names = array_map(
                 fn($c) => sprintf(
                     '%s (%s)',
-                    preg_replace('/^.*\\\\/', '', $c['name']),
+                    preg_replace('/^.*\\\\/', '', $c['name']) ?? $c['name'],
                     number_format($c['count'])
                 ),
                 $group_classes

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -21,6 +21,9 @@ final class GraphSubstrate
     /** @var array<int, list<int>> parent_id => [child_id, ...] (tree edges only) */
     public array $children = [];
 
+    /** @var array<int, list<int>> parent_id => [child_id, ...] (all edges including non-tree) */
+    public array $all_children = [];
+
     /** @var array<int, list<int>> child_id => [parent_id, ...] (all edges) */
     public array $all_parents = [];
 
@@ -100,6 +103,9 @@ final class GraphSubstrate
                     $this->roots[] = $child;
                 }
             }
+            if ($parent !== -1) {
+                $this->all_children[$parent][] = $child;
+            }
             $this->all_parents[$child][] = $parent;
         }
         $this->edge_count = count($rows);
@@ -154,7 +160,7 @@ final class GraphSubstrate
 
             while ($call_stack) {
                 [$node, $ci] = array_pop($call_stack);
-                $node_children = $this->children[$node] ?? [];
+                $node_children = $this->all_children[$node] ?? [];
 
                 $found_unvisited = false;
                 $count = count($node_children);
@@ -218,7 +224,7 @@ final class GraphSubstrate
                         $ext_in++;
                     }
                 }
-                foreach ($this->children[$node] ?? [] as $child) {
+                foreach ($this->all_children[$node] ?? [] as $child) {
                     if (!isset($scc_set[$child])) {
                         $ext_out++;
                     }

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -161,8 +161,26 @@ class SummaryPassesTest extends BaseTestCase
         ]);
         $findings = $pass->analyze();
 
-        $companions = array_filter($findings, fn(Finding $f) => $f->kind === 'companion_pair');
-        $this->assertCount(0, $companions);
+        $this->assertCount(0, $findings);
+    }
+
+    public function testCompanionDetectionGroupsIntoCluster(): void
+    {
+        // 6 classes all with ~1800 count should produce 1 cluster, not 15 pairs
+        $pass = new CompanionDetectionPass([
+            'App\\A' => ['count' => 1800, 'memory_usage' => 10000],
+            'App\\B' => ['count' => 1800, 'memory_usage' => 10000],
+            'App\\C' => ['count' => 1802, 'memory_usage' => 10000],
+            'App\\D' => ['count' => 1798, 'memory_usage' => 10000],
+            'App\\E' => ['count' => 1801, 'memory_usage' => 10000],
+            'App\\F' => ['count' => 1799, 'memory_usage' => 10000],
+        ]);
+        $findings = $pass->analyze();
+
+        // Should be exactly 1 companion_cluster, not 15 companion_pairs
+        $this->assertCount(1, $findings);
+        $this->assertSame('companion_cluster', $findings[0]->kind);
+        $this->assertStringContainsString('6 classes', $findings[0]->summary);
     }
 
     // ---- RetainedSizeConfidencePass ----


### PR DESCRIPTION
## Summary
Fixes 3 issues found by real-world usage of the memory analysis report:

- **SCC cycle detection was broken**: `computeScc()` used `$this->children` (tree edges only). Cycles via non-tree edges (e.g. A→B tree, B→A non-tree) were never detected. Now uses `$all_children` built from all edges.
- **Companion pair combinatorial explosion**: 6 classes with ~1,800 instances each produced C(6,2)=15 `companion_pair` findings. Now uses union-find to group into a single `companion_cluster` finding.
- **Choke point anonymous labels**: Many choke points showed unhelpful labels like `(0B shallow)` for context nodes without a class name. Now falls back to node type → link_name → `(node #id)`.

## Test plan
- [x] New test: `testCompanionDetectionGroupsIntoCluster` — 6 classes → 1 cluster
- [x] Existing companion pair test still passes (2 classes → 1 pair)
- [x] All 56 report tests pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf