### PR TITLE
Reduce report noise: filter redundant and structural findings

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -53,6 +53,28 @@ final class ChokePointPass implements PassInterface
             return [];
         }
 
+        // Filter out chain redundancy: if a node's tree parent is also
+        // a choke_point candidate, suppress the parent (keep the deeper one).
+        // This avoids listing every node on the same bottleneck path.
+        $candidate_set = [];
+        foreach ($chokepoints as $cp) {
+            $candidate_set[$cp[0]] = true;
+        }
+        $filtered = [];
+        foreach ($chokepoints as $cp) {
+            $has_child_candidate = false;
+            foreach ($this->substrate->children[$cp[0]] ?? [] as $child) {
+                if (isset($candidate_set[$child])) {
+                    $has_child_candidate = true;
+                    break;
+                }
+            }
+            if (!$has_child_candidate) {
+                $filtered[] = $cp;
+            }
+        }
+        $chokepoints = $filtered;
+
         // Build parent map for path lookup
         $parent_map = [];
         $rows = $this->db->query(

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -43,7 +43,11 @@ final class NonTreeEdgePass implements PassInterface
             FROM context_edges e
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
-                AND e.link_name NOT IN ('object_properties', 'array_elements', 'dynamic_properties')
+                AND e.link_name NOT IN (
+                    'object_properties', 'array_elements',
+                    'dynamic_properties', 'object_handlers',
+                    'name', 'key', 'value', 'class_entry'
+                )
             GROUP BY e.link_name
             HAVING count(*) > 10
             ORDER BY count(*) DESC
@@ -52,6 +56,10 @@ final class NonTreeEdgePass implements PassInterface
 
         $findings = [];
         foreach ($rows as $row) {
+            // Skip numeric indices (array element sharing, not meaningful)
+            if (ctype_digit($row['link_name'])) {
+                continue;
+            }
             $ref_count = (int)$row['ref_count'];
             $target_count = (int)$row['target_count'];
             $avg_refs = (float)$row['avg_refs'];
@@ -112,6 +120,11 @@ final class NonTreeEdgePass implements PassInterface
                 AND cnl.run_id = {$this->run_id}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
+                AND e.link_name NOT IN (
+                    'object_handlers', 'object_properties',
+                    'array_elements', 'dynamic_properties',
+                    'class_entry'
+                )
             GROUP BY e.link_name, cnl.size
             HAVING count(*) > 50 AND count(*) * cnl.size > 10240
             ORDER BY count(*) * cnl.size DESC

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
@@ -84,13 +84,13 @@ final class PerPropertyMemoryPass implements PassInterface
             }
         }
 
-        // Sort by total descending, filter > 100KB
+        // Sort by total descending, filter > 1MB for actionable findings
         uasort($stats, fn($a, $b) => $b['total'] <=> $a['total']);
 
         $findings = [];
         $i = 0;
         foreach ($stats as $s) {
-            if ($s['total'] < 102400 || $i >= 15) {
+            if ($s['total'] < 1024 * 1024 || $i >= 10) {
                 break;
             }
             $short = preg_replace('/^.*\\\\/', '', $s['class'])
@@ -101,9 +101,7 @@ final class PerPropertyMemoryPass implements PassInterface
 
             $findings[] = new Finding(
                 kind: 'expensive_property',
-                severity: $s['total'] > 1024 * 1024
-                    ? FindingSeverity::Medium
-                    : FindingSeverity::Low,
+                severity: FindingSeverity::Medium,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
                     '%s::$%s: %s occurrences x %dB = %.2f MB',

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -80,7 +80,42 @@ final class ReportGenerator
             $findings = array_merge($findings, $this->runPass(new RetainedSizeConfidencePass($substrate)));
         }
 
+        $findings = $this->deduplicateFindings($findings);
+
         return new ReportResult($meta, $findings);
+    }
+
+    /**
+     * Post-process findings to reduce redundancy.
+     * @param list<Finding> $findings
+     * @return list<Finding>
+     */
+    private function deduplicateFindings(array $findings): array
+    {
+        $has_cycles = false;
+        foreach ($findings as $f) {
+            if ($f->kind === 'cycle_cluster' || $f->kind === 'micro_cycle') {
+                $has_cycles = true;
+                break;
+            }
+        }
+
+        // If cycles are present, limit shared_fanin to top 3
+        // (many shared_fanin findings are cycle back-references)
+        if ($has_cycles) {
+            $fanin_count = 0;
+            $findings = array_values(array_filter(
+                $findings,
+                function (Finding $f) use (&$fanin_count): bool {
+                    if ($f->kind === 'shared_fanin') {
+                        return ++$fanin_count <= 3;
+                    }
+                    return true;
+                },
+            ));
+        }
+
+        return $findings;
     }
 
     /**


### PR DESCRIPTION
## Summary

Reduce noise in memory analysis report output based on user feedback from real-world validation against php-imap, Monolog, Symfony Forms, and other codebases.

- **ChokePoint chain dedup**: suppress parent nodes when a child is also a choke_point candidate — keeps only the deepest gateway instead of listing every intermediate node on the same bottleneck path (6 findings → 1)
- **SharedFanin noise filter**: exclude VM-internal link_names (`name`, `key`, `value`, `class_entry`, `object_handlers`) and numeric array indices. Limit to top 3 when cycle_cluster findings exist (most fanin is cycle back-references)
- **ExpensiveProperty threshold**: raise from 100KB to 1MB — sub-MB findings like `op_array` (0.89 MB) and `doc_comment` (0.16 MB) are VM internals, not user-actionable
- **DedupCandidate**: exclude `object_handlers` (PHP VM always shares handler tables)

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf