### PR TITLE
Add retained property cost, call stack, PHP-style paths, and path resolution

### DIFF
--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -66,8 +66,9 @@ final class MemoryReportCommand extends Command
         $this->addOption(
             'full-analysis',
             null,
-            InputOption::VALUE_NONE,
-            'run all analysis passes regardless of snapshot size (may use significant memory)',
+            InputOption::VALUE_NEGATABLE,
+            'run all analysis passes (default: on; --no-full-analysis to limit for very large snapshots)',
+            true,
         );
     }
 

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -168,6 +168,14 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             'CREATE INDEX IF NOT EXISTS idx_context_node_attributes_run_node'
             . ' ON context_node_attributes(run_id, node_id)'
         );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_node_locations_run_type'
+            . ' ON context_node_locations(run_id, location_type)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_edges_run_link_parent_tree'
+            . ' ON context_edges(run_id, link_name, parent_node_id, is_tree)'
+        );
     }
 
     private function createViews(\PDO $db): void

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -37,7 +37,7 @@ final class TextReportFormatter implements ReportFormatterInterface
         $info = [];
 
         foreach ($result->findings as $finding) {
-            if ($finding->kind === 'overview' || $finding->kind === 'coverage_gap') {
+            if (in_array($finding->kind, ['overview', 'coverage_gap', 'call_stack'], true)) {
                 $overview[] = $finding;
             } elseif (
                 in_array($finding->kind, ['root_blame', 'retained_exact', 'retained_approximate'], true)
@@ -54,7 +54,15 @@ final class TextReportFormatter implements ReportFormatterInterface
         if ($overview !== []) {
             $lines[] = '=== Overview ===';
             foreach ($overview as $finding) {
-                $lines[] = '  ' . $finding->summary;
+                if ($finding->kind === 'call_stack' && $finding->hypothesis !== '') {
+                    $lines[] = '';
+                    $lines[] = '  Call Stack at capture:';
+                    foreach (explode("\n", $finding->hypothesis) as $frame) {
+                        $lines[] = '    ' . $frame;
+                    }
+                } else {
+                    $lines[] = '  ' . $finding->summary;
+                }
             }
             $lines[] = '';
         }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+/**
+ * Shows the call stack at the time of snapshot capture.
+ */
+final class CallStackPass implements PassInterface
+{
+    public function __construct(
+        private \PDO $db,
+        private int $run_id,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $rows = $this->db->query("
+            SELECT
+                e.link_name as frame_no,
+                fn.value as function_name,
+                ln.value as lineno
+            FROM context_edges e
+            JOIN context_nodes cn
+                ON cn.node_id = e.child_node_id
+                AND cn.type = 'CallFrameContext'
+                AND cn.run_id = {$this->run_id}
+            LEFT JOIN context_node_attributes fn
+                ON fn.node_id = e.child_node_id
+                AND fn.key = 'function_name'
+                AND fn.run_id = {$this->run_id}
+            LEFT JOIN context_node_attributes ln
+                ON ln.node_id = e.child_node_id
+                AND ln.key = 'lineno'
+                AND ln.run_id = {$this->run_id}
+            WHERE e.is_tree = 1
+                AND e.run_id = {$this->run_id}
+                AND e.parent_node_id IN (
+                    SELECT cn2.node_id
+                    FROM context_nodes cn2
+                    WHERE cn2.type = 'CallFramesContext'
+                        AND cn2.run_id = {$this->run_id}
+                )
+            ORDER BY cast(e.link_name as integer)
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $frames = [];
+        foreach ($rows as $row) {
+            $fn = $row['function_name'] ?? '?';
+            $ln = $row['lineno'] ?? null;
+            $frames[] = $ln !== null
+                ? "{$fn}:{$ln}"
+                : (string)$fn;
+        }
+
+        $lines = [];
+        foreach ($frames as $i => $frame) {
+            $lines[] = "#{$i} {$frame}";
+        }
+
+        return [
+            new Finding(
+                kind: 'call_stack',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'Call stack: ' . implode(' -> ', $frames),
+                facts: [
+                    'frames' => $frames,
+                    'depth' => count($frames),
+                ],
+                hypothesis: implode("\n", $lines),
+            ),
+        ];
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -108,7 +108,7 @@ final class ChokePointPass implements PassInterface
             // Build a meaningful label: prefer class_name > location_type > node type > link_name
             $label = '';
             if ($class) {
-                $label = preg_replace('/^.*\\\\/', '', $class);
+                $label = $class;
             } elseif ($loc_type !== '') {
                 $label = $loc_type;
             } else {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 
 final class ChokePointPass implements PassInterface
 {
@@ -86,6 +87,8 @@ final class ChokePointPass implements PassInterface
         }
         unset($rows);
 
+        $labeler = new NodeLabeler($this->db, $this->run_id);
+
         $loc_stmt = $this->db->prepare(
             "SELECT class_name, location_type FROM context_node_locations"
             . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
@@ -124,7 +127,10 @@ final class ChokePointPass implements PassInterface
                     break;
                 }
                 [$parent, $link] = $parent_map[$cur];
-                $path_parts[] = $link;
+                $path_parts[] = $labeler->resolvePathLabel(
+                    (string)$link,
+                    $cur
+                );
                 if ($i === 0 && $label === '') {
                     $label = $link;
                 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 
 final class ChokePointPass implements PassInterface
 {
@@ -76,7 +77,7 @@ final class ChokePointPass implements PassInterface
         }
         $chokepoints = $filtered;
 
-        // Build parent map for path lookup
+        // Build parent map and node type map for path lookup
         $parent_map = [];
         $rows = $this->db->query(
             "SELECT child_node_id, parent_node_id, link_name FROM context_edges"
@@ -84,6 +85,17 @@ final class ChokePointPass implements PassInterface
         )->fetchAll(\PDO::FETCH_NUM);
         foreach ($rows as $r) {
             $parent_map[(int)$r[0]] = [(int)$r[1], $r[2]];
+        }
+        unset($rows);
+
+        /** @var array<int, string> */
+        $node_type_map = [];
+        $rows = $this->db->query(
+            "SELECT node_id, type FROM context_nodes"
+            . " WHERE run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
+        foreach ($rows as $r) {
+            $node_type_map[(int)$r[0]] = (string)$r[1];
         }
         unset($rows);
 
@@ -119,27 +131,32 @@ final class ChokePointPass implements PassInterface
                 }
             }
 
-            // Walk up to build path, use link_name as fallback label
-            $path_parts = [];
+            // Walk up to root for full PHP-syntax path
+            $up_parts = [];
+            $up_types = [];
             $cur = $node;
-            for ($i = 0; $i < 4; $i++) {
+            for ($i = 0; $i < 20; $i++) {
                 if (!isset($parent_map[$cur])) {
                     break;
                 }
                 [$parent, $link] = $parent_map[$cur];
-                $path_parts[] = $labeler->resolvePathLabel(
+                $resolved = $labeler->resolvePathLabel(
                     (string)$link,
                     $cur
                 );
-                if ($i === 0 && $label === '') {
-                    $label = $link;
+                array_unshift($up_parts, $resolved);
+                array_unshift($up_types, $node_type_map[$cur] ?? '');
+                if ($label === '') {
+                    $label = (string)$link;
                 }
                 $cur = $parent;
             }
             if ($label === '') {
                 $label = "(node #{$node})";
             }
-            $path = $path_parts ? implode(' <- ', $path_parts) : '(root)';
+            $path = $up_parts !== []
+                ? PathFormatter::toPhpSyntax($up_parts, $up_types)
+                : '(root)';
 
             $n_children = count($this->substrate->children[$node] ?? []);
 
@@ -148,11 +165,12 @@ final class ChokePointPass implements PassInterface
                 severity: FindingSeverity::High,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%s (%dB shallow) holds %.2f MB via %d children',
+                    '%s (%dB shallow) holds %.2f MB via %d children — %s',
                     $label,
                     $shallow,
                     $subtree / 1024 / 1024,
                     $n_children,
+                    $path,
                 ),
                 facts: [
                     'node_id' => $node,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -26,6 +26,7 @@ final class ChokePointPass implements PassInterface
         private GraphSubstrate $substrate,
         private \PDO $db,
         private int $run_id,
+        private int $heap_usage = 0,
     ) {
     }
 
@@ -160,9 +161,17 @@ final class ChokePointPass implements PassInterface
 
             $n_children = count($this->substrate->children[$node] ?? []);
 
+            $heap = max($this->heap_usage, 1);
+            $pct = $subtree / $heap * 100.0;
+            $severity = match (true) {
+                $pct > 30.0 => FindingSeverity::High,
+                $pct > 10.0 => FindingSeverity::Medium,
+                default => FindingSeverity::Low,
+            };
+
             $findings[] = new Finding(
                 kind: 'choke_point',
-                severity: FindingSeverity::High,
+                severity: $severity,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
                     '%s (%dB shallow) holds %.2f MB via %d children — %s',

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ClassRankingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ClassRankingPass.php
@@ -49,7 +49,7 @@ final class ClassRankingPass implements PassInterface
         foreach ($this->class_objects_summary as $class_name => $entry) {
             $pct = $entry['memory_usage'] / $total_object_memory * 100.0;
             if ($pct > 50.0) {
-                $short = preg_replace('/^.*\\\\/', '', $class_name) ?? $class_name;
+                $short = $class_name;
                 $avg_size = $entry['count'] > 0
                     ? (int)($entry['memory_usage'] / $entry['count'])
                     : 0;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -104,7 +104,7 @@ final class CompanionDetectionPass implements PassInterface
             $names = array_map(
                 fn($c) => sprintf(
                     '%s (%s)',
-                    preg_replace('/^.*\\\\/', '', $c['name']) ?? $c['name'],
+                    $c['name'],
                     number_format($c['count'])
                 ),
                 $group_classes

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -50,7 +50,11 @@ final class CycleClusterPass implements PassInterface
             foreach ($group as $profile) {
                 $total += $profile['total_size'];
             }
-            $groups_sorted[] = ['sig' => $sig, 'group' => $group, 'total' => $total];
+            $groups_sorted[] = [
+                'sig' => $sig,
+                'group' => $group,
+                'total' => $total,
+            ];
         }
         usort($groups_sorted, fn($a, $b) => $b['total'] <=> $a['total']);
 
@@ -59,6 +63,13 @@ final class CycleClusterPass implements PassInterface
             $group = $g['group'];
             $example = $group[0];
             $count = count($group);
+
+            // Build "Nx Class" composition string
+            $composition = $this->formatComposition($example['class_counts']);
+
+            // Object count vs total nodes
+            $object_count = array_sum($example['class_counts']);
+            $internal_count = $example['node_count'] - $object_count;
 
             // Micro-cycles (2 nodes)
             $is_micro = $example['node_count'] === 2;
@@ -72,11 +83,11 @@ final class CycleClusterPass implements PassInterface
                         '%s micro-cycle%s: %s (%.2f KB total)',
                         number_format($count),
                         $count > 1 ? 's' : '',
-                        $g['sig'],
+                        $composition,
                         $g['total'] / 1024,
                     ),
                     facts: [
-                        'pattern' => $g['sig'],
+                        'composition' => $composition,
                         'count' => $count,
                         'nodes_per_cycle' => $example['node_count'],
                         'total_size' => $g['total'],
@@ -88,33 +99,49 @@ final class CycleClusterPass implements PassInterface
                     impact_bytes: $g['total'],
                 );
             } else {
+                $node_desc = $internal_count > 0
+                    ? sprintf(
+                        '%d object%s + %d internal nodes per cycle',
+                        $object_count,
+                        $object_count > 1 ? 's' : '',
+                        $internal_count,
+                    )
+                    : sprintf(
+                        '%d object%s per cycle',
+                        $object_count,
+                        $object_count > 1 ? 's' : '',
+                    );
+
                 $findings[] = new Finding(
                     kind: 'cycle_cluster',
-                    severity: $g['total'] > 1024 * 100 ? FindingSeverity::Medium : FindingSeverity::Low,
+                    severity: $g['total'] > 1024 * 100
+                        ? FindingSeverity::Medium
+                        : FindingSeverity::Low,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%d identical cycle%s: %s (%d nodes each, %.2f KB total)',
+                        '%d identical cycle%s (%s, %.2f KB total)',
                         $count,
                         $count > 1 ? 's' : '',
-                        $g['sig'],
-                        $example['node_count'],
+                        $node_desc,
                         $g['total'] / 1024,
                     ),
                     facts: [
-                        'pattern' => $g['sig'],
+                        'composition' => $composition,
                         'count' => $count,
-                        'nodes_per_cycle' => $example['node_count'],
+                        'object_count_per_cycle' => $object_count,
+                        'internal_nodes_per_cycle' => $internal_count,
                         'size_per_cycle' => $example['total_size'],
                         'total_size' => $g['total'],
                         'ext_incoming' => $example['ext_in'],
                         'ext_outgoing' => $example['ext_out'],
                         'single_owner_likelihood' => $example['single_owner_likelihood'],
                     ],
-                    hypothesis: $example['single_owner_likelihood'] === 'high'
-                        ? 'Single entry point — breaking the owner reference likely frees this cycle'
-                        : ($count > 10
-                            ? "{$count} identical cycles — a structural pattern, not accidental"
-                            : 'Circular reference chain'),
+                    hypothesis: "Per cycle: {$composition}\n"
+                        . ($example['single_owner_likelihood'] === 'high'
+                            ? 'Single entry point — breaking the owner reference likely frees this cycle'
+                            : ($count > 10
+                                ? "{$count} identical cycles — a structural pattern, not accidental"
+                                : 'Circular reference chain')),
                     next_checks: [
                         'Identify the back-reference causing the cycle',
                         'Consider using WeakReference or explicit cleanup',
@@ -126,5 +153,18 @@ final class CycleClusterPass implements PassInterface
         }
 
         return $findings;
+    }
+
+    /**
+     * Format class_counts as "1x Message + 3x Attachment + 1x AttachmentCollection"
+     * @param array<string, int> $class_counts
+     */
+    private function formatComposition(array $class_counts): string
+    {
+        $parts = [];
+        foreach ($class_counts as $cls => $cnt) {
+            $parts[] = "{$cnt}x {$cls}";
+        }
+        return implode(' + ', $parts);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -27,7 +27,8 @@ final class CycleClusterPass implements PassInterface
 
     /**
      * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress MixedOperand, InvalidOperand
      * @psalm-suppress PossiblyInvalidArgument, InvalidArgument
      */
     #[\Override]
@@ -37,13 +38,11 @@ final class CycleClusterPass implements PassInterface
             return [];
         }
 
-        // Group by signature
         $pattern_groups = [];
         foreach ($this->substrate->scc_profiles as $profile) {
             $pattern_groups[$profile['signature']][] = $profile;
         }
 
-        // Sort by total memory impact
         $groups_sorted = [];
         foreach ($pattern_groups as $sig => $group) {
             $total = 0;
@@ -63,18 +62,14 @@ final class CycleClusterPass implements PassInterface
             $group = $g['group'];
             $example = $group[0];
             $count = count($group);
+            $class_count = count($example['class_counts']);
 
-            // Build "Nx Class" composition string
-            $composition = $this->formatComposition($example['class_counts']);
-
-            // Object count vs total nodes
-            $object_count = array_sum($example['class_counts']);
-            $internal_count = $example['node_count'] - $object_count;
+            $composition = $this->formatComposition(
+                $example['class_counts']
+            );
 
             // Micro-cycles (2 nodes)
-            $is_micro = $example['node_count'] === 2;
-
-            if ($is_micro) {
+            if ($example['node_count'] === 2) {
                 $findings[] = new Finding(
                     kind: 'micro_cycle',
                     severity: FindingSeverity::Low,
@@ -89,81 +84,108 @@ final class CycleClusterPass implements PassInterface
                     facts: [
                         'composition' => $composition,
                         'count' => $count,
-                        'nodes_per_cycle' => $example['node_count'],
+                        'class_count' => $class_count,
                         'total_size' => $g['total'],
                     ],
-                    hypothesis: 'Bidirectional references between two objects',
+                    hypothesis: 'Bidirectional references'
+                        . ' between two objects',
                     next_checks: [
-                        'Check if back-reference can be replaced with WeakReference',
+                        'Check if back-reference can use WeakReference',
                     ],
                     impact_bytes: $g['total'],
                 );
-            } else {
-                $node_desc = $internal_count > 0
-                    ? sprintf(
-                        '%d object%s + %d internal nodes per cycle',
-                        $object_count,
-                        $object_count > 1 ? 's' : '',
-                        $internal_count,
-                    )
-                    : sprintf(
-                        '%d object%s per cycle',
-                        $object_count,
-                        $object_count > 1 ? 's' : '',
-                    );
+                continue;
+            }
 
+            // Large DI-container-like cycles (many classes, typically 1 instance)
+            if ($class_count > 15 && $count <= 2) {
                 $findings[] = new Finding(
-                    kind: 'cycle_cluster',
-                    severity: $g['total'] > 1024 * 100
-                        ? FindingSeverity::Medium
-                        : FindingSeverity::Low,
+                    kind: 'di_container_cycle',
+                    severity: FindingSeverity::Info,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%d identical cycle%s (%s, %.2f KB total)',
+                        '%d classes forming %d cycle%s (%.2f KB)',
+                        $class_count,
                         $count,
                         $count > 1 ? 's' : '',
-                        $node_desc,
                         $g['total'] / 1024,
                     ),
                     facts: [
                         'composition' => $composition,
                         'count' => $count,
-                        'object_count_per_cycle' => $object_count,
-                        'internal_nodes_per_cycle' => $internal_count,
-                        'size_per_cycle' => $example['total_size'],
+                        'class_count' => $class_count,
                         'total_size' => $g['total'],
-                        'ext_incoming' => $example['ext_in'],
-                        'ext_outgoing' => $example['ext_out'],
-                        'single_owner_likelihood' => $example['single_owner_likelihood'],
                     ],
-                    hypothesis: "Per cycle: {$composition}\n"
-                        . ($example['single_owner_likelihood'] === 'high'
-                            ? 'Single entry point — breaking the owner reference likely frees this cycle'
-                            : ($count > 10
-                                ? "{$count} identical cycles — a structural pattern, not accidental"
-                                : 'Circular reference chain')),
+                    hypothesis: 'Structural cost of DI container.'
+                        . "\nTop classes: {$composition}",
                     next_checks: [
-                        'Identify the back-reference causing the cycle',
-                        'Consider using WeakReference or explicit cleanup',
+                        'Reducing container instances'
+                        . ' (workers/tests) reduces this',
                     ],
                     impact_bytes: $g['total'],
-                    evidence_node_ids: array_slice($example['nodes'], 0, 5),
                 );
+                continue;
             }
+
+            // Normal cycle clusters
+            $findings[] = new Finding(
+                kind: 'cycle_cluster',
+                severity: $g['total'] > 1024 * 100
+                    ? FindingSeverity::Medium
+                    : FindingSeverity::Low,
+                confidence: FindingConfidence::High,
+                summary: sprintf(
+                    '%d identical cycle%s (%d classes, %.2f KB total)',
+                    $count,
+                    $count > 1 ? 's' : '',
+                    $class_count,
+                    $g['total'] / 1024,
+                ),
+                facts: [
+                    'composition' => $composition,
+                    'count' => $count,
+                    'class_count' => $class_count,
+                    'total_size' => $g['total'],
+                    'ext_incoming' => $example['ext_in'],
+                    'single_owner_likelihood' => $example['single_owner_likelihood'],
+                ],
+                hypothesis: "Per cycle: {$composition}\n"
+                    . ($example['single_owner_likelihood'] === 'high'
+                        ? 'Single entry point — breaking the owner'
+                        . ' reference likely frees this cycle'
+                        : ($count > 10
+                            ? "{$count} identical cycles"
+                            . ' — a structural pattern'
+                            : 'Circular reference chain')),
+                next_checks: [
+                    'Identify the back-reference causing the cycle',
+                    'Consider using WeakReference or explicit cleanup',
+                ],
+                impact_bytes: $g['total'],
+                evidence_node_ids: array_slice($example['nodes'], 0, 5),
+            );
         }
 
         return $findings;
     }
 
     /**
-     * Format class_counts as "1x Message + 3x Attachment + 1x AttachmentCollection"
+     * Format class_counts as "1x Message + 3x Attachment".
+     * Truncates to top 5 if more than 5 classes.
      * @param array<string, int> $class_counts
      */
     private function formatComposition(array $class_counts): string
     {
         $parts = [];
+        $i = 0;
         foreach ($class_counts as $cls => $cnt) {
+            if ($i >= 5) {
+                $remaining = count($class_counts) - 5;
+                $parts[] = "... +{$remaining} more";
+                break;
+            }
             $parts[] = "{$cnt}x {$cls}";
+            $i++;
         }
         return implode(' + ', $parts);
     }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 
 final class DrillDownPass implements PassInterface
 {
@@ -41,9 +42,14 @@ final class DrillDownPass implements PassInterface
             . " WHERE child_node_id = ? AND is_tree = 1"
             . " AND run_id = {$this->run_id} LIMIT 1"
         );
+        $type_stmt = $this->db->prepare(
+            "SELECT type FROM context_nodes"
+            . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
+        );
         $labeler = new NodeLabeler($this->db, $this->run_id);
 
         $path_parts = [];
+        $path_types = [];
         $path_sizes = [];
         $current_children = $this->substrate->roots;
 
@@ -69,7 +75,13 @@ final class DrillDownPass implements PassInterface
                 $heaviest[0]
             );
 
+            $type_stmt->execute([$heaviest[0]]);
+            $type_row = $type_stmt->fetch(\PDO::FETCH_NUM);
+            /** @var string $node_type */
+            $node_type = $type_row ? $type_row[0] : '';
+
             $path_parts[] = $name;
+            $path_types[] = $node_type;
             $path_sizes[] = $heaviest[1];
 
             $current_children = $this->substrate->children[$heaviest[0]] ?? [];
@@ -79,7 +91,7 @@ final class DrillDownPass implements PassInterface
             return [];
         }
 
-        $path_str = implode(' -> ', $path_parts);
+        $path_str = PathFormatter::toPhpSyntax($path_parts, $path_types);
         $total_size = $path_sizes[0] ?? 0;
 
         return [

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 
 final class DrillDownPass implements PassInterface
 {
@@ -29,8 +30,8 @@ final class DrillDownPass implements PassInterface
 
     /**
      * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, MixedArgumentTypeCoercion
-     * @psalm-suppress InvalidOperand
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress MixedOperand, MixedArgumentTypeCoercion, InvalidOperand
      */
     #[\Override]
     public function analyze(): array
@@ -40,6 +41,7 @@ final class DrillDownPass implements PassInterface
             . " WHERE child_node_id = ? AND is_tree = 1"
             . " AND run_id = {$this->run_id} LIMIT 1"
         );
+        $labeler = new NodeLabeler($this->db, $this->run_id);
 
         $path_parts = [];
         $path_sizes = [];
@@ -60,7 +62,12 @@ final class DrillDownPass implements PassInterface
             $heaviest = $branches[0];
             $link_stmt->execute([$heaviest[0]]);
             $r = $link_stmt->fetch(\PDO::FETCH_NUM);
-            $name = $r ? $r[0] : '?';
+            /** @var string $raw_name */
+            $raw_name = $r ? $r[0] : '?';
+            $name = $labeler->resolvePathLabel(
+                $raw_name,
+                $heaviest[0]
+            );
 
             $path_parts[] = $name;
             $path_sizes[] = $heaviest[1];
@@ -90,9 +97,10 @@ final class DrillDownPass implements PassInterface
                     'sizes' => $path_sizes,
                     'depth' => count($path_parts),
                 ],
-                hypothesis: 'Heaviest memory path — the primary chain of memory consumption',
+                hypothesis: 'Heaviest memory path'
+                    . ' — the primary chain of memory consumption',
                 next_checks: [
-                    'Examine the leaf of this path for the actual data consuming memory',
+                    'Examine the leaf for the actual data consuming memory',
                     'Check if the accumulation can be bounded or streamed',
                 ],
                 impact_bytes: $total_size,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
@@ -61,8 +61,7 @@ final class DynamicPropertiesPass implements PassInterface
 
         $findings = [];
         foreach ($rows as $row) {
-            $short = preg_replace('/^.*\\\\/', '', $row['class_name'])
-                ?? $row['class_name'];
+            $short = $row['class_name'];
             $dp_size = (int)$row['dp_size'];
             $cnt = (int)$row['cnt'];
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -28,18 +28,40 @@ final class NonTreeEdgePass implements PassInterface
     /**
      * @return list<Finding>
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
-     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument
+     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
      */
     #[\Override]
     public function analyze(): array
     {
-        // Classify shared references by link_name
+        // Classify shared references by link_name with class context
         $rows = $this->db->query("
             SELECT
                 e.link_name,
                 count(*) as ref_count,
                 count(DISTINCT e.child_node_id) as target_count,
-                round(count(*) * 1.0 / max(1, count(DISTINCT e.child_node_id)), 1) as avg_refs
+                round(
+                    count(*) * 1.0
+                    / max(1, count(DISTINCT e.child_node_id)),
+                    1
+                ) as avg_refs,
+                (SELECT cnl_src.class_name
+                    FROM context_edges e_pp
+                    JOIN context_node_locations cnl_src
+                        ON cnl_src.node_id = e_pp.parent_node_id
+                        AND cnl_src.run_id = {$this->run_id}
+                        AND cnl_src.location_type = 'ZendObjectMemoryLocation'
+                    WHERE e_pp.child_node_id = e.parent_node_id
+                        AND e_pp.link_name = 'object_properties'
+                        AND e_pp.run_id = {$this->run_id}
+                    LIMIT 1
+                ) as source_class,
+                (SELECT cnl_tgt.class_name
+                    FROM context_node_locations cnl_tgt
+                    WHERE cnl_tgt.node_id = e.child_node_id
+                        AND cnl_tgt.run_id = {$this->run_id}
+                        AND cnl_tgt.class_name IS NOT NULL
+                    LIMIT 1
+                ) as target_class
             FROM context_edges e
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
@@ -63,33 +85,41 @@ final class NonTreeEdgePass implements PassInterface
             $ref_count = (int)$row['ref_count'];
             $target_count = (int)$row['target_count'];
             $avg_refs = (float)$row['avg_refs'];
+            $src = $row['source_class'] ?? null;
+            $tgt = $row['target_class'] ?? null;
+            $qualified = $src
+                ? "{$src}::\${$row['link_name']}"
+                : $row['link_name'];
+            $target_label = $tgt ? " ({$tgt})" : '';
 
             if ($target_count === 1 && $ref_count > 50) {
-                // Singleton pattern: many refs to one target
                 $findings[] = new Finding(
                     kind: 'shared_singleton',
                     severity: FindingSeverity::Info,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%s: %s refs -> 1 target [singleton, normal]',
-                        $row['link_name'],
+                        '%s%s: %s refs -> 1 target [singleton]',
+                        $qualified,
+                        $target_label,
                         number_format($ref_count),
                     ),
                     facts: [
                         'link_name' => $row['link_name'],
+                        'source_class' => $src,
+                        'target_class' => $tgt,
                         'ref_count' => $ref_count,
                         'target_count' => $target_count,
                     ],
                 );
             } elseif ($target_count > 1 && $avg_refs > 2.0) {
-                // Fan-in: multiple refs to multiple targets
                 $findings[] = new Finding(
                     kind: 'shared_fanin',
                     severity: FindingSeverity::Medium,
                     confidence: FindingConfidence::Medium,
                     summary: sprintf(
-                        '%s: %s refs -> %s targets (%.1f each)',
-                        $row['link_name'],
+                        '%s -> %s (%s refs -> %s targets, %.1f each)',
+                        $qualified,
+                        $tgt ?? '?',
                         number_format($ref_count),
                         number_format($target_count),
                         $avg_refs,
@@ -113,10 +143,24 @@ final class NonTreeEdgePass implements PassInterface
             SELECT
                 e.link_name,
                 cnl.size,
+                cnl.class_name as target_class,
                 count(*) as cnt,
-                count(*) * cnl.size as total_waste
+                count(*) * cnl.size as total_waste,
+                (SELECT cnl_src.class_name
+                    FROM context_edges e_pp
+                    JOIN context_node_locations cnl_src
+                        ON cnl_src.node_id = e_pp.parent_node_id
+                        AND cnl_src.run_id = {$this->run_id}
+                        AND cnl_src.location_type
+                            = 'ZendObjectMemoryLocation'
+                    WHERE e_pp.child_node_id = e.parent_node_id
+                        AND e_pp.link_name = 'object_properties'
+                        AND e_pp.run_id = {$this->run_id}
+                    LIMIT 1
+                ) as source_class
             FROM context_edges e
-            JOIN context_node_locations cnl ON cnl.node_id = e.child_node_id
+            JOIN context_node_locations cnl
+                ON cnl.node_id = e.child_node_id
                 AND cnl.run_id = {$this->run_id}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
@@ -135,20 +179,30 @@ final class NonTreeEdgePass implements PassInterface
             $cnt = (int)$row['cnt'];
             $size = (int)$row['size'];
             $total = (int)$row['total_waste'];
+            $dedup_src = $row['source_class'] ?? null;
+            $dedup_tgt = $row['target_class'] ?? null;
+            $dedup_label = $dedup_src
+                ? "{$dedup_src}::\${$row['link_name']}"
+                : $row['link_name'];
+            if ($dedup_tgt) {
+                $dedup_label .= " ({$dedup_tgt})";
+            }
 
             $findings[] = new Finding(
                 kind: 'dedup_candidate',
                 severity: $total > 102400 ? FindingSeverity::Low : FindingSeverity::Info,
                 confidence: FindingConfidence::Low,
                 summary: sprintf(
-                    '%s: %s copies x %dB ALL SAME SIZE = %.2f KB wasted',
-                    $row['link_name'],
+                    '%s: %s copies x %dB SAME SIZE = %.2f KB',
+                    $dedup_label,
                     number_format($cnt),
                     $size,
                     $total / 1024,
                 ),
                 facts: [
                     'link_name' => $row['link_name'],
+                    'source_class' => $dedup_src,
+                    'target_class' => $dedup_tgt,
                     'count' => $cnt,
                     'each_size' => $size,
                     'total_waste' => $total,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
@@ -93,8 +93,7 @@ final class PerPropertyMemoryPass implements PassInterface
             if ($s['total'] < 1024 * 1024 || $i >= 10) {
                 break;
             }
-            $short = preg_replace('/^.*\\\\/', '', $s['class'])
-                ?? $s['class'];
+            $short = $s['class'];
             $avg = $s['count'] > 0
                 ? (int)($s['total'] / $s['count'])
                 : 0;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 
 final class PropertyScalingPass implements PassInterface
 {
@@ -26,18 +27,18 @@ final class PropertyScalingPass implements PassInterface
         private \PDO $db,
         private int $run_id,
         private array $class_objects_summary,
+        private ?GraphSubstrate $substrate = null,
     ) {
     }
 
     /**
      * @return list<Finding>
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
-     * @psalm-suppress MixedOperand, InvalidOperand
+     * @psalm-suppress MixedOperand, InvalidOperand, MixedArrayOffset
      */
     #[\Override]
     public function analyze(): array
     {
-        // Find dominant class (> 50% of object memory)
         $total_object_memory = 0;
         foreach ($this->class_objects_summary as $entry) {
             $total_object_memory += $entry['memory_usage'];
@@ -61,9 +62,13 @@ final class PropertyScalingPass implements PassInterface
             return [];
         }
 
+        $use_retained = $this->substrate !== null
+            && $this->substrate->subtree_sizes !== [];
+
         $rows = $this->db->query("
             SELECT
                 e_prop.link_name,
+                e_prop.child_node_id,
                 count(*) as total_refs,
                 count(DISTINCT e_prop.child_node_id) as distinct_targets,
                 sum(CASE WHEN e_prop.is_tree = 1
@@ -91,8 +96,35 @@ final class PropertyScalingPass implements PassInterface
             return [];
         }
 
+        // Collect child_node_ids per property for retained size lookup
+        $prop_children = [];
+        if ($use_retained) {
+            $child_rows = $this->db->query("
+                SELECT
+                    e_prop.link_name,
+                    e_prop.child_node_id
+                FROM context_node_locations cnl_obj
+                JOIN context_edges e_to_props
+                    ON e_to_props.parent_node_id = cnl_obj.node_id
+                    AND e_to_props.link_name = 'object_properties'
+                    AND e_to_props.run_id = {$this->run_id}
+                JOIN context_edges e_prop
+                    ON e_prop.parent_node_id = e_to_props.child_node_id
+                    AND e_prop.is_tree = 1
+                    AND e_prop.run_id = {$this->run_id}
+                WHERE cnl_obj.class_name = "
+                . $this->db->quote($dominant_class) . "
+                    AND cnl_obj.run_id = {$this->run_id}
+            ")->fetchAll(\PDO::FETCH_ASSOC);
+            foreach ($child_rows as $cr) {
+                $prop_children[$cr['link_name']][] = (int)$cr['child_node_id'];
+            }
+            unset($child_rows);
+        }
+
         $per_instance = [];
         $shared = [];
+        $scalar_count = 0;
 
         foreach ($rows as $row) {
             $distinct = (int)$row['distinct_targets'];
@@ -107,38 +139,74 @@ final class PropertyScalingPass implements PassInterface
                 $scaling = 'PARTIALLY SHARED';
             }
 
-            $entry = [
-                'property' => $row['link_name'],
-                'distinct_targets' => $distinct,
-                'total_refs' => $total_refs,
-                'tree_size' => $tree_size,
-                'scaling' => $scaling,
-            ];
+            // Compute retained size if available
+            $prop_name = $row['link_name'];
+            $retained_total = 0;
+            if ($use_retained && isset($prop_children[$prop_name])) {
+                foreach ($prop_children[$prop_name] as $cid) {
+                    $retained_total += $this->substrate->subtree_sizes[$cid] ?? 0;
+                }
+            }
 
-            if ($scaling === 'SHARED') {
-                $shared[] = $entry;
+            $size = $use_retained && $retained_total > 0
+                ? $retained_total
+                : $tree_size;
+
+            if ($scaling !== 'SHARED') {
+                // Skip size=0 PER-INSTANCE (scalar zval, already in object size)
+                if ($size === 0) {
+                    $scalar_count++;
+                    continue;
+                }
+                $per_instance[] = [
+                    'property' => $prop_name,
+                    'distinct_targets' => $distinct,
+                    'total_refs' => $total_refs,
+                    'size' => $size,
+                    'retained' => $use_retained,
+                    'scaling' => $scaling,
+                ];
             } else {
-                $per_instance[] = $entry;
+                $shared[] = [
+                    'property' => $prop_name,
+                    'distinct_targets' => $distinct,
+                    'total_refs' => $total_refs,
+                    'size' => $size,
+                    'scaling' => $scaling,
+                ];
             }
         }
 
         $short = preg_replace('/^.*\\\\/', '', $dominant_class)
             ?? $dominant_class;
+        $size_label = $use_retained ? 'retained' : 'shallow';
 
         $lines = [];
         if ($per_instance !== []) {
-            $lines[] = 'PER-INSTANCE (scales with count):';
-            foreach (array_slice($per_instance, 0, 5) as $p) {
+            $lines[] = "PER-INSTANCE ({$size_label}, scales with count):";
+            usort(
+                $per_instance,
+                fn($a, $b) => $b['size'] <=> $a['size']
+            );
+            foreach (array_slice($per_instance, 0, 8) as $p) {
+                $avg = $p['distinct_targets'] > 0
+                    ? (int)($p['size'] / $p['distinct_targets'])
+                    : 0;
                 $lines[] = sprintf(
                     '  $%s: %s copies x %dB = %.2f KB',
                     $p['property'],
                     number_format($p['distinct_targets']),
-                    $p['distinct_targets'] > 0
-                        ? (int)($p['tree_size'] / $p['distinct_targets'])
-                        : 0,
-                    $p['tree_size'] / 1024,
+                    $avg,
+                    $p['size'] / 1024,
                 );
             }
+        }
+        if ($scalar_count > 0) {
+            $lines[] = sprintf(
+                '(%d scalar properties per-instance,'
+                . ' included in object size)',
+                $scalar_count
+            );
         }
         if ($shared !== []) {
             $shared_names = array_map(
@@ -150,7 +218,7 @@ final class PropertyScalingPass implements PassInterface
         }
 
         $per_instance_total = array_sum(
-            array_column($per_instance, 'tree_size')
+            array_column($per_instance, 'size')
         );
 
         return [
@@ -159,13 +227,15 @@ final class PropertyScalingPass implements PassInterface
                 severity: FindingSeverity::Medium,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    '%s (%s instances): %d per-instance props (%.2f KB/instance), %d shared',
+                    '%s (%s instances): %d per-instance props'
+                    . ' (%.2f KB/instance %s), %d shared',
                     $short,
                     number_format($dominant_count),
                     count($per_instance),
                     $dominant_count > 0
                         ? $per_instance_total / $dominant_count / 1024
                         : 0,
+                    $size_label,
                     count($shared),
                 ),
                 facts: [
@@ -173,14 +243,18 @@ final class PropertyScalingPass implements PassInterface
                     'instance_count' => $dominant_count,
                     'per_instance_properties' => $per_instance,
                     'shared_properties' => $shared,
+                    'scalar_properties_count' => $scalar_count,
                     'per_instance_total_bytes' => $per_instance_total,
+                    'size_mode' => $size_label,
                 ],
                 hypothesis: 'Per-instance properties scale linearly;'
                     . ' shared properties use CoW.'
                     . "\n" . implode("\n", $lines),
                 next_checks: [
-                    'Per-instance properties with small values may benefit from lazy init',
-                    'Check if per-instance arrays can be replaced with defaults',
+                    'Per-instance props with small values'
+                    . ' may benefit from lazy init',
+                    'Check if per-instance arrays can be replaced'
+                    . ' with defaults',
                 ],
                 impact_bytes: $per_instance_total,
             ),

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -177,8 +177,7 @@ final class PropertyScalingPass implements PassInterface
             }
         }
 
-        $short = preg_replace('/^.*\\\\/', '', $dominant_class)
-            ?? $dominant_class;
+        $short = $dominant_class;
         $size_label = $use_retained ? 'retained' : 'shallow';
 
         $lines = [];
@@ -193,7 +192,8 @@ final class PropertyScalingPass implements PassInterface
                     ? (int)($p['size'] / $p['distinct_targets'])
                     : 0;
                 $lines[] = sprintf(
-                    '  $%s: %s copies x %dB = %.2f KB',
+                    '  %s::$%s: %s copies x %dB = %.2f KB',
+                    $short,
                     $p['property'],
                     number_format($p['distinct_targets']),
                     $avg,
@@ -210,7 +210,7 @@ final class PropertyScalingPass implements PassInterface
         }
         if ($shared !== []) {
             $shared_names = array_map(
-                fn($s) => '$' . $s['property'],
+                fn($s) => $short . '::$' . $s['property'],
                 array_slice($shared, 0, 10)
             );
             $lines[] = 'SHARED (constant cost): '

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+final class PropertyScalingPass implements PassInterface
+{
+    /**
+     * @param array<string, array{count: int, memory_usage: int}> $class_objects_summary
+     */
+    public function __construct(
+        private \PDO $db,
+        private int $run_id,
+        private array $class_objects_summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress MixedOperand, InvalidOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        // Find dominant class (> 50% of object memory)
+        $total_object_memory = 0;
+        foreach ($this->class_objects_summary as $entry) {
+            $total_object_memory += $entry['memory_usage'];
+        }
+        if ($total_object_memory === 0) {
+            return [];
+        }
+
+        $dominant_class = null;
+        $dominant_count = 0;
+        foreach ($this->class_objects_summary as $name => $entry) {
+            $pct = $entry['memory_usage'] / $total_object_memory * 100.0;
+            if ($pct > 50.0 && $entry['count'] > 100) {
+                $dominant_class = $name;
+                $dominant_count = $entry['count'];
+                break;
+            }
+        }
+
+        if ($dominant_class === null) {
+            return [];
+        }
+
+        $rows = $this->db->query("
+            SELECT
+                e_prop.link_name,
+                count(*) as total_refs,
+                count(DISTINCT e_prop.child_node_id) as distinct_targets,
+                sum(CASE WHEN e_prop.is_tree = 1
+                    THEN COALESCE(cnl_val.size, 0) ELSE 0
+                END) as tree_size
+            FROM context_node_locations cnl_obj
+            JOIN context_edges e_to_props
+                ON e_to_props.parent_node_id = cnl_obj.node_id
+                AND e_to_props.link_name = 'object_properties'
+                AND e_to_props.run_id = {$this->run_id}
+            JOIN context_edges e_prop
+                ON e_prop.parent_node_id = e_to_props.child_node_id
+                AND e_prop.run_id = {$this->run_id}
+            LEFT JOIN context_node_locations cnl_val
+                ON cnl_val.node_id = e_prop.child_node_id
+                AND cnl_val.run_id = {$this->run_id}
+            WHERE cnl_obj.class_name = "
+            . $this->db->quote($dominant_class) . "
+                AND cnl_obj.run_id = {$this->run_id}
+            GROUP BY e_prop.link_name
+            ORDER BY tree_size DESC
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $per_instance = [];
+        $shared = [];
+
+        foreach ($rows as $row) {
+            $distinct = (int)$row['distinct_targets'];
+            $total_refs = (int)$row['total_refs'];
+            $tree_size = (int)$row['tree_size'];
+
+            if ($distinct === 1) {
+                $scaling = 'SHARED';
+            } elseif ($distinct >= $total_refs * 0.9) {
+                $scaling = 'PER-INSTANCE';
+            } else {
+                $scaling = 'PARTIALLY SHARED';
+            }
+
+            $entry = [
+                'property' => $row['link_name'],
+                'distinct_targets' => $distinct,
+                'total_refs' => $total_refs,
+                'tree_size' => $tree_size,
+                'scaling' => $scaling,
+            ];
+
+            if ($scaling === 'SHARED') {
+                $shared[] = $entry;
+            } else {
+                $per_instance[] = $entry;
+            }
+        }
+
+        $short = preg_replace('/^.*\\\\/', '', $dominant_class)
+            ?? $dominant_class;
+
+        $lines = [];
+        if ($per_instance !== []) {
+            $lines[] = 'PER-INSTANCE (scales with count):';
+            foreach (array_slice($per_instance, 0, 5) as $p) {
+                $lines[] = sprintf(
+                    '  $%s: %s copies x %dB = %.2f KB',
+                    $p['property'],
+                    number_format($p['distinct_targets']),
+                    $p['distinct_targets'] > 0
+                        ? (int)($p['tree_size'] / $p['distinct_targets'])
+                        : 0,
+                    $p['tree_size'] / 1024,
+                );
+            }
+        }
+        if ($shared !== []) {
+            $shared_names = array_map(
+                fn($s) => '$' . $s['property'],
+                array_slice($shared, 0, 10)
+            );
+            $lines[] = 'SHARED (constant cost): '
+                . implode(', ', $shared_names);
+        }
+
+        $per_instance_total = array_sum(
+            array_column($per_instance, 'tree_size')
+        );
+
+        return [
+            new Finding(
+                kind: 'property_scaling',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    '%s (%s instances): %d per-instance props (%.2f KB/instance), %d shared',
+                    $short,
+                    number_format($dominant_count),
+                    count($per_instance),
+                    $dominant_count > 0
+                        ? $per_instance_total / $dominant_count / 1024
+                        : 0,
+                    count($shared),
+                ),
+                facts: [
+                    'class_name' => $dominant_class,
+                    'instance_count' => $dominant_count,
+                    'per_instance_properties' => $per_instance,
+                    'shared_properties' => $shared,
+                    'per_instance_total_bytes' => $per_instance_total,
+                ],
+                hypothesis: 'Per-instance properties scale linearly;'
+                    . ' shared properties use CoW.'
+                    . "\n" . implode("\n", $lines),
+                next_checks: [
+                    'Per-instance properties with small values may benefit from lazy init',
+                    'Check if per-instance arrays can be replaced with defaults',
+                ],
+                impact_bytes: $per_instance_total,
+            ),
+        ];
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -34,7 +34,7 @@ final class PropertyScalingPass implements PassInterface
     /**
      * @return list<Finding>
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
-     * @psalm-suppress MixedOperand, InvalidOperand, MixedArrayOffset
+     * @psalm-suppress MixedOperand, InvalidOperand, MixedArrayOffset, PossiblyInvalidArgument
      */
     #[\Override]
     public function analyze(): array
@@ -62,125 +62,35 @@ final class PropertyScalingPass implements PassInterface
             return [];
         }
 
-        $use_retained = $this->substrate !== null
-            && $this->substrate->subtree_sizes !== [];
+        if ($this->substrate !== null) {
+            $props = $this->analyzeWithGraph($dominant_class);
+        } else {
+            $props = $this->analyzeWithSql($dominant_class);
+        }
 
-        $rows = $this->db->query("
-            SELECT
-                e_prop.link_name,
-                e_prop.child_node_id,
-                count(*) as total_refs,
-                count(DISTINCT e_prop.child_node_id) as distinct_targets,
-                min(e_prop.child_node_id) as sample_child_id,
-                sum(CASE WHEN e_prop.is_tree = 1
-                    THEN COALESCE(cnl_val.size, 0) ELSE 0
-                END) as tree_size
-            FROM context_node_locations cnl_obj
-            JOIN context_edges e_to_props
-                ON e_to_props.parent_node_id = cnl_obj.node_id
-                AND e_to_props.link_name = 'object_properties'
-                AND e_to_props.run_id = {$this->run_id}
-            JOIN context_edges e_prop
-                ON e_prop.parent_node_id = e_to_props.child_node_id
-                AND e_prop.run_id = {$this->run_id}
-            LEFT JOIN context_node_locations cnl_val
-                ON cnl_val.node_id = e_prop.child_node_id
-                AND cnl_val.run_id = {$this->run_id}
-            WHERE cnl_obj.class_name = "
-            . $this->db->quote($dominant_class) . "
-                AND cnl_obj.run_id = {$this->run_id}
-            GROUP BY e_prop.link_name
-            ORDER BY tree_size DESC
-        ")->fetchAll(\PDO::FETCH_ASSOC);
-
-        if ($rows === []) {
+        if ($props === []) {
             return [];
         }
 
-        // Collect child_node_ids per property for retained size lookup
-        $prop_children = [];
-        if ($use_retained) {
-            $child_rows = $this->db->query("
-                SELECT
-                    e_prop.link_name,
-                    e_prop.child_node_id
-                FROM context_node_locations cnl_obj
-                JOIN context_edges e_to_props
-                    ON e_to_props.parent_node_id = cnl_obj.node_id
-                    AND e_to_props.link_name = 'object_properties'
-                    AND e_to_props.run_id = {$this->run_id}
-                JOIN context_edges e_prop
-                    ON e_prop.parent_node_id = e_to_props.child_node_id
-                    AND e_prop.is_tree = 1
-                    AND e_prop.run_id = {$this->run_id}
-                WHERE cnl_obj.class_name = "
-                . $this->db->quote($dominant_class) . "
-                    AND cnl_obj.run_id = {$this->run_id}
-            ")->fetchAll(\PDO::FETCH_ASSOC);
-            foreach ($child_rows as $cr) {
-                $prop_children[$cr['link_name']][] = (int)$cr['child_node_id'];
-            }
-            unset($child_rows);
-        }
+        $use_retained = $this->substrate !== null
+            && $this->substrate->subtree_sizes !== [];
 
         $per_instance = [];
         $shared = [];
         $scalar_count = 0;
 
-        foreach ($rows as $row) {
-            $distinct = (int)$row['distinct_targets'];
-            $total_refs = (int)$row['total_refs'];
-            $tree_size = (int)$row['tree_size'];
-
-            if ($distinct === 1) {
-                $scaling = 'SHARED';
-            } elseif ($distinct >= $total_refs * 0.9) {
-                $scaling = 'PER-INSTANCE';
-            } else {
-                $scaling = 'PARTIALLY SHARED';
-            }
-
-            // Compute retained size if available
-            $prop_name = $row['link_name'];
-            $retained_total = 0;
-            if ($use_retained && isset($prop_children[$prop_name])) {
-                foreach ($prop_children[$prop_name] as $cid) {
-                    $retained_total += $this->substrate->subtree_sizes[$cid] ?? 0;
-                }
-            }
-
-            $size = $use_retained && $retained_total > 0
-                ? $retained_total
-                : $tree_size;
-
-            if ($scaling !== 'SHARED') {
-                // Skip size=0 PER-INSTANCE (scalar zval, already in object size)
-                if ($size === 0) {
+        foreach ($props as $p) {
+            if ($p['scaling'] !== 'SHARED') {
+                if ($p['size'] === 0) {
                     $scalar_count++;
                     continue;
                 }
-                $per_instance[] = [
-                    'property' => $prop_name,
-                    'distinct_targets' => $distinct,
-                    'total_refs' => $total_refs,
-                    'size' => $size,
-                    'retained' => $use_retained,
-                    'scaling' => $scaling,
-                ];
+                $per_instance[] = $p;
             } else {
-                $sample_id = (int)($row['sample_child_id'] ?? 0);
-                $shared[] = [
-                    'property' => $prop_name,
-                    'distinct_targets' => $distinct,
-                    'total_refs' => $total_refs,
-                    'size' => $size,
-                    'scaling' => $scaling,
-                    'sample_child_id' => $sample_id,
-                ];
+                $shared[] = $p;
             }
         }
 
-        // Classify sharing reason for shared properties
         $this->classifySharedReasons($shared);
 
         $short = $dominant_class;
@@ -272,6 +182,173 @@ final class PropertyScalingPass implements PassInterface
     }
 
     /**
+     * In-memory analysis using GraphSubstrate. O(nodes).
+     * @return list<array<string, mixed>>
+     * @psalm-suppress InvalidOperand
+     */
+    private function analyzeWithGraph(string $dominant_class): array
+    {
+        assert($this->substrate !== null);
+        $use_retained = $this->substrate->subtree_sizes !== [];
+
+        // Load link_names for all tree edges
+        $link_names = $this->loadLinkNames();
+
+        // For each object of dominant_class, walk children to find
+        // object_properties → property children
+        /** @var array<string, array{distinct: array<int, true>, total_refs: int, size: int}> */
+        $prop_stats = [];
+
+        foreach ($this->substrate->node_classes as $node_id => $cls) {
+            if ($cls !== $dominant_class) {
+                continue;
+            }
+            foreach ($this->substrate->children[$node_id] ?? [] as $child) {
+                if (($link_names[$child] ?? '') !== 'object_properties') {
+                    continue;
+                }
+                // child = ObjectPropertiesContext
+                foreach ($this->substrate->children[$child] ?? [] as $prop_child) {
+                    $prop_name = $link_names[$prop_child] ?? null;
+                    if ($prop_name === null) {
+                        continue;
+                    }
+                    if (!isset($prop_stats[$prop_name])) {
+                        $prop_stats[$prop_name] = [
+                            'distinct' => [],
+                            'total_refs' => 0,
+                            'size' => 0,
+                        ];
+                    }
+                    $prop_stats[$prop_name]['distinct'][$prop_child] = true;
+                    $prop_stats[$prop_name]['total_refs']++;
+                    // Use retained if available, else shallow
+                    if ($use_retained) {
+                        $prop_stats[$prop_name]['size']
+                            += $this->substrate->subtree_sizes[$prop_child] ?? 0;
+                    } else {
+                        $prop_stats[$prop_name]['size']
+                            += $this->substrate->node_sizes[$prop_child] ?? 0;
+                    }
+                }
+                break;
+            }
+        }
+
+        // Also count non-tree refs for scaling classification
+        // (check all_children for non-tree property edges)
+        // Not needed for graph — tree edges are sufficient for
+        // distinct_targets counting.
+
+        $results = [];
+        foreach ($prop_stats as $prop_name => $stat) {
+            $distinct = count($stat['distinct']);
+            $total_refs = $stat['total_refs'];
+
+            if ($distinct === 1) {
+                $scaling = 'SHARED';
+            } elseif ($distinct >= $total_refs * 0.9) {
+                $scaling = 'PER-INSTANCE';
+            } else {
+                $scaling = 'PARTIALLY SHARED';
+            }
+
+            // Get a sample child_id for shared reason classification
+            $sample_id = array_key_first($stat['distinct']) ?? 0;
+
+            $results[] = [
+                'property' => $prop_name,
+                'distinct_targets' => $distinct,
+                'total_refs' => $total_refs,
+                'size' => $stat['size'],
+                'scaling' => $scaling,
+                'sample_child_id' => $sample_id,
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * SQL-based analysis (Phase 2 fallback).
+     * @return list<array<string, mixed>>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, InvalidOperand
+     */
+    private function analyzeWithSql(string $dominant_class): array
+    {
+        $rows = $this->db->query("
+            SELECT
+                e_prop.link_name,
+                count(*) as total_refs,
+                count(DISTINCT e_prop.child_node_id) as distinct_targets,
+                min(e_prop.child_node_id) as sample_child_id,
+                sum(CASE WHEN e_prop.is_tree = 1
+                    THEN COALESCE(cnl_val.size, 0) ELSE 0
+                END) as tree_size
+            FROM context_node_locations cnl_obj
+            JOIN context_edges e_to_props
+                ON e_to_props.parent_node_id = cnl_obj.node_id
+                AND e_to_props.link_name = 'object_properties'
+                AND e_to_props.run_id = {$this->run_id}
+            JOIN context_edges e_prop
+                ON e_prop.parent_node_id = e_to_props.child_node_id
+                AND e_prop.run_id = {$this->run_id}
+            LEFT JOIN context_node_locations cnl_val
+                ON cnl_val.node_id = e_prop.child_node_id
+                AND cnl_val.run_id = {$this->run_id}
+            WHERE cnl_obj.class_name = "
+            . $this->db->quote($dominant_class) . "
+                AND cnl_obj.run_id = {$this->run_id}
+            GROUP BY e_prop.link_name
+            ORDER BY tree_size DESC
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        $results = [];
+        foreach ($rows as $row) {
+            $distinct = (int)$row['distinct_targets'];
+            $total_refs = (int)$row['total_refs'];
+
+            if ($distinct === 1) {
+                $scaling = 'SHARED';
+            } elseif ($distinct >= $total_refs * 0.9) {
+                $scaling = 'PER-INSTANCE';
+            } else {
+                $scaling = 'PARTIALLY SHARED';
+            }
+
+            $results[] = [
+                'property' => $row['link_name'],
+                'distinct_targets' => $distinct,
+                'total_refs' => $total_refs,
+                'size' => (int)$row['tree_size'],
+                'scaling' => $scaling,
+                'sample_child_id' => (int)$row['sample_child_id'],
+            ];
+        }
+        return $results;
+    }
+
+    /**
+     * Load link_name for each child_node_id (tree edges).
+     * @return array<int, string>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadLinkNames(): array
+    {
+        $rows = $this->db->query(
+            "SELECT child_node_id, link_name FROM context_edges"
+            . " WHERE is_tree = 1 AND run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        $map = [];
+        foreach ($rows as $r) {
+            $map[(int)$r[0]] = (string)$r[1];
+        }
+        unset($rows);
+        return $map;
+    }
+
+    /**
      * Classify sharing reason for each shared property.
      * @param list<array<string, mixed>> $shared
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
@@ -288,7 +365,6 @@ final class PropertyScalingPass implements PassInterface
         }
         $placeholders = implode(',', $child_ids);
 
-        // Get node type and location_type for shared targets
         $info = [];
         $rows = $this->db->query(
             "SELECT cn.node_id, cn.type, cnl.location_type"

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -71,6 +71,7 @@ final class PropertyScalingPass implements PassInterface
                 e_prop.child_node_id,
                 count(*) as total_refs,
                 count(DISTINCT e_prop.child_node_id) as distinct_targets,
+                min(e_prop.child_node_id) as sample_child_id,
                 sum(CASE WHEN e_prop.is_tree = 1
                     THEN COALESCE(cnl_val.size, 0) ELSE 0
                 END) as tree_size
@@ -167,15 +168,20 @@ final class PropertyScalingPass implements PassInterface
                     'scaling' => $scaling,
                 ];
             } else {
+                $sample_id = (int)($row['sample_child_id'] ?? 0);
                 $shared[] = [
                     'property' => $prop_name,
                     'distinct_targets' => $distinct,
                     'total_refs' => $total_refs,
                     'size' => $size,
                     'scaling' => $scaling,
+                    'sample_child_id' => $sample_id,
                 ];
             }
         }
+
+        // Classify sharing reason for shared properties
+        $this->classifySharedReasons($shared);
 
         $short = $dominant_class;
         $size_label = $use_retained ? 'retained' : 'shallow';
@@ -210,10 +216,14 @@ final class PropertyScalingPass implements PassInterface
         }
         if ($shared !== []) {
             $shared_names = array_map(
-                fn($s) => $short . '::$' . $s['property'],
+                function ($s) use ($short): string {
+                    $reason = $s['share_reason'] ?? '';
+                    $suffix = $reason !== '' ? " ({$reason})" : '';
+                    return $short . '::$' . $s['property'] . $suffix;
+                },
                 array_slice($shared, 0, 10)
             );
-            $lines[] = 'SHARED (constant cost): '
+            $lines[] = 'SHARED: '
                 . implode(', ', $shared_names);
         }
 
@@ -248,7 +258,7 @@ final class PropertyScalingPass implements PassInterface
                     'size_mode' => $size_label,
                 ],
                 hypothesis: 'Per-instance properties scale linearly;'
-                    . ' shared properties use CoW.'
+                    . ' shared properties have constant cost.'
                     . "\n" . implode("\n", $lines),
                 next_checks: [
                     'Per-instance props with small values'
@@ -259,5 +269,66 @@ final class PropertyScalingPass implements PassInterface
                 impact_bytes: $per_instance_total,
             ),
         ];
+    }
+
+    /**
+     * Classify sharing reason for each shared property.
+     * @param list<array<string, mixed>> $shared
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     */
+    private function classifySharedReasons(array &$shared): void
+    {
+        if ($shared === []) {
+            return;
+        }
+
+        $child_ids = [];
+        foreach ($shared as $s) {
+            $child_ids[] = (int)$s['sample_child_id'];
+        }
+        $placeholders = implode(',', $child_ids);
+
+        // Get node type and location_type for shared targets
+        $info = [];
+        $rows = $this->db->query(
+            "SELECT cn.node_id, cn.type, cnl.location_type"
+            . " FROM context_nodes cn"
+            . " LEFT JOIN context_node_locations cnl"
+            . " ON cnl.node_id = cn.node_id"
+            . " AND cnl.run_id = cn.run_id"
+            . " WHERE cn.run_id = {$this->run_id}"
+            . " AND cn.node_id IN ({$placeholders})"
+        )->fetchAll(\PDO::FETCH_ASSOC);
+        foreach ($rows as $r) {
+            $info[(int)$r['node_id']] = [
+                'type' => (string)($r['type'] ?? ''),
+                'loc_type' => (string)($r['location_type'] ?? ''),
+            ];
+        }
+
+        foreach ($shared as &$s) {
+            $cid = (int)$s['sample_child_id'];
+            $node_info = $info[$cid] ?? null;
+
+            if ($node_info === null) {
+                $s['share_reason'] = 'shared';
+                continue;
+            }
+
+            $type = $node_info['type'];
+            $loc = $node_info['loc_type'];
+
+            if ($type === 'PhpReferenceContext') {
+                $s['share_reason'] = 'PHP reference';
+            } elseif (str_contains($loc, 'Object')) {
+                $s['share_reason'] = 'same instance';
+            } elseif (str_contains($loc, 'Array')) {
+                $s['share_reason'] = 'array, CoW';
+            } elseif (str_contains($loc, 'String')) {
+                $s['share_reason'] = 'interned string';
+            } else {
+                $s['share_reason'] = 'shared';
+            }
+        }
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -81,7 +81,7 @@ final class StructuralDedupPass implements PassInterface
         usort($dedup_candidates, fn($a, $b) => $b['total_size'] <=> $a['total_size']);
 
         foreach (array_slice($dedup_candidates, 0, 10) as $g) {
-            $short = preg_replace('/^.*\\\\/', '', $g['class']) ?? $g['class'];
+            $short = $g['class'];
             $is_empty = $g['props'] === '';
             $waste = ($g['count'] - 1) * $g['size'];
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -16,13 +16,21 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 
 final class TopArraysPass implements PassInterface
 {
+    /** @var array<int, array{0: int, 1: string}>|null */
+    private ?array $parentMapCache = null;
+    /** @var array<int, string>|null */
+    private ?array $nodeTypeCache = null;
+
     public function __construct(
         private \PDO $db,
         private int $run_id,
+        private ?GraphSubstrate $substrate = null,
     ) {
     }
 
@@ -76,7 +84,10 @@ final class TopArraysPass implements PassInterface
             }
 
             $elements = (int)($row['element_count'] ?? 0);
-            $path = $this->buildOwnerPath($row, $labeler);
+            $node_id = (int)$row['node_id'];
+            $path = $this->substrate !== null
+                ? $this->buildFullPath($node_id, $labeler)
+                : $this->buildOwnerPath($row, $labeler);
 
             $findings[] = new Finding(
                 kind: 'large_array',
@@ -114,6 +125,64 @@ final class TopArraysPass implements PassInterface
     }
 
     /**
+     * Walk from node to root via tree parent edges.
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function buildFullPath(int $node_id, NodeLabeler $labeler): string
+    {
+        assert($this->substrate !== null);
+
+        if ($this->parentMapCache === null) {
+            $this->parentMapCache = [];
+            $rows = $this->db->query(
+                "SELECT child_node_id, parent_node_id, link_name"
+                . " FROM context_edges WHERE is_tree = 1"
+                . " AND run_id = {$this->run_id}"
+            )->fetchAll(\PDO::FETCH_NUM);
+            foreach ($rows as $r) {
+                $this->parentMapCache[(int)$r[0]] = [(int)($r[1] ?? -1), (string)$r[2]];
+            }
+            unset($rows);
+
+            $this->nodeTypeCache = [];
+            $rows = $this->db->query(
+                "SELECT node_id, type FROM context_nodes"
+                . " WHERE run_id = {$this->run_id}"
+            )->fetchAll(\PDO::FETCH_NUM);
+            foreach ($rows as $r) {
+                $this->nodeTypeCache[(int)$r[0]] = (string)$r[1];
+            }
+            unset($rows);
+        }
+
+        $parts = [];
+        $types = [];
+        $cur = $node_id;
+        for ($i = 0; $i < 20; $i++) {
+            if (!isset($this->parentMapCache[$cur])) {
+                break;
+            }
+            [$parent, $link] = $this->parentMapCache[$cur];
+            $resolved = $labeler->resolvePathLabel($link, $cur);
+            array_unshift($parts, $resolved);
+            array_unshift($types, $this->nodeTypeCache[$cur] ?? '');
+            $cur = $parent;
+        }
+
+        return PathFormatter::toPhpSyntax($parts, $types);
+    }
+
+    private const STRUCTURAL_LINKS = [
+        'object_properties',
+        'array_elements',
+        'local_variables',
+        'symbol_table',
+        'dynamic_properties',
+        'value',
+        'call_frames',
+    ];
+
+    /**
      * @param array<string, mixed> $row
      * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
      */
@@ -121,15 +190,15 @@ final class TopArraysPass implements PassInterface
         array $row,
         NodeLabeler $labeler,
     ): string {
-        $parts = [];
+        $raw_parts = [];
 
         if (($row['link3'] ?? null) !== null) {
-            $parts[] = (string)$row['link3'];
+            $raw_parts[] = (string)$row['link3'];
         }
 
         if (($row['link2'] ?? null) !== null) {
             $parent2_id = (int)($row['parent2_id'] ?? 0);
-            $parts[] = $labeler->resolvePathLabel(
+            $raw_parts[] = $labeler->resolvePathLabel(
                 (string)$row['link2'],
                 $parent2_id
             );
@@ -139,13 +208,19 @@ final class TopArraysPass implements PassInterface
         if ($parent_class) {
             $short = preg_replace('/^.*\\\\/', '', $parent_class)
                 ?? $parent_class;
-            $parts[] = $short;
+            $raw_parts[] = $short;
         }
 
         if (($row['link1'] ?? null) !== null) {
-            $parts[] = (string)$row['link1'];
+            $raw_parts[] = (string)$row['link1'];
         }
 
-        return implode(' -> ', $parts);
+        // Filter structural intermediaries and join with ->
+        $filtered = array_values(array_filter(
+            $raw_parts,
+            fn(string $p) => !in_array($p, self::STRUCTURAL_LINKS, true)
+        ));
+
+        return implode('->', $filtered);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 
 final class TopArraysPass implements PassInterface
 {
@@ -27,32 +28,46 @@ final class TopArraysPass implements PassInterface
 
     /**
      * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
-     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand
+     * @psalm-suppress InvalidOperand, PossiblyInvalidArgument, InvalidArgument
      */
     #[\Override]
     public function analyze(): array
     {
+        // 3-hop ancestor: gp_link -> parent_link -> owner -> array
         $rows = $this->db->query("
             SELECT
                 va.node_id,
                 va.total_size,
                 va.element_count,
-                e_parent.link_name as parent_link,
-                cnl_parent.class_name as parent_class,
-                e_grandparent.link_name as grandparent_link
+                e1.link_name as link1,
+                e1.parent_node_id as parent1_id,
+                cnl_p1.class_name as parent1_class,
+                e2.link_name as link2,
+                e2.parent_node_id as parent2_id,
+                e3.link_name as link3
             FROM v_arrays va
-            LEFT JOIN context_edges e_parent ON e_parent.child_node_id = va.node_id
-                AND e_parent.is_tree = 1 AND e_parent.run_id = {$this->run_id}
-            LEFT JOIN context_node_locations cnl_parent ON cnl_parent.node_id = e_parent.parent_node_id
-                AND cnl_parent.run_id = {$this->run_id}
-            LEFT JOIN context_edges e_grandparent ON e_grandparent.child_node_id = e_parent.parent_node_id
-                AND e_grandparent.is_tree = 1 AND e_grandparent.run_id = {$this->run_id}
+            LEFT JOIN context_edges e1
+                ON e1.child_node_id = va.node_id
+                AND e1.is_tree = 1
+                AND e1.run_id = {$this->run_id}
+            LEFT JOIN context_node_locations cnl_p1
+                ON cnl_p1.node_id = e1.parent_node_id
+                AND cnl_p1.run_id = {$this->run_id}
+            LEFT JOIN context_edges e2
+                ON e2.child_node_id = e1.parent_node_id
+                AND e2.is_tree = 1
+                AND e2.run_id = {$this->run_id}
+            LEFT JOIN context_edges e3
+                ON e3.child_node_id = e2.parent_node_id
+                AND e3.is_tree = 1
+                AND e3.run_id = {$this->run_id}
             WHERE va.run_id = {$this->run_id}
             ORDER BY va.total_size DESC
             LIMIT 10
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
+        $labeler = new NodeLabeler($this->db, $this->run_id);
         $findings = [];
         foreach ($rows as $row) {
             $total = (int)$row['total_size'];
@@ -61,22 +76,19 @@ final class TopArraysPass implements PassInterface
             }
 
             $elements = (int)($row['element_count'] ?? 0);
-            $path_parts = array_filter([
-                $row['parent_class'] ? preg_replace('/^.*\\\\/', '', $row['parent_class']) : null,
-                $row['grandparent_link'],
-                $row['parent_link'],
-            ]);
-            $path = $path_parts ? implode(' -> ', $path_parts) : '(root)';
+            $path = $this->buildOwnerPath($row, $labeler);
 
             $findings[] = new Finding(
                 kind: 'large_array',
-                severity: $total > 1024 * 1024 ? FindingSeverity::Medium : FindingSeverity::Low,
+                severity: $total > 1024 * 1024
+                    ? FindingSeverity::Medium
+                    : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
                     '%.2f MB array, %s elements — %s',
                     $total / 1024 / 1024,
                     number_format($elements),
-                    $path,
+                    $path ?: '(root)',
                 ),
                 facts: [
                     'node_id' => (int)$row['node_id'],
@@ -84,17 +96,56 @@ final class TopArraysPass implements PassInterface
                     'element_count' => $elements,
                     'owner_path' => $path,
                 ],
-                hypothesis: 'Large array allocation; may be a cache, buffer, or accumulator',
+                hypothesis: 'Large array allocation;'
+                    . ' may be a cache, buffer, or accumulator',
                 next_checks: [
                     'Check if array size is bounded',
                     'Consider SplFixedArray for known-size collections',
                 ],
                 impact_bytes: $total,
                 evidence_node_ids: [(int)$row['node_id']],
-                replay_query: "SELECT * FROM v_arrays WHERE run_id = {$this->run_id} ORDER BY total_size DESC LIMIT 10",
+                replay_query: "SELECT * FROM v_arrays"
+                    . " WHERE run_id = {$this->run_id}"
+                    . " ORDER BY total_size DESC LIMIT 10",
             );
         }
 
         return $findings;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
+     */
+    private function buildOwnerPath(
+        array $row,
+        NodeLabeler $labeler,
+    ): string {
+        $parts = [];
+
+        if (($row['link3'] ?? null) !== null) {
+            $parts[] = (string)$row['link3'];
+        }
+
+        if (($row['link2'] ?? null) !== null) {
+            $parent2_id = (int)($row['parent2_id'] ?? 0);
+            $parts[] = $labeler->resolvePathLabel(
+                (string)$row['link2'],
+                $parent2_id
+            );
+        }
+
+        $parent_class = $row['parent1_class'] ?? null;
+        if ($parent_class) {
+            $short = preg_replace('/^.*\\\\/', '', $parent_class)
+                ?? $parent_class;
+            $parts[] = $short;
+        }
+
+        if (($row['link1'] ?? null) !== null) {
+            $parts[] = (string)$row['link1'];
+        }
+
+        return implode(' -> ', $parts);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -184,7 +184,8 @@ final class TopArraysPass implements PassInterface
 
     /**
      * @param array<string, mixed> $row
-     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
+     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison
+     * @psalm-suppress InvalidArgument, MixedArgumentTypeCoercion
      */
     private function buildOwnerPath(
         array $row,
@@ -206,9 +207,7 @@ final class TopArraysPass implements PassInterface
 
         $parent_class = $row['parent1_class'] ?? null;
         if ($parent_class) {
-            $short = preg_replace('/^.*\\\\/', '', $parent_class)
-                ?? $parent_class;
-            $raw_parts[] = $short;
+            $raw_parts[] = $parent_class;
         }
 
         if (($row['link1'] ?? null) !== null) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -76,34 +76,70 @@ final class TopArraysPass implements PassInterface
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
         $labeler = new NodeLabeler($this->db, $this->run_id);
-        $findings = [];
+        $use_retained = $this->substrate !== null
+            && $this->substrate->subtree_sizes !== [];
+
+        // If substrate available, sort by retained size instead
+        $entries = [];
         foreach ($rows as $row) {
-            $total = (int)$row['total_size'];
-            if ($total < 10240) {
+            $table_size = (int)$row['total_size'];
+            $node_id = (int)$row['node_id'];
+            $retained = $use_retained
+                ? ($this->substrate->subtree_sizes[$node_id] ?? $table_size)
+                : $table_size;
+            $entries[] = [
+                'row' => $row,
+                'table_size' => $table_size,
+                'retained' => $retained,
+                'node_id' => $node_id,
+            ];
+        }
+        usort($entries, fn($a, $b) => $b['retained'] <=> $a['retained']);
+
+        $findings = [];
+        foreach (array_slice($entries, 0, 10) as $entry) {
+            $row = $entry['row'];
+            $table_size = $entry['table_size'];
+            $retained = $entry['retained'];
+            $node_id = $entry['node_id'];
+
+            if ($retained < 10240 && $table_size < 10240) {
                 continue;
             }
 
             $elements = (int)($row['element_count'] ?? 0);
-            $node_id = (int)$row['node_id'];
             $path = $this->substrate !== null
                 ? $this->buildFullPath($node_id, $labeler)
                 : $this->buildOwnerPath($row, $labeler);
 
+            if ($use_retained && $retained > $table_size) {
+                $summary = sprintf(
+                    '%.2f MB retained (table: %.2f KB), %s elements — %s',
+                    $retained / 1024 / 1024,
+                    $table_size / 1024,
+                    number_format($elements),
+                    $path ?: '(root)',
+                );
+            } else {
+                $summary = sprintf(
+                    '%.2f MB array, %s elements — %s',
+                    $table_size / 1024 / 1024,
+                    number_format($elements),
+                    $path ?: '(root)',
+                );
+            }
+
             $findings[] = new Finding(
                 kind: 'large_array',
-                severity: $total > 1024 * 1024
+                severity: $retained > 1024 * 1024
                     ? FindingSeverity::Medium
                     : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
-                summary: sprintf(
-                    '%.2f MB array, %s elements — %s',
-                    $total / 1024 / 1024,
-                    number_format($elements),
-                    $path ?: '(root)',
-                ),
+                summary: $summary,
                 facts: [
-                    'node_id' => (int)$row['node_id'],
-                    'total_size' => $total,
+                    'node_id' => $node_id,
+                    'table_size' => $table_size,
+                    'retained_size' => $retained,
                     'element_count' => $elements,
                     'owner_path' => $path,
                 ],
@@ -113,11 +149,70 @@ final class TopArraysPass implements PassInterface
                     'Check if array size is bounded',
                     'Consider SplFixedArray for known-size collections',
                 ],
-                impact_bytes: $total,
-                evidence_node_ids: [(int)$row['node_id']],
+                impact_bytes: $retained,
+                evidence_node_ids: [$node_id],
                 replay_query: "SELECT * FROM v_arrays"
                     . " WHERE run_id = {$this->run_id}"
                     . " ORDER BY total_size DESC LIMIT 10",
+            );
+        }
+
+        // Sparse array detection: table_size >> element_count
+        // table_size (bytes) = nTableSize * 32 (sizeof Bucket)
+        $sparse_rows = $this->db->query("
+            SELECT
+                va.node_id,
+                va.table_size,
+                va.element_count,
+                va.table_size / 32 as capacity
+            FROM v_arrays va
+            WHERE va.run_id = {$this->run_id}
+                AND va.table_size >= 32768
+                AND va.element_count > 0
+                AND va.element_count * 4 < va.table_size / 32
+            ORDER BY va.table_size DESC
+            LIMIT 5
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        foreach ($sparse_rows as $sr) {
+            $s_node = (int)$sr['node_id'];
+            $s_table = (int)$sr['table_size'];
+            $s_count = (int)$sr['element_count'];
+            $s_capacity = (int)$sr['capacity'];
+            $utilization = $s_capacity > 0
+                ? $s_count / $s_capacity * 100.0
+                : 0;
+            $s_path = $this->substrate !== null
+                ? $this->buildFullPath($s_node, $labeler)
+                : '(use --full-analysis for path)';
+
+            $findings[] = new Finding(
+                kind: 'sparse_array',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    '%.2f KB table, %s/%s slots used (%.1f%%) — %s',
+                    $s_table / 1024,
+                    number_format($s_count),
+                    number_format($s_capacity),
+                    $utilization,
+                    $s_path,
+                ),
+                facts: [
+                    'node_id' => $s_node,
+                    'table_size' => $s_table,
+                    'element_count' => $s_count,
+                    'capacity' => $s_capacity,
+                    'utilization_pct' => round($utilization, 1),
+                ],
+                hypothesis: 'Array with many empty slots — likely after'
+                    . ' mass unset() without reallocation',
+                next_checks: [
+                    'Use array_values() to repack the array',
+                    'Or rebuild with only needed elements',
+                ],
+                impact_bytes: $s_table,
+                evidence_node_ids: [$s_node],
             );
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -180,7 +180,8 @@ final class TopStringsPass implements PassInterface
 
     /**
      * @param array<string, mixed> $row
-     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
+     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison
+     * @psalm-suppress InvalidArgument, MixedArgumentTypeCoercion
      */
     private function buildOwnerPath(
         array $row,
@@ -202,9 +203,7 @@ final class TopStringsPass implements PassInterface
 
         $parent_class = $row['parent1_class'] ?? null;
         if ($parent_class) {
-            $short = preg_replace('/^.*\\\\/', '', $parent_class)
-                ?? $parent_class;
-            $raw_parts[] = $short;
+            $raw_parts[] = $parent_class;
         }
 
         if (($row['link1'] ?? null) !== null) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 
 final class TopStringsPass implements PassInterface
 {
@@ -27,30 +28,47 @@ final class TopStringsPass implements PassInterface
 
     /**
      * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
-     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand
+     * @psalm-suppress InvalidOperand, PossiblyInvalidArgument, InvalidArgument
      */
     #[\Override]
     public function analyze(): array
     {
+        // 3-hop ancestor: grandparent -> parent -> link_name -> string
         $rows = $this->db->query("
             SELECT
                 cnl.node_id,
                 cnl.size,
                 substr(cnl.string_value, 1, 80) as preview,
-                e.link_name as parent_link,
-                cnl_parent.class_name as parent_class
+                e1.link_name as link1,
+                e1.parent_node_id as parent1_id,
+                cnl_p1.class_name as parent1_class,
+                e2.link_name as link2,
+                e2.parent_node_id as parent2_id,
+                e3.link_name as link3
             FROM context_node_locations cnl
-            LEFT JOIN context_edges e ON e.child_node_id = cnl.node_id
-                AND e.is_tree = 1 AND e.run_id = {$this->run_id}
-            LEFT JOIN context_node_locations cnl_parent ON cnl_parent.node_id = e.parent_node_id
-                AND cnl_parent.run_id = {$this->run_id}
+            LEFT JOIN context_edges e1
+                ON e1.child_node_id = cnl.node_id
+                AND e1.is_tree = 1
+                AND e1.run_id = {$this->run_id}
+            LEFT JOIN context_node_locations cnl_p1
+                ON cnl_p1.node_id = e1.parent_node_id
+                AND cnl_p1.run_id = {$this->run_id}
+            LEFT JOIN context_edges e2
+                ON e2.child_node_id = e1.parent_node_id
+                AND e2.is_tree = 1
+                AND e2.run_id = {$this->run_id}
+            LEFT JOIN context_edges e3
+                ON e3.child_node_id = e2.parent_node_id
+                AND e3.is_tree = 1
+                AND e3.run_id = {$this->run_id}
             WHERE cnl.run_id = {$this->run_id}
                 AND cnl.location_type = 'ZendStringMemoryLocation'
             ORDER BY cnl.size DESC
             LIMIT 10
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
+        $labeler = new NodeLabeler($this->db, $this->run_id);
         $findings = [];
         foreach ($rows as $row) {
             $size = (int)$row['size'];
@@ -58,10 +76,7 @@ final class TopStringsPass implements PassInterface
                 continue;
             }
 
-            $parent_class = $row['parent_class']
-                ? preg_replace('/^.*\\\\/', '', $row['parent_class'])
-                : null;
-            $context = implode(' -> ', array_filter([$parent_class, $row['parent_link']]));
+            $path = $this->buildOwnerPath($row, $labeler);
             $preview = $row['preview'] ?? '';
             if (strlen($preview) > 60) {
                 $preview = substr($preview, 0, 57) . '...';
@@ -69,27 +84,67 @@ final class TopStringsPass implements PassInterface
 
             $findings[] = new Finding(
                 kind: 'large_string',
-                severity: $size > 102400 ? FindingSeverity::Medium : FindingSeverity::Low,
+                severity: $size > 102400
+                    ? FindingSeverity::Medium
+                    : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%.2f KB string — %s%s',
+                    '%.2f KB — %s%s',
                     $size / 1024,
-                    $context ? "{$context}: " : '',
+                    $path ? "{$path}: " : '',
                     $preview ?: '(binary)',
                 ),
                 facts: [
                     'node_id' => (int)$row['node_id'],
                     'size' => $size,
-                    'owner' => $context,
+                    'owner_path' => $path,
                     'preview' => $preview,
                 ],
                 impact_bytes: $size,
                 evidence_node_ids: [(int)$row['node_id']],
-                replay_query: "SELECT node_id, size, substr(string_value, 1, 80) FROM context_node_locations"
-                    . " WHERE location_type = 'ZendStringMemoryLocation' ORDER BY size DESC LIMIT 10",
             );
         }
 
         return $findings;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
+     */
+    private function buildOwnerPath(
+        array $row,
+        NodeLabeler $labeler,
+    ): string {
+        $parts = [];
+
+        // 3rd hop (grandparent's parent link)
+        if (($row['link3'] ?? null) !== null) {
+            $parts[] = (string)$row['link3'];
+        }
+
+        // 2nd hop (parent's parent link), resolve frame labels
+        if (($row['link2'] ?? null) !== null) {
+            $parent2_id = (int)($row['parent2_id'] ?? 0);
+            $parts[] = $labeler->resolvePathLabel(
+                (string)$row['link2'],
+                $parent2_id
+            );
+        }
+
+        // 1st hop: prefer class_name, else link_name
+        $parent_class = $row['parent1_class'] ?? null;
+        if ($parent_class) {
+            $short = preg_replace('/^.*\\\\/', '', $parent_class)
+                ?? $parent_class;
+            $parts[] = $short;
+        }
+
+        // Property link
+        if (($row['link1'] ?? null) !== null) {
+            $parts[] = (string)$row['link1'];
+        }
+
+        return implode(' -> ', $parts);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -16,13 +16,21 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 
 final class TopStringsPass implements PassInterface
 {
+    /** @var array<int, array{0: int, 1: string}>|null */
+    private ?array $parentMapCache = null;
+    /** @var array<int, string>|null */
+    private ?array $nodeTypeCache = null;
+
     public function __construct(
         private \PDO $db,
         private int $run_id,
+        private ?GraphSubstrate $substrate = null,
     ) {
     }
 
@@ -76,7 +84,10 @@ final class TopStringsPass implements PassInterface
                 continue;
             }
 
-            $path = $this->buildOwnerPath($row, $labeler);
+            $node_id = (int)$row['node_id'];
+            $path = $this->substrate !== null
+                ? $this->buildFullPath($node_id, $labeler)
+                : $this->buildOwnerPath($row, $labeler);
             $preview = $row['preview'] ?? '';
             if (strlen($preview) > 60) {
                 $preview = substr($preview, 0, 57) . '...';
@@ -109,6 +120,65 @@ final class TopStringsPass implements PassInterface
     }
 
     /**
+     * Walk from node to root via tree parent edges, resolve with NodeLabeler + PathFormatter.
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function buildFullPath(int $node_id, NodeLabeler $labeler): string
+    {
+        assert($this->substrate !== null);
+
+        // Build parent map with link_names (loaded once, cached in substrate wouldn't help here)
+        if ($this->parentMapCache === null) {
+            $this->parentMapCache = [];
+            $rows = $this->db->query(
+                "SELECT child_node_id, parent_node_id, link_name"
+                . " FROM context_edges WHERE is_tree = 1"
+                . " AND run_id = {$this->run_id}"
+            )->fetchAll(\PDO::FETCH_NUM);
+            foreach ($rows as $r) {
+                $this->parentMapCache[(int)$r[0]] = [(int)($r[1] ?? -1), (string)$r[2]];
+            }
+            unset($rows);
+
+            $this->nodeTypeCache = [];
+            $rows = $this->db->query(
+                "SELECT node_id, type FROM context_nodes"
+                . " WHERE run_id = {$this->run_id}"
+            )->fetchAll(\PDO::FETCH_NUM);
+            foreach ($rows as $r) {
+                $this->nodeTypeCache[(int)$r[0]] = (string)$r[1];
+            }
+            unset($rows);
+        }
+
+        $parts = [];
+        $types = [];
+        $cur = $node_id;
+        for ($i = 0; $i < 20; $i++) {
+            if (!isset($this->parentMapCache[$cur])) {
+                break;
+            }
+            [$parent, $link] = $this->parentMapCache[$cur];
+            $resolved = $labeler->resolvePathLabel($link, $cur);
+            array_unshift($parts, $resolved);
+            array_unshift($types, $this->nodeTypeCache[$cur] ?? '');
+            $cur = $parent;
+        }
+
+        return PathFormatter::toPhpSyntax($parts, $types);
+    }
+
+    private const STRUCTURAL_LINKS = [
+        'object_properties',
+        'array_elements',
+        'local_variables',
+        'symbol_table',
+        'dynamic_properties',
+        'value',
+        'call_frames',
+    ];
+
+    /**
      * @param array<string, mixed> $row
      * @psalm-suppress MixedArgument, MixedAssignment, RiskyTruthyFalsyComparison, InvalidArgument
      */
@@ -116,35 +186,37 @@ final class TopStringsPass implements PassInterface
         array $row,
         NodeLabeler $labeler,
     ): string {
-        $parts = [];
+        $raw_parts = [];
 
-        // 3rd hop (grandparent's parent link)
         if (($row['link3'] ?? null) !== null) {
-            $parts[] = (string)$row['link3'];
+            $raw_parts[] = (string)$row['link3'];
         }
 
-        // 2nd hop (parent's parent link), resolve frame labels
         if (($row['link2'] ?? null) !== null) {
             $parent2_id = (int)($row['parent2_id'] ?? 0);
-            $parts[] = $labeler->resolvePathLabel(
+            $raw_parts[] = $labeler->resolvePathLabel(
                 (string)$row['link2'],
                 $parent2_id
             );
         }
 
-        // 1st hop: prefer class_name, else link_name
         $parent_class = $row['parent1_class'] ?? null;
         if ($parent_class) {
             $short = preg_replace('/^.*\\\\/', '', $parent_class)
                 ?? $parent_class;
-            $parts[] = $short;
+            $raw_parts[] = $short;
         }
 
-        // Property link
         if (($row['link1'] ?? null) !== null) {
-            $parts[] = (string)$row['link1'];
+            $raw_parts[] = (string)$row['link1'];
         }
 
-        return implode(' -> ', $parts);
+        // Filter structural intermediaries and join with ->
+        $filtered = array_values(array_filter(
+            $raw_parts,
+            fn(string $p) => !in_array($p, self::STRUCTURAL_LINKS, true)
+        ));
+
+        return implode('->', $filtered);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -15,6 +15,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report;
 
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\PassInterface;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BlameAllocationPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\CallStackPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChokePointPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ClassRankingPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CompanionDetectionPass;
@@ -61,6 +62,7 @@ final class ReportGenerator
 
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
         if ($full_analysis || $node_count < 500000) {
+            $findings = array_merge($findings, $this->runPass(new CallStackPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new DynamicPropertiesPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(
                 new PropertyScalingPass($db, $run_id, $class_objects)

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -61,12 +61,16 @@ final class ReportGenerator
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
 
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
+        $run_phase3 = $full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000);
         if ($full_analysis || $node_count < 500000) {
             $findings = array_merge($findings, $this->runPass(new CallStackPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new DynamicPropertiesPass($db, $run_id)));
-            $findings = array_merge($findings, $this->runPass(
-                new PropertyScalingPass($db, $run_id, $class_objects)
-            ));
+            // PropertyScaling: deferred to Phase 3 if graph available (retained size)
+            if (!$run_phase3) {
+                $findings = array_merge($findings, $this->runPass(
+                    new PropertyScalingPass($db, $run_id, $class_objects)
+                ));
+            }
             $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
@@ -74,11 +78,14 @@ final class ReportGenerator
         }
 
         // Phase 3: Graph-based passes (< 500K edges, or --full-analysis)
-        if ($full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000)) {
+        if ($run_phase3) {
             $substrate = GraphSubstrate::loadFromDb($db, $run_id);
             $meta['scc_count'] = count($substrate->scc_profiles);
 
             $findings = array_merge($findings, $this->runPass(new CycleClusterPass($substrate)));
+            $findings = array_merge($findings, $this->runPass(
+                new PropertyScalingPass($db, $run_id, $class_objects, $substrate)
+            ));
             $findings = array_merge($findings, $this->runPass(new PerPropertyMemoryPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new DrillDownPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new ChokePointPass($substrate, $db, $run_id)));

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -65,14 +65,15 @@ final class ReportGenerator
         if ($full_analysis || $node_count < 500000) {
             $findings = array_merge($findings, $this->runPass(new CallStackPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new DynamicPropertiesPass($db, $run_id)));
-            // PropertyScaling: deferred to Phase 3 if graph available (retained size)
+            // PropertyScaling, TopArrays, TopStrings: deferred to Phase 3
+            // if graph available (full path + retained size)
             if (!$run_phase3) {
                 $findings = array_merge($findings, $this->runPass(
                     new PropertyScalingPass($db, $run_id, $class_objects)
                 ));
+                $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
+                $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
             }
-            $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
-            $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id)));
         }
@@ -87,6 +88,8 @@ final class ReportGenerator
                 new PropertyScalingPass($db, $run_id, $class_objects, $substrate)
             ));
             $findings = array_merge($findings, $this->runPass(new PerPropertyMemoryPass($substrate, $db, $run_id)));
+            $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id, $substrate)));
+            $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new DrillDownPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new ChokePointPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new BlameAllocationPass($substrate, $db, $run_id)));

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -109,27 +109,35 @@ final class ReportGenerator
     private function deduplicateFindings(array $findings): array
     {
         $has_cycles = false;
+        $has_property_scaling = false;
         foreach ($findings as $f) {
             if ($f->kind === 'cycle_cluster' || $f->kind === 'micro_cycle') {
                 $has_cycles = true;
-                break;
+            }
+            if ($f->kind === 'property_scaling') {
+                $has_property_scaling = true;
             }
         }
 
-        // If cycles are present, limit shared_fanin to top 3
-        // (many shared_fanin findings are cycle back-references)
-        if ($has_cycles) {
-            $fanin_count = 0;
-            $findings = array_values(array_filter(
-                $findings,
-                function (Finding $f) use (&$fanin_count): bool {
-                    if ($f->kind === 'shared_fanin') {
-                        return ++$fanin_count <= 3;
-                    }
-                    return true;
-                },
-            ));
-        }
+        $fanin_count = 0;
+        $findings = array_values(array_filter(
+            $findings,
+            function (Finding $f) use (
+                $has_cycles,
+                $has_property_scaling,
+                &$fanin_count,
+            ): bool {
+                // Limit shared_fanin when cycles exist
+                if ($has_cycles && $f->kind === 'shared_fanin') {
+                    return ++$fanin_count <= 3;
+                }
+                // Suppress shared_singleton when PropertyScaling covers it
+                if ($has_property_scaling && $f->kind === 'shared_singleton') {
+                    return false;
+                }
+                return true;
+            },
+        ));
 
         return $findings;
     }

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -51,6 +51,15 @@ final class ReportGenerator
 
         // Phase 1: Summary-based passes (always run)
         $summary = $this->loadSummary($db, $run_id);
+        /** @var array<string, mixed> $flat_summary */
+        $flat_summary = [];
+        /** @psalm-suppress MixedAssignment */
+        foreach ($summary as $entry) {
+            foreach ($entry as $k => $v) {
+                $flat_summary[$k] = $v;
+            }
+        }
+        $heap_usage = (int)($flat_summary['zend_mm_heap_usage'] ?? 0);
         $location_types = $this->loadLocationTypes($db, $run_id);
         $class_objects = $this->loadClassObjects($db, $run_id);
 
@@ -91,7 +100,9 @@ final class ReportGenerator
             $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new DrillDownPass($substrate, $db, $run_id)));
-            $findings = array_merge($findings, $this->runPass(new ChokePointPass($substrate, $db, $run_id)));
+            $findings = array_merge($findings, $this->runPass(
+                new ChokePointPass($substrate, $db, $run_id, $heap_usage)
+            ));
             $findings = array_merge($findings, $this->runPass(new BlameAllocationPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new RetainedSizeConfidencePass($substrate)));
         }

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -24,6 +24,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Pass\DynamicPropertiesPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\NonTreeEdgePass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\OverviewPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\PerPropertyMemoryPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\PropertyScalingPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\RetainedSizeConfidencePass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\StructuralDedupPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\TopArraysPass;
@@ -61,6 +62,9 @@ final class ReportGenerator
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
         if ($full_analysis || $node_count < 500000) {
             $findings = array_merge($findings, $this->runPass(new DynamicPropertiesPass($db, $run_id)));
+            $findings = array_merge($findings, $this->runPass(
+                new PropertyScalingPass($db, $run_id, $class_objects)
+            ));
             $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -234,8 +234,7 @@ final class GraphSubstrate
             arsort($class_counts);
             $signature_parts = [];
             foreach ($class_counts as $cls => $cnt) {
-                $short = preg_replace('/^.*\\\\/', '', $cls);
-                $signature_parts[] = "{$short}:{$cnt}";
+                $signature_parts[] = "{$cls}:{$cnt}";
             }
             $signature = implode(', ', $signature_parts);
 

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+/**
+ * Resolves node IDs to human-readable labels for report output.
+ *
+ * Call frame numbers become "function_name:lineno",
+ * objects become their short class name, etc.
+ */
+final class NodeLabeler
+{
+    /** @var array<int, string> node_id => "function_name:lineno" */
+    private array $frame_labels = [];
+
+    /** @var bool */
+    private bool $loaded = false;
+
+    public function __construct(
+        private \PDO $db,
+        private int $run_id,
+    ) {
+    }
+
+    /**
+     * Resolve a link_name like "1" into "functionName:42" if the
+     * target node is a CallFrameContext with function_name attribute.
+     *
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    public function resolvePathLabel(
+        string $link_name,
+        int $child_node_id,
+    ): string {
+        $this->ensureLoaded();
+
+        if (isset($this->frame_labels[$child_node_id])) {
+            return $this->frame_labels[$child_node_id];
+        }
+
+        return $link_name;
+    }
+
+    /** @psalm-suppress MixedArrayAccess, MixedAssignment, MixedPropertyTypeCoercion */
+    private function ensureLoaded(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+        $this->loaded = true;
+
+        // Load function_name and lineno from CallFrameContext nodes
+        $rows = $this->db->query("
+            SELECT
+                a_fn.node_id,
+                a_fn.value as function_name,
+                a_ln.value as lineno
+            FROM context_node_attributes a_fn
+            LEFT JOIN context_node_attributes a_ln
+                ON a_ln.node_id = a_fn.node_id
+                AND a_ln.run_id = a_fn.run_id
+                AND a_ln.key = 'lineno'
+            WHERE a_fn.run_id = {$this->run_id}
+                AND a_fn.key = 'function_name'
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        foreach ($rows as $row) {
+            $fn = $row['function_name'] ?? '';
+            $ln = $row['lineno'] ?? '';
+            $label = $ln !== '' ? "{$fn}:{$ln}" : $fn;
+            $this->frame_labels[(int)$row['node_id']] = $label;
+        }
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+/**
+ * Converts raw context paths to PHP-style syntax.
+ *
+ * Raw:  call_frames -> <main>:28 -> local_variables -> messages
+ *       -> array_elements -> 0 -> value -> object_properties -> structure -> raw
+ * PHP:  <main>:28::$messages[0]->structure->raw
+ *
+ * Structural intermediaries (call_frames, local_variables, object_properties,
+ * array_elements, value) are collapsed. Variable names get $, array indices get [].
+ */
+final class PathFormatter
+{
+    /** Context types that are structural and should be skipped */
+    private const STRUCTURAL = [
+        'call_frames',
+        'local_variables',
+        'symbol_table',
+        'object_properties',
+        'array_elements',
+        'value',
+        'object_handlers',
+        'dynamic_properties',
+    ];
+
+    /**
+     * Format a raw path (from link_names) into PHP-style syntax.
+     *
+     * @param list<string> $parts resolved link_names (frame names already resolved)
+     * @param list<string> $node_types context_nodes.type for each child node
+     */
+    public static function toPhpSyntax(
+        array $parts,
+        array $node_types = [],
+    ): string {
+        if ($parts === []) {
+            return '(root)';
+        }
+
+        $segments = [];
+        $prev_type = '';
+        $in_variable_table = false;
+        $in_object_props = false;
+        $in_array_elements = false;
+
+        for ($i = 0; $i < count($parts); $i++) {
+            $part = $parts[$i];
+            $type = $node_types[$i] ?? '';
+
+            // Skip structural intermediaries
+            if (in_array($part, self::STRUCTURAL, true)) {
+                if ($part === 'local_variables' || $part === 'symbol_table') {
+                    $in_variable_table = true;
+                } elseif ($part === 'object_properties') {
+                    $in_object_props = true;
+                } elseif ($part === 'array_elements') {
+                    $in_array_elements = true;
+                }
+                $prev_type = $type;
+                continue;
+            }
+
+            // Format based on context
+            if ($in_array_elements && $part !== 'value') {
+                // Array index
+                if ($segments !== []) {
+                    $last = count($segments) - 1;
+                    $segments[$last] .= "[{$part}]";
+                } else {
+                    $segments[] = "[{$part}]";
+                }
+                $in_array_elements = false;
+                $prev_type = $type;
+                continue;
+            }
+
+            if ($in_variable_table) {
+                // Local variable — add $ prefix
+                $segments[] = '$' . $part;
+                $in_variable_table = false;
+            } elseif ($in_object_props) {
+                // Object property — add -> prefix
+                if ($segments !== []) {
+                    $segments[] = '->' . $part;
+                } else {
+                    $segments[] = $part;
+                }
+                $in_object_props = false;
+            } elseif (
+                $type === 'CallFrameContext'
+                || str_contains($part, ':')
+                || $part === '<main>'
+                || str_contains($part, '()')
+            ) {
+                // Call frame — use :: separator for the next segment
+                $segments[] = $part . '::';
+            } elseif (
+                $type === 'ObjectContext'
+                || $prev_type === 'ObjectContext'
+            ) {
+                // Object node — show class name
+                if ($segments !== []) {
+                    $segments[] = '->' . $part;
+                } else {
+                    $segments[] = $part;
+                }
+            } else {
+                $segments[] = $part;
+            }
+
+            $in_array_elements = false;
+            $prev_type = $type;
+        }
+
+        if ($segments === []) {
+            return implode(' -> ', $parts);
+        }
+
+        // Join segments, collapsing :: with the next segment
+        $result = '';
+        foreach ($segments as $seg) {
+            if (str_ends_with($result, '::')) {
+                $result .= $seg;
+            } elseif (
+                str_starts_with($seg, '->')
+                || str_starts_with($seg, '[')
+            ) {
+                $result .= $seg;
+            } elseif ($result !== '') {
+                $result .= '->' . $seg;
+            } else {
+                $result = $seg;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
@@ -180,7 +180,8 @@ class ReportGeneratorTest extends BaseTestCase
 
         $paths = $this->findByKind($result, 'bottleneck_path');
         $this->assertNotEmpty($paths);
-        $this->assertStringContainsString('call_frames', $paths[0]->summary);
+        // Path is PHP-syntax formatted; check for meaningful parts
+        $this->assertStringContainsString('container', $paths[0]->summary);
     }
 
     public function testChokePointDetected(): void


### PR DESCRIPTION
## Summary

Addresses all high-priority improvement requests from real-world testing feedback.

### PropertyScalingPass (new, Phase 2/3)
For the dominant class, classifies each property as PER-INSTANCE / SHARED / PARTIALLY SHARED:
- **Retained size**: uses `subtree_sizes` from GraphSubstrate when available (Phase 3), showing true per-property cost including child allocations. Falls back to shallow size in Phase 2.
- **Scalar filtering**: excludes size=0 PER-INSTANCE properties (bool/int/float/null stored as zval slots, already counted in object shallow size). Shows count separately.

```
[MEDIUM] property_scaling: User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
  PER-INSTANCE (retained, scales with count):
    $attributes: 10,000 copies x 500B = 4,882.81 KB
    $casts: 10,000 copies x 56B = 546.88 KB
  (14 scalar properties per-instance, included in object size)
  SHARED (constant cost): $relations, $fillable, $guarded, ...
```

### CallStackPass (new, Phase 2)
Shows the call stack at snapshot capture time in the Overview section:
```
=== Overview ===
  Heap: 174.73 MB (100.0% analyzed)

  Call Stack at capture:
    #0 sleep()
    #1 <main>:28
```

### PathFormatter (new) + NodeLabeler
Converts raw context paths to PHP syntax:
```
Before: call_frames -> 1 -> local_variables -> messages -> array_elements -> 0 -> value -> object_properties -> structure -> raw
After:  <main>:28::$messages[0]->structure->raw
```

Structural intermediaries (call_frames, local_variables, object_properties, array_elements, value) are collapsed. Applied to bottleneck_path via DrillDownPass. NodeLabeler resolves frame numbers to `function_name:lineno`, used by DrillDown, ChokePoint, TopStrings, TopArrays.

### TopStringsPass / TopArraysPass
Upgraded from 1-hop to 3-hop ancestor paths with NodeLabeler resolution.

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf