### PR TITLE
Improve dedup findings, unify size formatting, and polish report output

### DIFF
--- a/docs/internals/memory-report-architecture.md
+++ b/docs/internals/memory-report-architecture.md
@@ -39,32 +39,43 @@ Implementation: `Finding.php`, `FindingSeverity.php`, `FindingConfidence.php`.
 
 ```
 MemoryReportCommand::execute()
+  ├── --memory-limit → ini_set()
   ├── PDO("sqlite:snapshot.db")
-  └── ReportGenerator::generateFromDb($db, $run_id)
-        ├── loadMeta() → node_count, edge_count
+  └── ReportGenerator::generateFromDb($db, $run_id, $full_analysis)
+        ├── loadMeta() → node_count, edge_count, captured_at
         ├── Phase 1: Summary passes (always)
         │     ├── OverviewPass($summary)
         │     ├── TypeBreakdownPass($location_types)
         │     ├── ClassRankingPass($class_objects)
         │     └── CompanionDetectionPass($class_objects)
-        ├── Phase 2: SQL passes (< 500K nodes)
+        ├── Phase 2: SQL passes (or --no-full-analysis < 500K nodes)
+        │     ├── CallStackPass($db)
         │     ├── DynamicPropertiesPass($db)
-        │     ├── PerPropertyMemoryPass($db)
+        │     └── StructuralDedupPass($db)
+        │     ┌─ (deferred to Phase 3 when substrate available):
+        │     ├── PropertyScalingPass($db, $class_objects)
         │     ├── TopArraysPass($db)
         │     ├── TopStringsPass($db)
-        │     ├── NonTreeEdgePass($db)
-        │     └── StructuralDedupPass($db)
-        ├── Phase 3: Graph passes (< 500K edges)
+        │     └── NonTreeEdgePass($db)
+        ├── Phase 3: Graph passes (or --no-full-analysis < 500K edges)
         │     ├── GraphSubstrate::loadFromDb($db)
         │     │     ├── loadNodeSizes()
-        │     │     ├── loadEdges()
+        │     │     ├── loadEdges() → children, all_children, all_parents
         │     │     ├── computeSubtreeSizes() [post-order DFS]
-        │     │     └── computeScc() [Tarjan's algorithm]
+        │     │     └── computeScc() [Tarjan's, uses all_children]
         │     ├── CycleClusterPass($substrate)
-        │     ├── DrillDownPass($substrate, $db)
-        │     ├── ChokePointPass($substrate, $db)
+        │     ├── PropertyScalingPass($db, $class_objects, $substrate) [retained]
+        │     ├── PerPropertyMemoryPass($substrate, $db) [class-qualified, O(edges)]
+        │     ├── OwnershipPatternPass($substrate, $db) [1:1 ownership]
+        │     ├── TopArraysPass($db, $substrate) [retained + full path]
+        │     ├── TopStringsPass($db, $substrate) [full path]
+        │     ├── NonTreeEdgePass($db, $substrate) [retained dedup]
+        │     ├── DrillDownPass($substrate, $db) [PHP syntax path]
+        │     ├── ChokePointPass($substrate, $db, $heap_usage) [% severity]
         │     ├── BlameAllocationPass($substrate, $db)
         │     └── RetainedSizeConfidencePass($substrate)
+        ├── deduplicateFindings() → suppress redundancies
+        ├── sortFindings() → severity + impact_bytes order
         └── ReportResult($meta, $findings)
               └── TextReportFormatter / JsonReportFormatter
 ```
@@ -92,19 +103,19 @@ graph from SQLite into PHP arrays and computes reusable structures:
 - `$node_sizes[node_id]`: shallow size per node
 - `$node_classes[node_id]`: class name per node
 - `$children[parent_id]`: int-only adjacency list (tree edges)
+- `$all_children[parent_id]`: forward adjacency (all edges, for SCC)
 - `$all_parents[child_id]`: reverse adjacency (all edges)
 - `$roots[]`: nodes with NULL parent
 
 **Post-order DFS**:
 - `$subtree_sizes[node_id]`: tree-based retained size
 
-**Tarjan SCC** (iterative, stack-based):
+**Tarjan SCC** (iterative, stack-based, uses `$all_children`):
 - `$node_to_scc[node_id]`: SCC membership
 - `$scc_profiles[scc_id]`: node count, total size, external in/out edges,
-  class composition signature, single-owner likelihood
+  class composition, single-owner likelihood
 
-All computed once, shared by CycleClusterPass, DrillDownPass,
-ChokePointPass, BlameAllocationPass, RetainedSizeConfidencePass.
+All computed once, shared by all Phase 3 passes.
 
 Measured performance:
 
@@ -114,61 +125,106 @@ Measured performance:
 | 1M | 1s | 0.6s | 0.8s | **2.4s** | ~300 MB |
 | 2.5M | 7s | 1.6s | - | **~10s** | ~1.2 GB |
 
+## Substrate Utilities
+
+### NodeLabeler
+
+Resolves call frame node IDs to `function_name:lineno` labels.
+Used by DrillDownPass, ChokePointPass, TopStringsPass, TopArraysPass.
+
+### PathFormatter
+
+Converts raw context tree paths to PHP syntax:
+```
+call_frames -> 1 -> local_variables -> messages -> array_elements -> 0
+  → <main>:28::$messages[0]->structure->raw
+```
+
+Structural intermediaries collapsed: `call_frames`, `local_variables`,
+`object_properties`, `array_elements`, `value`.
+
+### SizeFormatter
+
+Consistent human-readable byte formatting across all findings:
+```
+< 1 KB  → "999 B"
+< 1 MB  → "15.20 KB"
+< 1 GB  → "153.76 MB"
+>= 1 GB → "1.23 GB"
+```
+
 ## Computation Passes
 
 ### Phase 1: Summary-Based (always run)
 
-These passes use only data from the `summary`, `location_types_summary`,
-and `class_objects_summary` tables. Zero additional memory. Works for
-any target size.
+Uses only `summary`, `location_types_summary`, `class_objects_summary`.
+Zero additional memory.
 
 | Pass | Source | Emits |
 |---|---|---|
-| 1. OverviewPass | summary table | `overview`, `coverage_gap` |
-| 2. TypeBreakdownPass | location_types_summary | `dominant_type` |
-| 3. ClassRankingPass | class_objects_summary | `dominant_class` |
-| 4. CompanionDetectionPass | class_objects_summary | `companion_pair` |
+| OverviewPass | summary table | `overview`, `coverage_gap` |
+| TypeBreakdownPass | location_types_summary | `dominant_type` |
+| ClassRankingPass | class_objects_summary | `dominant_class` |
+| CompanionDetectionPass | class_objects_summary | `companion_cluster` |
 
-### Phase 2: SQL-Based (< 500K nodes)
+### Phase 2: SQL-Based
 
-These passes run SQL queries against the full context tables.
-
-| Pass | Source | Emits |
-|---|---|---|
-| 5. DynamicPropertiesPass | context_edges (link_name = 'dynamic_properties') | `dynamic_properties_overhead` |
-| 6. PerPropertyMemoryPass | context_edges + context_node_locations | `expensive_property` |
-| 7. TopArraysPass | v_arrays + 3-hop ancestor | `large_array` |
-| 8. TopStringsPass | context_node_locations (ZendString) | `large_string` |
-| 9. NonTreeEdgePass | context_edges (is_tree = 0) | `shared_singleton`, `shared_fanin`, `dedup_candidate` |
-| 10. StructuralDedupPass | context_node_locations + context_edges (shape hash) | `structural_duplicate`, `empty_object` |
-
-### Phase 3: Graph-Based (< 500K edges)
-
-These passes use the in-memory GraphSubstrate.
+SQL queries against context tables. Some passes deferred to Phase 3
+when graph substrate is available (for retained sizes and full paths).
 
 | Pass | Source | Emits |
 |---|---|---|
-| 11. CycleClusterPass | SCC profiles | `cycle_cluster`, `micro_cycle` |
-| 12. DrillDownPass | subtree_sizes + children | `bottleneck_path` |
-| 13. ChokePointPass | subtree_sizes + node_sizes | `choke_point` |
-| 14. BlameAllocationPass | node_sizes + tree/all edges | `root_blame` |
-| 15. RetainedSizeConfidencePass | SCC profiles | `retained_exact`, `retained_approximate` |
+| CallStackPass | context_nodes + attributes | `call_stack` |
+| DynamicPropertiesPass | context_edges | `dynamic_properties_overhead` |
+| StructuralDedupPass | context_node_locations + edges | `structural_duplicate`, `empty_object` |
+| PropertyScalingPass* | context_edges + locations | `property_scaling` |
+| TopArraysPass* | v_arrays + ancestors | `large_array`, `sparse_array` |
+| TopStringsPass* | context_node_locations | `large_string` |
+| NonTreeEdgePass* | context_edges (is_tree=0) | `shared_singleton`, `shared_fanin`, `dedup_candidate` |
+
+\* Deferred to Phase 3 when substrate available.
+
+### Phase 3: Graph-Based
+
+In-memory graph traversal using GraphSubstrate.
+
+| Pass | Source | Emits |
+|---|---|---|
+| CycleClusterPass | SCC profiles | `cycle_cluster`, `micro_cycle`, `di_container_cycle` |
+| PropertyScalingPass | substrate + SQL | `property_scaling` (retained) |
+| PerPropertyMemoryPass | substrate + link_names | `expensive_property` (class-qualified) |
+| OwnershipPatternPass | substrate + link_names | `ownership_pattern` |
+| TopArraysPass | v_arrays + substrate | `large_array` (retained), `sparse_array` |
+| TopStringsPass | SQL + substrate | `large_string` (full path) |
+| NonTreeEdgePass | SQL + substrate | `dedup_candidate` (retained + value comparison) |
+| DrillDownPass | subtree_sizes + children | `bottleneck_path` (PHP syntax) |
+| ChokePointPass | subtree_sizes + heap_usage | `choke_point` (%-based severity) |
+| BlameAllocationPass | node_sizes + edges | `root_blame` |
+| RetainedSizeConfidencePass | SCC profiles | `retained_exact`, `retained_approximate` |
+
+## Post-Processing
+
+### deduplicateFindings()
+
+- Limit `shared_fanin` to top 3 when cycles exist
+- Suppress `shared_singleton` when `property_scaling` covers it
+
+### sortFindings()
+
+Sort by severity (HIGH → WARNING → MEDIUM → LOW → INFO), then
+`impact_bytes` descending within same severity.
 
 ## Adaptive Complexity
 
-The `ReportGenerator` checks `node_count` and `edge_count` from the
-database to decide which phases to run:
+Default is full analysis (`--full-analysis` on). Use `--no-full-analysis`
+to limit for very large snapshots:
 
 | Target size | Phases | Strategy |
 |---|---|---|
-| < 500K nodes, < 500K edges | All 15 passes | Full analysis |
-| < 500K nodes, >= 500K edges | Phase 1 + 2 | SQL analysis, no graph |
-| >= 500K nodes | Phase 1 only | Summary + heuristics |
-
-This prevents out-of-memory errors when analyzing very large snapshots.
-
-The `--full-analysis` flag (passed as `$full_analysis = true` to
-`generateFromDb()`) bypasses these limits and forces all phases to run.
+| Default (full) | All phases | Full analysis with retained sizes |
+| --no-full-analysis, < 500K nodes/edges | Phase 1 + 2 + 3 | Same as full |
+| --no-full-analysis, >= 500K edges | Phase 1 + 2 | SQL only, no graph |
+| --no-full-analysis, >= 500K nodes | Phase 1 only | Summary + heuristics |
 
 ## File Layout
 
@@ -177,61 +233,73 @@ src/Inspector/Output/MemoryOutput/Report/
 ├── Finding.php                    # Value object
 ├── FindingSeverity.php            # Enum: high|medium|low|info|warning
 ├── FindingConfidence.php          # Enum: high|medium|low
-├── ReportGenerator.php            # Orchestrator
+├── ReportGenerator.php            # Orchestrator + post-processing
 ├── ReportResult.php               # Meta + findings container
 ├── Formatter/
 │   ├── ReportFormatterInterface.php
 │   ├── TextReportFormatter.php    # Human-readable text
 │   └── JsonReportFormatter.php    # Structured JSON
 ├── Pass/
-│   ├── PassInterface.php          # Common interface
-│   ├── OverviewPass.php           # Pass 1
-│   ├── TypeBreakdownPass.php      # Pass 2
-│   ├── ClassRankingPass.php       # Pass 3
-│   ├── CompanionDetectionPass.php # Pass 4
-│   ├── DynamicPropertiesPass.php  # Pass 5
-│   ├── PerPropertyMemoryPass.php  # Pass 6
-│   ├── TopArraysPass.php         # Pass 7 (renumbered from design)
-│   ├── TopStringsPass.php        # Pass 8
-│   ├── NonTreeEdgePass.php       # Pass 9
-│   ├── StructuralDedupPass.php   # Pass 10
-│   ├── CycleClusterPass.php      # Pass 11
-│   ├── DrillDownPass.php         # Pass 12
-│   ├── ChokePointPass.php        # Pass 13
-│   ├── BlameAllocationPass.php   # Pass 14
-│   └── RetainedSizeConfidencePass.php  # Pass 15
+│   ├── PassInterface.php
+│   ├── OverviewPass.php
+│   ├── TypeBreakdownPass.php
+│   ├── ClassRankingPass.php
+│   ├── CompanionDetectionPass.php
+│   ├── CallStackPass.php
+│   ├── DynamicPropertiesPass.php
+│   ├── PropertyScalingPass.php     # SQL or graph (retained)
+│   ├── PerPropertyMemoryPass.php   # Graph-based, class-qualified
+│   ├── OwnershipPatternPass.php    # 1:1 ownership detection
+│   ├── TopArraysPass.php           # SQL or graph (retained + path)
+│   ├── TopStringsPass.php          # SQL or graph (full path)
+│   ├── NonTreeEdgePass.php         # SQL or graph (retained dedup)
+│   ├── StructuralDedupPass.php
+│   ├── CycleClusterPass.php
+│   ├── DrillDownPass.php           # PHP syntax path
+│   ├── ChokePointPass.php          # %-based severity
+│   ├── BlameAllocationPass.php
+│   └── RetainedSizeConfidencePass.php
 └── Substrate/
-    └── GraphSubstrate.php         # Graph load + DFS + Tarjan SCC
+    ├── GraphSubstrate.php          # Graph load + DFS + Tarjan SCC
+    ├── NodeLabeler.php             # Frame number → function_name:lineno
+    ├── PathFormatter.php           # Raw path → PHP syntax
+    └── SizeFormatter.php           # Consistent byte formatting
 
 src/Inspector/Output/MemoryOutput/
-├── ReportMemoryOutput.php         # MemoryOutputInterface for inline mode
+├── ReportMemoryOutput.php          # MemoryOutputInterface for inline mode
 
 src/Command/Inspector/
-├── MemoryReportCommand.php        # inspector:memory:report command
+├── MemoryReportCommand.php         # inspector:memory:report command
 ```
 
 ## Design Principles
 
-1. **Graph algorithms in PHP, results in DB, queries in SQL.**
-   SCC/DFS/BFS are computed in PHP. Subsequent analysis uses SQL JOINs
-   and aggregations against the existing context tables.
+1. **Graph algorithms in PHP, results shared in-memory.**
+   SCC/DFS/BFS are computed once in PHP via GraphSubstrate.
+   All Phase 3 passes share the same substrate instance.
 
-2. **Computation once, findings many.**
-   Graph load + DFS + SCC happen once via GraphSubstrate. All graph
-   passes share the same substrate instance.
+2. **Retained over shallow.**
+   When graph substrate is available, passes use `subtree_sizes`
+   for retained cost (arrays, properties, dedup candidates).
 
 3. **Findings over numbers.**
    Don't show "top 10 classes." Show "this class is 95% of objects,
    which is abnormal, and here's the likely cause."
 
-4. **Confidence on everything.**
-   Every finding says how sure it is (`confidence`) and why it might
-   be wrong (shared memory fraction for blame, cycle count for
-   retained size).
+4. **PHP syntax for paths.**
+   `<main>:28::$messages[0]->structure->raw` instead of raw
+   context tree paths with structural intermediaries.
 
-5. **Replay everything.**
-   Every finding includes `replay_query` — the SQL to reproduce it
-   directly against the SQLite database.
+5. **FQCN for all class names.**
+   `App\Models\User` instead of `User`. Unambiguous identification.
+
+6. **Consistent formatting.**
+   All sizes via `SizeFormatter::format()`. All findings sorted
+   by severity + impact. No ad-hoc formatting patterns.
+
+7. **Confidence on everything.**
+   Every finding says how sure it is (`confidence`). Dedup candidates
+   report actual value identity percentage for strings.
 
 ## Finding Types Catalog
 
@@ -239,22 +307,27 @@ src/Command/Inspector/
 |---|---|---|---|
 | `overview` | info | OverviewPass | All |
 | `coverage_gap` | warning | OverviewPass | Guzzle (8.6%), Fiber (pre-fix) |
+| `call_stack` | info | CallStackPass | All |
 | `dominant_type` | high/medium | TypeBreakdownPass | smalot (arrays 86%), php-imap (strings 87%) |
-| `dominant_class` | high | ClassRankingPass | PrinsFrank (95.3%), PHPStan (213K) |
-| `companion_pair` | medium | CompanionDetectionPass | PhpSpreadsheet, CommonMark, PhpWord, Forms |
+| `dominant_class` | high | ClassRankingPass | PrinsFrank (95.3%), Eloquent (98.2%) |
+| `companion_cluster` | medium | CompanionDetectionPass | PhpSpreadsheet, CommonMark, Symfony Forms |
+| `property_scaling` | medium | PropertyScalingPass | Eloquent (per-instance vs shared props) |
+| `ownership_pattern` | medium | OwnershipPatternPass | CommonMark (DotAccessData 246K) |
 | `dynamic_properties_overhead` | medium/low | DynamicPropertiesPass | Monolog (93K DateTimeImmutable) |
-| `expensive_property` | medium/low | PerPropertyMemoryPass | Monolog (message 11.5 MB) |
-| `large_array` | medium/low | TopArraysPass | smalot (uchrCache 2.6 MB) |
+| `expensive_property` | medium | PerPropertyMemoryPass | php-imap (Structure::$raw 40 MB) |
+| `large_array` | medium/low | TopArraysPass | smalot (uchrCache 2.6 MB), Eloquent (15 MB retained) |
+| `sparse_array` | medium | TopArraysPass | Arrays after mass unset() |
 | `large_string` | medium/low | TopStringsPass | php-imap (raw 210 KB x 200) |
 | `shared_singleton` | info | NonTreeEdgePass | Symfony Forms (formFactory) |
-| `shared_fanin` | medium | NonTreeEdgePass | php-imap (oMessage) |
+| `shared_fanin` | info | NonTreeEdgePass | php-imap (Attachment::$oMessage) |
 | `dedup_candidate` | low/info | NonTreeEdgePass | Symfony Forms (dispatcher 1,801x) |
 | `structural_duplicate` | medium/low | StructuralDedupPass | CommonMark (246K empty Data) |
 | `empty_object` | medium/low | StructuralDedupPass | CommonMark, Symfony Forms |
-| `cycle_cluster` | medium/low | CycleClusterPass | php-imap (201x), SimplePie (1x2K), Forms (1,802x) |
-| `micro_cycle` | low | CycleClusterPass | Symfony Forms (OptionsResolver <-> Closure) |
-| `bottleneck_path` | high | DrillDownPass | PHP-Parser ($ast 89 MB), CommonMark (71 MB) |
-| `choke_point` | high | ChokePointPass | Eloquent (Collection 72B -> 15 MB) |
+| `cycle_cluster` | medium/low | CycleClusterPass | php-imap (201x), Symfony Forms (1,802x) |
+| `micro_cycle` | low | CycleClusterPass | Symfony Forms (OptionsResolver ↔ Closure) |
+| `di_container_cycle` | info | CycleClusterPass | Laravel (54 classes, 74 KB) |
+| `bottleneck_path` | high | DrillDownPass | PHP-Parser (89 MB), CommonMark (71 MB) |
+| `choke_point` | high/medium/low | ChokePointPass | Eloquent (Collection → 15 MB) |
 | `root_blame` | info | BlameAllocationPass | Eloquent (class_table 48%, call_frames 35%) |
 | `retained_exact` | info | RetainedSizeConfidencePass | Monolog (DAG, no cycles) |
 | `retained_approximate` | info | RetainedSizeConfidencePass | php-imap (201 cycles) |

--- a/docs/memory-report.md
+++ b/docs/memory-report.md
@@ -39,34 +39,47 @@ Example output:
 ======================================================================
 
 === Overview ===
-  Heap: 41.70 MB (99.5% analyzed), VM stack: 0.02 MB, Compiler arena: 0.01 MB
+  Captured: 2026-03-28T17:58:56Z
+  Heap: 153.76 MB (99.5% analyzed), VM stack: 256.00 KB, Compiler arena: 32.00 KB
+
+  Call Stack at capture:
+    #0 sleep()
+    #1 <main>:28
 
 === Findings ===
 
-  [HIGH] dominant_class: CrossReferenceEntryInUseObject: 100,203 instances, 95.3% of object memory (6.88 MB)
+  [HIGH] dominant_class: App\Models\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)
     Unbounded accumulation — likely a loop without limit
-    Next: Check if count scales with input size; Look for owner path to find the accumulating container
+    Next: Check if count scales with input size; Look for owner path
 
-  [HIGH] bottleneck_path: call_frames -> 1 -> local_variables -> $crossReferenceSections (41.50 MB)
+  [HIGH] bottleneck_path: <main>:28::$users->items (153.76 MB)
     Heaviest memory path — the primary chain of memory consumption
-    Next: Examine the leaf of this path for the actual data consuming memory
 
-  [MEDIUM] cycle_cluster: 201 identical cycles: Attachment:3, Message:1 (15 nodes each, 170.89 KB total)
+  [MEDIUM] property_scaling: App\Models\User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
+    PER-INSTANCE (retained, scales with count):
+      App\Models\User::$attributes: 10,000 copies x 599 B = 5.86 MB
+      App\Models\User::$casts: 10,000 copies x 376 B = 3.67 MB
+    (14 scalar properties per-instance, included in object size)
+    SHARED: App\Models\User::$relations (array, CoW), App\Models\User::$fillable (array, CoW)
+
+  [MEDIUM] cycle_cluster: 201 identical cycles (3 classes, 170.31 KB total)
+    Per cycle: 1x Webklex\PHPIMAP\Message + 3x Webklex\PHPIMAP\Attachment + 1x Webklex\PHPIMAP\AttachmentCollection
     Single entry point — breaking the owner reference likely frees this cycle
-    Next: Identify the back-reference causing the cycle; Consider using WeakReference or explicit cleanup
 
-  [LOW] dedup_candidate: dispatcher: 1,801 copies x 88B ALL SAME SIZE = 154.77 KB wasted
-    Multiple copies of same-size objects via shared references; may be shareable
+  [MEDIUM] companion_cluster: FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB
+
+  [LOW] dedup_candidate: Attachment::$part (Part): 600 copies x 312 B = 182.81 KB
+    195/600 copies have identical content (32%). Example: "--boundary_mixed..."
 
 === Root Blame Allocation ===
 
-  Root Branch                Exclusive    Shared     Total   % Heap
+  Root Branch                Exclusive     Shared      Total   % Heap
   ----------------------------------------------------------------------
-  call_frames                  38.50M     1.20M    39.70M    95.2%
-  class_table                   1.80M     0.10M     1.90M     4.6%
+  call_frames                  38.50 MB    1.20 MB   39.70 MB   95.2%
+  class_table                   1.80 MB  100.00 KB    1.90 MB    4.6%
 
 === Additional Info ===
-  [retained_approximate] 201 cycles (3,015 nodes) — retained size is approximate; collapse to DAG for exact
+  [retained_approximate] 201 cycles (3,015 nodes) — retained size is approximate
 
 ======================================================================
 ```
@@ -89,19 +102,20 @@ Each finding includes machine-readable fields:
     "node_count": 137922,
     "edge_count": 200709,
     "php_version": "v84",
-    "heap_memory_analyzed_percentage": 99.52
+    "heap_memory_analyzed_percentage": 99.52,
+    "captured_at": "2026-03-28T17:58:56Z"
   },
   "findings": [
     {
       "kind": "dominant_class",
       "severity": "high",
       "confidence": "high",
-      "summary": "CrossReferenceEntryInUseObject: 100,203 instances, 95.3% of object memory (6.88 MB)",
+      "summary": "App\\Models\\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)",
       "facts": {
-        "class_name": "..\\CrossReferenceEntryInUseObject",
-        "count": 100203,
-        "memory_bytes": 7214612,
-        "percentage_of_object_memory": 95.3,
+        "class_name": "App\\Models\\User",
+        "count": 10000,
+        "memory_bytes": 720000,
+        "percentage_of_object_memory": 98.2,
         "avg_size": 72
       },
       "hypothesis": "Unbounded accumulation — likely a loop without limit",
@@ -109,8 +123,7 @@ Each finding includes machine-readable fields:
         "Check if count scales with input size",
         "Look for owner path to find the accumulating container"
       ],
-      "impact_bytes": 7214612,
-      "replay_query": "SELECT class_name, count, memory_usage FROM class_objects_summary ORDER BY memory_usage DESC LIMIT 1"
+      "impact_bytes": 720000
     }
   ]
 }
@@ -127,14 +140,15 @@ Usage:
   inspector:memory:report [options] <db-file>
 
 Arguments:
-  db-file                     Path to the SQLite database file
+  db-file                                Path to the SQLite database file
 
 Options:
-  -f, --output-format=FORMAT  Output format: report (text) or report-json [default: report]
-  -o, --output=PATH           Output file path (default: stdout)
-      --run-id=ID             Run ID to analyze [default: 1]
-      --pretty-print          Pretty print JSON output (default: on)
-      --full-analysis         Run all passes regardless of snapshot size (may use significant memory)
+  -f, --output-format=FORMAT             Output format: report (text) or report-json [default: report]
+  -o, --output=PATH                      Output file path (default: stdout)
+      --run-id=ID                        Run ID to analyze [default: 1]
+      --pretty-print|--no-pretty-print   Pretty print JSON output (default: on)
+      --full-analysis|--no-full-analysis Run all passes (default: on; --no-full-analysis for large snapshots)
+      --memory-limit=LIMIT               Set PHP memory_limit (e.g. 2G, 512M)
 ```
 
 ### `inspector:memory` with report format
@@ -149,48 +163,56 @@ sudo ./reli inspector:memory -p <pid> -f report -o report.txt  # to file
 
 ## Finding Types
 
-Each finding has a `kind`, `severity` (high/medium/low/info/warning), and `confidence` (high/medium/low).
+Findings are sorted by severity (HIGH first), then by `impact_bytes` descending within the same severity. Each finding has a `kind`, `severity`, `confidence`, and optional `impact_bytes`.
+
+All class names use fully qualified names (FQCN). Paths use PHP syntax: `<main>:28::$messages[0]->structure->raw`.
 
 ### High Severity
 
 | Kind | Description | Example |
 |---|---|---|
-| `dominant_class` | One class > 50% of object memory | "100,203 CrossReferenceEntryInUseObject = 95.3%" |
+| `dominant_class` | One class > 50% of object memory | "App\Models\User: 10,000 x 72 B = 98.2%" |
 | `dominant_type` | One memory type > 80% of heap | "ZendString accounts for 87% of heap" |
-| `bottleneck_path` | Heaviest memory path from root | "call_frames -> $users -> Collection -> items[] (16 MB)" |
-| `choke_point` | Small node retaining large subtree | "MarkdownParser (152B) holds 73 MB via closedBlockParsers" |
+| `bottleneck_path` | Heaviest memory path from root (PHP syntax) | "<main>:28::$users->items (153.76 MB)" |
+| `choke_point` | Small node retaining large subtree (> 30% heap) | "MarkdownParser (152 B) holds 73.00 MB" |
 
 ### Medium Severity
 
 | Kind | Description | Example |
 |---|---|---|
-| `dominant_type` | One memory type > 50% of heap | "ZendObject accounts for 66% of heap" |
-| `companion_pair` | Two classes with matching instance counts | "Cell (200,020) always paired with IgnoredErrors (200,020)" |
-| `companion_cluster` | N classes with matching instance counts | "6 classes with ~1,800 instances each: A, B, C, D, E, F" |
-| `dynamic_properties_overhead` | Classes with dynamic property tables (> 1 MB) | "93,315 DateTimeImmutable with dynamic props = 5.1 MB" |
-| `expensive_property` | Class-qualified property consuming memory (> 100 KB) | "Message::$raw: 200 occurrences x 210KB = 41 MB" |
-| `cycle_cluster` | Group of identical circular reference patterns | "201 identical Message <-> Attachment cycles" |
-| `shared_fanin` | Multiple references to shared objects | "oMessage: 603 refs -> 201 targets (3.0 each)" |
-| `structural_duplicate` | Objects with identical shape (class + size + properties) | "246K Data objects with NO properties = 13.4 MB" |
-| `empty_object` | Objects with no stored properties | "OrderedHashMap: 1,600 x 88B, no properties stored" |
-| `large_array` | Individual large arrays (> 1 MB) | "2.62 MB, 65K elements — Font -> uchrCache" |
-| `large_string` | Individual large strings (> 100 KB) | "210 KB — structure -> raw (email body)" |
+| `dominant_type` | One memory type 50-80% of heap | "ZendObject accounts for 66% of heap" |
+| `companion_cluster` | Classes with matching instance counts | "FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB" |
+| `property_scaling` | Per-instance vs shared property breakdown | "User: 5 per-instance (0.49 KB/instance), 12 shared" |
+| `ownership_pattern` | 1:1 parent-child class ownership | "DotAccessData (246K) owned 1:1 by 12 classes (100%)" |
+| `dynamic_properties_overhead` | Classes with dynamic property tables | "93,315 DateTimeImmutable = 4.98 MB" |
+| `expensive_property` | Class-qualified property > 1 MB | "Message::$raw: 200 x 210.00 KB = 41.02 MB" |
+| `cycle_cluster` | Group of identical circular references | "201 identical cycles (3 classes, 170.31 KB)" |
+| `choke_point` | Subtree 10-30% of heap | "Collection (72 B) holds 15.00 MB" |
+| `structural_duplicate` | Objects with identical shape | "246K Data x 56 B = 13.40 MB" |
+| `empty_object` | Objects with no stored properties | "OrderedHashMap: 1,600 x 88 B" |
+| `large_array` | Large arrays (retained size when available) | "15.30 MB retained (table: 160.00 KB), 10,000 elements" |
+| `large_string` | Large strings with owner path | "205.88 KB — <main>:67::$messages[0]->structure->raw" |
+| `sparse_array` | Arrays with low slot utilization | "256.00 KB table, 5/16,384 slots (0.03%)" |
 
 ### Low Severity
 
 | Kind | Description | Example |
 |---|---|---|
-| `micro_cycle` | Two-node circular references | "1,802 OptionsResolver <-> Closure micro-cycles" |
-| `dedup_candidate` | Same-size objects that may be shareable | "dispatcher: 1,801 copies x 88B = 155 KB wasted" |
+| `micro_cycle` | Two-node circular references | "1,802 micro-cycles: 1x OptionsResolver + 1x Closure" |
+| `choke_point` | Subtree > 1 MB but < 10% of heap | "classMap (1.51 MB)" |
+| `dedup_candidate` | Same-size shared objects with value comparison | "600 copies x 312 B — 32% identical" |
 
 ### Info
 
 | Kind | Description |
 |---|---|
 | `overview` | Heap total/usage, VM stack, compiler arena, analyzed percentage |
+| `call_stack` | Call stack at the time of snapshot capture |
 | `shared_singleton` | Many references to one target (normal singleton pattern) |
-| `root_blame` | Memory attributed to each root branch (call_frames, class_table, etc.) |
-| `retained_exact` | No cycles — retained size computation is exact |
+| `shared_fanin` | Multiple references to shared objects (supplementary) |
+| `di_container_cycle` | Large DI container cycle (structural cost, >15 classes) |
+| `root_blame` | Memory attributed to each root branch |
+| `retained_exact` | No cycles — retained size is exact |
 | `retained_approximate` | Cycles exist — retained size is approximate |
 
 ### Warning
@@ -201,28 +223,32 @@ Each finding has a `kind`, `severity` (high/medium/low/info/warning), and `confi
 
 ## Analysis Phases
 
-The report generator adapts its analysis depth based on snapshot size:
+By default, full analysis runs all phases (`--full-analysis` is on). Use `--no-full-analysis` to limit analysis for very large snapshots.
 
 | Snapshot size | Phases run | Strategy |
 |---|---|---|
-| Any size | Phase 1 (Passes 1-6) | Summary + SQL: overview, types, classes, companions, dynamic properties, per-property |
-| < 500K nodes | Phase 2 (Passes 7-11) | SQL-heavy: cycles (SCC), top arrays/strings, shared refs, structural dedup |
-| < 500K edges | Phase 3 (Passes 12-15) | Full graph: drill-down, choke points, blame allocation, retained size confidence |
+| Any size | Phase 1 | Summary: overview, call stack, types, classes, companions |
+| < 500K nodes | Phase 2 | SQL: dynamic properties, structural dedup |
+| < 500K edges | Phase 3 | Graph: SCC, drill-down, choke points, blame, property scaling, expensive property, ownership, top arrays/strings, non-tree edges, retained size |
 
-For very large snapshots (> 500K nodes), only the lightweight summary-based passes run, avoiding graph loading that would consume too much memory.
+When `--no-full-analysis` is set, Phase 2 skips at >= 500K nodes and Phase 3 skips at >= 500K edges.
 
-To force all passes regardless of snapshot size, use `--full-analysis`:
+Several passes are deferred from Phase 2 to Phase 3 when graph substrate is available, to benefit from retained sizes and full-path resolution:
+- PropertyScalingPass (retained per-property cost)
+- PerPropertyMemoryPass (class-qualified, O(edges) in-memory)
+- TopArraysPass / TopStringsPass (full PHP-syntax paths)
+- NonTreeEdgePass (retained size for dedup candidates)
 
-```bash
-./reli inspector:memory:report snapshot.db --full-analysis
-```
-
-This may use significant memory (e.g. ~300 MB for 1M edges, ~2 GB for 6M edges).
+Memory usage for graph load: ~300 MB for 1M edges, ~2 GB for 6M edges.
 
 ## Tips
 
 - **Start with the SQLite workflow**: Capture once, analyze many times. The `inspector:memory:report` command is fast on an existing database.
+- **Use `--memory-limit=2G`** for large snapshots instead of `php -d memory_limit=2G`.
 - **Use JSON for CI/automation**: The `report-json` format is designed for programmatic consumption — pipe it to `jq`, feed it to an LLM, or integrate into monitoring.
-- **Check `replay_query`**: Many findings include the SQL query that produced them. Run it directly on the SQLite database to explore further.
-- **Look at `impact_bytes`**: Findings are not all equal. Focus on findings with the largest `impact_bytes` for the biggest memory savings.
-- **Companion pairs**: When two classes have nearly identical instance counts, reducing one will likely reduce the other. Find the owner relationship to understand which one drives the allocation.
+- **Findings are sorted**: HIGH severity and largest impact appear first. Focus on the top findings.
+- **Check `impact_bytes`**: Findings are not all equal. Focus on findings with the largest `impact_bytes` for the biggest memory savings.
+- **Class names are FQCN**: All class names use fully qualified names for unambiguous identification.
+- **Paths use PHP syntax**: `<main>:28::$messages[0]->structure->raw` instead of raw context tree paths.
+- **Companion clusters**: When classes have matching counts, reducing one reduces the others. The `ownership_pattern` finding shows the actual parent-child relationship.
+- **Property scaling**: The `property_scaling` finding shows which properties scale with instance count (per-instance) vs which are shared (CoW). Per-instance properties with small values may benefit from lazy initialization.

--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -70,11 +70,23 @@ final class MemoryReportCommand extends Command
             'run all analysis passes (default: on; --no-full-analysis to limit for very large snapshots)',
             true,
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
+
         Log::info('start memory:report command');
 
         $db_file = (string)$input->getArgument('db-file');

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Formatter;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportResult;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TextReportFormatter implements ReportFormatterInterface
 {
@@ -115,11 +116,11 @@ final class TextReportFormatter implements ReportFormatterInterface
                 /** @var float $pct */
                 $pct = $facts['percentage'] ?? 0;
                 $lines[] = sprintf(
-                    '  %-25s %9.2fM %9.2fM %9.2fM %7.1f%%',
+                    '  %-25s %10s %10s %10s %7.1f%%',
                     $root_name,
-                    $exclusive / 1024 / 1024,
-                    $shared / 1024 / 1024,
-                    $total / 1024 / 1024,
+                    SizeFormatter::format($exclusive),
+                    SizeFormatter::format($shared),
+                    SizeFormatter::format($total),
                     $pct,
                 );
             }

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -54,6 +54,11 @@ final class TextReportFormatter implements ReportFormatterInterface
         // Overview section
         if ($overview !== []) {
             $lines[] = '=== Overview ===';
+            /** @var string|null $captured_at */
+            $captured_at = $result->meta['captured_at'] ?? null;
+            if (is_string($captured_at) && $captured_at !== '') {
+                $lines[] = '  Captured: ' . $captured_at;
+            }
             foreach ($overview as $finding) {
                 if ($finding->kind === 'call_stack' && $finding->hypothesis !== '') {
                     $lines[] = '';

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class BlameAllocationPass implements PassInterface
 {
@@ -150,12 +151,12 @@ final class BlameAllocationPass implements PassInterface
                     ? FindingConfidence::Low
                     : FindingConfidence::High,
                 summary: sprintf(
-                    '%s: %.2f MB (%.1f%%) — %.2f MB exclusive, %.2f MB shared',
+                    '%s: %s (%.1f%%) — %s exclusive, %s shared',
                     $b['name'],
-                    $b['total'] / 1024 / 1024,
+                    SizeFormatter::format($b['total']),
                     $pct,
-                    $b['exclusive'] / 1024 / 1024,
-                    $b['shared'] / 1024 / 1024,
+                    SizeFormatter::format($b['exclusive']),
+                    SizeFormatter::format($b['shared']),
                 ),
                 facts: [
                     'root_name' => $b['name'],

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class ChokePointPass implements PassInterface
 {
@@ -174,10 +175,10 @@ final class ChokePointPass implements PassInterface
                 severity: $severity,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%s (%dB shallow) holds %.2f MB via %d children — %s',
+                    '%s (%s shallow) holds %s via %d children — %s',
                     $label,
-                    $shallow,
-                    $subtree / 1024 / 1024,
+                    SizeFormatter::format($shallow),
+                    SizeFormatter::format($subtree),
                     $n_children,
                     $path,
                 ),

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ClassRankingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ClassRankingPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class ClassRankingPass implements PassInterface
 {
@@ -59,12 +60,12 @@ final class ClassRankingPass implements PassInterface
                     severity: FindingSeverity::High,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%s: %s instances x %dB = %.1f%% of object memory (%.2f MB)',
+                        '%s: %s instances x %s = %.1f%% of object memory (%s)',
                         $short,
                         number_format($entry['count']),
-                        $avg_size,
+                        SizeFormatter::format($avg_size),
                         $pct,
-                        $entry['memory_usage'] / 1024 / 1024,
+                        SizeFormatter::format($entry['memory_usage']),
                     ),
                     facts: [
                         'class_name' => $class_name,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -111,65 +111,44 @@ final class CompanionDetectionPass implements PassInterface
                 $group_classes
             );
 
-            if (count($members) === 2) {
-                $findings[] = new Finding(
-                    kind: 'companion_pair',
-                    severity: FindingSeverity::Medium,
-                    confidence: FindingConfidence::Medium,
-                    summary: sprintf(
-                        '%s always paired with %s',
-                        $names[0],
-                        $names[1],
-                    ),
-                    facts: [
-                        'classes' => array_map(
-                            fn($c) => [
-                                'name' => $c['name'],
-                                'count' => $c['count'],
-                            ],
-                            $group_classes
-                        ),
-                        'total_memory' => $total_memory,
-                    ],
-                    hypothesis: 'These classes are likely created together'
-                        . ' — one owns the other',
-                    next_checks: [
-                        'Check if one class references the other',
-                        'Reducing one will likely reduce the other',
-                    ],
-                    impact_bytes: $total_memory,
+            $summary = count($members) === 2
+                ? sprintf(
+                    '%s always paired with %s — %.2f MB',
+                    $names[0],
+                    $names[1],
+                    $total_memory / 1024 / 1024,
+                )
+                : sprintf(
+                    '%d classes x ~%s instances (%.2f MB): %s',
+                    count($members),
+                    number_format($group_classes[0]['count']),
+                    $total_memory / 1024 / 1024,
+                    implode(', ', $names),
                 );
-            } else {
-                $findings[] = new Finding(
-                    kind: 'companion_cluster',
-                    severity: FindingSeverity::Medium,
-                    confidence: FindingConfidence::Medium,
-                    summary: sprintf(
-                        '%d classes x ~%s instances (%.2f MB): %s',
-                        count($members),
-                        number_format($group_classes[0]['count']),
-                        $total_memory / 1024 / 1024,
-                        implode(', ', $names),
+
+            $findings[] = new Finding(
+                kind: 'companion_cluster',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Medium,
+                summary: $summary,
+                facts: [
+                    'classes' => array_map(
+                        fn($c) => [
+                            'name' => $c['name'],
+                            'count' => $c['count'],
+                        ],
+                        $group_classes
                     ),
-                    facts: [
-                        'classes' => array_map(
-                            fn($c) => [
-                                'name' => $c['name'],
-                                'count' => $c['count'],
-                            ],
-                            $group_classes
-                        ),
-                        'total_memory' => $total_memory,
-                    ],
-                    hypothesis: 'These classes are created together'
-                        . ' as a group — likely one per entity',
-                    next_checks: [
-                        'Find the common owner that creates all of them',
-                        'Reducing the owner count reduces all proportionally',
-                    ],
-                    impact_bytes: $total_memory,
-                );
-            }
+                    'total_memory' => $total_memory,
+                ],
+                hypothesis: 'These classes are created together'
+                    . ' — reducing one reduces the others',
+                next_checks: [
+                    'Find the common owner that creates all',
+                    'Reducing the owner count reduces all',
+                ],
+                impact_bytes: $total_memory,
+            );
         }
 
         return $findings;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -103,9 +103,10 @@ final class CompanionDetectionPass implements PassInterface
 
             $names = array_map(
                 fn($c) => sprintf(
-                    '%s (%s)',
+                    '%s (%s, %.2f MB)',
                     $c['name'],
-                    number_format($c['count'])
+                    number_format($c['count']),
+                    $c['memory'] / 1024 / 1024,
                 ),
                 $group_classes
             );
@@ -144,9 +145,10 @@ final class CompanionDetectionPass implements PassInterface
                     severity: FindingSeverity::Medium,
                     confidence: FindingConfidence::Medium,
                     summary: sprintf(
-                        '%d classes with ~%s instances each: %s',
+                        '%d classes x ~%s instances (%.2f MB): %s',
                         count($members),
                         number_format($group_classes[0]['count']),
+                        $total_memory / 1024 / 1024,
                         implode(', ', $names),
                     ),
                     facts: [

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CompanionDetectionPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class CompanionDetectionPass implements PassInterface
 {
@@ -103,26 +104,26 @@ final class CompanionDetectionPass implements PassInterface
 
             $names = array_map(
                 fn($c) => sprintf(
-                    '%s (%s, %.2f MB)',
+                    '%s (%s, %s)',
                     $c['name'],
                     number_format($c['count']),
-                    $c['memory'] / 1024 / 1024,
+                    SizeFormatter::format($c['memory']),
                 ),
                 $group_classes
             );
 
             $summary = count($members) === 2
                 ? sprintf(
-                    '%s always paired with %s — %.2f MB',
+                    '%s always paired with %s — %s',
                     $names[0],
                     $names[1],
-                    $total_memory / 1024 / 1024,
+                    SizeFormatter::format($total_memory),
                 )
                 : sprintf(
-                    '%d classes x ~%s instances (%.2f MB): %s',
+                    '%d classes x ~%s instances (%s): %s',
                     count($members),
                     number_format($group_classes[0]['count']),
-                    $total_memory / 1024 / 1024,
+                    SizeFormatter::format($total_memory),
                     implode(', ', $names),
                 );
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class CycleClusterPass implements PassInterface
 {
@@ -75,11 +76,11 @@ final class CycleClusterPass implements PassInterface
                     severity: FindingSeverity::Low,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%s micro-cycle%s: %s (%.2f KB total)',
+                        '%s micro-cycle%s: %s (%s total)',
                         number_format($count),
                         $count > 1 ? 's' : '',
                         $composition,
-                        $g['total'] / 1024,
+                        SizeFormatter::format($g['total']),
                     ),
                     facts: [
                         'composition' => $composition,
@@ -104,11 +105,11 @@ final class CycleClusterPass implements PassInterface
                     severity: FindingSeverity::Info,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%d classes forming %d cycle%s (%.2f KB)',
+                        '%d classes forming %d cycle%s (%s)',
                         $class_count,
                         $count,
                         $count > 1 ? 's' : '',
-                        $g['total'] / 1024,
+                        SizeFormatter::format($g['total']),
                     ),
                     facts: [
                         'composition' => $composition,
@@ -135,11 +136,11 @@ final class CycleClusterPass implements PassInterface
                     : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%d identical cycle%s (%d classes, %.2f KB total)',
+                    '%d identical cycle%s (%d classes, %s total)',
                     $count,
                     $count > 1 ? 's' : '',
                     $class_count,
-                    $g['total'] / 1024,
+                    SizeFormatter::format($g['total']),
                 ),
                 facts: [
                     'composition' => $composition,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class DrillDownPass implements PassInterface
 {
@@ -100,9 +101,9 @@ final class DrillDownPass implements PassInterface
                 severity: FindingSeverity::High,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%s (%.2f MB)',
+                    '%s (%s)',
                     $path_str,
-                    $total_size / 1024 / 1024,
+                    SizeFormatter::format($total_size),
                 ),
                 facts: [
                     'path' => $path_parts,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class DynamicPropertiesPass implements PassInterface
 {
@@ -72,10 +73,10 @@ final class DynamicPropertiesPass implements PassInterface
                     : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%s %s with dynamic properties = %.2f MB overhead',
+                    '%s %s with dynamic properties = %s overhead',
                     number_format($cnt),
                     $short,
-                    $dp_size / 1024 / 1024,
+                    SizeFormatter::format($dp_size),
                 ),
                 facts: [
                     'class_name' => $row['class_name'],

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -16,12 +16,14 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 
 final class NonTreeEdgePass implements PassInterface
 {
     public function __construct(
         private \PDO $db,
         private int $run_id,
+        private ?GraphSubstrate $substrate = null,
     ) {
     }
 
@@ -220,14 +222,30 @@ final class NonTreeEdgePass implements PassInterface
             LIMIT 10
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
+        $use_retained = $this->substrate !== null
+            && $this->substrate->subtree_sizes !== [];
+
         foreach ($dedup_rows as $row) {
             $cnt = (int)$row['cnt'];
-            $size = (int)$row['size'];
+            $shallow_size = (int)$row['size'];
             $total = (int)$row['total_waste'];
 
             // Skip array headers (always 56B) — "SAME SIZE" is meaningless
             if (($row['location_type'] ?? '') === 'ZendArrayMemoryLocation') {
                 continue;
+            }
+
+            // Use retained size when substrate available
+            $size = $shallow_size;
+            if ($use_retained) {
+                $retained = $this->getRetainedForDedup(
+                    (string)$row['link_name'],
+                    $shallow_size,
+                );
+                if ($retained > $shallow_size) {
+                    $size = $retained;
+                    $total = $cnt * $retained;
+                }
             }
 
             $dedup_src = $row['source_class'] ?? null;
@@ -251,7 +269,7 @@ final class NonTreeEdgePass implements PassInterface
             // Check actual duplication for representative examples
             $examples = $this->getDedupExamples(
                 $row['link_name'],
-                $size,
+                $shallow_size,
             );
 
             $hypothesis = 'Multiple copies of same-size objects'
@@ -296,10 +314,11 @@ final class NonTreeEdgePass implements PassInterface
                     : FindingSeverity::Info,
                 confidence: $confidence,
                 summary: sprintf(
-                    '%s: %s copies x %dB SAME SIZE = %.2f KB',
+                    '%s: %s copies x %dB%s = %.2f KB',
                     $dedup_label,
                     number_format($cnt),
                     $size,
+                    $size > $shallow_size ? ' retained' : '',
                     $total / 1024,
                 ),
                 facts: [
@@ -317,6 +336,47 @@ final class NonTreeEdgePass implements PassInterface
         }
 
         return $findings;
+    }
+
+    /**
+     * Get average retained size for a dedup candidate group.
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function getRetainedForDedup(
+        string $link_name,
+        int $shallow_size,
+    ): int {
+        assert($this->substrate !== null);
+
+        // Sample up to 20 child_node_ids from this group
+        $rows = $this->db->query("
+            SELECT e.child_node_id
+            FROM context_edges e
+            JOIN context_node_locations cnl
+                ON cnl.node_id = e.child_node_id
+                AND cnl.run_id = {$this->run_id}
+                AND cnl.size = {$shallow_size}
+            WHERE e.run_id = {$this->run_id}
+                AND e.is_tree = 0
+                AND e.link_name = " . $this->db->quote($link_name) . "
+            LIMIT 20
+        ")->fetchAll(\PDO::FETCH_COLUMN);
+
+        if ($rows === []) {
+            return $shallow_size;
+        }
+
+        $total = 0;
+        $count = 0;
+        foreach ($rows as $nid) {
+            $retained = $this->substrate->subtree_sizes[(int)$nid] ?? 0;
+            if ($retained > 0) {
+                $total += $retained;
+                $count++;
+            }
+        }
+
+        return $count > 0 ? (int)($total / $count) : $shallow_size;
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -147,18 +147,61 @@ final class NonTreeEdgePass implements PassInterface
                 cnl.class_name as target_class,
                 count(*) as cnt,
                 count(*) * cnl.size as total_waste,
-                (SELECT cnl_src.class_name
-                    FROM context_edges e_pp
-                    JOIN context_node_locations cnl_src
-                        ON cnl_src.node_id = e_pp.parent_node_id
-                        AND cnl_src.run_id = {$this->run_id}
-                        AND cnl_src.location_type
-                            = 'ZendObjectMemoryLocation'
-                    WHERE e_pp.child_node_id = e.parent_node_id
-                        AND e_pp.link_name = 'object_properties'
-                        AND e_pp.run_id = {$this->run_id}
+                COALESCE(
+                    (SELECT cnl_src.class_name
+                        FROM context_edges e_pp
+                        JOIN context_node_locations cnl_src
+                            ON cnl_src.node_id = e_pp.parent_node_id
+                            AND cnl_src.run_id = {$this->run_id}
+                            AND cnl_src.location_type
+                                = 'ZendObjectMemoryLocation'
+                        WHERE e_pp.child_node_id = e.parent_node_id
+                            AND e_pp.link_name = 'object_properties'
+                            AND e_pp.run_id = {$this->run_id}
+                        LIMIT 1
+                    ),
+                    (SELECT cnl_arr.class_name
+                        FROM context_edges e_elem
+                        JOIN context_edges e_elems
+                            ON e_elems.child_node_id
+                                = e_elem.parent_node_id
+                            AND e_elems.link_name = 'array_elements'
+                            AND e_elems.run_id = {$this->run_id}
+                        JOIN context_edges e_prop
+                            ON e_prop.child_node_id
+                                = e_elems.parent_node_id
+                            AND e_prop.run_id = {$this->run_id}
+                        JOIN context_edges e_op
+                            ON e_op.child_node_id
+                                = e_prop.parent_node_id
+                            AND e_op.link_name = 'object_properties'
+                            AND e_op.run_id = {$this->run_id}
+                        JOIN context_node_locations cnl_arr
+                            ON cnl_arr.node_id = e_op.parent_node_id
+                            AND cnl_arr.run_id = {$this->run_id}
+                            AND cnl_arr.location_type
+                                = 'ZendObjectMemoryLocation'
+                        WHERE e_elem.child_node_id
+                            = e.parent_node_id
+                            AND e_elem.run_id = {$this->run_id}
+                        LIMIT 1
+                    )
+                ) as source_class,
+                (SELECT e_prop2.link_name
+                    FROM context_edges e_elem2
+                    JOIN context_edges e_elems2
+                        ON e_elems2.child_node_id
+                            = e_elem2.parent_node_id
+                        AND e_elems2.link_name = 'array_elements'
+                        AND e_elems2.run_id = {$this->run_id}
+                    JOIN context_edges e_prop2
+                        ON e_prop2.child_node_id
+                            = e_elems2.parent_node_id
+                        AND e_prop2.run_id = {$this->run_id}
+                    WHERE e_elem2.child_node_id = e.parent_node_id
+                        AND e_elem2.run_id = {$this->run_id}
                     LIMIT 1
-                ) as source_class
+                ) as owner_prop
             FROM context_edges e
             JOIN context_node_locations cnl
                 ON cnl.node_id = e.child_node_id
@@ -182,9 +225,18 @@ final class NonTreeEdgePass implements PassInterface
             $total = (int)$row['total_waste'];
             $dedup_src = $row['source_class'] ?? null;
             $dedup_tgt = $row['target_class'] ?? null;
-            $dedup_label = $dedup_src
-                ? "{$dedup_src}::\${$row['link_name']}"
-                : $row['link_name'];
+            $owner_prop = $row['owner_prop'] ?? null;
+
+            // Build label: Class::$prop[link] or Class::$prop or link_name
+            if ($dedup_src && $owner_prop) {
+                // Array element path: Class::$prop[link_name]
+                $dedup_label = "{$dedup_src}::\${$owner_prop}"
+                    . "[{$row['link_name']}]";
+            } elseif ($dedup_src) {
+                $dedup_label = "{$dedup_src}::\${$row['link_name']}";
+            } else {
+                $dedup_label = $row['link_name'];
+            }
             if ($dedup_tgt) {
                 $dedup_label .= " ({$dedup_tgt})";
             }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class NonTreeEdgePass implements PassInterface
 {
@@ -314,12 +315,12 @@ final class NonTreeEdgePass implements PassInterface
                     : FindingSeverity::Info,
                 confidence: $confidence,
                 summary: sprintf(
-                    '%s: %s copies x %dB%s = %.2f KB',
+                    '%s: %s copies x %s%s = %s',
                     $dedup_label,
                     number_format($cnt),
-                    $size,
+                    SizeFormatter::format($size),
                     $size > $shallow_size ? ' retained' : '',
-                    $total / 1024,
+                    SizeFormatter::format($total),
                 ),
                 facts: [
                     'link_name' => $row['link_name'],

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -29,6 +29,7 @@ final class NonTreeEdgePass implements PassInterface
      * @return list<Finding>
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
      * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
+     * @psalm-suppress MixedArgumentTypeCoercion
      */
     #[\Override]
     public function analyze(): array
@@ -188,10 +189,53 @@ final class NonTreeEdgePass implements PassInterface
                 $dedup_label .= " ({$dedup_tgt})";
             }
 
+            // Check actual duplication for representative examples
+            $examples = $this->getDedupExamples(
+                $row['link_name'],
+                $size,
+            );
+
+            $hypothesis = 'Multiple copies of same-size objects'
+                . ' via shared references; may be shareable';
+            $confidence = FindingConfidence::Low;
+
+            if ($examples['type'] === 'string') {
+                if ($examples['identical_count'] > 0) {
+                    $pct = $cnt > 0
+                        ? $examples['identical_count'] / $cnt * 100.0
+                        : 0;
+                    $hypothesis = sprintf(
+                        '%d/%d copies have identical content (%.0f%%).'
+                        . ' Example: "%s"',
+                        $examples['identical_count'],
+                        $cnt,
+                        $pct,
+                        $examples['sample_value'],
+                    );
+                    $confidence = $pct > 50.0
+                        ? FindingConfidence::High
+                        : FindingConfidence::Medium;
+                } else {
+                    $hypothesis = sprintf(
+                        'Same size but different content.'
+                        . ' Examples: "%s", "%s"',
+                        $examples['samples'][0] ?? '?',
+                        $examples['samples'][1] ?? '?',
+                    );
+                }
+            } elseif ($examples['type'] === 'object') {
+                $hypothesis .= sprintf(
+                    '. Examples: %s',
+                    implode(', ', array_slice($examples['samples'], 0, 3)),
+                );
+            }
+
             $findings[] = new Finding(
                 kind: 'dedup_candidate',
-                severity: $total > 102400 ? FindingSeverity::Low : FindingSeverity::Info,
-                confidence: FindingConfidence::Low,
+                severity: $total > 102400
+                    ? FindingSeverity::Low
+                    : FindingSeverity::Info,
+                confidence: $confidence,
                 summary: sprintf(
                     '%s: %s copies x %dB SAME SIZE = %.2f KB',
                     $dedup_label,
@@ -206,12 +250,101 @@ final class NonTreeEdgePass implements PassInterface
                     'count' => $cnt,
                     'each_size' => $size,
                     'total_waste' => $total,
+                    'examples' => $examples,
                 ],
-                hypothesis: 'Multiple copies of same-size objects via shared references; may be shareable',
+                hypothesis: $hypothesis,
                 impact_bytes: $total,
             );
         }
 
         return $findings;
+    }
+
+    /**
+     * Get representative examples for a dedup candidate group.
+     * For strings: check if values are actually identical.
+     * For objects: show class + property count.
+     *
+     * @return array<string, mixed>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     */
+    private function getDedupExamples(
+        string $link_name,
+        int $size,
+    ): array {
+        // Check if targets are strings with string_value
+        $str_rows = $this->db->query("
+            SELECT
+                cnl.string_value,
+                count(*) as cnt
+            FROM context_edges e
+            JOIN context_node_locations cnl
+                ON cnl.node_id = e.child_node_id
+                AND cnl.run_id = {$this->run_id}
+            WHERE e.run_id = {$this->run_id}
+                AND e.is_tree = 0
+                AND e.link_name = " . $this->db->quote($link_name) . "
+                AND cnl.size = {$size}
+                AND cnl.string_value IS NOT NULL
+            GROUP BY cnl.string_value
+            ORDER BY count(*) DESC
+            LIMIT 5
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($str_rows !== []) {
+            $top = $str_rows[0];
+            $top_count = (int)$top['cnt'];
+            $top_value = $top['string_value'] ?? '';
+            if (strlen($top_value) > 60) {
+                $top_value = substr($top_value, 0, 57) . '...';
+            }
+            $samples = array_map(
+                function ($r) {
+                    $v = $r['string_value'] ?? '';
+                    return strlen($v) > 40
+                        ? substr($v, 0, 37) . '...'
+                        : $v;
+                },
+                $str_rows
+            );
+            return [
+                'type' => 'string',
+                'identical_count' => $top_count > 1 ? $top_count : 0,
+                'sample_value' => $top_value,
+                'samples' => $samples,
+                'distinct_values' => count($str_rows),
+            ];
+        }
+
+        // For non-string targets, show class/size samples
+        $obj_rows = $this->db->query("
+            SELECT
+                cnl.class_name,
+                cnl.location_type,
+                cnl.size
+            FROM context_edges e
+            JOIN context_node_locations cnl
+                ON cnl.node_id = e.child_node_id
+                AND cnl.run_id = {$this->run_id}
+            WHERE e.run_id = {$this->run_id}
+                AND e.is_tree = 0
+                AND e.link_name = " . $this->db->quote($link_name) . "
+                AND cnl.size = {$size}
+            LIMIT 3
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        $samples = [];
+        foreach ($obj_rows as $r) {
+            $label = $r['class_name']
+                ?? $r['location_type']
+                ?? 'unknown';
+            $samples[] = "{$label} ({$r['size']}B)";
+        }
+
+        return [
+            'type' => 'object',
+            'samples' => $samples,
+            'identical_count' => 0,
+        ];
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -115,7 +115,7 @@ final class NonTreeEdgePass implements PassInterface
             } elseif ($target_count > 1 && $avg_refs > 2.0) {
                 $findings[] = new Finding(
                     kind: 'shared_fanin',
-                    severity: FindingSeverity::Medium,
+                    severity: FindingSeverity::Info,
                     confidence: FindingConfidence::Medium,
                     summary: sprintf(
                         '%s -> %s (%s refs -> %s targets, %.1f each)',
@@ -145,6 +145,7 @@ final class NonTreeEdgePass implements PassInterface
                 e.link_name,
                 cnl.size,
                 cnl.class_name as target_class,
+                cnl.location_type,
                 count(*) as cnt,
                 count(*) * cnl.size as total_waste,
                 COALESCE(
@@ -223,6 +224,12 @@ final class NonTreeEdgePass implements PassInterface
             $cnt = (int)$row['cnt'];
             $size = (int)$row['size'];
             $total = (int)$row['total_waste'];
+
+            // Skip array headers (always 56B) — "SAME SIZE" is meaningless
+            if (($row['location_type'] ?? '') === 'ZendArrayMemoryLocation') {
+                continue;
+            }
+
             $dedup_src = $row['source_class'] ?? null;
             $dedup_tgt = $row['target_class'] ?? null;
             $owner_prop = $row['owner_prop'] ?? null;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class OverviewPass implements PassInterface
 {
@@ -51,11 +52,11 @@ final class OverviewPass implements PassInterface
             severity: FindingSeverity::Info,
             confidence: FindingConfidence::High,
             summary: sprintf(
-                'Heap: %.2f MB (%.1f%% analyzed), VM stack: %.2f MB, Compiler arena: %.2f MB',
-                $heap_usage / 1024 / 1024,
+                'Heap: %s (%.1f%% analyzed), VM stack: %s, Compiler arena: %s',
+                SizeFormatter::format($heap_usage),
                 $analyzed_pct,
-                $vm_stack / 1024 / 1024,
-                $compiler_arena / 1024 / 1024,
+                SizeFormatter::format($vm_stack),
+                SizeFormatter::format($compiler_arena),
             ),
             facts: [
                 'heap_total' => $heap_total,
@@ -77,9 +78,9 @@ final class OverviewPass implements PassInterface
                 severity: FindingSeverity::Warning,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    'Only %.1f%% of heap analyzed — %.2f MB unaccounted',
+                    'Only %.1f%% of heap analyzed — %s unaccounted',
                     $analyzed_pct,
-                    $gap_bytes / 1024 / 1024,
+                    SizeFormatter::format($gap_bytes),
                 ),
                 facts: [
                     'analyzed_percentage' => $analyzed_pct,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 /**
  * Class-qualified per-property memory analysis using GraphSubstrate.
@@ -103,12 +104,12 @@ final class PerPropertyMemoryPass implements PassInterface
                 severity: FindingSeverity::Medium,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    '%s::$%s: %s occurrences x %dB = %.2f MB',
+                    '%s::$%s: %s occurrences x %s = %s',
                     $short,
                     $s['prop'],
                     number_format($s['count']),
-                    $avg,
-                    $s['total'] / 1024 / 1024,
+                    SizeFormatter::format($avg),
+                    SizeFormatter::format($s['total']),
                 ),
                 facts: [
                     'class_name' => $s['class'],

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class PropertyScalingPass implements PassInterface
 {
@@ -108,12 +109,12 @@ final class PropertyScalingPass implements PassInterface
                     ? (int)($p['size'] / $p['distinct_targets'])
                     : 0;
                 $lines[] = sprintf(
-                    '  %s::$%s: %s copies x %dB = %.2f KB',
+                    '  %s::$%s: %s copies x %s = %s',
                     $short,
                     $p['property'],
                     number_format($p['distinct_targets']),
-                    $avg,
-                    $p['size'] / 1024,
+                    SizeFormatter::format($avg),
+                    SizeFormatter::format($p['size']),
                 );
             }
         }
@@ -148,13 +149,15 @@ final class PropertyScalingPass implements PassInterface
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
                     '%s (%s instances): %d per-instance props'
-                    . ' (%.2f KB/instance %s), %d shared',
+                    . ' (%s/instance %s), %d shared',
                     $short,
                     number_format($dominant_count),
                     count($per_instance),
-                    $dominant_count > 0
-                        ? $per_instance_total / $dominant_count / 1024
-                        : 0,
+                    SizeFormatter::format(
+                        $dominant_count > 0
+                            ? (int)($per_instance_total / $dominant_count)
+                            : 0
+                    ),
                     $size_label,
                     count($shared),
                 ),

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class StructuralDedupPass implements PassInterface
 {
@@ -91,11 +92,11 @@ final class StructuralDedupPass implements PassInterface
                     severity: $g['total_size'] > 102400 ? FindingSeverity::Medium : FindingSeverity::Low,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%s: %s instances x %dB, no properties stored (%.2f KB)',
+                        '%s: %s instances x %s, no properties stored (%s)',
                         $short,
                         number_format($g['count']),
-                        $g['size'],
-                        $g['total_size'] / 1024,
+                        SizeFormatter::format($g['size']),
+                        SizeFormatter::format($g['total_size']),
                     ),
                     facts: [
                         'class_name' => $g['class'],
@@ -113,12 +114,12 @@ final class StructuralDedupPass implements PassInterface
                     severity: $waste > 102400 ? FindingSeverity::Medium : FindingSeverity::Low,
                     confidence: FindingConfidence::Medium,
                     summary: sprintf(
-                        '%s: %s identical shapes x %dB = %.2f KB (theoretical saving: %.2f KB)',
+                        '%s: %s identical shapes x %s = %s (theoretical saving: %s)',
                         $short,
                         number_format($g['count']),
-                        $g['size'],
-                        $g['total_size'] / 1024,
-                        $waste / 1024,
+                        SizeFormatter::format($g['size']),
+                        SizeFormatter::format($g['total_size']),
+                        SizeFormatter::format($waste),
                     ),
                     facts: [
                         'class_name' => $g['class'],

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TopArraysPass implements PassInterface
 {
@@ -114,16 +115,16 @@ final class TopArraysPass implements PassInterface
 
             if ($use_retained && $retained > $table_size) {
                 $summary = sprintf(
-                    '%.2f MB retained (table: %.2f KB), %s elements — %s',
-                    $retained / 1024 / 1024,
-                    $table_size / 1024,
+                    '%s retained (table: %s), %s elements — %s',
+                    SizeFormatter::format($retained),
+                    SizeFormatter::format($table_size),
                     number_format($elements),
                     $path ?: '(root)',
                 );
             } else {
                 $summary = sprintf(
-                    '%.2f MB array, %s elements — %s',
-                    $table_size / 1024 / 1024,
+                    '%s array, %s elements — %s',
+                    SizeFormatter::format($table_size),
                     number_format($elements),
                     $path ?: '(root)',
                 );
@@ -191,8 +192,8 @@ final class TopArraysPass implements PassInterface
                 severity: FindingSeverity::Medium,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    '%.2f KB table, %s/%s slots used (%.1f%%) — %s',
-                    $s_table / 1024,
+                    '%s table, %s/%s slots used (%.1f%%) — %s',
+                    SizeFormatter::format($s_table),
                     number_format($s_count),
                     number_format($s_capacity),
                     $utilization,

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TopStringsPass implements PassInterface
 {
@@ -100,8 +101,8 @@ final class TopStringsPass implements PassInterface
                     : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
                 summary: sprintf(
-                    '%.2f KB — %s%s',
-                    $size / 1024,
+                    '%s — %s%s',
+                    SizeFormatter::format($size),
                     $path ? "{$path}: " : '',
                     $preview ?: '(binary)',
                 ),

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TypeBreakdownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TypeBreakdownPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TypeBreakdownPass implements PassInterface
 {
@@ -57,11 +58,11 @@ final class TypeBreakdownPass implements PassInterface
                     severity: $pct > 80.0 ? FindingSeverity::High : FindingSeverity::Medium,
                     confidence: FindingConfidence::High,
                     summary: sprintf(
-                        '%s accounts for %.1f%% of heap (%s, %.2f MB)',
+                        '%s accounts for %.1f%% of heap (%s, %s)',
                         $short_type,
                         $pct,
                         number_format($entry['count']),
-                        $entry['memory_usage'] / 1024 / 1024,
+                        SizeFormatter::format($entry['memory_usage']),
                     ),
                     facts: [
                         'type' => $type,

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -83,8 +83,8 @@ final class ReportGenerator
                 ));
                 $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
                 $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
+                $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
             }
-            $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id)));
         }
 
@@ -101,6 +101,7 @@ final class ReportGenerator
             $findings = array_merge($findings, $this->runPass(new OwnershipPatternPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id, $substrate)));
+            $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new DrillDownPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(
                 new ChokePointPass($substrate, $db, $run_id, $heap_usage)

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -225,6 +225,12 @@ final class ReportGenerator
         );
         $meta['edge_count'] = (int)$stmt->fetchColumn();
 
+        // Capture timestamp
+        $stmt = $db->query(
+            "SELECT created_at FROM runs WHERE run_id = {$run_id}"
+        );
+        $meta['captured_at'] = $stmt->fetchColumn() ?: null;
+
         return $meta;
     }
 

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -110,6 +110,7 @@ final class ReportGenerator
         }
 
         $findings = $this->deduplicateFindings($findings);
+        $this->sortFindings($findings);
 
         return new ReportResult($meta, $findings);
     }
@@ -153,6 +154,29 @@ final class ReportGenerator
         ));
 
         return $findings;
+    }
+
+    /**
+     * Sort findings by severity (high first), then impact_bytes descending.
+     * @param list<Finding> $findings
+     */
+    private function sortFindings(array &$findings): void
+    {
+        $order = [
+            'high' => 0,
+            'warning' => 1,
+            'medium' => 2,
+            'low' => 3,
+            'info' => 4,
+        ];
+        usort($findings, function (Finding $a, Finding $b) use ($order): int {
+            $sa = $order[$a->severity->value] ?? 5;
+            $sb = $order[$b->severity->value] ?? 5;
+            if ($sa !== $sb) {
+                return $sa <=> $sb;
+            }
+            return $b->impact_bytes <=> $a->impact_bytes;
+        });
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/SizeFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/SizeFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+/**
+ * Consistent human-readable byte size formatting.
+ *
+ * < 1 KB  → "999 B"
+ * < 1 MB  → "15.2 KB"
+ * < 1 GB  → "153.76 MB"
+ * >= 1 GB → "1.23 GB"
+ */
+final class SizeFormatter
+{
+    /** @psalm-suppress InvalidOperand */
+    public static function format(int|float $bytes): string
+    {
+        $bytes = (float)$bytes;
+        if ($bytes < 1024) {
+            return number_format($bytes, 0) . ' B';
+        }
+        if ($bytes < 1024 * 1024) {
+            return number_format($bytes / 1024, 2) . ' KB';
+        }
+        if ($bytes < 1024 * 1024 * 1024) {
+            return number_format($bytes / 1024 / 1024, 2) . ' MB';
+        }
+        return number_format($bytes / 1024 / 1024 / 1024, 2) . ' GB';
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -120,7 +120,7 @@ class SummaryPassesTest extends BaseTestCase
         $this->assertStringContainsString('BigClass', $f->summary);
         $this->assertStringContainsString('10,000', $f->summary);
         // Per-entity cost: 5000000 / 10000 = 500
-        $this->assertStringContainsString('500B', $f->summary);
+        $this->assertStringContainsString('500 B', $f->summary);
         $this->assertSame(500, $f->facts['avg_size']);
     }
 

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -140,7 +140,7 @@ class SummaryPassesTest extends BaseTestCase
         ]);
         $findings = $pass->analyze();
 
-        $companions = array_filter($findings, fn(Finding $f) => $f->kind === 'companion_pair');
+        $companions = array_filter($findings, fn(Finding $f) => $f->kind === 'companion_cluster');
         $this->assertCount(1, $companions);
     }
 
@@ -152,7 +152,7 @@ class SummaryPassesTest extends BaseTestCase
         ]);
         $findings = $pass->analyze();
 
-        $companions = array_filter($findings, fn(Finding $f) => $f->kind === 'companion_pair');
+        $companions = array_filter($findings, fn(Finding $f) => $f->kind === 'companion_cluster');
         $this->assertCount(0, $companions);
     }
 

--- a/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
@@ -139,7 +139,7 @@ class ReportGeneratorTest extends BaseTestCase
         $this->buildDbWithLocations($locations);
         $result = $this->generateReport();
 
-        $companions = $this->findByKind($result, 'companion_pair');
+        $companions = $this->findByKind($result, 'companion_cluster');
         $this->assertNotEmpty($companions);
         $this->assertStringContainsString('ClassA', $companions[0]->summary);
         $this->assertStringContainsString('ClassB', $companions[0]->summary);


### PR DESCRIPTION
## Summary

Multiple improvements to report output quality based on real-world validation feedback.

### Dedup candidate improvements
- **Value comparison**: for string targets, queries `string_value` to check actual content duplication. Reports identical count and confidence (HIGH >50%, MEDIUM <50%): `"195/600 copies have identical content (32%). Example: '--boundary...'"`. For objects, shows class+size samples.
- **Array owner path**: walks up `ArrayElementContext` edges to find owning object and property: `"User::$attributes[key]: 20,099 copies x 41 B"` instead of just `"key: 20,099 copies"`.
- **Retained size**: when graph substrate available, samples `subtree_sizes` for average retained cost instead of shallow size.
- **Filter array headers**: skip `ZendArrayMemoryLocation` (always 56B) — "SAME SIZE" is meaningless for them.

### Companion detection
- **Merge companion_pair into companion_cluster**: unified under one finding type. Size=2 displays as `"A always paired with B — 2.93 MB"`, size>2 as `"6 classes x ~1,806 instances (3.84 MB): ..."`.
- **Memory cost**: all companion findings now show memory usage per class and combined total.

### Size formatting
- **SizeFormatter utility**: consistent formatting across all 16 pass files. `< 1 KB → "999 B"`, `< 1 MB → "15.20 KB"`, `< 1 GB → "153.76 MB"`. No more `40056B` vs `39.12 KB` vs `0.04 MB` inconsistencies.

### Finding ordering
- **Sort by severity + impact**: all findings sorted by severity (HIGH first), then `impact_bytes` descending within same severity. Largest problems appear first.

### shared_fanin
- **Downgraded to INFO**: supplementary information, not actionable. Cycle back-references already reported by `cycle_cluster`.

### CLI improvements
- **`--memory-limit` option**: `reli inspector:memory:report foo.db --memory-limit=2G` — avoids awkward `php -d memory_limit=2G` in Docker.
- **Capture timestamp**: Overview section now shows `Captured: 2026-03-28T17:58:56Z` from `runs.created_at`.

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf