### PR TITLE
Add PHP stream resource tracking and data collection

### DIFF
--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -164,7 +164,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 // zend_compile.h
@@ -1167,34 +1167,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1164,3 +1164,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1193,3 +1193,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -166,7 +166,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 // zend_compile.h
@@ -1196,34 +1196,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -166,7 +166,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef uintptr_t zend_type;
@@ -1190,34 +1190,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1187,3 +1187,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -163,7 +163,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef uintptr_t zend_type;
@@ -1183,34 +1183,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1180,3 +1180,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1218,3 +1218,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -162,7 +162,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef uintptr_t zend_type;
@@ -1221,34 +1221,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1245,3 +1245,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -162,7 +162,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	int               handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1248,34 +1248,35 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
+	uint8_t fgetss_state;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1415,3 +1415,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -160,9 +160,9 @@ struct _zend_object {
 
 struct _zend_resource {
 	zend_refcounted_h gc;
-	int               handle; // TODO: may be removed ???
+	zend_long         handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1418,34 +1418,34 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -163,9 +163,9 @@ struct _zend_object {
 
 struct _zend_resource {
 	zend_refcounted_h gc;
-	int               handle; // TODO: may be removed ???
+	zend_long         handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1462,34 +1462,34 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint16_t flags_bitfield;
+	uint8_t flags_bitfield;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1459,3 +1459,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -166,7 +166,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	zend_long         handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1504,34 +1504,34 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
 	uint16_t flags_bitfield;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1501,3 +1501,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1589,3 +1589,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -167,7 +167,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	zend_long         handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1592,34 +1592,34 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
 	uint16_t flags_bitfield;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -167,7 +167,7 @@ struct _zend_resource {
 	zend_refcounted_h gc;
 	zend_long         handle; // TODO: may be removed ???
 	int               type;
-	void             *ptr;
+	uintptr_t         ptr;
 };
 
 typedef struct {
@@ -1611,34 +1611,34 @@ typedef struct _php_basic_globals {
 
 // main/php_streams.h
 typedef struct _php_stream_ops {
-	void *write;
-	void *read;
-	void *close;
-	void *flush;
+	uintptr_t write;
+	uintptr_t read;
+	uintptr_t close;
+	uintptr_t flush;
 	const char *label;
-	void *seek;
-	void *cast;
-	void *stat;
-	void *set_option;
+	uintptr_t seek;
+	uintptr_t cast;
+	uintptr_t stat;
+	uintptr_t set_option;
 } php_stream_ops;
 
 struct _php_stream {
 	const php_stream_ops *ops;
-	void *abstract;
-	void *readfilters_head;
-	void *readfilters_tail;
+	uintptr_t abstract;
+	uintptr_t readfilters_head;
+	uintptr_t readfilters_tail;
 	struct _php_stream *readfilters_stream;
-	void *writefilters_head;
-	void *writefilters_tail;
+	uintptr_t writefilters_head;
+	uintptr_t writefilters_tail;
 	struct _php_stream *writefilters_stream;
-	void *wrapper;
-	void *wrapperthis;
+	uintptr_t wrapper;
+	uintptr_t wrapperthis;
 	zval wrapperdata;
 	uint16_t flags_bitfield;
 	char mode[16];
 	uint32_t flags;
 	zend_resource *res;
-	void *stdiocast;
+	uintptr_t stdiocast;
 	char *orig_path;
 	zend_resource *ctx;
 	zend_off_t position;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1608,3 +1608,61 @@ typedef struct _php_shutdown_function_entry {
 typedef struct _php_basic_globals {
 	HashTable *user_shutdown_function_names;
 } php_basic_globals;
+
+// main/php_streams.h
+typedef struct _php_stream_ops {
+	void *write;
+	void *read;
+	void *close;
+	void *flush;
+	const char *label;
+	void *seek;
+	void *cast;
+	void *stat;
+	void *set_option;
+} php_stream_ops;
+
+struct _php_stream {
+	const php_stream_ops *ops;
+	void *abstract;
+	void *readfilters_head;
+	void *readfilters_tail;
+	struct _php_stream *readfilters_stream;
+	void *writefilters_head;
+	void *writefilters_tail;
+	struct _php_stream *writefilters_stream;
+	void *wrapper;
+	void *wrapperthis;
+	zval wrapperdata;
+	uint16_t flags_bitfield;
+	char mode[16];
+	uint32_t flags;
+	zend_resource *res;
+	void *stdiocast;
+	char *orig_path;
+	zend_resource *ctx;
+	zend_off_t position;
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+	size_t chunk_size;
+	struct _php_stream *enclosing_stream;
+};
+
+typedef struct _php_stream php_stream;
+
+// main/streams/memory.c
+typedef struct {
+	zend_string *data;
+	size_t fpos;
+	int mode;
+} php_stream_memory_data;
+
+typedef struct {
+	php_stream *innerstream;
+	size_t smax;
+	int mode;
+	zval meta;
+	char *tmpdir;
+} php_stream_temp_data;

--- a/src/Lib/PhpInternals/Types/Php/PhpStream.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStream.php
@@ -11,47 +11,46 @@
 
 declare(strict_types=1);
 
-namespace Reli\Lib\PhpInternals\Types\Zend;
+namespace Reli\Lib\PhpInternals\Types\Php;
 
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-/**
- * @psalm-consistent-constructor
- */
-final class ZendResource implements CDataDereferencable
+final class PhpStream implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public ZendRefcountedH $gc;
+    public int $ops;
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $type;
+    public int $abstract;
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $ptr;
+    public int $res;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-     * @param Pointer<ZendResource> $pointer
+     * @param CastedCData<\FFI\PhpInternals\php_stream> $casted_cdata
+     * @param Pointer<PhpStream> $pointer
      */
     public function __construct(
         private CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
-        unset($this->gc);
-        unset($this->type);
-        unset($this->ptr);
+        unset($this->ops);
+        unset($this->abstract);
+        unset($this->res);
     }
 
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'gc' => $this->gc = new ZendRefcountedH(
-                $this->casted_cdata->casted->gc
+            'ops' => $this->ops = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->ops
             ),
-            'type' => $this->type = $this->casted_cdata->casted->type,
-            'ptr' => $this->ptr = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->ptr
+            'abstract' => $this->abstract = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->abstract
+            ),
+            'res' => $this->res = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->res
             ),
         };
     }
@@ -59,17 +58,14 @@ final class ZendResource implements CDataDereferencable
     #[\Override]
     public static function getCTypeName(): string
     {
-        return 'zend_resource';
+        return 'php_stream';
     }
 
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
+        /** @var CastedCData<\FFI\PhpInternals\php_stream> $casted_cdata */
+        return new self($casted_cdata, $pointer);
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Php/PhpStream.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStream.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Php;
 
+use FFI\CData;
+use FFI\PhpInternals\php_stream;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
@@ -28,7 +30,7 @@ final class PhpStream implements CDataDereferencable
     public int $res;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\php_stream> $casted_cdata
+     * @param CastedCData<php_stream> $casted_cdata
      * @param Pointer<PhpStream> $pointer
      */
     public function __construct(
@@ -62,7 +64,10 @@ final class PhpStream implements CDataDereferencable
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /** @var CastedCData<\FFI\PhpInternals\php_stream> $casted_cdata */
+        /**
+         * @var CastedCData<php_stream> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
         return new self($casted_cdata, $pointer);
     }
 

--- a/src/Lib/PhpInternals/Types/Php/PhpStream.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStream.php
@@ -46,9 +46,7 @@ final class PhpStream implements CDataDereferencable
             'ops' => $this->ops = FFIHelper::castPointerToInt(
                 $this->casted_cdata->casted->ops
             ),
-            'abstract' => $this->abstract = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->abstract
-            ),
+            'abstract' => $this->abstract = $this->casted_cdata->casted->abstract,
             'res' => $this->res = FFIHelper::castPointerToInt(
                 $this->casted_cdata->casted->res
             ),

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamMemoryData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamMemoryData.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Php;
 
+use FFI\PhpInternals\php_stream_memory_data;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
@@ -26,7 +27,7 @@ final class PhpStreamMemoryData implements CDataDereferencable
     public int $fpos;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\php_stream_memory_data> $casted_cdata
+     * @param CastedCData<php_stream_memory_data> $casted_cdata
      * @param Pointer<PhpStreamMemoryData> $pointer
      */
     public function __construct(
@@ -56,7 +57,10 @@ final class PhpStreamMemoryData implements CDataDereferencable
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /** @var CastedCData<\FFI\PhpInternals\php_stream_memory_data> $casted_cdata */
+        /**
+         * @var CastedCData<php_stream_memory_data> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
         return new self($casted_cdata, $pointer);
     }
 

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamMemoryData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamMemoryData.php
@@ -11,65 +11,53 @@
 
 declare(strict_types=1);
 
-namespace Reli\Lib\PhpInternals\Types\Zend;
+namespace Reli\Lib\PhpInternals\Types\Php;
 
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-/**
- * @psalm-consistent-constructor
- */
-final class ZendResource implements CDataDereferencable
+final class PhpStreamMemoryData implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public ZendRefcountedH $gc;
+    public int $data;
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $type;
-    /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $ptr;
+    public int $fpos;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-     * @param Pointer<ZendResource> $pointer
+     * @param CastedCData<\FFI\PhpInternals\php_stream_memory_data> $casted_cdata
+     * @param Pointer<PhpStreamMemoryData> $pointer
      */
     public function __construct(
         private CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
-        unset($this->gc);
-        unset($this->type);
-        unset($this->ptr);
+        unset($this->data);
+        unset($this->fpos);
     }
 
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'gc' => $this->gc = new ZendRefcountedH(
-                $this->casted_cdata->casted->gc
+            'data' => $this->data = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->data
             ),
-            'type' => $this->type = $this->casted_cdata->casted->type,
-            'ptr' => $this->ptr = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->ptr
-            ),
+            'fpos' => $this->fpos = $this->casted_cdata->casted->fpos,
         };
     }
 
     #[\Override]
     public static function getCTypeName(): string
     {
-        return 'zend_resource';
+        return 'php_stream_memory_data';
     }
 
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
+        /** @var CastedCData<\FFI\PhpInternals\php_stream_memory_data> $casted_cdata */
+        return new self($casted_cdata, $pointer);
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamOps.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamOps.php
@@ -11,47 +11,35 @@
 
 declare(strict_types=1);
 
-namespace Reli\Lib\PhpInternals\Types\Zend;
+namespace Reli\Lib\PhpInternals\Types\Php;
 
+use FFI\PhpInternals\php_stream_ops;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-/**
- * @psalm-consistent-constructor
- */
-final class ZendResource implements CDataDereferencable
+final class PhpStreamOps implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public ZendRefcountedH $gc;
-    /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $type;
-    /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $ptr;
+    public int $label;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-     * @param Pointer<ZendResource> $pointer
+     * @param CastedCData<php_stream_ops> $casted_cdata
+     * @param Pointer<PhpStreamOps> $pointer
      */
     public function __construct(
         private CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
-        unset($this->gc);
-        unset($this->type);
-        unset($this->ptr);
+        unset($this->label);
     }
 
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'gc' => $this->gc = new ZendRefcountedH(
-                $this->casted_cdata->casted->gc
-            ),
-            'type' => $this->type = $this->casted_cdata->casted->type,
-            'ptr' => $this->ptr = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->ptr
+            'label' => $this->label = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->label
             ),
         };
     }
@@ -59,17 +47,14 @@ final class ZendResource implements CDataDereferencable
     #[\Override]
     public static function getCTypeName(): string
     {
-        return 'zend_resource';
+        return 'php_stream_ops';
     }
 
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
+        /** @var CastedCData<php_stream_ops> $casted_cdata */
+        return new self($casted_cdata, $pointer);
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamOps.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamOps.php
@@ -53,7 +53,10 @@ final class PhpStreamOps implements CDataDereferencable
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /** @var CastedCData<php_stream_ops> $casted_cdata */
+        /**
+         * @var CastedCData<php_stream_ops> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
         return new self($casted_cdata, $pointer);
     }
 

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamTempData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamTempData.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Php;
 
+use FFI\PhpInternals\php_stream_temp_data;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
@@ -26,7 +27,7 @@ final class PhpStreamTempData implements CDataDereferencable
     public int $smax;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\php_stream_temp_data> $casted_cdata
+     * @param CastedCData<php_stream_temp_data> $casted_cdata
      * @param Pointer<PhpStreamTempData> $pointer
      */
     public function __construct(
@@ -56,7 +57,10 @@ final class PhpStreamTempData implements CDataDereferencable
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /** @var CastedCData<\FFI\PhpInternals\php_stream_temp_data> $casted_cdata */
+        /**
+         * @var CastedCData<php_stream_temp_data> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
         return new self($casted_cdata, $pointer);
     }
 

--- a/src/Lib/PhpInternals/Types/Php/PhpStreamTempData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStreamTempData.php
@@ -11,65 +11,53 @@
 
 declare(strict_types=1);
 
-namespace Reli\Lib\PhpInternals\Types\Zend;
+namespace Reli\Lib\PhpInternals\Types\Php;
 
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
 
-/**
- * @psalm-consistent-constructor
- */
-final class ZendResource implements CDataDereferencable
+final class PhpStreamTempData implements CDataDereferencable
 {
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public ZendRefcountedH $gc;
+    public int $innerstream;
     /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $type;
-    /** @psalm-suppress PropertyNotSetInConstructor */
-    public int $ptr;
+    public int $smax;
 
     /**
-     * @param CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-     * @param Pointer<ZendResource> $pointer
+     * @param CastedCData<\FFI\PhpInternals\php_stream_temp_data> $casted_cdata
+     * @param Pointer<PhpStreamTempData> $pointer
      */
     public function __construct(
         private CastedCData $casted_cdata,
         private Pointer $pointer,
     ) {
-        unset($this->gc);
-        unset($this->type);
-        unset($this->ptr);
+        unset($this->innerstream);
+        unset($this->smax);
     }
 
     public function __get(string $field_name): mixed
     {
         return match ($field_name) {
-            'gc' => $this->gc = new ZendRefcountedH(
-                $this->casted_cdata->casted->gc
+            'innerstream' => $this->innerstream = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->innerstream
             ),
-            'type' => $this->type = $this->casted_cdata->casted->type,
-            'ptr' => $this->ptr = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->ptr
-            ),
+            'smax' => $this->smax = $this->casted_cdata->casted->smax,
         };
     }
 
     #[\Override]
     public static function getCTypeName(): string
     {
-        return 'zend_resource';
+        return 'php_stream_temp_data';
     }
 
     #[\Override]
     public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
     {
-        /**
-         * @var CastedCData<\FFI\PhpInternals\zend_resource> $casted_cdata
-         * @var Pointer<self> $pointer
-         */
-        return new static($casted_cdata, $pointer);
+        /** @var CastedCData<\FFI\PhpInternals\php_stream_temp_data> $casted_cdata */
+        return new self($casted_cdata, $pointer);
     }
 
     #[\Override]

--- a/src/Lib/PhpInternals/Types/Zend/ZendResource.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendResource.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
-use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -50,9 +49,7 @@ final class ZendResource implements CDataDereferencable
                 $this->casted_cdata->casted->gc
             ),
             'type' => $this->type = $this->casted_cdata->casted->type,
-            'ptr' => $this->ptr = FFIHelper::castPointerToInt(
-                $this->casted_cdata->casted->ptr
-            ),
+            'ptr' => $this->ptr = $this->casted_cdata->casted->ptr,
         };
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -647,9 +647,10 @@ final class MemoryLocationsCollector
                     $resource_context,
                 );
             }
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
             // Reading stream data is best-effort; if the memory is
             // unmapped or the layout doesn't match, just skip it.
+            @file_put_contents('/tmp/reli-stream-debug.log', "stream probe failed: ptr=" . dechex($ptr_address) . " err=" . $e->getMessage() . "\n", FILE_APPEND);
             return;
         }
     }
@@ -684,7 +685,7 @@ final class MemoryLocationsCollector
             $data_address,
             $zend_type_reader->sizeOf('zend_string'),
         );
-        $string_context = $this->collectStringPointer(
+        $string_context = $this->collectZendStringPointer(
             $string_pointer,
             $memory_locations,
             $dereferencer,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -37,6 +37,11 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
 use Reli\Lib\PhpInternals\Types\Zend\ZendObject;
 use Reli\Lib\PhpInternals\Types\Zend\ZendObjectsStore;
 use Reli\Lib\PhpInternals\Types\Zend\ZendReference;
+use Reli\Lib\PhpInternals\Types\C\RawString;
+use Reli\Lib\PhpInternals\Types\Php\PhpStream;
+use Reli\Lib\PhpInternals\Types\Php\PhpStreamMemoryData;
+use Reli\Lib\PhpInternals\Types\Php\PhpStreamOps;
+use Reli\Lib\PhpInternals\Types\Php\PhpStreamTempData;
 use Reli\Lib\PhpInternals\Types\Zend\ZendResource;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
 use Reli\Lib\PhpInternals\Types\Zend\ZendWeakMap;
@@ -514,6 +519,7 @@ final class MemoryLocationsCollector
                 $zval->value->res,
                 $memory_locations,
                 $dereferencer,
+                $zend_type_reader,
                 $context_pools,
             );
         } elseif ($zval->isIndirect()) {
@@ -538,6 +544,7 @@ final class MemoryLocationsCollector
         Pointer $pointer,
         MemoryLocations $memory_locations,
         Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
         ContextPools $context_pools
     ): ResourceContext {
         if ($memory_locations->has($pointer->address)) {
@@ -552,10 +559,205 @@ final class MemoryLocationsCollector
         $resource = $dereferencer->deref($pointer);
         $memory_location = ZendResourceMemoryLocation::fromZendReference($resource);
         $memory_locations->add($memory_location);
-        return $context_pools
+        $resource_context = $context_pools
             ->resource_context_pool
             ->getContextForLocation($memory_location)
         ;
+        $this->tryCollectStreamData(
+            $resource,
+            $pointer,
+            $memory_locations,
+            $dereferencer,
+            $zend_type_reader,
+            $context_pools,
+            $resource_context,
+        );
+        return $resource_context;
+    }
+
+    private function tryCollectStreamData(
+        ZendResource $resource,
+        Pointer $resource_pointer,
+        MemoryLocations $memory_locations,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ContextPools $context_pools,
+        ResourceContext $resource_context,
+    ): void {
+        $ptr_address = $resource->ptr;
+        if ($ptr_address === 0) {
+            return;
+        }
+
+        try {
+            $php_stream_pointer = new Pointer(
+                PhpStream::class,
+                $ptr_address,
+                $zend_type_reader->sizeOf('php_stream'),
+            );
+            $php_stream = $dereferencer->deref($php_stream_pointer);
+
+            // Validate: php_stream.res should point back to the zend_resource
+            if ($php_stream->res !== $resource_pointer->address) {
+                return;
+            }
+
+            // Read ops->label to determine stream type
+            $ops_address = $php_stream->ops;
+            if ($ops_address === 0) {
+                return;
+            }
+            $ops_pointer = new Pointer(
+                PhpStreamOps::class,
+                $ops_address,
+                $zend_type_reader->sizeOf('php_stream_ops'),
+            );
+            $ops = $dereferencer->deref($ops_pointer);
+
+            $label_address = $ops->label;
+            if ($label_address === 0) {
+                return;
+            }
+            $label_pointer = new Pointer(
+                RawString::class,
+                $label_address,
+                32,
+            );
+            $label = (string)$dereferencer->deref($label_pointer);
+
+            $resource_context->stream_type_label = $label;
+
+            // For MEMORY streams, collect the zend_string data buffer
+            if ($label === 'MEMORY') {
+                $this->collectMemoryStreamData(
+                    $php_stream,
+                    $memory_locations,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $context_pools,
+                    $resource_context,
+                );
+            } elseif ($label === 'TEMP') {
+                $this->collectTempStreamData(
+                    $php_stream,
+                    $memory_locations,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $context_pools,
+                    $resource_context,
+                );
+            }
+        } catch (\Throwable) {
+            // Reading stream data is best-effort; if the memory is
+            // unmapped or the layout doesn't match, just skip it.
+            return;
+        }
+    }
+
+    private function collectMemoryStreamData(
+        PhpStream $php_stream,
+        MemoryLocations $memory_locations,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ContextPools $context_pools,
+        ResourceContext $resource_context,
+    ): void {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return;
+        }
+
+        $mem_data_pointer = new Pointer(
+            PhpStreamMemoryData::class,
+            $abstract_address,
+            $zend_type_reader->sizeOf('php_stream_memory_data'),
+        );
+        $mem_data = $dereferencer->deref($mem_data_pointer);
+
+        $data_address = $mem_data->data;
+        if ($data_address === 0) {
+            return;
+        }
+
+        $string_pointer = new Pointer(
+            ZendString::class,
+            $data_address,
+            $zend_type_reader->sizeOf('zend_string'),
+        );
+        $string_context = $this->collectStringPointer(
+            $string_pointer,
+            $memory_locations,
+            $dereferencer,
+            $context_pools,
+        );
+        $resource_context->add('stream_memory_data', $string_context);
+    }
+
+    private function collectTempStreamData(
+        PhpStream $php_stream,
+        MemoryLocations $memory_locations,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ContextPools $context_pools,
+        ResourceContext $resource_context,
+    ): void {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return;
+        }
+
+        $temp_data_pointer = new Pointer(
+            PhpStreamTempData::class,
+            $abstract_address,
+            $zend_type_reader->sizeOf('php_stream_temp_data'),
+        );
+        $temp_data = $dereferencer->deref($temp_data_pointer);
+
+        $innerstream_address = $temp_data->innerstream;
+        if ($innerstream_address === 0) {
+            return;
+        }
+
+        // Read the inner stream to check if it's a MEMORY stream
+        $inner_pointer = new Pointer(
+            PhpStream::class,
+            $innerstream_address,
+            $zend_type_reader->sizeOf('php_stream'),
+        );
+        $inner_stream = $dereferencer->deref($inner_pointer);
+
+        $inner_ops_address = $inner_stream->ops;
+        if ($inner_ops_address === 0) {
+            return;
+        }
+        $inner_ops_pointer = new Pointer(
+            PhpStreamOps::class,
+            $inner_ops_address,
+            $zend_type_reader->sizeOf('php_stream_ops'),
+        );
+        $inner_ops = $dereferencer->deref($inner_ops_pointer);
+
+        $inner_label_address = $inner_ops->label;
+        if ($inner_label_address === 0) {
+            return;
+        }
+        $inner_label_pointer = new Pointer(
+            RawString::class,
+            $inner_label_address,
+            32,
+        );
+        $inner_label = (string)$dereferencer->deref($inner_label_pointer);
+
+        if ($inner_label === 'MEMORY') {
+            $this->collectMemoryStreamData(
+                $inner_stream,
+                $memory_locations,
+                $dereferencer,
+                $zend_type_reader,
+                $context_pools,
+                $resource_context,
+            );
+        }
     }
 
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -647,10 +647,9 @@ final class MemoryLocationsCollector
                     $resource_context,
                 );
             }
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             // Reading stream data is best-effort; if the memory is
             // unmapped or the layout doesn't match, just skip it.
-            @file_put_contents('/tmp/reli-stream-debug.log', "stream probe failed: ptr=" . dechex($ptr_address) . " err=" . $e->getMessage() . "\n", FILE_APPEND);
             return;
         }
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
@@ -19,6 +19,8 @@ final class ResourceContext implements ReferenceContext
 {
     use ReferenceContextDefault;
 
+    public ?string $stream_type_label = null;
+
     public function __construct(
         public ZendResourceMemoryLocation $memory_location,
     ) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
@@ -31,4 +31,14 @@ final class ResourceContext implements ReferenceContext
     {
         return [$this->memory_location];
     }
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        $contexts = [];
+        if ($this->stream_type_label !== null) {
+            $contexts['stream_type_label'] = $this->stream_type_label;
+        }
+        return $contexts;
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2183,4 +2183,180 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             'Should find at least one WeakMap with tracked entries'
         );
     }
+
+    #[DataProvider('provideFromV80')]
+    public function testStreamResourceTracking(string $php_version, string $docker_image_name): void
+    {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            $memory_stream = fopen('php://memory', 'r+');
+            fwrite($memory_stream, str_repeat('M', 1024));
+            $temp_stream = fopen('php://temp', 'r+');
+            fwrite($temp_stream, str_repeat('T', 512));
+            $file_stream = fopen('php://stdout', 'w');
+            fputs($file_stream, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $context_analyzer = new ContextAnalyzer();
+        $sink = new ArrayContextTreeSink();
+        $context_analyzer->analyze(
+            $collected_memories->top_reference_context,
+            $sink,
+        );
+        $contexts_analyzed = $sink->getResult();
+
+        // Search for ResourceContext nodes with stream_type_label
+        $found_memory = false;
+        $found_temp = false;
+        $found_stdio = false;
+        $found_memory_data_link = false;
+        $findStreams = function (array $tree) use (
+            &$findStreams,
+            &$found_memory,
+            &$found_temp,
+            &$found_stdio,
+            &$found_memory_data_link,
+        ): void {
+            foreach ($tree as $key => $value) {
+                if (!is_array($value) || $key === '#locations') {
+                    continue;
+                }
+                $type = $value['#type'] ?? null;
+                $label = $value['stream_type_label'] ?? null;
+                if ($type === 'ResourceContext' && $label !== null) {
+                    if ($label === 'MEMORY') {
+                        $found_memory = true;
+                        if (isset($value['stream_memory_data'])) {
+                            $found_memory_data_link = true;
+                        }
+                    }
+                    if ($label === 'TEMP') {
+                        $found_temp = true;
+                        // TEMP with small data should also link memory data
+                        if (isset($value['stream_memory_data'])) {
+                            $found_memory_data_link = true;
+                        }
+                    }
+                    if ($label === 'STDIO') {
+                        $found_stdio = true;
+                    }
+                }
+                $findStreams($value);
+            }
+        };
+        $findStreams($contexts_analyzed);
+
+        $this->assertTrue($found_memory, 'Should find a php://memory stream (label=MEMORY)');
+        $this->assertTrue($found_temp, 'Should find a php://temp stream (label=TEMP)');
+        $this->assertTrue($found_stdio, 'Should find a STDIO stream');
+        $this->assertTrue(
+            $found_memory_data_link,
+            'Should find stream_memory_data link for MEMORY or TEMP stream'
+        );
+    }
 }

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -329,6 +329,31 @@ class zend_resource extends CData
     public zend_refcounted_h $gc;
     public int $handle;
     public int $type;
+    public int $ptr;
+}
+
+class php_stream_ops extends CData
+{
+    public ?CPointer $label;
+}
+
+class php_stream extends CData
+{
+    public ?CPointer $ops;
+    public int $abstract;
+    public ?CPointer $res;
+}
+
+class php_stream_memory_data extends CData
+{
+    public ?CPointer $data;
+    public int $fpos;
+}
+
+class php_stream_temp_data extends CData
+{
+    public ?CPointer $innerstream;
+    public int $smax;
 }
 class zend_type extends CData
 {


### PR DESCRIPTION
## Summary
This PR adds comprehensive tracking and data collection for PHP stream resources (php://memory, php://temp, etc.). The implementation allows the memory profiler to inspect stream internals and collect the underlying data buffers associated with stream resources.

## Key Changes

- **New Type Definitions**: Added FFI type wrappers for PHP stream structures:
  - `PhpStream`: Represents a php_stream structure with ops, abstract, and res pointers
  - `PhpStreamOps`: Represents php_stream_ops with the label field for stream type identification
  - `PhpStreamMemoryData`: Represents memory stream internal data structure
  - `PhpStreamTempData`: Represents temporary stream internal data structure

- **Stream Data Collection**: Enhanced `MemoryLocationsCollector` to:
  - Detect and classify stream resources by type (MEMORY, TEMP, etc.) via the ops->label field
  - Collect underlying zend_string data buffers for MEMORY streams
  - Handle nested streams in TEMP streams that wrap MEMORY streams
  - Implement best-effort error handling for unmapped or malformed stream memory

- **Resource Context Enhancement**: Extended `ResourceContext` with:
  - `stream_type_label` field to store the stream type identifier
  - Support for linking collected stream data back to the resource context

- **Header Updates**: Updated PHP version headers (v70-v85) to:
  - Add php_stream, php_stream_ops, php_stream_memory_data, and php_stream_temp_data type definitions
  - Fix zend_resource.ptr type from `void*` to `uintptr_t` for proper pointer handling across all versions

- **Test Coverage**: Added comprehensive integration test `testStreamResourceTracking` that:
  - Creates memory, temp, and file streams
  - Verifies stream type detection and data collection
  - Validates that stream data buffers are properly tracked in memory locations

## Implementation Details

The stream tracking is implemented as a best-effort feature that gracefully handles edge cases:
- Validates that php_stream.res points back to the original zend_resource
- Safely handles null or invalid pointers
- Catches exceptions during stream probing to avoid disrupting the overall memory collection process
- Supports nested stream structures (TEMP streams wrapping MEMORY streams)

https://claude.ai/code/session_01Uq2CtLGYQxNMPfMwwhf72V