### PR TITLE
Add resource leak detection, fixed-impact display, and doc updates

### DIFF
--- a/docs/internals/memory-report-architecture.md
+++ b/docs/internals/memory-report-architecture.md
@@ -190,7 +190,7 @@ In-memory graph traversal using GraphSubstrate.
 
 | Pass | Source | Emits |
 |---|---|---|
-| CycleClusterPass | SCC profiles + all_children + DB | `cycle_cluster` (back-ref, entry path, retained), `micro_cycle`, `di_container_cycle` |
+| CycleClusterPass | SCC profiles + all_children + DB | `cycle_cluster` (back-ref, entry path, retained), `micro_cycle`, `di_container_cycle`, `resource_leak_risk` |
 | PropertyScalingPass | substrate + SQL | `property_scaling` (retained) |
 | PerPropertyMemoryPass | substrate + link_names | `expensive_property` (class-qualified) |
 | OwnershipPatternPass | substrate + link_names | `ownership_pattern` |
@@ -326,6 +326,7 @@ src/Command/Inspector/
 | `cycle_cluster` | medium/low | CycleClusterPass | php-imap (201x), Symfony Forms (1,802x) |
 | `micro_cycle` | low | CycleClusterPass | Symfony Forms (OptionsResolver ↔ Closure) |
 | `di_container_cycle` | info | CycleClusterPass | Laravel (54 classes, 74 KB) |
+| `resource_leak_risk` | high | CycleClusterPass | PDO/Mysqli downstream of SCC |
 | `bottleneck_path` | high | DrillDownPass | PHP-Parser (89 MB), CommonMark (71 MB) |
 | `choke_point` | high/medium/low | ChokePointPass | Eloquent (Collection → 15 MB) |
 | `root_blame` | info | BlameAllocationPass | Eloquent (class_table 48%, call_frames 35%) |

--- a/docs/memory-report.md
+++ b/docs/memory-report.md
@@ -48,21 +48,25 @@ Example output:
 
 === Findings ===
 
-  [HIGH] dominant_class: App\Models\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)
+  [HIGH   ] 703.13 KB impacted
+    dominant_class: App\Models\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)
     Unbounded accumulation — likely a loop without limit
     Next: Check if count scales with input size; Look for owner path
 
-  [HIGH] bottleneck_path: <main>:28::$users->items (153.76 MB)
+  [HIGH   ] 153.76 MB impacted
+    bottleneck_path: <main>:28::$users->items (153.76 MB)
     Heaviest memory path — the primary chain of memory consumption
 
-  [MEDIUM] property_scaling: App\Models\User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
+  [MEDIUM ] 9.53 MB impacted
+    property_scaling: App\Models\User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
     PER-INSTANCE (retained, scales with count):
       App\Models\User::$attributes: 10,000 copies x 599 B = 5.86 MB
       App\Models\User::$casts: 10,000 copies x 376 B = 3.67 MB
     (14 scalar properties per-instance, included in object size)
     SHARED: App\Models\User::$relations (array, CoW), App\Models\User::$fillable (array, CoW)
 
-  [MEDIUM] cycle_cluster: 200 identical cycles (3 classes, 170.31 KB shallow, 42.50 MB retained)
+  [MEDIUM ] 42.50 MB impacted
+    cycle_cluster: 200 identical cycles (3 classes, 170.31 KB shallow, 42.50 MB retained)
     Per cycle: 1x Webklex\PHPIMAP\Message + 3x Webklex\PHPIMAP\Attachment + 1x Webklex\PHPIMAP\AttachmentCollection
     Back-reference: Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message
     Example: <main>:28::$messages[0]->attachments->items[0]
@@ -70,9 +74,11 @@ Example output:
     Single entry point — breaking the back-reference likely frees this cycle
     Next: Break Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message to eliminate all 200 cycles
 
-  [MEDIUM] companion_cluster: FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB
+  [MEDIUM ] —
+    companion_cluster: FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB
 
-  [LOW] dedup_candidate: Attachment::$part (Part): 600 copies x 312 B = 182.81 KB
+  [LOW    ] 182.81 KB impacted
+    dedup_candidate: Attachment::$part (Part): 600 copies x 312 B = 182.81 KB
     195/600 copies have identical content (32%). Example: "--boundary_mixed..."
 
 === Root Blame Allocation ===
@@ -167,7 +173,16 @@ sudo ./reli inspector:memory -p <pid> -f report -o report.txt  # to file
 
 ## Finding Types
 
-Findings are sorted by severity (HIGH first), then by `impact_bytes` descending within the same severity. Each finding has a `kind`, `severity`, `confidence`, and optional `impact_bytes`.
+Findings are sorted by severity (HIGH first), then by `impact_bytes` descending within the same severity. Each finding shows its impact on the first line for easy visual scanning:
+
+```
+  [HIGH   ] 153.76 MB impacted
+    bottleneck_path: <main>::$messages[0]->structure->parts
+  [MEDIUM ] 40.21 MB impacted
+    expensive_property: Structure::$raw (200 x 211.00 KB)
+  [MEDIUM ] —
+    companion_cluster: 4 classes x ~200 instances
+```
 
 All class names use fully qualified names (FQCN). Paths use PHP syntax: `<main>:28::$messages[0]->structure->raw`.
 
@@ -179,6 +194,7 @@ All class names use fully qualified names (FQCN). Paths use PHP syntax: `<main>:
 | `dominant_type` | One memory type > 80% of heap | "ZendString accounts for 87% of heap" |
 | `bottleneck_path` | Heaviest memory path from root (PHP syntax) | "<main>:28::$users->items (153.76 MB)" |
 | `choke_point` | Small node retaining large subtree (> 30% heap) | "MarkdownParser (152 B) holds 73.00 MB" |
+| `resource_leak_risk` | PDO/Mysqli held by circular reference | "PDO held by cycle (Repository, Service)" |
 
 ### Medium Severity
 

--- a/docs/memory-report.md
+++ b/docs/memory-report.md
@@ -48,16 +48,16 @@ Example output:
 
 === Findings ===
 
-  [HIGH]     703.13 KB impacted
+  [HIGH]  703.13 KB impacted
     dominant_class: App\Models\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)
     Unbounded accumulation — likely a loop without limit
     Next: Check if count scales with input size; Look for owner path
 
-  [HIGH]     153.76 MB impacted
+  [HIGH]  153.76 MB impacted
     bottleneck_path: <main>:28::$users->items (153.76 MB)
     Heaviest memory path — the primary chain of memory consumption
 
-  [MEDIUM]   9.53 MB impacted
+  [MEDIUM]  9.53 MB impacted
     property_scaling: App\Models\User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
     PER-INSTANCE (retained, scales with count):
       App\Models\User::$attributes: 10,000 copies x 599 B = 5.86 MB
@@ -65,7 +65,7 @@ Example output:
     (14 scalar properties per-instance, included in object size)
     SHARED: App\Models\User::$relations (array, CoW), App\Models\User::$fillable (array, CoW)
 
-  [MEDIUM]   42.50 MB impacted
+  [MEDIUM]  42.50 MB impacted
     cycle_cluster: 200 identical cycles (3 classes, 170.31 KB shallow, 42.50 MB retained)
     Per cycle: 1x Webklex\PHPIMAP\Message + 3x Webklex\PHPIMAP\Attachment + 1x Webklex\PHPIMAP\AttachmentCollection
     Back-reference: Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message
@@ -74,10 +74,10 @@ Example output:
     Single entry point — breaking the back-reference likely frees this cycle
     Next: Break Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message to eliminate all 200 cycles
 
-  [MEDIUM]   —
+  [MEDIUM]  —
     companion_cluster: FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB
 
-  [LOW]      182.81 KB impacted
+  [LOW]  182.81 KB impacted
     dedup_candidate: Attachment::$part (Part): 600 copies x 312 B = 182.81 KB
     195/600 copies have identical content (32%). Example: "--boundary_mixed..."
 
@@ -176,11 +176,11 @@ sudo ./reli inspector:memory -p <pid> -f report -o report.txt  # to file
 Findings are sorted by severity (HIGH first), then by `impact_bytes` descending within the same severity. Each finding shows its impact on the first line for easy visual scanning:
 
 ```
-  [HIGH]     153.76 MB impacted
+  [HIGH]  153.76 MB impacted
     bottleneck_path: <main>::$messages[0]->structure->parts
-  [MEDIUM]   40.21 MB impacted
+  [MEDIUM]  40.21 MB impacted
     expensive_property: Structure::$raw (200 x 211.00 KB)
-  [MEDIUM]   —
+  [MEDIUM]  —
     companion_cluster: 4 classes x ~200 instances
 ```
 

--- a/docs/memory-report.md
+++ b/docs/memory-report.md
@@ -48,16 +48,16 @@ Example output:
 
 === Findings ===
 
-  [HIGH   ] 703.13 KB impacted
+  [HIGH]     703.13 KB impacted
     dominant_class: App\Models\User: 10,000 instances x 72 B = 98.2% of object memory (703.13 KB)
     Unbounded accumulation — likely a loop without limit
     Next: Check if count scales with input size; Look for owner path
 
-  [HIGH   ] 153.76 MB impacted
+  [HIGH]     153.76 MB impacted
     bottleneck_path: <main>:28::$users->items (153.76 MB)
     Heaviest memory path — the primary chain of memory consumption
 
-  [MEDIUM ] 9.53 MB impacted
+  [MEDIUM]   9.53 MB impacted
     property_scaling: App\Models\User (10,000 instances): 5 per-instance props (0.49 KB/instance retained), 12 shared
     PER-INSTANCE (retained, scales with count):
       App\Models\User::$attributes: 10,000 copies x 599 B = 5.86 MB
@@ -65,7 +65,7 @@ Example output:
     (14 scalar properties per-instance, included in object size)
     SHARED: App\Models\User::$relations (array, CoW), App\Models\User::$fillable (array, CoW)
 
-  [MEDIUM ] 42.50 MB impacted
+  [MEDIUM]   42.50 MB impacted
     cycle_cluster: 200 identical cycles (3 classes, 170.31 KB shallow, 42.50 MB retained)
     Per cycle: 1x Webklex\PHPIMAP\Message + 3x Webklex\PHPIMAP\Attachment + 1x Webklex\PHPIMAP\AttachmentCollection
     Back-reference: Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message
@@ -74,10 +74,10 @@ Example output:
     Single entry point — breaking the back-reference likely frees this cycle
     Next: Break Webklex\PHPIMAP\Attachment::$oMessage -> Webklex\PHPIMAP\Message to eliminate all 200 cycles
 
-  [MEDIUM ] —
+  [MEDIUM]   —
     companion_cluster: FormBuilder (3,611, 1.74 MB) always paired with Closure (3,619, 1.19 MB) — 2.93 MB
 
-  [LOW    ] 182.81 KB impacted
+  [LOW]      182.81 KB impacted
     dedup_candidate: Attachment::$part (Part): 600 copies x 312 B = 182.81 KB
     195/600 copies have identical content (32%). Example: "--boundary_mixed..."
 
@@ -176,11 +176,11 @@ sudo ./reli inspector:memory -p <pid> -f report -o report.txt  # to file
 Findings are sorted by severity (HIGH first), then by `impact_bytes` descending within the same severity. Each finding shows its impact on the first line for easy visual scanning:
 
 ```
-  [HIGH   ] 153.76 MB impacted
+  [HIGH]     153.76 MB impacted
     bottleneck_path: <main>::$messages[0]->structure->parts
-  [MEDIUM ] 40.21 MB impacted
+  [MEDIUM]   40.21 MB impacted
     expensive_property: Structure::$raw (200 x 211.00 KB)
-  [MEDIUM ] —
+  [MEDIUM]   —
     companion_cluster: 4 classes x ~200 instances
 ```
 

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -91,8 +91,8 @@ final class TextReportFormatter implements ReportFormatterInterface
                     . ' impacted'
                     : "\u{2014}";
                 $lines[] = sprintf(
-                    '  [%-7s] %s',
-                    $tag,
+                    '  %-10s %s',
+                    "[{$tag}]",
                     $impact,
                 );
                 $lines[] = "    {$finding->kind}: {$finding->summary}";

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -86,14 +86,26 @@ final class TextReportFormatter implements ReportFormatterInterface
 
             foreach ($actionable as $finding) {
                 $tag = strtoupper($finding->severity->value);
-                $lines[] = "  [{$tag}] {$finding->kind}: {$finding->summary}";
+                $impact = $finding->impact_bytes > 0
+                    ? SizeFormatter::format($finding->impact_bytes)
+                    . ' impacted'
+                    : "\u{2014}";
+                $lines[] = sprintf(
+                    '  [%-7s] %s',
+                    $tag,
+                    $impact,
+                );
+                $lines[] = "    {$finding->kind}: {$finding->summary}";
 
                 if ($finding->hypothesis !== '') {
-                    $lines[] = "    {$finding->hypothesis}";
+                    foreach (explode("\n", $finding->hypothesis) as $h) {
+                        $lines[] = "    {$h}";
+                    }
                 }
 
                 if ($finding->next_checks !== []) {
-                    $lines[] = '    Next: ' . implode('; ', $finding->next_checks);
+                    $lines[] = '    Next: '
+                        . implode('; ', $finding->next_checks);
                 }
 
                 $lines[] = '';

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -90,11 +90,7 @@ final class TextReportFormatter implements ReportFormatterInterface
                     ? SizeFormatter::format($finding->impact_bytes)
                     . ' impacted'
                     : "\u{2014}";
-                $lines[] = sprintf(
-                    '  %-10s %s',
-                    "[{$tag}]",
-                    $impact,
-                );
+                $lines[] = "  [{$tag}] {$impact}";
                 $lines[] = "    {$finding->kind}: {$finding->summary}";
 
                 if ($finding->hypothesis !== '') {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -230,7 +230,134 @@ final class CycleClusterPass implements PassInterface
             );
         }
 
+        // Check for resource-holding classes downstream of SCCs
+        $resource_findings = $this->detectResourceLeakRisks();
+        $findings = array_merge($findings, $resource_findings);
+
         return $findings;
+    }
+
+    /**
+     * Detect PDO/PDOStatement/Mysqli downstream of SCCs.
+     * @return list<Finding>
+     */
+    private function detectResourceLeakRisks(): array
+    {
+        $resource_classes = [
+            'PDO', 'PDOStatement',
+            'Mysqli', 'mysqli', 'mysqli_stmt', 'mysqli_result',
+        ];
+
+        $findings = [];
+        $seen_risks = [];
+
+        foreach ($this->substrate->scc_profiles as $profile) {
+            $scc_set = array_flip($profile['nodes']);
+
+            // Check ext_outgoing: children of SCC nodes that are outside SCC
+            foreach ($profile['nodes'] as $node) {
+                foreach ($this->substrate->children[$node] ?? [] as $child) {
+                    if (isset($scc_set[$child])) {
+                        continue;
+                    }
+                    $this->checkDownstreamForResources(
+                        $child,
+                        $resource_classes,
+                        $profile,
+                        $seen_risks,
+                        $findings,
+                    );
+                }
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Walk downstream from a node looking for resource-holding classes.
+     * @param list<string> $resource_classes
+     * @param array<string, mixed> $profile
+     * @param array<string, true> $seen_risks
+     * @param list<Finding> $findings
+     * @psalm-suppress MixedArgument, MixedArrayAccess
+     */
+    private function checkDownstreamForResources(
+        int $start_node,
+        array $resource_classes,
+        array $profile,
+        array &$seen_risks,
+        array &$findings,
+    ): void {
+        // BFS limited depth
+        $queue = [$start_node];
+        $qi = 0;
+        $visited = [];
+        while ($qi < count($queue) && $qi < 50) {
+            $node = $queue[$qi++];
+            if (isset($visited[$node])) {
+                continue;
+            }
+            $visited[$node] = true;
+
+            $cls = $this->substrate->node_classes[$node] ?? null;
+            if ($cls !== null) {
+                foreach ($resource_classes as $rc) {
+                    if ($cls === $rc || str_ends_with($cls, "\\{$rc}")) {
+                        $key = $cls . ':' . (string)$profile['signature'];
+                        if (isset($seen_risks[$key])) {
+                            continue;
+                        }
+                        $seen_risks[$key] = true;
+
+                        /** @var array<string, int> $cc */
+                        $cc = $profile['class_counts'];
+                        $scc_classes = implode(
+                            ', ',
+                            array_keys($cc)
+                        );
+
+                        $findings[] = new Finding(
+                            kind: 'resource_leak_risk',
+                            severity: FindingSeverity::High,
+                            confidence: FindingConfidence::Medium,
+                            summary: sprintf(
+                                '%s held by cycle (%s)',
+                                $cls,
+                                $scc_classes,
+                            ),
+                            facts: [
+                                'resource_class' => $cls,
+                                'scc_classes' => $scc_classes,
+                                'scc_signature' => $profile['signature'],
+                            ],
+                            hypothesis: sprintf(
+                                'Circular reference prevents timely'
+                                . " destruction of %s.\n"
+                                . 'Connection/resource not released'
+                                . " until GC cycle collection.\n"
+                                . 'With persistent connections, GC'
+                                . ' may trigger unexpected rollback.',
+                                $cls
+                            ),
+                            next_checks: [
+                                'Break the circular reference to ensure'
+                                . ' deterministic resource cleanup',
+                                'Especially dangerous in long-running'
+                                . ' workers (connection pool exhaustion)',
+                            ],
+                        );
+                    }
+                }
+            }
+
+            // Continue BFS
+            foreach ($this->substrate->children[$node] ?? [] as $child) {
+                if (!isset($visited[$child])) {
+                    $queue[] = $child;
+                }
+            }
+        }
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -63,8 +63,8 @@ class TextReportFormatterTest extends BaseTestCase
         $output = $formatter->format($result);
 
         $this->assertStringContainsString('=== Findings ===', $output);
-        $this->assertStringContainsString('[HIGH] dominant_class', $output);
-        $this->assertStringContainsString('Foo: 10,000 instances', $output);
+        $this->assertStringContainsString('[HIGH', $output);
+        $this->assertStringContainsString('dominant_class: Foo: 10,000 instances', $output);
         $this->assertStringContainsString('Unbounded accumulation', $output);
         $this->assertStringContainsString('Next: Check loop; Check container', $output);
     }
@@ -88,8 +88,8 @@ class TextReportFormatterTest extends BaseTestCase
         $formatter = new TextReportFormatter();
         $output = $formatter->format($result);
 
-        $high_pos = strpos($output, '[HIGH]');
-        $low_pos = strpos($output, '[LOW]');
+        $high_pos = strpos($output, '[HIGH');
+        $low_pos = strpos($output, '[LOW');
         $this->assertNotFalse($high_pos);
         $this->assertNotFalse($low_pos);
         $this->assertLessThan($low_pos, $high_pos);


### PR DESCRIPTION
## Summary

### Resource leak detection (`resource_leak_risk`)
BFS downstream from SCC nodes to detect PDO, PDOStatement, Mysqli held by circular references:
```
[HIGH] —
  resource_leak_risk: PDO held by cycle (Repository, Service)
    Circular reference prevents timely destruction of PDO.
    Connection/resource not released until GC cycle collection.
    With persistent connections, GC may trigger unexpected rollback.
```
Especially dangerous in long-running workers (connection pool exhaustion) and with persistent connections (GC-triggered rollbacks causing hard-to-reproduce bugs).

### Fixed-impact display layout
Impact bytes now on first line for easy scanning:
```
[HIGH] 153.76 MB impacted
  bottleneck_path: <main>::$messages[0]->structure->parts

[MEDIUM] 42.50 MB impacted
  cycle_cluster: 200 identical cycles (3 classes, 170.31 KB shallow, 42.50 MB retained)

[MEDIUM] —
  companion_cluster: 4 classes x ~200 instances
```
Multi-line hypothesis (back-reference, entry path, property scaling details) now properly indented.

### Documentation
Updated memory-report.md and internals doc:
- `resource_leak_risk` in High Severity table and Finding catalog
- Example output updated to new layout
- Display format description added

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf