### PR TITLE
Add GcPendingPass: detect objects likely awaiting GC cycle collection

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/GcPendingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/GcPendingPass.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+
+/**
+ * Detects objects that are likely GC-pending garbage:
+ * reachable only via objects_store AND members of an SCC.
+ *
+ * These are candidates for "unreachable from user code but kept alive
+ * by circular references, awaiting GC cycle collection".
+ */
+final class GcPendingPass implements PassInterface
+{
+    public function __construct(
+        private GraphSubstrate $substrate,
+        private \PDO $db,
+        private int $run_id,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress MixedOperand, InvalidOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        if ($this->substrate->scc_profiles === []) {
+            return [];
+        }
+
+        // Find which root branch each node belongs to (BFS from roots)
+        $root_link_names = $this->loadRootLinkNames();
+        $node_root_owner = [];
+
+        foreach ($this->substrate->roots as $root) {
+            $queue = [$root];
+            $qi = 0;
+            $node_root_owner[$root] = $root;
+            while ($qi < count($queue)) {
+                $node = $queue[$qi++];
+                foreach ($this->substrate->children[$node] ?? [] as $child) {
+                    if (!isset($node_root_owner[$child])) {
+                        $node_root_owner[$child] = $root;
+                        $queue[] = $child;
+                    }
+                }
+            }
+        }
+
+        // Find the objects_store root
+        $objects_store_root = null;
+        foreach ($this->substrate->roots as $root) {
+            if (($root_link_names[$root] ?? '') === 'objects_store') {
+                $objects_store_root = $root;
+                break;
+            }
+        }
+
+        if ($objects_store_root === null) {
+            return [];
+        }
+
+        // Collect SCC members owned by objects_store
+        $gc_candidates = [];
+        foreach ($this->substrate->node_to_scc as $node => $scc_id) {
+            $owner = $node_root_owner[$node] ?? null;
+            if ($owner !== $objects_store_root) {
+                continue;
+            }
+            $cls = $this->substrate->node_classes[$node] ?? null;
+            if ($cls === null) {
+                continue;
+            }
+            if (!isset($gc_candidates[$cls])) {
+                $gc_candidates[$cls] = ['count' => 0, 'size' => 0];
+            }
+            $gc_candidates[$cls]['count']++;
+            $gc_candidates[$cls]['size']
+                += $this->substrate->node_sizes[$node] ?? 0;
+        }
+
+        if ($gc_candidates === []) {
+            return [];
+        }
+
+        arsort($gc_candidates);
+        $total_count = 0;
+        $total_size = 0;
+        $class_list = [];
+        foreach ($gc_candidates as $cls => $info) {
+            $total_count += $info['count'];
+            $total_size += $info['size'];
+            $class_list[] = sprintf(
+                '%dx %s',
+                $info['count'],
+                $cls
+            );
+        }
+
+        $top_classes = implode(
+            ', ',
+            array_slice($class_list, 0, 5)
+        );
+        if (count($class_list) > 5) {
+            $top_classes .= sprintf(
+                ', ... +%d more',
+                count($class_list) - 5
+            );
+        }
+
+        return [
+            new Finding(
+                kind: 'gc_pending_candidate',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Low,
+                summary: sprintf(
+                    '%s objects (%s) reachable only via objects_store',
+                    number_format($total_count),
+                    SizeFormatter::format($total_size),
+                ),
+                facts: [
+                    'total_count' => $total_count,
+                    'total_size' => $total_size,
+                    'classes' => $gc_candidates,
+                ],
+                hypothesis: "Classes: {$top_classes}\n"
+                    . 'These MAY be unreachable from user code and'
+                    . " awaiting GC cycle collection.\n"
+                    . 'Note: reli may not track all reference paths;'
+                    . ' false positive possible.',
+                next_checks: [
+                    'If this grows across snapshots, it indicates a leak',
+                    'Break circular references for deterministic cleanup',
+                ],
+                impact_bytes: $total_size,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<int, string> root_node_id => link_name
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadRootLinkNames(): array
+    {
+        $rows = $this->db->query(
+            "SELECT child_node_id, link_name FROM context_edges"
+            . " WHERE parent_node_id IS NULL AND is_tree = 1"
+            . " AND run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        $map = [];
+        foreach ($rows as $r) {
+            $map[(int)$r[0]] = (string)$r[1];
+        }
+        return $map;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -22,6 +22,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Pass\CompanionDetectionPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CycleClusterPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\DrillDownPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\DynamicPropertiesPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\GcPendingPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\NonTreeEdgePass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\OverviewPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\OwnershipPatternPass;
@@ -108,6 +109,7 @@ final class ReportGenerator
             ));
             $findings = array_merge($findings, $this->runPass(new BlameAllocationPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(new RetainedSizeConfidencePass($substrate)));
+            $findings = array_merge($findings, $this->runPass(new GcPendingPass($substrate, $db, $run_id)));
         }
 
         $findings = $this->deduplicateFindings($findings);


### PR DESCRIPTION
## Summary

Detects objects likely awaiting GC cycle collection: reachable only via `objects_store` AND members of an SCC (circular reference).

### Algorithm
1. BFS from each root to assign root ownership per node
2. Find the `objects_store` root
3. Collect SCC members owned exclusively by `objects_store`
4. Group by class, report count and size

### Output
```
[MEDIUM] gc_pending_candidate: 500 objects (2.30 MB) reachable only via objects_store
  Classes: 200x Message, 300x Attachment
  These MAY be unreachable from user code and awaiting GC cycle collection.
  Note: reli may not track all reference paths; false positive possible.
```

### Design decisions
- **Severity: MEDIUM** — not HIGH because reli may not track all reference paths (extension internals, etc.), so false positives are possible
- **Confidence: LOW** — same reason
- If count grows across snapshots, it confirms a leak
- GC cycle collector runs when potential cycle buffer reaches 10,000; few large cycles may never trigger GC, silently leaking memory

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf