### PR TITLE
Add edge strength (strong/weak/structural) to context tree edges

### DIFF
--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -173,15 +173,16 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             )
         ');
 
-        $db->exec('
+        $db->exec("
             CREATE TABLE IF NOT EXISTS context_edges (
                 run_id INTEGER NOT NULL,
                 parent_node_id INTEGER,
                 child_node_id INTEGER NOT NULL,
                 link_name TEXT NOT NULL,
-                is_tree INTEGER NOT NULL
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
             )
-        ');
+        ");
 
         $db->exec("
             CREATE TABLE IF NOT EXISTS context_node_locations (
@@ -239,6 +240,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $db->exec(
             'CREATE INDEX IF NOT EXISTS idx_context_edges_run_link_parent_tree'
             . ' ON context_edges(run_id, link_name, parent_node_id, is_tree)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_edges_run_strength'
+            . ' ON context_edges(run_id, strength)'
         );
     }
 
@@ -394,19 +399,20 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
         // Copy context_edges
         $rows = $source->prepare(
-            'SELECT parent_node_id, child_node_id, link_name, is_tree FROM context_edges WHERE run_id = ?'
+            'SELECT parent_node_id, child_node_id, link_name, is_tree, strength'
+            . ' FROM context_edges WHERE run_id = ?'
         );
         $rows->execute([$source_run_id]);
         $insert = $target->prepare(
-            'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree)'
-            . ' VALUES (?, ?, ?, ?, ?)'
+            'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
         );
         /** @psalm-suppress MixedAssignment */
         while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
             /** @psalm-suppress MixedArrayAccess */
             $insert->execute([
                 $run_id, $row['parent_node_id'], $row['child_node_id'],
-                $row['link_name'], $row['is_tree'],
+                $row['link_name'], $row['is_tree'], $row['strength'] ?? 'strong',
             ]);
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -254,9 +254,9 @@ final class CycleClusterPass implements PassInterface
         foreach ($this->substrate->getSccProfiles() as $profile) {
             $scc_set = array_flip($profile['nodes']);
 
-            // Check ext_outgoing: children of SCC nodes that are outside SCC
+            // Check ext_outgoing: strong children of SCC nodes that are outside SCC
             foreach ($profile['nodes'] as $node) {
-                foreach ($this->substrate->getChildren($node) as $child) {
+                foreach ($this->substrate->getStrongChildren($node) as $child) {
                     if (isset($scc_set[$child])) {
                         continue;
                     }
@@ -351,8 +351,8 @@ final class CycleClusterPass implements PassInterface
                 }
             }
 
-            // Continue BFS
-            foreach ($this->substrate->getChildren($node) as $child) {
+            // Continue BFS via strong edges only
+            foreach ($this->substrate->getStrongChildren($node) as $child) {
                 if (!isset($visited[$child])) {
                     $queue[] = $child;
                 }
@@ -418,8 +418,9 @@ final class CycleClusterPass implements PassInterface
         foreach ($nodes as $node) {
             $shallow_total += $this->substrate->getNodeSize($node);
 
-            // Add downstream retained from tree children outside SCC
-            foreach ($this->substrate->getChildren($node) as $child) {
+
+            // Add downstream retained from strong tree children outside SCC
+            foreach ($this->substrate->getStrongChildren($node) as $child) {
                 if (!isset($scc_set[$child])) {
                     $downstream
                         += $this->substrate->getSubtreeSize($child);

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -69,11 +69,7 @@ final class NonTreeEdgePass implements PassInterface
             FROM context_edges e
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
-                AND e.link_name NOT IN (
-                    'object_properties', 'array_elements',
-                    'dynamic_properties', 'object_handlers',
-                    'name', 'key', 'value', 'class_entry'
-                )
+                AND e.strength = 'strong'
             GROUP BY e.link_name
             HAVING count(*) > 10
             ORDER BY count(*) DESC
@@ -212,11 +208,7 @@ final class NonTreeEdgePass implements PassInterface
                 AND cnl.run_id = {$this->run_id}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
-                AND e.link_name NOT IN (
-                    'object_handlers', 'object_properties',
-                    'array_elements', 'dynamic_properties',
-                    'class_entry'
-                )
+                AND e.strength = 'strong'
             GROUP BY e.link_name, cnl.size
             HAVING count(*) > 50 AND count(*) * cnl.size > 10240
             ORDER BY count(*) * cnl.size DESC

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -97,6 +97,13 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
     /** @return list<int> */
     #[\Override]
+    public function getStrongChildren(int $nodeId): array
+    {
+        return $this->strong_children[$nodeId] ?? [];
+    }
+
+    /** @return list<int> */
+    #[\Override]
     public function getAllChildren(int $nodeId): array
     {
         $idx = $this->nodeIdToIndex($nodeId);
@@ -104,6 +111,13 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             return [];
         }
         return $this->csrSlice($this->allOffsets, $this->allEdges, $idx);
+    }
+
+    /** @return list<int> */
+    #[\Override]
+    public function getStrongAllChildren(int $nodeId): array
+    {
+        return $this->strong_all_children[$nodeId] ?? [];
     }
 
     /** @return list<int> */
@@ -379,7 +393,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private function loadEdgesFfi(\PDO $db, int $run_id): void
     {
         $rows = $db->query(
-            "SELECT parent_node_id, child_node_id, is_tree"
+            "SELECT parent_node_id, child_node_id, is_tree, strength"
             . " FROM context_edges WHERE run_id = {$run_id}"
         )->fetchAll(\PDO::FETCH_NUM);
 
@@ -397,6 +411,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $parent = $r[0] === null ? -1 : (int)$r[0];
             $child = (int)$r[1];
             $is_tree = (int)$r[2];
+            $strength = (string)($r[3] ?? 'strong');
+            $is_strong = $strength === 'strong';
 
             $parentIdx = $this->nodeIdToIndex($parent);
             $childIdx = $this->nodeIdToIndex($child);
@@ -404,6 +420,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             if ($is_tree) {
                 $treeDegree[$parentIdx] = $treeDegree[$parentIdx] + 1;
                 $treeEdgeCount++;
+                if ($is_strong) {
+                    $this->strong_children[$parent][] = $child;
+                }
                 if ($parent === -1) {
                     $this->roots[] = $child;
                 }
@@ -411,6 +430,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             if ($parent !== -1) {
                 $allDegree[$parentIdx] = $allDegree[$parentIdx] + 1;
                 $allEdgeCount++;
+                if ($is_strong) {
+                    $this->strong_all_children[$parent][] = $child;
+                }
             }
             $revDegree[$childIdx] = $revDegree[$childIdx] + 1;
         }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -27,6 +27,12 @@ class GraphSubstrate
     /** @var array<int, list<int>> child_id => [parent_id, ...] (all edges) */
     public array $all_parents = [];
 
+    /** @var array<int, list<int>> parent_id => [child_id, ...] (strong tree edges only) */
+    public array $strong_children = [];
+
+    /** @var array<int, list<int>> parent_id => [child_id, ...] (strong edges including non-tree) */
+    public array $strong_all_children = [];
+
     /** @var list<int> root node IDs (parent_node_id IS NULL) */
     public array $roots = [];
 
@@ -108,9 +114,21 @@ class GraphSubstrate
     }
 
     /** @return list<int> */
+    public function getStrongChildren(int $nodeId): array
+    {
+        return $this->strong_children[$nodeId] ?? [];
+    }
+
+    /** @return list<int> */
     public function getAllChildren(int $nodeId): array
     {
         return $this->all_children[$nodeId] ?? [];
+    }
+
+    /** @return list<int> */
+    public function getStrongAllChildren(int $nodeId): array
+    {
+        return $this->strong_all_children[$nodeId] ?? [];
     }
 
     /** @return list<int> */
@@ -225,7 +243,7 @@ class GraphSubstrate
     protected function loadEdges(\PDO $db, int $run_id): void
     {
         $rows = $db->query(
-            "SELECT parent_node_id, child_node_id, is_tree"
+            "SELECT parent_node_id, child_node_id, is_tree, strength"
             . " FROM context_edges WHERE run_id = {$run_id}"
         )->fetchAll(\PDO::FETCH_NUM);
 
@@ -233,15 +251,23 @@ class GraphSubstrate
             $parent = $r[0] === null ? -1 : (int)$r[0];
             $child = (int)$r[1];
             $is_tree = (int)$r[2];
+            $strength = (string)($r[3] ?? 'strong');
+            $is_strong = $strength === 'strong';
 
             if ($is_tree) {
                 $this->children[$parent][] = $child;
+                if ($is_strong) {
+                    $this->strong_children[$parent][] = $child;
+                }
                 if ($parent === -1) {
                     $this->roots[] = $child;
                 }
             }
             if ($parent !== -1) {
                 $this->all_children[$parent][] = $child;
+                if ($is_strong) {
+                    $this->strong_all_children[$parent][] = $child;
+                }
             }
             $this->all_parents[$child][] = $parent;
         }
@@ -260,13 +286,13 @@ class GraphSubstrate
             [$node, $processed] = array_pop($stack);
             if ($processed) {
                 $size = $this->node_sizes[$node] ?? 0;
-                foreach ($this->children[$node] ?? [] as $child) {
+                foreach ($this->strong_children[$node] ?? [] as $child) {
                     $size += $this->subtree_sizes[$child] ?? 0;
                 }
                 $this->subtree_sizes[$node] = $size;
             } else {
                 $stack[] = [$node, true];
-                foreach ($this->children[$node] ?? [] as $child) {
+                foreach ($this->strong_children[$node] ?? [] as $child) {
                     if (!isset($this->subtree_sizes[$child])) {
                         $stack[] = [$child, false];
                     }
@@ -297,7 +323,7 @@ class GraphSubstrate
 
             while ($call_stack) {
                 [$node, $ci] = array_pop($call_stack);
-                $node_children = $this->all_children[$node] ?? [];
+                $node_children = $this->strong_all_children[$node] ?? [];
 
                 $found_unvisited = false;
                 $count = count($node_children);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ArrayContextTreeSink.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\Process\MemoryLocation;
 
 final class ArrayContextTreeSink implements ContextTreeSink
@@ -35,10 +36,12 @@ final class ArrayContextTreeSink implements ContextTreeSink
         string $type,
         iterable $locations,
         array $attributes,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
         $node = [
             '#node_id' => $node_id,
             '#type' => $type,
+            '#edge_strength' => $edge_strength->value,
         ];
 
         if ($locations instanceof \Traversable) {
@@ -69,8 +72,12 @@ final class ArrayContextTreeSink implements ContextTreeSink
         int $reference_node_id,
         ?int $parent_node_id,
         string $link_name,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
-        $ref = ['#reference_node_id' => $reference_node_id];
+        $ref = [
+            '#reference_node_id' => $reference_node_id,
+            '#edge_strength' => $edge_strength->value,
+        ];
 
         if ($parent_node_id === null) {
             $this->root[$link_name] = $ref;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
 use WeakMap;
@@ -38,7 +39,8 @@ final class ContextAnalyzer
         foreach ($reference_context->getLinks() as $link_name => $linked_context) {
             /** @psalm-suppress RedundantCastGivenDocblockType -- int keys occur at runtime */
             $link_name = (string)$link_name;
-            $this->analyzeContext($linked_context, $link_name, $parent_node_id, $sink, $memo);
+            $edge_strength = $reference_context->getLinkStrength($link_name);
+            $this->analyzeContext($linked_context, $link_name, $parent_node_id, $sink, $memo, $edge_strength);
         }
 
         if ($sink->allowsRelease()) {
@@ -100,18 +102,19 @@ final class ContextAnalyzer
         ?int $parent_node_id,
         ContextTreeSink $sink,
         WeakMap $memo,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
         // SentinelContext: already emitted to DB in a previous branch,
         // just record the reference edge.
         if ($linked_context instanceof SentinelContext) {
-            $sink->emitReference($linked_context->node_id, $parent_node_id, $link_name);
+            $sink->emitReference($linked_context->node_id, $parent_node_id, $link_name, $edge_strength);
             return;
         }
 
         $existing_node_id = $memo[$linked_context] ?? null;
         if ($existing_node_id !== null && $existing_node_id >= 0) {
             // Fully emitted — just add a reference edge
-            $sink->emitReference($existing_node_id, $parent_node_id, $link_name);
+            $sink->emitReference($existing_node_id, $parent_node_id, $link_name, $edge_strength);
             return;
         }
 
@@ -136,6 +139,7 @@ final class ContextAnalyzer
             $linked_context->getName(),
             $linked_context->getLocations(),
             $contexts,
+            $edge_strength,
         );
 
         $this->analyze($linked_context, $sink, $current_node_id, $memo);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextTreeSink.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\Process\MemoryLocation;
 
 interface ContextTreeSink
@@ -28,12 +29,14 @@ interface ContextTreeSink
         string $type,
         iterable $locations,
         array $attributes,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void;
 
     public function emitReference(
         int $reference_node_id,
         ?int $parent_node_id,
         string $link_name,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void;
 
     /** Whether traversed context nodes can release their child references for GC */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/PdoContextTreeSink.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\Process\MemoryLocation;
 
@@ -27,7 +28,7 @@ final class PdoContextTreeSink implements ContextTreeSink
     private const EDGE_BATCH_SIZE = 200;
     private const LOCATION_COLUMNS = 10;
     private const ATTR_COLUMNS = 4;
-    private const EDGE_COLUMNS = 5;
+    private const EDGE_COLUMNS = 6;
 
     private \PDOStatement $node_stmt;
 
@@ -76,9 +77,10 @@ final class PdoContextTreeSink implements ContextTreeSink
         string $type,
         iterable $locations,
         array $attributes,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
         $this->node_stmt->execute([$this->run_id, $node_id, $type]);
-        $this->bufferEdge($parent_node_id, $node_id, $link_name, 1);
+        $this->bufferEdge($parent_node_id, $node_id, $link_name, 1, $edge_strength);
 
         foreach ($locations as $location) {
             $class = $location::class;
@@ -132,8 +134,9 @@ final class PdoContextTreeSink implements ContextTreeSink
         int $reference_node_id,
         ?int $parent_node_id,
         string $link_name,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
-        $this->bufferEdge($parent_node_id, $reference_node_id, $link_name, 0);
+        $this->bufferEdge($parent_node_id, $reference_node_id, $link_name, 0, $edge_strength);
     }
 
     public function flush(): void
@@ -188,13 +191,19 @@ final class PdoContextTreeSink implements ContextTreeSink
             );
     }
 
-    private function bufferEdge(?int $parent_node_id, int $child_node_id, string $link_name, int $is_tree): void
-    {
+    private function bufferEdge(
+        ?int $parent_node_id,
+        int $child_node_id,
+        string $link_name,
+        int $is_tree,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
+    ): void {
         $this->edge_buffer[] = $this->run_id;
         $this->edge_buffer[] = $parent_node_id;
         $this->edge_buffer[] = $child_node_id;
         $this->edge_buffer[] = $link_name;
         $this->edge_buffer[] = $is_tree;
+        $this->edge_buffer[] = $edge_strength->value;
         $this->edge_row_count++;
 
         if ($this->edge_row_count >= self::EDGE_BATCH_SIZE) {
@@ -215,8 +224,8 @@ final class PdoContextTreeSink implements ContextTreeSink
     {
         return $this->edge_batch_stmts[$row_count]
             ??= $this->db->prepare(
-                'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree)'
-                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?)'))
+                'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength)'
+                . ' VALUES ' . implode(',', array_fill(0, $row_count, '(?,?,?,?,?,?)'))
             );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ClassDefinitionContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ClassDefinitionContext.php
@@ -28,6 +28,15 @@ final class ClassDefinitionContext implements ReferenceContext
         return ['#is_internal' => $this->is_internal];
     }
 
+    #[\Override]
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return match ($link_name) {
+            'class_entry' => EdgeStrength::Structural,
+            default => EdgeStrength::Strong,
+        };
+    }
+
     public function getMethods(): ?DefinedFunctionsContext
     {
         /** @var DefinedFunctionsContext|null */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/EdgeStrength.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/EdgeStrength.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+enum EdgeStrength: string
+{
+    case Strong = 'strong';
+    case Weak = 'weak';
+    case Structural = 'structural';
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContext.php
@@ -29,4 +29,13 @@ final class ObjectContext implements ReferenceContext
     {
         return [$this->memory_location];
     }
+
+    #[\Override]
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return match ($link_name) {
+            'object_handlers' => EdgeStrength::Structural,
+            default => EdgeStrength::Strong,
+        };
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectsStoreContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectsStoreContext.php
@@ -37,4 +37,10 @@ final class ObjectsStoreContext implements ReferenceContext
             '#count' => count($this->referencing_contexts),
         ];
     }
+
+    #[\Override]
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return EdgeStrength::Weak;
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
@@ -29,6 +29,8 @@ interface ReferenceContext
 
     public function getContexts(): iterable;
 
+    public function getLinkStrength(string $link_name): EdgeStrength;
+
     /** Release child references to allow GC of traversed subtrees */
     public function releaseLinks(): void;
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
@@ -48,6 +48,11 @@ trait ReferenceContextDefault
         return [];
     }
 
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return EdgeStrength::Strong;
+    }
+
     public function releaseLinks(): void
     {
         $this->referencing_contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
@@ -63,4 +63,10 @@ final class SentinelContext implements ReferenceContext
     public function releaseLinks(): void
     {
     }
+
+    #[\Override]
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return EdgeStrength::Strong;
+    }
 }

--- a/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
+++ b/tests/Inspector/Output/MemoryOutput/PdoMemoryOutputTest.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\Process\MemoryLocation;
 
@@ -345,6 +346,7 @@ class PdoMemoryOutputTest extends BaseTestCase
         $badContext->allows('getLocations')->andReturns([]);
         $badContext->allows('getContexts')->andReturns([]);
         $badContext->allows('releaseLinks');
+        $badContext->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
 
         $result = new MemoryAnalysisResult([], $badContext);
         $output = new PdoMemoryOutput($driver);
@@ -380,6 +382,7 @@ class PdoMemoryOutputTest extends BaseTestCase
         $context->allows('getLocations')->andReturns($locations);
         $context->allows('getContexts')->andReturns($attributes);
         $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
         return $context;
     }
 

--- a/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\Process\MemoryLocation;
 
@@ -339,6 +340,7 @@ class ReportGeneratorTest extends BaseTestCase
         $context->allows('getLocations')->andReturns($locations);
         $context->allows('getContexts')->andReturns($attributes);
         $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
         return $context;
     }
 

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\Process\MemoryLocation;
 
@@ -310,6 +311,7 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
         $context->allows('getLocations')->andReturns($locations);
         $context->allows('getContexts')->andReturns($attributes);
         $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
         return $context;
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\Process\MemoryLocation;
 
@@ -152,6 +153,102 @@ class GraphSubstrateTest extends BaseTestCase
         $this->assertContains('App\\MyClass', $substrate->node_classes);
     }
 
+    public function testWeakEdgeExcludedFromSubtreeSize(): void
+    {
+        $weak_child = $this->createMockContextWithStrength('weak_child', [], [
+            new ZendObjectMemoryLocation(0x3000, 500, 1, 7, 'App\\WeakChild'),
+        ]);
+        $strong_child = $this->createMockContextWithStrength('strong_child', [], [
+            new ZendObjectMemoryLocation(0x2000, 200, 1, 7, 'App\\StrongChild'),
+        ]);
+        $parent = $this->createMockContextWithStrength(
+            'parent',
+            ['strong_link' => $strong_child, 'weak_link' => $weak_child],
+            [new ZendObjectMemoryLocation(0x1000, 100, 1, 7, 'App\\Parent')],
+            ['weak_link' => EdgeStrength::Weak],
+        );
+        $top = $this->createMockContextWithStrength('top', ['root' => $parent], []);
+        $this->buildDb($top);
+
+        $db = $this->openDb();
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        // Parent subtree = 100 (self) + 200 (strong child) = 300
+        // Weak child (500) should NOT be included
+        $parent_node_id = null;
+        foreach ($substrate->node_sizes as $nid => $size) {
+            if ($size === 100) {
+                $parent_node_id = $nid;
+                break;
+            }
+        }
+        $this->assertNotNull($parent_node_id);
+        $this->assertSame(300, $substrate->subtree_sizes[$parent_node_id]);
+    }
+
+    public function testStructuralEdgeExcludedFromSubtreeSize(): void
+    {
+        $structural_child = $this->createMockContextWithStrength('handlers', [], [
+            new ZendObjectMemoryLocation(0x3000, 400, 1, 7, 'App\\Handlers'),
+        ]);
+        $parent = $this->createMockContextWithStrength(
+            'parent',
+            ['object_handlers' => $structural_child],
+            [new ZendObjectMemoryLocation(0x1000, 100, 1, 7, 'App\\Parent')],
+            ['object_handlers' => EdgeStrength::Structural],
+        );
+        $top = $this->createMockContextWithStrength('top', ['root' => $parent], []);
+        $this->buildDb($top);
+
+        $db = $this->openDb();
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        // Parent subtree = 100 (self only), structural child excluded
+        $parent_node_id = null;
+        foreach ($substrate->node_sizes as $nid => $size) {
+            if ($size === 100) {
+                $parent_node_id = $nid;
+                break;
+            }
+        }
+        $this->assertNotNull($parent_node_id);
+        $this->assertSame(100, $substrate->subtree_sizes[$parent_node_id]);
+    }
+
+    public function testWeakEdgeExcludedFromScc(): void
+    {
+        // Create a shared node referenced via both strong and weak edges.
+        // The weak back-reference should NOT form a cycle in SCC.
+        $shared = $this->createMockContextWithStrength('shared', [], [
+            new ZendObjectMemoryLocation(0x3000, 64, 1, 7, 'App\\Shared'),
+        ]);
+        $parent = $this->createMockContextWithStrength(
+            'parent',
+            ['child' => $shared],
+            [new ZendObjectMemoryLocation(0x1000, 64, 1, 7, 'App\\Parent')],
+        );
+        // objects_store references via weak edge
+        $store = $this->createMockContextWithStrength(
+            'store',
+            ['obj1' => $shared],
+            [new MemoryLocation(0x4000, 32)],
+            ['obj1' => EdgeStrength::Weak],
+        );
+        $top = $this->createMockContextWithStrength(
+            'top',
+            ['tree' => $parent, 'objects_store' => $store],
+            [],
+            ['objects_store' => EdgeStrength::Weak],
+        );
+        $this->buildDb($top);
+
+        $db = $this->openDb();
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        // No cycles should exist since the back-reference is weak
+        $this->assertEmpty($substrate->scc_profiles);
+    }
+
     // ---- Helpers ----
 
     private function openDb(): \PDO
@@ -185,6 +282,36 @@ class GraphSubstrateTest extends BaseTestCase
         $context->allows('getLocations')->andReturns($locations);
         $context->allows('getContexts')->andReturns($attributes);
         $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturnUsing(
+            function (string $link_name) use ($links): EdgeStrength {
+                return EdgeStrength::Strong;
+            }
+        );
+        return $context;
+    }
+
+    /**
+     * @param array<string, ReferenceContext> $links
+     * @param list<MemoryLocation> $locations
+     * @param array<string, EdgeStrength> $link_strengths
+     */
+    private function createMockContextWithStrength(
+        string $name,
+        array $links,
+        array $locations,
+        array $link_strengths = [],
+    ): ReferenceContext {
+        $context = \Mockery::mock(ReferenceContext::class);
+        $context->allows('getName')->andReturns($name);
+        $context->allows('getLinks')->andReturns($links);
+        $context->allows('getLocations')->andReturns($locations);
+        $context->allows('getContexts')->andReturns([]);
+        $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturnUsing(
+            function (string $link_name) use ($link_strengths): EdgeStrength {
+                return $link_strengths[$link_name] ?? EdgeStrength::Strong;
+            }
+        );
         return $context;
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporterTest.php
@@ -19,6 +19,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ArrayHeaderContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayMemoryLocation;
@@ -89,6 +90,7 @@ class StreamingJsonFromDbExporterTest extends BaseTestCase
         $root->allows('getLocations')->andReturn([]);
         $root->allows('getContexts')->andReturn([]);
         $root->allows('releaseLinks');
+        $root->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
 
         $wrapper = \Mockery::mock(ReferenceContext::class);
         $wrapper->allows('getName')->andReturn('Wrapper');
@@ -96,6 +98,7 @@ class StreamingJsonFromDbExporterTest extends BaseTestCase
         $wrapper->allows('getLocations')->andReturn([]);
         $wrapper->allows('getContexts')->andReturn([]);
         $wrapper->allows('releaseLinks');
+        $wrapper->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
 
         $result = new MemoryAnalysisResult([['test' => 1]], $wrapper);
         $pdo_output->output($result);
@@ -154,6 +157,7 @@ class StreamingJsonFromDbExporterTest extends BaseTestCase
         $context->allows('getLocations')->andReturn([]);
         $context->allows('getContexts')->andReturn([]);
         $context->allows('releaseLinks');
+        $context->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
         return $context;
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/EdgeStrengthTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/EdgeStrengthTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ObjectsStoreMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectHandlersMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ClassDefinitionContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectHandlersContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectsStoreContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ScalarValueContext;
+
+class EdgeStrengthTest extends BaseTestCase
+{
+    public function testObjectContextHandlersIsStructural(): void
+    {
+        $object = new ObjectContext(
+            new ZendObjectMemoryLocation(0x1000, 64, 1, 7, 'App\\Foo'),
+        );
+        $this->assertSame(EdgeStrength::Structural, $object->getLinkStrength('object_handlers'));
+    }
+
+    public function testObjectContextPropertiesIsStrong(): void
+    {
+        $object = new ObjectContext(
+            new ZendObjectMemoryLocation(0x1000, 64, 1, 7, 'App\\Foo'),
+        );
+        $this->assertSame(EdgeStrength::Strong, $object->getLinkStrength('object_properties'));
+        $this->assertSame(EdgeStrength::Strong, $object->getLinkStrength('closure'));
+        $this->assertSame(EdgeStrength::Strong, $object->getLinkStrength('dynamic_properties'));
+    }
+
+    public function testObjectsStoreAllChildrenAreWeak(): void
+    {
+        $store = new ObjectsStoreContext(
+            new ObjectsStoreMemoryLocation(0x1000, 1024),
+        );
+        $this->assertSame(EdgeStrength::Weak, $store->getLinkStrength('0'));
+        $this->assertSame(EdgeStrength::Weak, $store->getLinkStrength('any_link'));
+    }
+
+    public function testClassDefinitionClassEntryIsStructural(): void
+    {
+        $cls = new ClassDefinitionContext(is_internal: false);
+        $this->assertSame(EdgeStrength::Structural, $cls->getLinkStrength('class_entry'));
+    }
+
+    public function testClassDefinitionMethodsIsStrong(): void
+    {
+        $cls = new ClassDefinitionContext(is_internal: false);
+        $this->assertSame(EdgeStrength::Strong, $cls->getLinkStrength('methods'));
+    }
+
+    public function testDefaultLinkStrengthIsStrong(): void
+    {
+        // ScalarValueContext uses the default trait
+        $ctx = new ScalarValueContext(42);
+        $this->assertSame(EdgeStrength::Strong, $ctx->getLinkStrength('anything'));
+    }
+
+    public function testAnalyzerPassesEdgeStrengthToSink(): void
+    {
+        $handlers = \Mockery::mock(ReferenceContext::class);
+        $handlers->allows('getName')->andReturns('handlers');
+        $handlers->allows('getLinks')->andReturns([]);
+        $handlers->allows('getLocations')->andReturns([]);
+        $handlers->allows('getContexts')->andReturns([]);
+        $handlers->allows('releaseLinks');
+        $handlers->allows('getLinkStrength')->andReturns(EdgeStrength::Strong);
+
+        $object = \Mockery::mock(ReferenceContext::class);
+        $object->allows('getName')->andReturns('object');
+        $object->allows('getLinks')->andReturns([
+            'object_handlers' => $handlers,
+        ]);
+        $object->allows('getLocations')->andReturns([]);
+        $object->allows('getContexts')->andReturns([]);
+        $object->allows('releaseLinks');
+        $object->allows('getLinkStrength')->with('object_handlers')->andReturns(EdgeStrength::Structural);
+
+        $sink = \Mockery::mock(ContextTreeSink::class);
+        $sink->allows('allowsRelease')->andReturns(false);
+        $sink->expects('emitNode')->once()->withArgs(function (
+            int $node_id,
+            ?int $parent_node_id,
+            string $link_name,
+            string $type,
+            iterable $locations,
+            array $attributes,
+            EdgeStrength $edge_strength,
+        ): bool {
+            return $link_name === 'object_handlers'
+                && $edge_strength === EdgeStrength::Structural;
+        });
+
+        $analyzer = new ContextAnalyzer();
+        $analyzer->analyze($object, $sink);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `EdgeStrength` enum to classify context edges as `strong`, `weak`, or `structural`
- Use only strong edges for retained size calculation, SCC cycle detection, and non-tree edge analysis
- `object_handlers` → structural, `objects_store` children → weak, `class_entry` → structural

## Background

PHP references differ in whether they increment refcount (strong) or not (weak/structural).
Previously all edges were treated equally, reducing precision of retained size and SCC analysis.

## Changes

### EdgeStrength enum
- `Strong`: normal references that increment refcount (properties, variables)
- `Weak`: references that don't increment refcount (objects_store entries)
- `Structural`: PHP VM internals (object_handlers, class_entry)

### ReferenceContext layer
- Add `getLinkStrength(string $link_name): EdgeStrength` to `ReferenceContext` interface
- Default `Strong` in `ReferenceContextDefault` trait
- `ObjectContext`: `object_handlers` → Structural
- `ObjectsStoreContext`: all children → Weak
- `ClassDefinitionContext`: `class_entry` → Structural

### ContextAnalyzer → Sink pipeline
- Add `EdgeStrength` parameter to `ContextTreeSink` interface
- `ContextAnalyzer` queries parent context for strength and passes it to sink
- `PdoContextTreeSink`: writes strength column to DB
- `ArrayContextTreeSink`: includes `#edge_strength` in JSON output

### DB schema
- Add `strength TEXT NOT NULL DEFAULT 'strong'` column to `context_edges`

### Analysis passes
- `GraphSubstrate`: add `strong_children` / `strong_all_children`; use only strong edges for retained size (subtree sum) and SCC (Tarjan)
- `CycleClusterPass`: use strong edges for retained calculation and resource leak detection
- `NonTreeEdgePass`: replace hard-coded link_name exclusion list with `strength = 'strong'` filter

## Test plan
- [x] EdgeStrengthTest: verify strength classification on Context classes and ContextAnalyzer propagation
- [x] GraphSubstrateTest: verify weak/structural edges excluded from subtree size and SCC
- [x] 104 related tests pass
- [x] phpcs clean

https://claude.ai/code/session_01ESY62BQ4dg5Sy5Wfa2yxTd