### PR TITLE
Implement streaming memory analysis with SQLite to reduce peak memory

### DIFF
--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -193,22 +193,58 @@ to the DB can be GC'd immediately.
 For a typical PHP process, tree depth is O(tens~hundreds) while total node
 count is O(tens of thousands). This changes peak memory from O(n) to O(depth).
 
-#### Proposed architecture
+#### What stays in PHP vs what goes to DB
+
+The collector needs fast address lookups during DFS to avoid re-traversal.
+Currently this is done via `$memory_locations->has($address)` and
+`$pool->getContextForLocation()`, both backed by PHP arrays of objects.
+
+On a pool cache hit, the returned Context is never read — it is only passed
+to a parent's `add()` as an opaque reference. Therefore the PHP side only
+needs to know *whether* an address was seen and *which node_id* it maps to.
+The actual Context data (type, properties, children) is only needed during
+the fresh path and can be written to the DB immediately.
 
 ```
-Collection phase:
-  ContextPool  →  seen_set: array<int, int>  (address → node_id)
-  ReferenceContext tree  →  DB tables: nodes + edges
-  MemoryLocations  →  DB table: memory_locations
+PHP side (kept in memory during collection):
+  array<int, int>  address → node_id     (~16 bytes per entry)
 
-  On fresh path:
-    Create Context → extract data → INSERT node → record in seen_set → discard
-  On cache hit:
-    Lookup node_id from seen_set → INSERT edge only → skip traversal
+DB side (streamed out):
+  nodes table:  id, type, address, size, refcount, value, ...
+  edges table:  parent_id, child_id, link_name
+```
+
+This replaces:
+- ContextPool arrays of Context objects → `array<int, int>` seen set
+- Full ReferenceContext tree → DB edges
+- MemoryLocations collection → DB node attributes
+
+#### Proposed collection flow
+
+```
+On fresh path:
+  Create Context → extract fields → INSERT node → seen[address] = node_id
+  → recurse into children → discard Context object after return
+On cache hit:
+  node_id = seen[address] → INSERT edge only → skip traversal
+```
+
+#### In-memory SQLite as default, file-backed as fallback
+
+Even in-memory SQLite stores data more compactly than PHP objects (~130-220
+bytes/node vs ~360 bytes/node) because it eliminates PHP object headers
+(~56 bytes each) and array bucket overhead. If memory is still tight, the
+same code can switch to file-backed SQLite by changing the connection string.
+
+```
+                    In-memory SQLite     File-backed SQLite
+Memory usage        ~40-60% of current   O(depth) only
+I/O cost            None                 Moderate (SSD: light)
+Code difference     None                 Connection string only
+```
 
 Analysis phase:
   Query DB instead of traversing in-memory tree
-```
 
 #### Trade-offs
 

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -1,330 +1,132 @@
-# Memory Analysis Optimization Ideas
+# Memory Analysis Optimization
 
 ## Problem
 
-The memory analysis feature (collecting and analyzing PHP process memory via
-`MemoryLocationsCollector`) has high memory consumption in the profiler process
-itself. The peak occurs at the end of the collection phase, when the full
-`ReferenceContext` tree and all `MemoryLocations` are held in memory
-simultaneously.
+The memory analysis feature (`MemoryLocationsCollector`) had high memory
+consumption in the profiler process itself. For large targets (e.g., 5.6 GB
+PHP process), the profiler would OOM at ~8 GB before completing collection.
 
-The memory footprint scales with the target process's complexity (number of
-objects, arrays, strings, functions, classes, etc.), and the composition varies
-per target, so optimizations must be broadly effective rather than targeting
-specific context types.
+## Implemented Optimizations
 
-## Architecture Overview
+### Streaming collection via SQLite intermediate (optimization 8)
 
-Key data structures at peak:
+**Status: Implemented**
 
-- **ReferenceContext tree**: 48 concrete context classes, each holding child
-  references in `$referencing_contexts` (`array<string, ReferenceContext>`) via
-  the `ReferenceContextDefault` trait.
-- **MemoryLocations**: `array<int => MemoryLocation>` collecting all memory
-  regions. 32 MemoryLocation subclasses.
-- **ContextPools**: 6 pools (String, Array, Object, PhpReference, Resource,
-  UserFunctionDefinition) holding strong references keyed by address for
-  deduplication.
+When a `ContextTreeSink` is passed to `collectAll()`, the collector operates
+in streaming mode:
 
-## Proposed Optimizations
+1. Each top-level branch (objects_store, function_table, etc.) is emitted to
+   a `PdoContextTreeSink` immediately after collection via `analyzeSingleLink()`
+2. Within branches, inner loops (array elements, object properties, local
+   variables) also emit per-iteration via `emitChildIfStreaming()`
+3. After each emission, `flushPoolsIfStreaming()` converts pool entries to
+   lightweight sentinels and clears the pools
 
-### 1. Convert `$referencing_contexts` array to typed properties (high impact)
-
-Many context classes have a fixed, statically known set of child link names.
-For example, `ArrayHeaderContext` only ever has an `array_elements` link. The
-current design stores these in a generic `array<string, ReferenceContext>`,
-paying PHP array bucket overhead (~36 bytes) plus string key cost per entry.
-
-**Approach**: For context classes with known child types, replace the
-`$referencing_contexts` array with dedicated typed properties (e.g.,
-`public ?ArrayElementsContext $array_elements = null`). Context classes with
-truly dynamic children (e.g., `ArrayElementsContext` whose keys are runtime
-array keys) would keep the array.
-
-**Effect**: Eliminates array bucket + string key overhead per link. Applies
-uniformly across all context types.
-
-### 2. Inline MemoryLocation into Context (high impact)
-
-Currently each Context that has a location holds a separate MemoryLocation
-object. Every PHP object carries ~56 bytes of header overhead.
-
-Survey of the 48 context classes:
-- **21 classes** have no MemoryLocation (category A)
-- **25 classes** have exactly one MemoryLocation (category B)
-- **2 classes** have two MemoryLocations (category C: `DefinedFunctionsContext`,
-  `OpArrayContext`)
-
-**Approach**: For category B (the majority), inline the MemoryLocation's fields
-(`address`, `size`, and subclass-specific fields like `refcount`, `type_info`,
-`value`) directly as properties of the Context class. Introduce a
-`LocatedReferenceContext` interface with a `getMemoryLocation()` method that
-reconstructs a MemoryLocation on demand. Category C (only 2 classes) gets
-individual treatment.
-
-**Effect**: Saves ~56 bytes per Context instance (object header of the
-eliminated MemoryLocation). Since the most numerous context types (String,
-Array, Object) are all category B, savings scale with target process complexity.
-
-### 3. Truncate/lazy-load string values (target-dependent impact)
-
-`ZendStringMemoryLocation::$value` stores the full string content read from the
-target process. For string-heavy applications this can be significant.
-
-**Options**:
-- Store only the first N bytes + length for display purposes.
-- Omit the value entirely during collection and re-read from the target process
-  on demand during analysis (requires the target process to still be alive).
-
-**Effect**: Highly dependent on target process. Large impact for applications
-with many large strings; minimal for others.
-
-### 4. SoA (Structure of Arrays) for MemoryLocations collection (medium impact)
-
-`MemoryLocations` stores `array<int => MemoryLocation>` — an associative array
-of objects. Each entry incurs both array bucket overhead and object header
-overhead.
-
-**Approach**: Replace with parallel arrays (or `SplFixedArray` / FFI buffers)
-for address, size, and type fields. Eliminates per-entry object headers.
-
-**Effect**: Reduces overhead for the flat MemoryLocations collection. Less
-impactful than optimizations 1-2 if the ReferenceContext tree dominates memory.
-
-### 5. Post-collection pool disposal + streaming analysis (high impact on post-peak)
-
-The ContextPools hold strong references to all pooled contexts. This prevents
-GC even after `releaseLinks()` is called on the ReferenceContext tree.
-
-**Approach**: After `collectAll()` completes, dispose of (or nullify) the
-ContextPools entirely. Then during analysis, call `releaseLinks()` on
-already-analyzed subtrees to allow GC.
-
-**Important caveat**: This does NOT reduce peak memory (which occurs at the end
-of collection). It only accelerates memory reclamation during the analysis
-phase.
-
-**Caveat on WeakReference alternative**: Using `WeakReference` in pools instead
-of destroying them is safe in a two-phase (collect-then-analyze) design, since
-the tree holds strong references during collection. However, it would break if
-collection and analysis were interleaved — a shared context could be GC'd after
-one parent releases it but before the collector links it from another parent.
-
-### 6. Integer keys for `$referencing_contexts` (low-medium impact)
-
-Where `$referencing_contexts` is retained (dynamic children), replace string
-keys with integer constants or enum values. PHP optimizes integer-keyed arrays
-as packed arrays with lower per-entry overhead (~32 bytes vs ~72 bytes for
-string keys).
-
-**Applicability**: Limited to contexts where link names can be mapped to a
-finite set of integers. Not applicable to `ArrayElementsContext` where keys
-are arbitrary runtime values.
-
-### 7. Eliminate wrapper contexts for array elements / scalar values (high impact, high cost)
-
-`ArrayElementContext` is an empty wrapper (no properties, no MemoryLocation)
-created per array element, and `ScalarValueContext` is created per scalar zval.
-For a 10,000-element integer array, this produces 20,000 Context objects.
-
-**Possible approaches**:
-- Remove `ArrayElementContext` and attach value contexts directly to
-  `ArrayElementsContext`.
-- Store scalar values as plain PHP values in a native array instead of wrapping
-  them in `ScalarValueContext`.
-- For associative keys, store key StringContexts in a separate structure.
-
-**Effect**: Could eliminate the majority of Context objects for scalar-heavy
-data (config arrays, DB result sets). Scalar arrays would drop from
-`O(2n)` contexts to near zero.
-
-**Trade-off**: Breaks the uniform "everything is a ReferenceContext tree"
-design. Analysis/traversal code would need special cases for scalar storage,
-reducing code clarity. The clean tree structure is a significant
-maintainability asset — adding type-specific branching throughout the analyzer
-is a real cost.
-
-**Verdict**: Deferred. Consider only after optimizations 1-2 are applied and
-profiled. If peak memory is still problematic, this is the next lever, but the
-complexity cost is non-trivial.
-
-### 8. DB-backed streaming collection (highest impact on peak, architectural change)
-
-The current design builds the entire ReferenceContext tree in memory during
-collection, then serializes it (e.g., to JSON) during analysis. Peak memory
-occurs at the end of collection when the full tree is held in memory.
-
-#### Key insight: contexts are opaque on pool cache hit
-
-When a ContextPool returns a cached context (address already seen), the
-collector does NOT read any properties from it. It only:
-1. Returns it to the caller
-2. Caller attaches it to a parent via `add()`
-
-This means during collection, a cached context is used purely as an identity
-token ("same node"). No data is extracted from it. All population (via `add()`
-and property assignment) happens exclusively on the fresh path.
-
-This makes it possible to replace the in-memory context with a database record
-ID — the collector only needs to know "this address was already seen, here's
-its ID" to record the edge.
-
-#### Why DB enables what JSON cannot
-
-The collector traverses via DFS. With JSON output, the entire tree must be
-held in memory until the final `json_encode`. With a database:
-
+**Collection order** (streaming mode only):
 ```
-visit node → INSERT into DB → recurse into children → return → discard node
+included_files → interned_strings → objects_store → function_table →
+class_table → global_variables → global_constants → global_callbacks →
+modules → call_frames
 ```
 
-Memory held at any point is proportional to the **depth** of the DFS stack,
-not the total number of nodes. Sibling subtrees that have already been written
-to the DB can be GC'd immediately.
+objects_store is collected first so that subsequent phases hit sentinels
+for most objects/arrays/strings instead of recursively expanding.
 
-```
-        Root
-       / | \
-      A   B   C      ← while traversing B, A is already in DB and GC'd
-     /\   |
-    D  E  F          ← while traversing F, D and E are GC'd
-```
+Non-streaming mode preserves the original 0.12.x collection order.
 
-For a typical PHP process, tree depth is O(tens~hundreds) while total node
-count is O(tens of thousands). This changes peak memory from O(n) to O(depth).
+### Shallow object collection with deferred edges
 
-#### What stays in PHP vs what goes to DB
+**Status: Implemented**
 
-The collector needs fast address lookups during DFS to avoid re-traversal.
-Currently this is done via `$memory_locations->has($address)` and
-`$pool->getContextForLocation()`, both backed by PHP arrays of objects.
+During objects_store collection, `defer_unseen_objects` is enabled inside
+`collectZendObject`. Property references to unseen objects, arrays, and PHP
+references return null instead of recursing. A deferred edge is recorded:
 
-On a pool cache hit, the returned Context is never read — it is only passed
-to a parent's `add()` as an opaque reference. Therefore the PHP side only
-needs to know *whether* an address was seen and *which node_id* it maps to.
-The actual Context data (type, properties, children) is only needed during
-the fresh path and can be written to the DB immediately.
-
-```
-PHP side (kept in memory during collection):
-  array<int, int>  address → node_id     (~16 bytes per entry)
-
-DB side (streamed out):
-  nodes table:  id, type, address, size, refcount, value, ...
-  edges table:  parent_id, child_id, link_name
+```php
+$this->deferred_object_edges[] = [parent_node_id, child_address, link_name, pointer_type];
 ```
 
-This replaces:
-- ContextPool arrays of Context objects → `array<int, int>` seen set
-- Full ReferenceContext tree → DB edges
-- MemoryLocations collection → DB node attributes
+After all phases complete, deferred edges are resolved:
+1. If the child address has a sentinel → emit reference edge
+2. Otherwise → collect the target with defer off and emit normally
 
-#### Proposed collection flow
+Dynamic properties, closures, generators, fibers, and weak references/maps
+are also skipped during defer mode to prevent bypassing the defer guard.
 
-```
-On fresh path:
-  Create Context → extract fields → INSERT node → seen[address] = node_id
-  → recurse into children → discard Context object after return
-On cache hit:
-  node_id = seen[address] → INSERT edge only → skip traversal
-```
+### Sentinel-based deduplication
 
-#### In-memory SQLite as default, file-backed as fallback
+**Status: Implemented**
 
-Even in-memory SQLite stores data more compactly than PHP objects (~130-220
-bytes/node vs ~360 bytes/node) because it eliminates PHP object headers
-(~56 bytes each) and array bucket overhead. If memory is still tight, the
-same code can switch to file-backed SQLite by changing the connection string.
+`ContextPools` maintains a sentinel map (`array<int, int>` address → node_id).
+After each branch emission, `convertToSentinels()` extracts node_ids from the
+analyzer's WeakMap and stores them. `getSentinel()` returns a shared
+`SentinelContext` (single instance, node_id updated per call) to avoid
+per-sentinel object overhead.
 
-```
-                    In-memory SQLite     File-backed SQLite
-Memory usage        ~40-60% of current   O(depth) only
-I/O cost            None                 Moderate (SSD: light)
-Code difference     None                 Connection string only
-```
+`ContextAnalyzer` recognizes `SentinelContext` and emits a reference edge
+without traversing.
 
-Analysis phase:
-  Query DB instead of traversing in-memory tree
+### Lightweight MemoryLocations
 
-#### Trade-offs
+**Status: Implemented**
 
-- **Pro**: Peak memory drops from O(total nodes) to O(tree depth). This is
-  the only approach that fundamentally changes the scaling characteristic.
-- **Pro**: Enables arbitrarily large target processes without OOM.
-- **Con**: Full architectural change — collector signatures change from
-  returning `ReferenceContext` to returning `int` (node_id), `add()` becomes
-  edge INSERT, analysis switches from tree traversal to DB queries.
-- **Con**: Write performance — thousands of INSERTs need batching/transactions.
-  SQLite with WAL mode and prepared statements should be adequate.
-- **Con**: Additional step for JSON output, though this is straightforward
-  (see below).
+In streaming mode, `MemoryLocations::createLightweight()` stores only
+`array<int, true>` (seen set) instead of full MemoryLocation objects.
+Type checks in collector cache-hit paths use direct pool address lookups
+(`getContextByAddress()`) instead of `instanceof` on MemoryLocation objects.
 
-#### JSON output compatibility
+### CachingDereferencer
 
-JSON output can be reconstructed from the DB by walking the tree via DFS
-and streaming with `fwrite`, without loading the full tree into memory:
+**Status: Implemented (streaming mode only)**
 
-```
-DB → DFS walk → fwrite() per node → JSON file (streaming, O(depth) memory)
-```
+`CachingDereferencer` wraps `RemoteProcessDereferencer` with a
+`(type, address) → result` cache (max 4096 entries, LRU eviction).
+Avoids repeated FFI allocation for the same class_entry when processing
+many objects of the same class.
 
-This replaces the current `json_encode($full_tree)` approach. Both collection
-and JSON export become streaming, so peak memory stays O(depth) throughout
-the entire pipeline:
+### Lazy-load memory dump regions
 
-```
-Process memory → [collect, stream to DB] → DB → [stream to JSON] → file
-                   O(depth) memory              O(depth) memory
-```
+**Status: Implemented**
 
-#### Relationship to other optimizations
+`MemoryDumpReaderFactory` builds a region index (address, size, file_offset)
+without loading region data. The anonymous `MemoryReaderInterface` reads from
+the dump file on demand via `fseek` + `fread`.
 
-This approach subsumes optimizations 5 (pool disposal) and 7 (wrapper
-elimination) — both become irrelevant when contexts are not retained in memory.
-Optimizations 1-2 (property inlining, MemoryLocation consolidation) are still
-useful if applied to the transient Context objects before DB serialization, as
-they reduce per-node processing overhead, though they no longer affect peak
-memory.
+### Streaming JSON export
 
-## Priority
+**Status: Implemented**
 
-**Incremental path** (preserves current architecture):
-Optimizations 1 and 2 are the strongest candidates: they reduce peak memory,
-apply uniformly regardless of target process composition, and are mechanically
-straightforward to implement. They also preserve the existing interface and
-tree structure.
+`StreamingJsonFromDbExporter` reads from SQLite and writes JSON via `fwrite`
+in a DFS walk. `JsonMemoryOutput` supports `pre_populated_db` to skip the
+in-memory tree walk entirely.
 
-**Architectural path** (if incremental is insufficient):
-Optimization 8 (DB-backed streaming) is the fundamental solution — it changes
-peak memory scaling from O(nodes) to O(depth). However, it requires
-rearchitecting the collector and analysis phases. Consider after measuring
-the effect of optimizations 1-2.
+### Direct DB output for DB formats
 
-Optimization 5 is a middle ground for post-peak reduction within the current
-architecture. Optimization 7 reduces node count but at the cost of code
-clarity.
+**Status: Implemented**
 
-### 9. MemoryLocations lightweight mode (medium impact, moderate cost)
+`MemoryOutputFactory::createStreamingSink()` returns the output DB's driver
+directly for sqlite3/mysql/postgresql formats, eliminating the temp file copy.
+Non-DB formats (json, report) use a temp SQLite.
 
-`MemoryLocations::$memory_locations` holds `array<int => MemoryLocation>` with
-full MemoryLocation subclass objects throughout the entire collection. For a
-5.6 GB target, this can hold hundreds of thousands of entries. The heaviest are
-`ZendStringMemoryLocation` objects, each carrying the full `$value` string.
+## Future Optimizations (not yet implemented)
 
-In streaming mode, all location data has already been emitted to the DB. The
-only remaining use of `MemoryLocations` is:
-1. `has($address)` — deduplication check (needs only address existence)
-2. `get($address)` — `instanceof` type checks on cache-hit paths
+### 1. Convert `$referencing_contexts` array to typed properties
 
-**Option A**: After emitting a MemoryLocation to DB, null out heavy properties
-(e.g., `ZendStringMemoryLocation::$value = ''`). Preserves `instanceof` checks
-while freeing the largest data. Requires making `$value` non-readonly or adding
-a `release()` method.
+For context classes with a fixed set of child link names, replace the generic
+array with dedicated typed properties. Eliminates array bucket overhead.
 
-**Option B**: Replace MemoryLocation objects with `address → class-string` map.
-Eliminates object overhead entirely but requires changing all `instanceof`
-checks in the collector to string comparisons.
+### 2. Inline MemoryLocation into Context
 
-**Option C**: Increase pool flush frequency so that `getSentinel()` handles
-most cache hits, reducing the number of `get()` calls that need full objects.
-The remaining `get()` calls (within a single iteration) are few and short-lived.
+For the 25 context classes with exactly one MemoryLocation, inline the fields
+directly as context properties. Saves ~56 bytes per instance.
+
+### 3. Truncate/lazy-load string values
+
+`ZendStringMemoryLocation::$value` stores full string content. Could truncate
+to first N bytes or omit entirely during collection.
+
+### Deferred edge resolution optimization
+
+The current deferred edge resolution at the end of collection can spike memory
+when many unresolved targets need full collection. Could be batched with
+intermediate flush cycles.

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -1,0 +1,129 @@
+# Memory Analysis Optimization Ideas
+
+## Problem
+
+The memory analysis feature (collecting and analyzing PHP process memory via
+`MemoryLocationsCollector`) has high memory consumption in the profiler process
+itself. The peak occurs at the end of the collection phase, when the full
+`ReferenceContext` tree and all `MemoryLocations` are held in memory
+simultaneously.
+
+The memory footprint scales with the target process's complexity (number of
+objects, arrays, strings, functions, classes, etc.), and the composition varies
+per target, so optimizations must be broadly effective rather than targeting
+specific context types.
+
+## Architecture Overview
+
+Key data structures at peak:
+
+- **ReferenceContext tree**: 48 concrete context classes, each holding child
+  references in `$referencing_contexts` (`array<string, ReferenceContext>`) via
+  the `ReferenceContextDefault` trait.
+- **MemoryLocations**: `array<int => MemoryLocation>` collecting all memory
+  regions. 32 MemoryLocation subclasses.
+- **ContextPools**: 6 pools (String, Array, Object, PhpReference, Resource,
+  UserFunctionDefinition) holding strong references keyed by address for
+  deduplication.
+
+## Proposed Optimizations
+
+### 1. Convert `$referencing_contexts` array to typed properties (high impact)
+
+Many context classes have a fixed, statically known set of child link names.
+For example, `ArrayHeaderContext` only ever has an `array_elements` link. The
+current design stores these in a generic `array<string, ReferenceContext>`,
+paying PHP array bucket overhead (~36 bytes) plus string key cost per entry.
+
+**Approach**: For context classes with known child types, replace the
+`$referencing_contexts` array with dedicated typed properties (e.g.,
+`public ?ArrayElementsContext $array_elements = null`). Context classes with
+truly dynamic children (e.g., `ArrayElementsContext` whose keys are runtime
+array keys) would keep the array.
+
+**Effect**: Eliminates array bucket + string key overhead per link. Applies
+uniformly across all context types.
+
+### 2. Inline MemoryLocation into Context (high impact)
+
+Currently each Context that has a location holds a separate MemoryLocation
+object. Every PHP object carries ~56 bytes of header overhead.
+
+Survey of the 48 context classes:
+- **21 classes** have no MemoryLocation (category A)
+- **25 classes** have exactly one MemoryLocation (category B)
+- **2 classes** have two MemoryLocations (category C: `DefinedFunctionsContext`,
+  `OpArrayContext`)
+
+**Approach**: For category B (the majority), inline the MemoryLocation's fields
+(`address`, `size`, and subclass-specific fields like `refcount`, `type_info`,
+`value`) directly as properties of the Context class. Introduce a
+`LocatedReferenceContext` interface with a `getMemoryLocation()` method that
+reconstructs a MemoryLocation on demand. Category C (only 2 classes) gets
+individual treatment.
+
+**Effect**: Saves ~56 bytes per Context instance (object header of the
+eliminated MemoryLocation). Since the most numerous context types (String,
+Array, Object) are all category B, savings scale with target process complexity.
+
+### 3. Truncate/lazy-load string values (target-dependent impact)
+
+`ZendStringMemoryLocation::$value` stores the full string content read from the
+target process. For string-heavy applications this can be significant.
+
+**Options**:
+- Store only the first N bytes + length for display purposes.
+- Omit the value entirely during collection and re-read from the target process
+  on demand during analysis (requires the target process to still be alive).
+
+**Effect**: Highly dependent on target process. Large impact for applications
+with many large strings; minimal for others.
+
+### 4. SoA (Structure of Arrays) for MemoryLocations collection (medium impact)
+
+`MemoryLocations` stores `array<int => MemoryLocation>` — an associative array
+of objects. Each entry incurs both array bucket overhead and object header
+overhead.
+
+**Approach**: Replace with parallel arrays (or `SplFixedArray` / FFI buffers)
+for address, size, and type fields. Eliminates per-entry object headers.
+
+**Effect**: Reduces overhead for the flat MemoryLocations collection. Less
+impactful than optimizations 1-2 if the ReferenceContext tree dominates memory.
+
+### 5. Post-collection pool disposal + streaming analysis (high impact on post-peak)
+
+The ContextPools hold strong references to all pooled contexts. This prevents
+GC even after `releaseLinks()` is called on the ReferenceContext tree.
+
+**Approach**: After `collectAll()` completes, dispose of (or nullify) the
+ContextPools entirely. Then during analysis, call `releaseLinks()` on
+already-analyzed subtrees to allow GC.
+
+**Important caveat**: This does NOT reduce peak memory (which occurs at the end
+of collection). It only accelerates memory reclamation during the analysis
+phase.
+
+**Caveat on WeakReference alternative**: Using `WeakReference` in pools instead
+of destroying them is safe in a two-phase (collect-then-analyze) design, since
+the tree holds strong references during collection. However, it would break if
+collection and analysis were interleaved — a shared context could be GC'd after
+one parent releases it but before the collector links it from another parent.
+
+### 6. Integer keys for `$referencing_contexts` (low-medium impact)
+
+Where `$referencing_contexts` is retained (dynamic children), replace string
+keys with integer constants or enum values. PHP optimizes integer-keyed arrays
+as packed arrays with lower per-entry overhead (~32 bytes vs ~72 bytes for
+string keys).
+
+**Applicability**: Limited to contexts where link names can be mapped to a
+finite set of integers. Not applicable to `ArrayElementsContext` where keys
+are arbitrary runtime values.
+
+## Priority
+
+Optimizations 1 and 2 are the strongest candidates: they reduce peak memory,
+apply uniformly regardless of target process composition, and are mechanically
+straightforward to implement. Optimization 5 is useful as a follow-up for
+reducing post-peak memory during analysis.

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -148,13 +148,103 @@ is a real cost.
 profiled. If peak memory is still problematic, this is the next lever, but the
 complexity cost is non-trivial.
 
+### 8. DB-backed streaming collection (highest impact on peak, architectural change)
+
+The current design builds the entire ReferenceContext tree in memory during
+collection, then serializes it (e.g., to JSON) during analysis. Peak memory
+occurs at the end of collection when the full tree is held in memory.
+
+#### Key insight: contexts are opaque on pool cache hit
+
+When a ContextPool returns a cached context (address already seen), the
+collector does NOT read any properties from it. It only:
+1. Returns it to the caller
+2. Caller attaches it to a parent via `add()`
+
+This means during collection, a cached context is used purely as an identity
+token ("same node"). No data is extracted from it. All population (via `add()`
+and property assignment) happens exclusively on the fresh path.
+
+This makes it possible to replace the in-memory context with a database record
+ID — the collector only needs to know "this address was already seen, here's
+its ID" to record the edge.
+
+#### Why DB enables what JSON cannot
+
+The collector traverses via DFS. With JSON output, the entire tree must be
+held in memory until the final `json_encode`. With a database:
+
+```
+visit node → INSERT into DB → recurse into children → return → discard node
+```
+
+Memory held at any point is proportional to the **depth** of the DFS stack,
+not the total number of nodes. Sibling subtrees that have already been written
+to the DB can be GC'd immediately.
+
+```
+        Root
+       / | \
+      A   B   C      ← while traversing B, A is already in DB and GC'd
+     /\   |
+    D  E  F          ← while traversing F, D and E are GC'd
+```
+
+For a typical PHP process, tree depth is O(tens~hundreds) while total node
+count is O(tens of thousands). This changes peak memory from O(n) to O(depth).
+
+#### Proposed architecture
+
+```
+Collection phase:
+  ContextPool  →  seen_set: array<int, int>  (address → node_id)
+  ReferenceContext tree  →  DB tables: nodes + edges
+  MemoryLocations  →  DB table: memory_locations
+
+  On fresh path:
+    Create Context → extract data → INSERT node → record in seen_set → discard
+  On cache hit:
+    Lookup node_id from seen_set → INSERT edge only → skip traversal
+
+Analysis phase:
+  Query DB instead of traversing in-memory tree
+```
+
+#### Trade-offs
+
+- **Pro**: Peak memory drops from O(total nodes) to O(tree depth). This is
+  the only approach that fundamentally changes the scaling characteristic.
+- **Pro**: Enables arbitrarily large target processes without OOM.
+- **Con**: Full architectural change — collector signatures change from
+  returning `ReferenceContext` to returning `int` (node_id), `add()` becomes
+  edge INSERT, analysis switches from tree traversal to DB queries.
+- **Con**: Write performance — thousands of INSERTs need batching/transactions.
+  SQLite with WAL mode and prepared statements should be adequate.
+- **Con**: Two output paths if JSON output is still needed (DB → JSON export).
+
+#### Relationship to other optimizations
+
+This approach subsumes optimizations 5 (pool disposal) and 7 (wrapper
+elimination) — both become irrelevant when contexts are not retained in memory.
+Optimizations 1-2 (property inlining, MemoryLocation consolidation) are still
+useful if applied to the transient Context objects before DB serialization, as
+they reduce per-node processing overhead, though they no longer affect peak
+memory.
+
 ## Priority
 
+**Incremental path** (preserves current architecture):
 Optimizations 1 and 2 are the strongest candidates: they reduce peak memory,
 apply uniformly regardless of target process composition, and are mechanically
 straightforward to implement. They also preserve the existing interface and
 tree structure.
 
-Optimization 5 is useful as a follow-up for reducing post-peak memory during
-analysis. Optimization 7 is the nuclear option — high impact but trades code
-clarity for memory savings.
+**Architectural path** (if incremental is insufficient):
+Optimization 8 (DB-backed streaming) is the fundamental solution — it changes
+peak memory scaling from O(nodes) to O(depth). However, it requires
+rearchitecting the collector and analysis phases. Consider after measuring
+the effect of optimizations 1-2.
+
+Optimization 5 is a middle ground for post-peak reduction within the current
+architecture. Optimization 7 reduces node count but at the cost of code
+clarity.

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -121,9 +121,40 @@ string keys).
 finite set of integers. Not applicable to `ArrayElementsContext` where keys
 are arbitrary runtime values.
 
+### 7. Eliminate wrapper contexts for array elements / scalar values (high impact, high cost)
+
+`ArrayElementContext` is an empty wrapper (no properties, no MemoryLocation)
+created per array element, and `ScalarValueContext` is created per scalar zval.
+For a 10,000-element integer array, this produces 20,000 Context objects.
+
+**Possible approaches**:
+- Remove `ArrayElementContext` and attach value contexts directly to
+  `ArrayElementsContext`.
+- Store scalar values as plain PHP values in a native array instead of wrapping
+  them in `ScalarValueContext`.
+- For associative keys, store key StringContexts in a separate structure.
+
+**Effect**: Could eliminate the majority of Context objects for scalar-heavy
+data (config arrays, DB result sets). Scalar arrays would drop from
+`O(2n)` contexts to near zero.
+
+**Trade-off**: Breaks the uniform "everything is a ReferenceContext tree"
+design. Analysis/traversal code would need special cases for scalar storage,
+reducing code clarity. The clean tree structure is a significant
+maintainability asset — adding type-specific branching throughout the analyzer
+is a real cost.
+
+**Verdict**: Deferred. Consider only after optimizations 1-2 are applied and
+profiled. If peak memory is still problematic, this is the next lever, but the
+complexity cost is non-trivial.
+
 ## Priority
 
 Optimizations 1 and 2 are the strongest candidates: they reduce peak memory,
 apply uniformly regardless of target process composition, and are mechanically
-straightforward to implement. Optimization 5 is useful as a follow-up for
-reducing post-peak memory during analysis.
+straightforward to implement. They also preserve the existing interface and
+tree structure.
+
+Optimization 5 is useful as a follow-up for reducing post-peak memory during
+analysis. Optimization 7 is the nuclear option — high impact but trades code
+clarity for memory savings.

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -220,7 +220,26 @@ Analysis phase:
   edge INSERT, analysis switches from tree traversal to DB queries.
 - **Con**: Write performance — thousands of INSERTs need batching/transactions.
   SQLite with WAL mode and prepared statements should be adequate.
-- **Con**: Two output paths if JSON output is still needed (DB → JSON export).
+- **Con**: Additional step for JSON output, though this is straightforward
+  (see below).
+
+#### JSON output compatibility
+
+JSON output can be reconstructed from the DB by walking the tree via DFS
+and streaming with `fwrite`, without loading the full tree into memory:
+
+```
+DB → DFS walk → fwrite() per node → JSON file (streaming, O(depth) memory)
+```
+
+This replaces the current `json_encode($full_tree)` approach. Both collection
+and JSON export become streaming, so peak memory stays O(depth) throughout
+the entire pipeline:
+
+```
+Process memory → [collect, stream to DB] → DB → [stream to JSON] → file
+                   O(depth) memory              O(depth) memory
+```
 
 #### Relationship to other optimizations
 

--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -303,3 +303,28 @@ the effect of optimizations 1-2.
 Optimization 5 is a middle ground for post-peak reduction within the current
 architecture. Optimization 7 reduces node count but at the cost of code
 clarity.
+
+### 9. MemoryLocations lightweight mode (medium impact, moderate cost)
+
+`MemoryLocations::$memory_locations` holds `array<int => MemoryLocation>` with
+full MemoryLocation subclass objects throughout the entire collection. For a
+5.6 GB target, this can hold hundreds of thousands of entries. The heaviest are
+`ZendStringMemoryLocation` objects, each carrying the full `$value` string.
+
+In streaming mode, all location data has already been emitted to the DB. The
+only remaining use of `MemoryLocations` is:
+1. `has($address)` — deduplication check (needs only address existence)
+2. `get($address)` — `instanceof` type checks on cache-hit paths
+
+**Option A**: After emitting a MemoryLocation to DB, null out heavy properties
+(e.g., `ZendStringMemoryLocation::$value = ''`). Preserves `instanceof` checks
+while freeing the largest data. Requires making `$value` non-readonly or adding
+a `release()` method.
+
+**Option B**: Replace MemoryLocation objects with `address → class-string` map.
+Eliminates object overhead entirely but requires changing all `instanceof`
+checks in the collector to string comparisons.
+
+**Option C**: Increase pool flush frequency so that `getSentinel()` handles
+most cache hits, reducing the number of `get()` calls that need full objects.
+The remaining `get()` calls (within a single iteration) are few and short-lived.

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -15,6 +15,8 @@ namespace Reli\Command\Inspector;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
@@ -110,77 +112,95 @@ final class MemoryCommand extends Command
             defer($scope_guard, fn () => $this->process_stopper->resume($process_specifier->pid));
         }
 
-        $collected_memories = $this->memory_locations_collector->collectAll(
-            $process_specifier,
-            $target_php_settings_version_decided,
-            $eg_address,
-            $cg_address,
-            $memory_profiler_settings->memory_exhaustion_error_details,
-            $bg_address,
-        );
-
-        $region_analyzer = new RegionAnalyzer(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
-
-        $analyzed_regions = $region_analyzer->analyze(
-            $collected_memories->memory_locations,
-        );
-
-        $summary = [
-            $analyzed_regions->summary->toArray()
-            + [
-                'memory_get_usage' => $collected_memories->memory_get_usage_size,
-                'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
-                'cached_chunks_size' => $collected_memories->cached_chunks_size,
-            ]
-            + [
-                'heap_memory_analyzed_percentage' =>
-                    (float)$analyzed_regions->summary->zend_mm_heap_usage
-                    /
-                    (float)$collected_memories->memory_get_usage_size * 100.0
-                ,
-            ]
-            + [
-                'php_version' => $target_php_settings_version_decided->php_version,
-                'analyzer' => ReliProfiler::toolSignature(),
-            ]
-        ];
-
-        // All output formats now go through a SQLite intermediate,
-        // so type/class summaries are always computed from DB via GROUP BY.
-        $location_types_summary = null;
-        $class_objects_summary = null;
-
-        // Region boundaries are small (a few entries each) — keep for PdoContextTreeSink.
-        // Everything else can be released before the tree walk.
-        $region_boundaries = new RegionBoundaries(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
-        $top_reference_context = $collected_memories->top_reference_context;
-
-        // Release the large flat location lists before the tree walk
-        unset($collected_memories, $analyzed_regions, $region_analyzer);
-
-        $result = new MemoryAnalysisResult(
-            $summary,
-            $top_reference_context,
-            $location_types_summary,
-            $class_objects_summary,
-        );
-
+        // Set up streaming sink: context tree is emitted to a temp SQLite
+        // during collection, releasing each branch immediately after emission.
         $output_factory = new MemoryOutputFactory();
-        $memory_output = $output_factory->create(
-            $memory_profiler_settings,
-            $region_boundaries,
-        );
-        $memory_output->output($result);
+        $region_boundaries = null;
+
+        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
+        if ($tmp_base === false) {
+            throw new \RuntimeException('Failed to create temporary file');
+        }
+        $tmp_path = $tmp_base . '.sqlite3';
+        @unlink($tmp_base);
+
+        try {
+            $sqlite_driver = new SqliteDriver($tmp_path);
+            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
+            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
+
+            $collected_memories = $this->memory_locations_collector->collectAll(
+                $process_specifier,
+                $target_php_settings_version_decided,
+                $eg_address,
+                $cg_address,
+                $memory_profiler_settings->memory_exhaustion_error_details,
+                $bg_address,
+                $sink,
+            );
+
+            $region_analyzer = new RegionAnalyzer(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
+
+            $analyzed_regions = $region_analyzer->analyze(
+                $collected_memories->memory_locations,
+            );
+
+            $summary = [
+                $analyzed_regions->summary->toArray()
+                + [
+                    'memory_get_usage' => $collected_memories->memory_get_usage_size,
+                    'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                    'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                ]
+                + [
+                    'heap_memory_analyzed_percentage' =>
+                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        /
+                        (float)$collected_memories->memory_get_usage_size * 100.0
+                    ,
+                ]
+                + [
+                    'php_version' => $target_php_settings_version_decided->php_version,
+                    'analyzer' => ReliProfiler::toolSignature(),
+                ]
+            ];
+
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
+
+            unset($collected_memories, $analyzed_regions, $region_analyzer);
+
+            // Finalize the streaming DB (summary, indexes, views)
+            $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
+
+            $result = new MemoryAnalysisResult(
+                $summary,
+                null,
+                null,
+                null,
+                $db,
+                $run_id,
+            );
+
+            $memory_output = $output_factory->create(
+                $memory_profiler_settings,
+                $region_boundaries,
+            );
+            $memory_output->output($result);
+        } finally {
+            if (file_exists($tmp_path)) {
+                @unlink($tmp_path);
+            }
+        }
 
         Log::info('end memory command');
         return 0;

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -21,9 +21,7 @@ use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConso
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
@@ -152,23 +150,10 @@ final class MemoryCommand extends Command
             ]
         ];
 
-        $is_db = in_array($memory_profiler_settings->output_format, ['sqlite3', 'mysql', 'postgresql'], true);
-
-        // For DB formats: type/class summaries are computed from DB via GROUP BY.
-        // For JSON: compute them in-memory as before.
+        // All output formats now go through a SQLite intermediate,
+        // so type/class summaries are always computed from DB via GROUP BY.
         $location_types_summary = null;
         $class_objects_summary = null;
-        if (!$is_db) {
-            $location_type_analyzer = new LocationTypeAnalyzer();
-            $location_types_summary = $location_type_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_type_usage;
-
-            $object_class_analyzer = new ObjectClassAnalyzer();
-            $class_objects_summary = $object_class_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_class_usage;
-        }
 
         // Region boundaries are small (a few entries each) — keep for PdoContextTreeSink.
         // Everything else can be released before the tree walk.

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -15,8 +15,6 @@ namespace Reli\Command\Inspector;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
-use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
-use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
@@ -112,23 +110,15 @@ final class MemoryCommand extends Command
             defer($scope_guard, fn () => $this->process_stopper->resume($process_specifier->pid));
         }
 
-        // Set up streaming sink: context tree is emitted to a temp SQLite
-        // during collection, releasing each branch immediately after emission.
+        // Set up streaming sink: for DB formats (sqlite3, mysql, postgresql)
+        // write directly to the output DB; for others use a temp SQLite.
         $output_factory = new MemoryOutputFactory();
-        $region_boundaries = null;
 
-        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
-        if ($tmp_base === false) {
-            throw new \RuntimeException('Failed to create temporary file');
-        }
-        $tmp_path = $tmp_base . '.sqlite3';
-        @unlink($tmp_base);
+        [$pdo_output, $sink, $run_id, $db, $temp_path] = $output_factory->createStreamingSink(
+            $memory_profiler_settings,
+        );
 
         try {
-            $sqlite_driver = new SqliteDriver($tmp_path);
-            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
-            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
-
             $collected_memories = $this->memory_locations_collector->collectAll(
                 $process_specifier,
                 $target_php_settings_version_decided,
@@ -182,23 +172,27 @@ final class MemoryCommand extends Command
             // Finalize the streaming DB (summary, indexes, views)
             $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
 
-            $result = new MemoryAnalysisResult(
-                $summary,
-                null,
-                null,
-                null,
-                $db,
-                $run_id,
-            );
+            // For DB formats the data is already in the output DB; done.
+            // For JSON/report, stream from the temp SQLite DB.
+            if ($temp_path !== null) {
+                $result = new MemoryAnalysisResult(
+                    $summary,
+                    null,
+                    null,
+                    null,
+                    $db,
+                    $run_id,
+                );
 
-            $memory_output = $output_factory->create(
-                $memory_profiler_settings,
-                $region_boundaries,
-            );
-            $memory_output->output($result);
+                $memory_output = $output_factory->create(
+                    $memory_profiler_settings,
+                    $region_boundaries,
+                );
+                $memory_output->output($result);
+            }
         } finally {
-            if (file_exists($tmp_path)) {
-                @unlink($tmp_path);
+            if ($temp_path !== null && file_exists($temp_path)) {
+                @unlink($temp_path);
             }
         }
 

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -18,9 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
@@ -101,21 +99,10 @@ final class CoreDumpReader
             ]
         ];
 
-        $is_db = in_array($memory_profiler_settings->output_format, ['sqlite3', 'mysql', 'postgresql'], true);
-
+        // All output formats now go through a SQLite intermediate,
+        // so type/class summaries are always computed from DB via GROUP BY.
         $location_types_summary = null;
         $class_objects_summary = null;
-        if (!$is_db) {
-            $location_type_analyzer = new LocationTypeAnalyzer();
-            $location_types_summary = $location_type_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_type_usage;
-
-            $object_class_analyzer = new ObjectClassAnalyzer();
-            $class_objects_summary = $object_class_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_class_usage;
-        }
 
         $region_boundaries = new RegionBoundaries(
             $collected_memories->chunk_memory_locations,

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -15,6 +15,8 @@ namespace Reli\Inspector\CoreDumpReader;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
@@ -59,73 +61,89 @@ final class CoreDumpReader
             $target_php_settings_version_decided
         );
 
-        $collected_memories = $this->memory_locations_collector->collectAll(
-            $process_specifier,
-            $target_php_settings_version_decided,
-            $eg_address,
-            $cg_address,
-            $memory_profiler_settings->memory_exhaustion_error_details,
-            $bg_address,
-        );
+        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
+        if ($tmp_base === false) {
+            throw new \RuntimeException('Failed to create temporary file');
+        }
+        $tmp_path = $tmp_base . '.sqlite3';
+        @unlink($tmp_base);
 
-        $region_analyzer = new RegionAnalyzer(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
+        try {
+            $sqlite_driver = new SqliteDriver($tmp_path);
+            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
+            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
 
-        $analyzed_regions = $region_analyzer->analyze(
-            $collected_memories->memory_locations,
-        );
+            $collected_memories = $this->memory_locations_collector->collectAll(
+                $process_specifier,
+                $target_php_settings_version_decided,
+                $eg_address,
+                $cg_address,
+                $memory_profiler_settings->memory_exhaustion_error_details,
+                $bg_address,
+                $sink,
+            );
 
-        $summary = [
-            $analyzed_regions->summary->toArray()
-            + [
-                'memory_get_usage' => $collected_memories->memory_get_usage_size,
-                'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
-                'cached_chunks_size' => $collected_memories->cached_chunks_size,
-            ]
-            + [
-                'heap_memory_analyzed_percentage' =>
-                    (float)$analyzed_regions->summary->zend_mm_heap_usage
-                    /
-                    (float)$collected_memories->memory_get_usage_size * 100.0
-                ,
-            ]
-            + [
-                'php_version' => $target_php_settings_version_decided->php_version,
-                'analyzer' => ReliProfiler::toolSignature(),
-            ]
-        ];
+            $region_analyzer = new RegionAnalyzer(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
 
-        // All output formats now go through a SQLite intermediate,
-        // so type/class summaries are always computed from DB via GROUP BY.
-        $location_types_summary = null;
-        $class_objects_summary = null;
+            $analyzed_regions = $region_analyzer->analyze(
+                $collected_memories->memory_locations,
+            );
 
-        $region_boundaries = new RegionBoundaries(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
-        $top_reference_context = $collected_memories->top_reference_context;
+            $summary = [
+                $analyzed_regions->summary->toArray()
+                + [
+                    'memory_get_usage' => $collected_memories->memory_get_usage_size,
+                    'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                    'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                ]
+                + [
+                    'heap_memory_analyzed_percentage' =>
+                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        /
+                        (float)$collected_memories->memory_get_usage_size * 100.0
+                    ,
+                ]
+                + [
+                    'php_version' => $target_php_settings_version_decided->php_version,
+                    'analyzer' => ReliProfiler::toolSignature(),
+                ]
+            ];
 
-        unset($collected_memories, $analyzed_regions, $region_analyzer);
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
 
-        $result = new MemoryAnalysisResult(
-            $summary,
-            $top_reference_context,
-            $location_types_summary,
-            $class_objects_summary,
-        );
+            unset($collected_memories, $analyzed_regions, $region_analyzer);
 
-        $output_factory = new MemoryOutputFactory();
-        $memory_output = $output_factory->create(
-            $memory_profiler_settings,
-            $region_boundaries,
-        );
-        $memory_output->output($result);
+            $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
+
+            $result = new MemoryAnalysisResult(
+                $summary,
+                null,
+                null,
+                null,
+                $db,
+                $run_id,
+            );
+
+            $output_factory = new MemoryOutputFactory();
+            $memory_output = $output_factory->create(
+                $memory_profiler_settings,
+                $region_boundaries,
+            );
+            $memory_output->output($result);
+        } finally {
+            if (file_exists($tmp_path)) {
+                @unlink($tmp_path);
+            }
+        }
     }
 }

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -15,8 +15,6 @@ namespace Reli\Inspector\CoreDumpReader;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
-use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
-use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
@@ -61,18 +59,12 @@ final class CoreDumpReader
             $target_php_settings_version_decided
         );
 
-        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
-        if ($tmp_base === false) {
-            throw new \RuntimeException('Failed to create temporary file');
-        }
-        $tmp_path = $tmp_base . '.sqlite3';
-        @unlink($tmp_base);
+        $output_factory = new MemoryOutputFactory();
+        [$pdo_output, $sink, $run_id, $db, $temp_path] = $output_factory->createStreamingSink(
+            $memory_profiler_settings,
+        );
 
         try {
-            $sqlite_driver = new SqliteDriver($tmp_path);
-            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
-            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
-
             $collected_memories = $this->memory_locations_collector->collectAll(
                 $process_specifier,
                 $target_php_settings_version_decided,
@@ -125,24 +117,25 @@ final class CoreDumpReader
 
             $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
 
-            $result = new MemoryAnalysisResult(
-                $summary,
-                null,
-                null,
-                null,
-                $db,
-                $run_id,
-            );
+            if ($temp_path !== null) {
+                $result = new MemoryAnalysisResult(
+                    $summary,
+                    null,
+                    null,
+                    null,
+                    $db,
+                    $run_id,
+                );
 
-            $output_factory = new MemoryOutputFactory();
-            $memory_output = $output_factory->create(
-                $memory_profiler_settings,
-                $region_boundaries,
-            );
-            $memory_output->output($result);
+                $memory_output = $output_factory->create(
+                    $memory_profiler_settings,
+                    $region_boundaries,
+                );
+                $memory_output->output($result);
+            }
         } finally {
-            if (file_exists($tmp_path)) {
-                @unlink($tmp_path);
+            if ($temp_path !== null && file_exists($temp_path)) {
+                @unlink($temp_path);
             }
         }
     }

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -18,9 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -87,21 +85,10 @@ final class MemoryDumpReader
             ]
         ];
 
-        $is_db = in_array($memory_profiler_settings->output_format, ['sqlite3', 'mysql', 'postgresql'], true);
-
+        // All output formats now go through a SQLite intermediate,
+        // so type/class summaries are always computed from DB via GROUP BY.
         $location_types_summary = null;
         $class_objects_summary = null;
-        if (!$is_db) {
-            $location_type_analyzer = new LocationTypeAnalyzer();
-            $location_types_summary = $location_type_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_type_usage;
-
-            $object_class_analyzer = new ObjectClassAnalyzer();
-            $class_objects_summary = $object_class_analyzer->analyze(
-                $analyzed_regions->regional_memory_locations->locations_in_zend_mm_heap,
-            )->per_class_usage;
-        }
 
         $region_boundaries = new RegionBoundaries(
             $collected_memories->chunk_memory_locations,

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -15,8 +15,6 @@ namespace Reli\Inspector\MemoryDump;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
-use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
-use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
@@ -47,18 +45,12 @@ final class MemoryDumpReader
         /** @var TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */
         $target_php_settings = new TargetPhpSettings(php_version: $this->php_version);
 
-        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
-        if ($tmp_base === false) {
-            throw new \RuntimeException('Failed to create temporary file');
-        }
-        $tmp_path = $tmp_base . '.sqlite3';
-        @unlink($tmp_base);
+        $output_factory = new MemoryOutputFactory();
+        [$pdo_output, $sink, $run_id, $db, $temp_path] = $output_factory->createStreamingSink(
+            $memory_profiler_settings,
+        );
 
         try {
-            $sqlite_driver = new SqliteDriver($tmp_path);
-            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
-            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
-
             $collected_memories = $this->memory_locations_collector->collectAll(
                 $process_specifier,
                 $target_php_settings,
@@ -111,24 +103,25 @@ final class MemoryDumpReader
 
             $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
 
-            $result = new MemoryAnalysisResult(
-                $summary,
-                null,
-                null,
-                null,
-                $db,
-                $run_id,
-            );
+            if ($temp_path !== null) {
+                $result = new MemoryAnalysisResult(
+                    $summary,
+                    null,
+                    null,
+                    null,
+                    $db,
+                    $run_id,
+                );
 
-            $output_factory = new MemoryOutputFactory();
-            $memory_output = $output_factory->create(
-                $memory_profiler_settings,
-                $region_boundaries,
-            );
-            $memory_output->output($result);
+                $memory_output = $output_factory->create(
+                    $memory_profiler_settings,
+                    $region_boundaries,
+                );
+                $memory_output->output($result);
+            }
         } finally {
-            if (file_exists($tmp_path)) {
-                @unlink($tmp_path);
+            if ($temp_path !== null && file_exists($temp_path)) {
+                @unlink($temp_path);
             }
         }
     }

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -15,6 +15,8 @@ namespace Reli\Inspector\MemoryDump;
 
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
@@ -45,73 +47,89 @@ final class MemoryDumpReader
         /** @var TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings */
         $target_php_settings = new TargetPhpSettings(php_version: $this->php_version);
 
-        $collected_memories = $this->memory_locations_collector->collectAll(
-            $process_specifier,
-            $target_php_settings,
-            $this->eg_address,
-            $this->cg_address,
-            $memory_profiler_settings->memory_exhaustion_error_details,
-            $this->bg_address,
-        );
+        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
+        if ($tmp_base === false) {
+            throw new \RuntimeException('Failed to create temporary file');
+        }
+        $tmp_path = $tmp_base . '.sqlite3';
+        @unlink($tmp_base);
 
-        $region_analyzer = new RegionAnalyzer(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
+        try {
+            $sqlite_driver = new SqliteDriver($tmp_path);
+            $pdo_output = new PdoMemoryOutput($sqlite_driver, null);
+            [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
 
-        $analyzed_regions = $region_analyzer->analyze(
-            $collected_memories->memory_locations,
-        );
+            $collected_memories = $this->memory_locations_collector->collectAll(
+                $process_specifier,
+                $target_php_settings,
+                $this->eg_address,
+                $this->cg_address,
+                $memory_profiler_settings->memory_exhaustion_error_details,
+                $this->bg_address,
+                $sink,
+            );
 
-        $summary = [
-            $analyzed_regions->summary->toArray()
-            + [
-                'memory_get_usage' => $collected_memories->memory_get_usage_size,
-                'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
-                'cached_chunks_size' => $collected_memories->cached_chunks_size,
-            ]
-            + [
-                'heap_memory_analyzed_percentage' =>
-                    (float)$analyzed_regions->summary->zend_mm_heap_usage
-                    /
-                    (float)$collected_memories->memory_get_usage_size * 100.0
-                ,
-            ]
-            + [
-                'php_version' => $target_php_settings->php_version,
-                'analyzer' => ReliProfiler::toolSignature(),
-            ]
-        ];
+            $region_analyzer = new RegionAnalyzer(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
 
-        // All output formats now go through a SQLite intermediate,
-        // so type/class summaries are always computed from DB via GROUP BY.
-        $location_types_summary = null;
-        $class_objects_summary = null;
+            $analyzed_regions = $region_analyzer->analyze(
+                $collected_memories->memory_locations,
+            );
 
-        $region_boundaries = new RegionBoundaries(
-            $collected_memories->chunk_memory_locations,
-            $collected_memories->huge_memory_locations,
-            $collected_memories->vm_stack_memory_locations,
-            $collected_memories->compiler_arena_memory_locations,
-        );
-        $top_reference_context = $collected_memories->top_reference_context;
+            $summary = [
+                $analyzed_regions->summary->toArray()
+                + [
+                    'memory_get_usage' => $collected_memories->memory_get_usage_size,
+                    'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                    'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                ]
+                + [
+                    'heap_memory_analyzed_percentage' =>
+                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        /
+                        (float)$collected_memories->memory_get_usage_size * 100.0
+                    ,
+                ]
+                + [
+                    'php_version' => $target_php_settings->php_version,
+                    'analyzer' => ReliProfiler::toolSignature(),
+                ]
+            ];
 
-        unset($collected_memories, $analyzed_regions, $region_analyzer);
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
 
-        $result = new MemoryAnalysisResult(
-            $summary,
-            $top_reference_context,
-            $location_types_summary,
-            $class_objects_summary,
-        );
+            unset($collected_memories, $analyzed_regions, $region_analyzer);
 
-        $output_factory = new MemoryOutputFactory();
-        $memory_output = $output_factory->create(
-            $memory_profiler_settings,
-            $region_boundaries,
-        );
-        $memory_output->output($result);
+            $pdo_output->finalizeStreaming($db, $run_id, $sink, $summary);
+
+            $result = new MemoryAnalysisResult(
+                $summary,
+                null,
+                null,
+                null,
+                $db,
+                $run_id,
+            );
+
+            $output_factory = new MemoryOutputFactory();
+            $memory_output = $output_factory->create(
+                $memory_profiler_settings,
+                $region_boundaries,
+            );
+            $memory_output->output($result);
+        } finally {
+            if (file_exists($tmp_path)) {
+                @unlink($tmp_path);
+            }
+        }
     }
 }

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -51,14 +51,15 @@ final class MemoryDumpReaderFactory
 
         $process_memory_map = new ProcessMemoryMap($parsed['memory_areas']);
         $path_resolver = new MappedPathResolver($path_mapping);
-        $regions = $parsed['regions'];
+        $region_index = $parsed['region_index'];
 
-        $memory_reader = new class ($regions, $process_memory_map, $path_resolver) implements MemoryReaderInterface {
+        $memory_reader = new class ($file_path, $region_index, $process_memory_map, $path_resolver) implements MemoryReaderInterface {
             /**
-             * @param array<array{address: int, size: int, data: string}> $regions
+             * @param list<array{address: int, size: int, file_offset: int}> $region_index
              */
             public function __construct(
-                private array $regions,
+                private string $file_path,
+                private array $region_index,
                 private ProcessMemoryMap $process_memory_map,
                 private MappedPathResolver $path_resolver,
             ) {
@@ -67,12 +68,28 @@ final class MemoryDumpReaderFactory
             #[\Override]
             public function read(int $pid, int $remote_address, int $size): CData
             {
-                foreach ($this->regions as $region) {
+                foreach ($this->region_index as $region) {
                     $region_start = $region['address'];
                     $region_end = $region_start + $region['size'];
                     if ($remote_address >= $region_start && ($remote_address + $size) <= $region_end) {
-                        $offset = $remote_address - $region_start;
-                        $data = substr($region['data'], $offset, $size);
+                        $offset_in_region = $remote_address - $region_start;
+                        $file_offset = $region['file_offset'] + $offset_in_region;
+
+                        $fp = fopen($this->file_path, 'rb');
+                        if ($fp === false) {
+                            throw new \RuntimeException("failed to open dump file: {$this->file_path}");
+                        }
+                        try {
+                            fseek($fp, $file_offset);
+                            $data = fread($fp, $size);
+                        } finally {
+                            fclose($fp);
+                        }
+                        if ($data === false || strlen($data) !== $size) {
+                            throw new \RuntimeException(
+                                "failed to read {$size} bytes at file offset {$file_offset}"
+                            );
+                        }
                         $cdata_buffer = FFIHelper::new("unsigned char[$size]");
                         if (is_null($cdata_buffer)) {
                             throw new \RuntimeException("failed to allocate memory");
@@ -153,6 +170,9 @@ final class MemoryDumpReaderFactory
     }
 
     /**
+     * Parse the dump file header and memory map, building an index of
+     * region offsets without loading region data into memory.
+     *
      * @param resource $fp
      * @return array{
      *     pid: int,
@@ -160,7 +180,7 @@ final class MemoryDumpReaderFactory
      *     eg_address: int,
      *     cg_address: int,
      *     memory_areas: ProcessMemoryArea[],
-     *     regions: array<array{address: int, size: int, data: string}>,
+     *     region_index: list<array{address: int, size: int, file_offset: int}>,
      * }
      */
     private function parse($fp): array
@@ -212,20 +232,22 @@ final class MemoryDumpReaderFactory
             );
         }
 
-        // Memory regions
-        $regions = [];
+        // Build region index: record file offsets without reading data
+        $region_index = [];
         for ($i = 0; $i < $region_count; $i++) {
             $address = $this->readInt64($fp);
             $size = $this->readInt64($fp);
-            $data = fread($fp, $size);
-            if ($data === false || strlen($data) !== $size) {
-                throw new \RuntimeException("failed to read memory region data at address 0x" . dechex($address));
+            $data_offset = ftell($fp);
+            if ($data_offset === false) {
+                throw new \RuntimeException("failed to get file position");
             }
-            $regions[] = [
+            $region_index[] = [
                 'address' => $address,
                 'size' => $size,
-                'data' => $data,
+                'file_offset' => $data_offset,
             ];
+            // Skip past the data without reading it
+            fseek($fp, $size, SEEK_CUR);
         }
 
         return [
@@ -234,7 +256,7 @@ final class MemoryDumpReaderFactory
             'eg_address' => $eg_address,
             'cg_address' => $cg_address,
             'memory_areas' => $memory_areas,
-            'regions' => $regions,
+            'region_index' => $region_index,
         ];
     }
 

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -53,7 +53,12 @@ final class MemoryDumpReaderFactory
         $path_resolver = new MappedPathResolver($path_mapping);
         $region_index = $parsed['region_index'];
 
-        $memory_reader = new class ($file_path, $region_index, $process_memory_map, $path_resolver) implements MemoryReaderInterface {
+        $memory_reader = new class (
+            $file_path,
+            $region_index,
+            $process_memory_map,
+            $path_resolver,
+        ) implements MemoryReaderInterface {
             /**
              * @param list<array{address: int, size: int, file_offset: int}> $region_index
              */

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -13,46 +13,143 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ArrayContextTreeSink;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 
 final class JsonMemoryOutput implements MemoryOutputInterface
 {
     public function __construct(
         private bool $pretty_print = false,
         private ?string $output_path = null,
+        private ?RegionBoundaries $region_boundaries = null,
     ) {
     }
 
     #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
-        $sink = new ArrayContextTreeSink();
-        $analyzer = new ContextAnalyzer();
-        $analyzer->analyze($result->context, $sink);
-
-        $flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
-        if ($this->pretty_print) {
-            $flags |= JSON_PRETTY_PRINT;
+        // Write context tree to a temporary SQLite DB, releasing contexts
+        // during the walk so they can be GC'd immediately.
+        $tmp_base = tempnam(sys_get_temp_dir(), 'reli_json_');
+        if ($tmp_base === false) {
+            throw new \RuntimeException('Failed to create temporary file for JSON export');
         }
-        $json = json_encode(
-            [
-                'summary' => $result->summary,
-                'location_types_summary' => $result->location_types_summary ?? [],
-                'class_objects_summary' => $result->class_objects_summary ?? [],
-                'context' => $sink->getResult(),
-            ],
-            $flags,
-            2147483647
+        $tmp_path = $tmp_base . '.sqlite3';
+        @unlink($tmp_base);
+
+        try {
+            $sqlite_driver = new SqliteDriver($tmp_path);
+            $pdo_output = new PdoMemoryOutput($sqlite_driver, $this->region_boundaries);
+            $pdo_output->output($result);
+
+            // Release the in-memory context tree — data is now in SQLite
+            unset($result);
+
+            // Stream JSON from the SQLite DB
+            $db = new \PDO("sqlite:{$tmp_path}");
+            $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+            $run_id = (int)$db->query('SELECT MAX(run_id) FROM runs')->fetchColumn();
+
+            $summary = $this->loadSummary($db, $run_id);
+            $location_types_summary = $this->loadLocationTypesSummary($db, $run_id);
+            $class_objects_summary = $this->loadClassObjectsSummary($db, $run_id);
+
+            $exporter = new StreamingJsonFromDbExporter($db, $run_id, $this->pretty_print);
+
+            if ($this->output_path !== null) {
+                $fp = fopen($this->output_path, 'w');
+                if ($fp === false) {
+                    throw new \RuntimeException("Cannot open output file: {$this->output_path}");
+                }
+                try {
+                    $exporter->export($summary, $location_types_summary, $class_objects_summary, $fp);
+                } finally {
+                    fclose($fp);
+                }
+            } else {
+                $fp = fopen('php://stdout', 'w');
+                if ($fp === false) {
+                    throw new \RuntimeException('Cannot open stdout');
+                }
+                $exporter->export($summary, $location_types_summary, $class_objects_summary, $fp);
+            }
+        } finally {
+            if (file_exists($tmp_path)) {
+                @unlink($tmp_path);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadSummary(\PDO $db, int $run_id): array
+    {
+        $stmt = $db->prepare(
+            'SELECT "key", "value" FROM summary WHERE run_id = ?'
         );
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException(json_last_error_msg());
+        $stmt->execute([$run_id]);
+        /** @var array<string, mixed> $entry */
+        $entry = [];
+        while (
+            /** @var array{key: string, value: string|null} */
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            /** @psalm-suppress MixedArrayAccess, MixedAssignment */
+            $decoded = json_decode((string)$row['value'], true);
+            /** @psalm-suppress MixedArrayAccess, MixedAssignment */
+            $entry[$row['key']] = $decoded !== null ? $decoded : $row['value'];
         }
+        /** @var array<int, array<string, mixed>> */
+        return [$entry];
+    }
 
-        if ($this->output_path !== null && $json !== false) {
-            file_put_contents($this->output_path, $json);
-        } elseif ($json !== false) {
-            echo $json;
+    /**
+     * @return array<string, array{count: int, memory_usage: int}>
+     */
+    private function loadLocationTypesSummary(\PDO $db, int $run_id): array
+    {
+        $stmt = $db->prepare(
+            'SELECT "type", "count", memory_usage FROM location_types_summary WHERE run_id = ?'
+        );
+        $stmt->execute([$run_id]);
+        $result = [];
+        while (
+            /** @var array{type: string, count: string, memory_usage: string} */
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            /** @psalm-suppress MixedArrayAccess */
+            $result[$row['type']] = [
+                'count' => (int)$row['count'],
+                'memory_usage' => (int)$row['memory_usage'],
+            ];
         }
+        /** @var array<string, array{count: int, memory_usage: int}> */
+        return $result;
+    }
+
+    /**
+     * @return array<string, array{count: int, memory_usage: int}>
+     */
+    private function loadClassObjectsSummary(\PDO $db, int $run_id): array
+    {
+        $stmt = $db->prepare(
+            'SELECT class_name, "count", memory_usage FROM class_objects_summary WHERE run_id = ?'
+        );
+        $stmt->execute([$run_id]);
+        $result = [];
+        while (
+            /** @var array{class_name: string, count: string, memory_usage: string} */
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            /** @psalm-suppress MixedArrayAccess */
+            $result[$row['class_name']] = [
+                'count' => (int)$row['count'],
+                'memory_usage' => (int)$row['memory_usage'],
+            ];
+        }
+        /** @var array<string, array{count: int, memory_usage: int}> */
+        return $result;
     }
 }

--- a/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/JsonMemoryOutput.php
@@ -28,6 +28,12 @@ final class JsonMemoryOutput implements MemoryOutputInterface
     #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
+        if ($result->pre_populated_db !== null && $result->pre_populated_run_id !== null) {
+            // Tree was already streamed to DB during collection
+            $this->streamJsonFromDb($result->pre_populated_db, $result->pre_populated_run_id);
+            return;
+        }
+
         // Write context tree to a temporary SQLite DB, releasing contexts
         // during the walk so they can be GC'd immediately.
         $tmp_base = tempnam(sys_get_temp_dir(), 'reli_json_');
@@ -78,6 +84,32 @@ final class JsonMemoryOutput implements MemoryOutputInterface
             if (file_exists($tmp_path)) {
                 @unlink($tmp_path);
             }
+        }
+    }
+
+    private function streamJsonFromDb(\PDO $db, int $run_id): void
+    {
+        $summary = $this->loadSummary($db, $run_id);
+        $location_types_summary = $this->loadLocationTypesSummary($db, $run_id);
+        $class_objects_summary = $this->loadClassObjectsSummary($db, $run_id);
+        $exporter = new StreamingJsonFromDbExporter($db, $run_id, $this->pretty_print);
+
+        if ($this->output_path !== null) {
+            $fp = fopen($this->output_path, 'w');
+            if ($fp === false) {
+                throw new \RuntimeException("Cannot open output file: {$this->output_path}");
+            }
+            try {
+                $exporter->export($summary, $location_types_summary, $class_objects_summary, $fp);
+            } finally {
+                fclose($fp);
+            }
+        } else {
+            $fp = fopen('php://stdout', 'w');
+            if ($fp === false) {
+                throw new \RuntimeException('Cannot open stdout');
+            }
+            $exporter->export($summary, $location_types_summary, $class_objects_summary, $fp);
         }
     }
 

--- a/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryAnalysisResult.php
@@ -21,12 +21,18 @@ final class MemoryAnalysisResult
      * @param array<int, array<string, mixed>> $summary
      * @param array<string, array{count: int, memory_usage: int}>|null $location_types_summary
      * @param array<string, array{count: int, memory_usage: int}>|null $class_objects_summary
+     * @param \PDO|null $pre_populated_db When the context tree was already streamed
+     *                                    to a database during collection, pass the
+     *                                    connection here. Output handlers can then
+     *                                    skip the in-memory tree walk.
      */
     public function __construct(
         public readonly array $summary,
-        public readonly ReferenceContext $context,
+        public readonly ?ReferenceContext $context,
         public readonly ?array $location_types_summary = null,
         public readonly ?array $class_objects_summary = null,
+        public readonly ?\PDO $pre_populated_db = null,
+        public readonly ?int $pre_populated_run_id = null,
     ) {
     }
 }

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
@@ -14,13 +14,43 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput;
 
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\MySqlDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\PostgreSqlDriver;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 
 final class MemoryOutputFactory
 {
+    /**
+     * Create a streaming sink that writes directly to the final output DB
+     * when the output format is a database, or to a temp SQLite otherwise.
+     *
+     * @return array{PdoMemoryOutput, PdoContextTreeSink, int, \PDO, string|null}
+     *         [pdo_output, sink, run_id, db, temp_path (null if writing to final DB)]
+     */
+    public function createStreamingSink(
+        MemoryProfilerSettings $settings,
+        ?RegionBoundaries $region_boundaries = null,
+    ): array {
+        $driver = $this->createPdoDriver($settings);
+        $temp_path = null;
+        if ($driver === null) {
+            // Non-DB format: use temp SQLite
+            $tmp_base = tempnam(sys_get_temp_dir(), 'reli_stream_');
+            if ($tmp_base === false) {
+                throw new \RuntimeException('Failed to create temporary file');
+            }
+            $temp_path = $tmp_base . '.sqlite3';
+            @unlink($tmp_base);
+            $driver = new SqliteDriver($temp_path);
+        }
+        $pdo_output = new PdoMemoryOutput($driver, $region_boundaries);
+        [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
+        return [$pdo_output, $sink, $run_id, $db, $temp_path];
+    }
+
     public function create(
         MemoryProfilerSettings $settings,
         ?RegionBoundaries $region_boundaries = null,
@@ -73,6 +103,43 @@ final class MemoryOutputFactory
                 "unsupported output format: {$settings->output_format}"
                 . " (supported: json, sqlite3, mysql, postgresql, report, report-json)"
             ),
+        };
+    }
+
+    /**
+     * Returns a PdoDriver for DB output formats, or null for non-DB formats.
+     */
+    private function createPdoDriver(MemoryProfilerSettings $settings): ?PdoDriverInterface
+    {
+        return match ($settings->output_format) {
+            'sqlite3' => new SqliteDriver(
+                $settings->output_path ?? throw new \RuntimeException(
+                    '--output is required when using sqlite3 format'
+                ),
+            ),
+            'mysql' => new MySqlDriver(
+                $settings->db_host,
+                $settings->db_port ?? 3306,
+                $settings->db_name ?? throw new \RuntimeException(
+                    '--db-name is required when using mysql format'
+                ),
+                $settings->db_user ?? throw new \RuntimeException(
+                    '--db-user is required when using mysql format'
+                ),
+                $settings->db_password ?? '',
+            ),
+            'postgresql' => new PostgreSqlDriver(
+                $settings->db_host,
+                $settings->db_port ?? 5432,
+                $settings->db_name ?? throw new \RuntimeException(
+                    '--db-name is required when using postgresql format'
+                ),
+                $settings->db_user ?? throw new \RuntimeException(
+                    '--db-user is required when using postgresql format'
+                ),
+                $settings->db_password ?? '',
+            ),
+            default => null,
         };
     }
 }

--- a/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
+++ b/src/Inspector/Output/MemoryOutput/MemoryOutputFactory.php
@@ -26,7 +26,7 @@ final class MemoryOutputFactory
         ?RegionBoundaries $region_boundaries = null,
     ): MemoryOutputInterface {
         return match ($settings->output_format) {
-            'json' => new JsonMemoryOutput($settings->pretty_print, $settings->output_path),
+            'json' => new JsonMemoryOutput($settings->pretty_print, $settings->output_path, $region_boundaries),
             'sqlite3' => new PdoMemoryOutput(
                 new SqliteDriver(
                     $settings->output_path ?? throw new \RuntimeException(

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -29,6 +29,32 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
+        if ($result->pre_populated_db !== null && $result->pre_populated_run_id !== null) {
+            // Context tree was already streamed to this DB during collection.
+            // Just copy the data to the target DB.
+            $target_db = $this->driver->createConnection();
+            $this->driver->tuneForBulkInsert($target_db);
+            $this->createTables($target_db);
+
+            $target_db->beginTransaction();
+            try {
+                $this->copyFromPrePopulatedDb(
+                    $result->pre_populated_db,
+                    $result->pre_populated_run_id,
+                    $target_db,
+                );
+                $target_db->commit();
+            } catch (\Throwable $e) {
+                $target_db->rollBack();
+                throw $e;
+            }
+
+            $this->driver->afterBulkInsert($target_db);
+            $this->createIndexes($target_db);
+            $this->createViews($target_db);
+            return;
+        }
+
         $db = $this->driver->createConnection();
         $this->driver->tuneForBulkInsert($db);
 
@@ -331,5 +357,93 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             ORDER BY SUM(size) DESC
         ");
         $stmt->execute([$run_id, $run_id]);
+    }
+
+    /**
+     * Copy all data from a pre-populated (temp) SQLite DB to the target DB.
+     */
+    private function copyFromPrePopulatedDb(\PDO $source, int $source_run_id, \PDO $target): void
+    {
+        $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
+
+        $run_id = $this->insertRun($target);
+
+        // Copy summary
+        $rows = $source->prepare('SELECT "key", "value" FROM summary WHERE run_id = ?');
+        $rows->execute([$source_run_id]);
+        $insert = $target->prepare(
+            "INSERT INTO summary (run_id, {$qi('key')}, {$qi('value')}) VALUES (?, ?, ?)"
+        );
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $insert->execute([$run_id, $row['key'], $row['value']]);
+        }
+
+        // Copy context_nodes
+        $rows = $source->prepare('SELECT node_id, type FROM context_nodes WHERE run_id = ?');
+        $rows->execute([$source_run_id]);
+        $insert = $target->prepare(
+            $this->driver->insertIgnoreSql('context_nodes', 'run_id, node_id, type', '?, ?, ?')
+        );
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $insert->execute([$run_id, $row['node_id'], $row['type']]);
+        }
+
+        // Copy context_edges
+        $rows = $source->prepare(
+            'SELECT parent_node_id, child_node_id, link_name, is_tree FROM context_edges WHERE run_id = ?'
+        );
+        $rows->execute([$source_run_id]);
+        $insert = $target->prepare(
+            'INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree)'
+            . ' VALUES (?, ?, ?, ?, ?)'
+        );
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $insert->execute([$run_id, $row['parent_node_id'], $row['child_node_id'], $row['link_name'], $row['is_tree']]);
+        }
+
+        // Copy context_node_locations
+        $rows = $source->prepare(
+            'SELECT node_id, address, size, location_type, class_name, string_value, refcount, type_info, region'
+            . ' FROM context_node_locations WHERE run_id = ?'
+        );
+        $rows->execute([$source_run_id]);
+        $insert = $target->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, class_name, string_value, refcount, type_info, region)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $insert->execute([
+                $run_id, $row['node_id'], $row['address'], $row['size'], $row['location_type'],
+                $row['class_name'], $row['string_value'], $row['refcount'], $row['type_info'], $row['region'],
+            ]);
+        }
+
+        // Copy context_node_attributes
+        $rows = $source->prepare(
+            "SELECT node_id, {$qi('key')}, {$qi('value')} FROM context_node_attributes WHERE run_id = ?"
+        );
+        $rows->execute([$source_run_id]);
+        $insert = $target->prepare(
+            "INSERT INTO context_node_attributes (run_id, node_id, {$qi('key')}, {$qi('value')})"
+            . ' VALUES (?, ?, ?, ?)'
+        );
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $insert->execute([$run_id, $row['node_id'], $row['key'], $row['value']]);
+        }
+
+        // Compute summaries from copied data
+        $this->insertLocationTypesSummaryFromDb($target, $run_id);
+        $this->insertClassObjectsSummaryFromDb($target, $run_id);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -39,10 +39,12 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             $run_id = $this->insertRun($db);
             $this->insertSummary($db, $run_id, $result->summary);
 
-            $sink = new PdoContextTreeSink($db, $this->driver, $run_id, $this->region_boundaries);
-            $analyzer = new ContextAnalyzer();
-            $analyzer->analyze($result->context, $sink);
-            $sink->flush();
+            if ($result->context !== null) {
+                $sink = new PdoContextTreeSink($db, $this->driver, $run_id, $this->region_boundaries);
+                $analyzer = new ContextAnalyzer();
+                $analyzer->analyze($result->context, $sink);
+                $sink->flush();
+            }
 
             $this->insertLocationTypesSummaryFromDb($db, $run_id);
             $this->insertClassObjectsSummaryFromDb($db, $run_id);
@@ -53,6 +55,42 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             throw $e;
         }
 
+        $this->driver->afterBulkInsert($db);
+        $this->createIndexes($db);
+        $this->createViews($db);
+    }
+
+    /**
+     * Create sink for streaming context tree directly during collection.
+     * The returned sink, run_id, and PDO connection can be passed to
+     * MemoryLocationsCollector::collectAll() for interleaved emission.
+     *
+     * @return array{PdoContextTreeSink, int, \PDO}
+     */
+    public function createStreamingSink(): array
+    {
+        $db = $this->driver->createConnection();
+        $this->driver->tuneForBulkInsert($db);
+        $this->createTables($db);
+        $db->beginTransaction();
+        $run_id = $this->insertRun($db);
+
+        $sink = new PdoContextTreeSink($db, $this->driver, $run_id, $this->region_boundaries);
+        return [$sink, $run_id, $db];
+    }
+
+    /**
+     * Finalize a streaming session started by createStreamingSink().
+     *
+     * @param array<int, array<string, mixed>> $summary
+     */
+    public function finalizeStreaming(\PDO $db, int $run_id, PdoContextTreeSink $sink, array $summary): void
+    {
+        $sink->flush();
+        $this->insertSummary($db, $run_id, $summary);
+        $this->insertLocationTypesSummaryFromDb($db, $run_id);
+        $this->insertClassObjectsSummaryFromDb($db, $run_id);
+        $db->commit();
         $this->driver->afterBulkInsert($db);
         $this->createIndexes($db);
         $this->createViews($db);

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -404,7 +404,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         /** @psalm-suppress MixedAssignment */
         while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
             /** @psalm-suppress MixedArrayAccess */
-            $insert->execute([$run_id, $row['parent_node_id'], $row['child_node_id'], $row['link_name'], $row['is_tree']]);
+            $insert->execute([
+                $run_id, $row['parent_node_id'], $row['child_node_id'],
+                $row['link_name'], $row['is_tree'],
+            ]);
         }
 
         // Copy context_node_locations

--- a/src/Inspector/Output/MemoryOutput/ReportMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/ReportMemoryOutput.php
@@ -32,6 +32,18 @@ final class ReportMemoryOutput implements MemoryOutputInterface
     #[\Override]
     public function output(MemoryAnalysisResult $result): void
     {
+        if ($result->pre_populated_db !== null && $result->pre_populated_run_id !== null) {
+            $generator = new ReportGenerator();
+            $report = $generator->generateFromDb($result->pre_populated_db, $result->pre_populated_run_id);
+            $formatted = $this->formatter->format($report);
+            if ($this->output_path !== null) {
+                file_put_contents($this->output_path, $formatted);
+            } else {
+                echo $formatted;
+            }
+            return;
+        }
+
         // Write to a temporary SQLite file first
         $tmp_base = tempnam(sys_get_temp_dir(), 'reli_report_');
         if ($tmp_base === false) {

--- a/src/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporter.php
+++ b/src/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporter.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+/**
+ * Streams JSON output from a SQLite database by DFS traversal.
+ * Memory usage is O(tree depth) rather than O(total nodes).
+ */
+final class StreamingJsonFromDbExporter
+{
+    private \PDOStatement $tree_children_stmt;
+    private \PDOStatement $locations_stmt;
+    private \PDOStatement $attributes_stmt;
+
+    private int $json_flags;
+
+    public function __construct(
+        private \PDO $db,
+        private int $run_id,
+        bool $pretty_print = false,
+    ) {
+        $this->tree_children_stmt = $db->prepare(
+            'SELECT child_node_id, link_name, is_tree'
+            . ' FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id IS NULL'
+            . ' ORDER BY rowid'
+        );
+        $this->locations_stmt = $db->prepare(
+            'SELECT address, size, location_type, class_name, string_value, refcount, type_info, region'
+            . ' FROM context_node_locations'
+            . ' WHERE run_id = ? AND node_id = ?'
+        );
+        $this->attributes_stmt = $db->prepare(
+            'SELECT "key", "value" FROM context_node_attributes WHERE run_id = ? AND node_id = ?'
+        );
+
+        $this->json_flags = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
+        if ($pretty_print) {
+            $this->json_flags |= JSON_PRETTY_PRINT;
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     * @param array<string, array{count: int, memory_usage: int}>|null $location_types_summary
+     * @param array<string, array{count: int, memory_usage: int}>|null $class_objects_summary
+     * @param resource $output
+     */
+    public function export(
+        array $summary,
+        ?array $location_types_summary,
+        ?array $class_objects_summary,
+        $output,
+    ): void {
+        fwrite($output, '{');
+        fwrite($output, '"summary":' . $this->jsonEncode($summary));
+        fwrite($output, ',"location_types_summary":' . $this->jsonEncode($location_types_summary ?? []));
+        fwrite($output, ',"class_objects_summary":' . $this->jsonEncode($class_objects_summary ?? []));
+        fwrite($output, ',"context":');
+        $this->exportRootContext($output);
+        fwrite($output, '}');
+    }
+
+    /** @param resource $output */
+    private function exportRootContext($output): void
+    {
+        fwrite($output, '{');
+        $this->tree_children_stmt->execute([$this->run_id]);
+        $first = true;
+        while (
+            /** @var array{child_node_id: int, link_name: string, is_tree: int} */
+            $row = $this->tree_children_stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            if (!$first) {
+                fwrite($output, ',');
+            }
+            $first = false;
+            /** @psalm-suppress MixedArrayAccess, MixedArgument */
+            fwrite($output, $this->jsonEncode($row['link_name']) . ':');
+            /** @psalm-suppress MixedArrayAccess */
+            if ($row['is_tree']) {
+                /** @psalm-suppress MixedArrayAccess, MixedArgument */
+                $this->exportNode($row['child_node_id'], $output);
+            } else {
+                /** @psalm-suppress MixedArrayAccess */
+                fwrite($output, $this->jsonEncode(['#reference_node_id' => $row['child_node_id']]));
+            }
+        }
+        fwrite($output, '}');
+    }
+
+    /** @param resource $output */
+    private function exportNode(int $node_id, $output): void
+    {
+        $type_stmt = $this->db->prepare(
+            'SELECT type FROM context_nodes WHERE run_id = ? AND node_id = ?'
+        );
+        $type_stmt->execute([$this->run_id, $node_id]);
+        /** @var string $type */
+        $type = $type_stmt->fetchColumn();
+
+        fwrite($output, '{');
+        fwrite($output, '"#node_id":' . $node_id);
+        fwrite($output, ',"#type":' . $this->jsonEncode($type));
+
+        // Locations
+        $this->locations_stmt->execute([$this->run_id, $node_id]);
+        /** @var list<array<string, mixed>> $locations */
+        $locations = $this->locations_stmt->fetchAll(\PDO::FETCH_ASSOC);
+        if ($locations !== []) {
+            fwrite($output, ',"#locations":' . $this->jsonEncode($locations));
+        }
+
+        // Attributes
+        $this->attributes_stmt->execute([$this->run_id, $node_id]);
+        while (
+            /** @var array{key: string, value: string|null} */
+            $attr = $this->attributes_stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            /** @psalm-suppress MixedArrayAccess, MixedAssignment */
+            $decoded = json_decode((string)$attr['value']);
+            /** @psalm-suppress MixedArrayAccess, MixedAssignment */
+            $value = $decoded !== null ? $decoded : $attr['value'];
+            /** @psalm-suppress MixedArrayAccess, MixedArgument */
+            fwrite($output, ',' . $this->jsonEncode($attr['key']) . ':' . $this->jsonEncode($value));
+        }
+
+        // Children (tree edges + reference edges)
+        $children_stmt = $this->db->prepare(
+            'SELECT child_node_id, link_name, is_tree'
+            . ' FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ?'
+            . ' ORDER BY rowid'
+        );
+        $children_stmt->execute([$this->run_id, $node_id]);
+        while (
+            /** @var array{child_node_id: int, link_name: string, is_tree: int} */
+            $child = $children_stmt->fetch(\PDO::FETCH_ASSOC)
+        ) {
+            /** @psalm-suppress MixedArrayAccess, MixedArgument */
+            fwrite($output, ',' . $this->jsonEncode($child['link_name']) . ':');
+            /** @psalm-suppress MixedArrayAccess */
+            if ($child['is_tree']) {
+                /** @psalm-suppress MixedArrayAccess, MixedArgument */
+                $this->exportNode($child['child_node_id'], $output);
+            } else {
+                /** @psalm-suppress MixedArrayAccess */
+                fwrite($output, $this->jsonEncode(['#reference_node_id' => $child['child_node_id']]));
+            }
+        }
+
+        fwrite($output, '}');
+    }
+
+    private function jsonEncode(mixed $value): string
+    {
+        $result = json_encode($value, $this->json_flags);
+        if ($result === false) {
+            throw new \RuntimeException('JSON encoding failed: ' . json_last_error_msg());
+        }
+        return $result;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -25,7 +25,7 @@ final class CollectedMemories
         public MemoryLocations $compiler_arena_memory_locations,
         public int $cached_chunks_size,
         public MemoryLocations $memory_locations,
-        public TopReferenceContext $top_reference_context,
+        public ?TopReferenceContext $top_reference_context,
         public int $memory_get_usage_size,
         public int $memory_get_usage_real_size,
     ) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
 use WeakMap;
 
 final class ContextAnalyzer
@@ -75,6 +76,13 @@ final class ContextAnalyzer
         ContextTreeSink $sink,
         WeakMap $memo,
     ): void {
+        // SentinelContext: already emitted to DB in a previous branch,
+        // just record the reference edge.
+        if ($linked_context instanceof SentinelContext) {
+            $sink->emitReference($linked_context->node_id, $parent_node_id, $link_name);
+            return;
+        }
+
         $existing_node_id = $memo[$linked_context] ?? null;
         if ($existing_node_id !== null) {
             $sink->emitReference($existing_node_id, $parent_node_id, $link_name);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -37,35 +37,68 @@ final class ContextAnalyzer
         foreach ($reference_context->getLinks() as $link_name => $linked_context) {
             /** @psalm-suppress RedundantCastGivenDocblockType -- int keys occur at runtime */
             $link_name = (string)$link_name;
-            $existing_node_id = $memo[$linked_context] ?? null;
-            if ($existing_node_id !== null) {
-                $sink->emitReference($existing_node_id, $parent_node_id, $link_name);
-                continue;
-            }
-
-            $current_node_id = $this->node_id++;
-            $memo[$linked_context] = $current_node_id;
-
-            $contexts = $linked_context->getContexts();
-            if (!is_array($contexts)) {
-                $contexts = iterator_to_array($contexts);
-            }
-            /** @var array<string, mixed> $contexts */
-
-            $sink->emitNode(
-                $current_node_id,
-                $parent_node_id,
-                $link_name,
-                $linked_context->getName(),
-                $linked_context->getLocations(),
-                $contexts,
-            );
-
-            $this->analyze($linked_context, $sink, $current_node_id, $memo);
+            $this->analyzeContext($linked_context, $link_name, $parent_node_id, $sink, $memo);
         }
 
         if ($sink->allowsRelease()) {
             $reference_context->releaseLinks();
         }
+    }
+
+    /**
+     * Emit a single named context and its subtree to the sink.
+     * Useful for streaming branches independently while sharing memo across them.
+     *
+     * @param WeakMap<ReferenceContext, int> $memo
+     */
+    public function analyzeSingleLink(
+        string $link_name,
+        ReferenceContext $context,
+        ContextTreeSink $sink,
+        ?int $parent_node_id = null,
+        ?WeakMap $memo = null,
+    ): void {
+        if ($memo === null) {
+            /** @var WeakMap<ReferenceContext, int> $memo */
+            $memo = new WeakMap();
+        }
+        $this->analyzeContext($context, $link_name, $parent_node_id, $sink, $memo);
+    }
+
+    /**
+     * @param WeakMap<ReferenceContext, int> $memo
+     */
+    private function analyzeContext(
+        ReferenceContext $linked_context,
+        string $link_name,
+        ?int $parent_node_id,
+        ContextTreeSink $sink,
+        WeakMap $memo,
+    ): void {
+        $existing_node_id = $memo[$linked_context] ?? null;
+        if ($existing_node_id !== null) {
+            $sink->emitReference($existing_node_id, $parent_node_id, $link_name);
+            return;
+        }
+
+        $current_node_id = $this->node_id++;
+        $memo[$linked_context] = $current_node_id;
+
+        $contexts = $linked_context->getContexts();
+        if (!is_array($contexts)) {
+            $contexts = iterator_to_array($contexts);
+        }
+        /** @var array<string, mixed> $contexts */
+
+        $sink->emitNode(
+            $current_node_id,
+            $parent_node_id,
+            $link_name,
+            $linked_context->getName(),
+            $linked_context->getLocations(),
+            $contexts,
+        );
+
+        $this->analyze($linked_context, $sink, $current_node_id, $memo);
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -47,6 +47,26 @@ final class ContextAnalyzer
     }
 
     /**
+     * Pre-assign a node_id to a context and register it in the memo,
+     * without emitting it yet. Used by the collector to register parent
+     * nodes before their children are collected and emitted.
+     *
+     * @param WeakMap<ReferenceContext, int> $memo
+     */
+    public function assignNodeId(
+        ReferenceContext $context,
+        WeakMap $memo,
+    ): int {
+        $existing = $memo[$context] ?? null;
+        if ($existing !== null) {
+            return $existing;
+        }
+        $node_id = $this->node_id++;
+        $memo[$context] = $node_id;
+        return $node_id;
+    }
+
+    /**
      * Emit a single named context and its subtree to the sink.
      * Useful for streaming branches independently while sharing memo across them.
      *

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
@@ -16,12 +16,17 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ArrayContextPool;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectContextPool;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\PhpReferenceContextPool;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContextPool;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContextPool;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContextPool;
 
 final class ContextPools
 {
+    /** @var array<int, SentinelContext> address → sentinel for cross-branch dedup */
+    private array $sentinels = [];
+
     public function __construct(
         public StringContextPool $string_context_pool,
         public ArrayContextPool $array_context_pool,
@@ -30,6 +35,16 @@ final class ContextPools
         public ResourceContextPool $resource_context_pool,
         public UserFunctionDefinitionContextPool $user_function_definition_context_pool,
     ) {
+    }
+
+    /**
+     * Check if a sentinel exists for the given address (streaming mode).
+     * Returns the sentinel if the address was already emitted to DB in
+     * a previous branch, or null if not.
+     */
+    public function getSentinel(int $address): ?SentinelContext
+    {
+        return $this->sentinels[$address] ?? null;
     }
 
     public static function createDefault(): self
@@ -52,5 +67,37 @@ final class ContextPools
         $this->php_reference_context_pool->clear();
         $this->resource_context_pool->clear();
         $this->user_function_definition_context_pool->clear();
+    }
+
+    /**
+     * Convert all pooled contexts to lightweight sentinels and clear the pools.
+     * For each pooled Context that has a node_id in memo, record a
+     * SentinelContext(node_id) keyed by address. The heavy Context objects
+     * become eligible for GC, while subsequent cache hits return the sentinel.
+     *
+     * @param \WeakMap<ReferenceContext, int> $memo
+     */
+    public function convertToSentinels(\WeakMap $memo): void
+    {
+        $this->convertPoolToSentinels($this->string_context_pool->drainWithAddresses(), $memo);
+        $this->convertPoolToSentinels($this->array_context_pool->drainWithAddresses(), $memo);
+        $this->convertPoolToSentinels($this->object_context_pool->drainWithAddresses(), $memo);
+        $this->convertPoolToSentinels($this->php_reference_context_pool->drainWithAddresses(), $memo);
+        $this->convertPoolToSentinels($this->resource_context_pool->drainWithAddresses(), $memo);
+        $this->convertPoolToSentinels($this->user_function_definition_context_pool->drainWithAddresses(), $memo);
+    }
+
+    /**
+     * @param iterable<int, ReferenceContext> $entries address => context
+     * @param \WeakMap<ReferenceContext, int> $memo
+     */
+    private function convertPoolToSentinels(iterable $entries, \WeakMap $memo): void
+    {
+        foreach ($entries as $address => $context) {
+            $node_id = $memo[$context] ?? null;
+            if ($node_id !== null) {
+                $this->sentinels[$address] = new SentinelContext($node_id);
+            }
+        }
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
@@ -24,8 +24,10 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefin
 
 final class ContextPools
 {
-    /** @var array<int, SentinelContext> address → sentinel for cross-branch dedup */
+    /** @var array<int, int> address → node_id for cross-branch dedup */
     private array $sentinels = [];
+
+    private SentinelContext $shared_sentinel;
 
     public function __construct(
         public StringContextPool $string_context_pool,
@@ -35,16 +37,22 @@ final class ContextPools
         public ResourceContextPool $resource_context_pool,
         public UserFunctionDefinitionContextPool $user_function_definition_context_pool,
     ) {
+        $this->shared_sentinel = new SentinelContext(0);
     }
 
     /**
-     * Check if a sentinel exists for the given address (streaming mode).
-     * Returns the sentinel if the address was already emitted to DB in
-     * a previous branch, or null if not.
+     * Check if the given address was already emitted to DB in a previous branch.
+     * Returns a shared SentinelContext with the node_id set, or null.
+     * The returned object is reused across calls — do not store it.
      */
     public function getSentinel(int $address): ?SentinelContext
     {
-        return $this->sentinels[$address] ?? null;
+        $node_id = $this->sentinels[$address] ?? null;
+        if ($node_id === null) {
+            return null;
+        }
+        $this->shared_sentinel->node_id = $node_id;
+        return $this->shared_sentinel;
     }
 
     public static function createDefault(): self
@@ -96,7 +104,7 @@ final class ContextPools
         foreach ($entries as $address => $context) {
             $node_id = $memo[$context] ?? null;
             if ($node_id !== null) {
-                $this->sentinels[$address] = new SentinelContext($node_id);
+                $this->sentinels[$address] = $node_id;
             }
         }
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
@@ -43,4 +43,14 @@ final class ContextPools
             new UserFunctionDefinitionContextPool(),
         );
     }
+
+    public function clear(): void
+    {
+        $this->string_context_pool->clear();
+        $this->array_context_pool->clear();
+        $this->object_context_pool->clear();
+        $this->php_reference_context_pool->clear();
+        $this->resource_context_pool->clear();
+        $this->user_function_definition_context_pool->clear();
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocations.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocations.php
@@ -25,25 +25,22 @@ final class MemoryLocations
     }
 
     /**
-     * Create a lightweight instance that stores only address → class-string
-     * instead of full MemoryLocation objects. For streaming mode where
-     * location data has already been emitted to the DB.
+     * Create a lightweight instance that stores only a set of seen
+     * addresses instead of full MemoryLocation objects.
+     * For streaming mode where location data has already been emitted to the DB.
      */
     public static function createLightweight(): self
     {
         return new self(lightweight: true);
     }
 
-    /** @var array<int, class-string<MemoryLocation>> */
-    private array $class_map = [];
-
-    /** @var array<int, int> address → size for dedup logic */
-    private array $size_map = [];
+    /** @var array<int, true> seen addresses for lightweight mode */
+    private array $seen = [];
 
     public function add(MemoryLocation $memory_location): void
     {
         if ($this->lightweight) {
-            $this->addLightweight($memory_location);
+            $this->seen[$memory_location->address] = true;
             return;
         }
         if ($this->has($memory_location->address)) {
@@ -63,31 +60,10 @@ final class MemoryLocations
         $this->memory_locations[$memory_location->address] = $memory_location;
     }
 
-    private function addLightweight(MemoryLocation $memory_location): void
-    {
-        $address = $memory_location->address;
-        if (isset($this->class_map[$address])) {
-            $recorded_class = $this->class_map[$address];
-            if ($recorded_class === ZendArrayTableOverheadMemoryLocation::class) {
-                // Override overhead with the real location
-                $this->class_map[$address] = $memory_location::class;
-                $this->size_map[$address] = $memory_location->size;
-                return;
-            } elseif ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
-                return;
-            }
-            if ($memory_location->size < ($this->size_map[$address] ?? 0)) {
-                return;
-            }
-        }
-        $this->class_map[$address] = $memory_location::class;
-        $this->size_map[$address] = $memory_location->size;
-    }
-
     public function has(int $address): bool
     {
         if ($this->lightweight) {
-            return isset($this->class_map[$address]);
+            return isset($this->seen[$address]);
         }
         return isset($this->memory_locations[$address]);
     }
@@ -95,21 +71,6 @@ final class MemoryLocations
     public function get(int $address): MemoryLocation
     {
         return $this->memory_locations[$address];
-    }
-
-    /**
-     * Get the class name of the MemoryLocation at the given address.
-     * Works in both normal and lightweight modes.
-     *
-     * @return class-string<MemoryLocation>|null
-     */
-    public function getClass(int $address): ?string
-    {
-        if ($this->lightweight) {
-            return $this->class_map[$address] ?? null;
-        }
-        $loc = $this->memory_locations[$address] ?? null;
-        return $loc !== null ? $loc::class : null;
     }
 
     public function contains(MemoryLocation $memory_location): bool

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocations.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocations.php
@@ -19,12 +19,33 @@ final class MemoryLocations
 {
     /** @param array<MemoryLocation> $memory_locations */
     public function __construct(
-        public array $memory_locations = []
+        public array $memory_locations = [],
+        private bool $lightweight = false,
     ) {
     }
 
+    /**
+     * Create a lightweight instance that stores only address → class-string
+     * instead of full MemoryLocation objects. For streaming mode where
+     * location data has already been emitted to the DB.
+     */
+    public static function createLightweight(): self
+    {
+        return new self(lightweight: true);
+    }
+
+    /** @var array<int, class-string<MemoryLocation>> */
+    private array $class_map = [];
+
+    /** @var array<int, int> address → size for dedup logic */
+    private array $size_map = [];
+
     public function add(MemoryLocation $memory_location): void
     {
+        if ($this->lightweight) {
+            $this->addLightweight($memory_location);
+            return;
+        }
         if ($this->has($memory_location->address)) {
             $recorded_memory_location = $this->get($memory_location->address);
             if ($recorded_memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
@@ -42,14 +63,53 @@ final class MemoryLocations
         $this->memory_locations[$memory_location->address] = $memory_location;
     }
 
+    private function addLightweight(MemoryLocation $memory_location): void
+    {
+        $address = $memory_location->address;
+        if (isset($this->class_map[$address])) {
+            $recorded_class = $this->class_map[$address];
+            if ($recorded_class === ZendArrayTableOverheadMemoryLocation::class) {
+                // Override overhead with the real location
+                $this->class_map[$address] = $memory_location::class;
+                $this->size_map[$address] = $memory_location->size;
+                return;
+            } elseif ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
+                return;
+            }
+            if ($memory_location->size < ($this->size_map[$address] ?? 0)) {
+                return;
+            }
+        }
+        $this->class_map[$address] = $memory_location::class;
+        $this->size_map[$address] = $memory_location->size;
+    }
+
     public function has(int $address): bool
     {
+        if ($this->lightweight) {
+            return isset($this->class_map[$address]);
+        }
         return isset($this->memory_locations[$address]);
     }
 
     public function get(int $address): MemoryLocation
     {
         return $this->memory_locations[$address];
+    }
+
+    /**
+     * Get the class name of the MemoryLocation at the given address.
+     * Works in both normal and lightweight modes.
+     *
+     * @return class-string<MemoryLocation>|null
+     */
+    public function getClass(int $address): ?string
+    {
+        if ($this->lightweight) {
+            return $this->class_map[$address] ?? null;
+        }
+        $loc = $this->memory_locations[$address] ?? null;
+        return $loc !== null ? $loc::class : null;
     }
 
     public function contains(MemoryLocation $memory_location): bool

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -297,12 +297,22 @@ final class MemoryLocationsCollector
 
         $context_pools = ContextPools::createDefault();
 
+        // In streaming mode, set up the analyzer and memo early so we can
+        // emit each branch right after collection and release it.
+        $analyzer = $sink !== null ? new ContextAnalyzer() : null;
+        /** @var \WeakMap<ReferenceContext, int>|null $memo */
+        $memo = $sink !== null ? new \WeakMap() : null;
+
         $included_files_context = $this->collectIncludedFiles(
             $eg->included_files,
             $dereferencer,
             $memory_locations,
             $context_pools,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('included_files', $included_files_context, $sink, null, $memo);
+            unset($included_files_context);
+        }
 
         $interned_strings_context = $this->collectInternedStrings(
             $cg->interned_strings,
@@ -312,6 +322,10 @@ final class MemoryLocationsCollector
             $memory_locations,
             $context_pools,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('interned_strings', $interned_strings_context, $sink, null, $memo);
+            unset($interned_strings_context);
+        }
 
         assert(!is_null($eg->function_table));
         assert(!is_null($eg->class_table));
@@ -330,6 +344,10 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('global_variables', $global_variables_context, $sink, null, $memo);
+            unset($global_variables_context);
+        }
 
         $call_frames_context = $this->collectCallFrames(
             $eg,
@@ -340,6 +358,7 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        // call_frames emission is deferred — memory_limit_error may replace it below
 
         $defined_functions_context = $this->collectFunctionTable(
             $function_table,
@@ -350,6 +369,10 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('function_table', $defined_functions_context, $sink, null, $memo);
+            unset($defined_functions_context);
+        }
 
         $defined_classes_context = $this->collectClassTable(
             $class_table,
@@ -360,6 +383,10 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('class_table', $defined_classes_context, $sink, null, $memo);
+            unset($defined_classes_context);
+        }
 
         $global_constants_context = $this->collectGlobalConstants(
             $zend_constants,
@@ -370,6 +397,10 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('global_constants', $global_constants_context, $sink, null, $memo);
+            unset($global_constants_context);
+        }
 
         try {
             $global_callbacks_context = $this->collectGlobalCallbacks(
@@ -384,6 +415,10 @@ final class MemoryLocationsCollector
         } catch (\Throwable $e) {
             Log::info('failed to collect global callbacks', ['error' => $e->getMessage()]);
             $global_callbacks_context = new GlobalCallbacksContext();
+        }
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('global_callbacks', $global_callbacks_context, $sink, null, $memo);
+            unset($global_callbacks_context);
         }
 
         try {
@@ -400,6 +435,10 @@ final class MemoryLocationsCollector
             Log::info('failed to collect modules', ['error' => $e->getMessage()]);
             $modules_context = new ModulesContext();
         }
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('modules', $modules_context, $sink, null, $memo);
+            unset($modules_context);
+        }
 
         $objects_store_context = $this->collectObjectsStore(
             $eg->objects_store,
@@ -410,6 +449,10 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
+            unset($objects_store_context);
+        }
 
         if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
             $call_frames_context = $this->collectRealCallStackOnMemoryLimitViolation(
@@ -425,31 +468,10 @@ final class MemoryLocationsCollector
             );
         }
 
-        if ($sink !== null) {
-            // Streaming mode: emit each branch to the sink immediately,
-            // then release it. Shared contexts (via pools) are tracked
-            // by the memo WeakMap across all branches, ensuring proper
-            // reference deduplication.
-            $analyzer = new ContextAnalyzer();
-            /** @var \WeakMap<ReferenceContext, int> $memo */
-            $memo = new \WeakMap();
-
-            /** @var array<string, ReferenceContext> $branches */
-            $branches = [
-                'call_frames' => $call_frames_context,
-                'global_variables' => $global_variables_context,
-                'function_table' => $defined_functions_context,
-                'class_table' => $defined_classes_context,
-                'global_constants' => $global_constants_context,
-                'included_files' => $included_files_context,
-                'interned_strings' => $interned_strings_context,
-                'global_callbacks' => $global_callbacks_context,
-                'modules' => $modules_context,
-                'objects_store' => $objects_store_context,
-            ];
-            foreach ($branches as $link_name => $branch_context) {
-                $analyzer->analyzeSingleLink($link_name, $branch_context, $sink, null, $memo);
-            }
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            // Emit the deferred call_frames branch (may have been replaced above)
+            $analyzer->analyzeSingleLink('call_frames', $call_frames_context, $sink, null, $memo);
+            unset($call_frames_context);
 
             $context_pools->clear();
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -161,6 +161,24 @@ final class MemoryLocationsCollector
     }
 
     /**
+     * In streaming mode, convert current pool entries to sentinels
+     * and clear the pools. This releases the heavy Context objects
+     * that were created during the current iteration, keeping only
+     * the address→node_id map for cross-reference deduplication.
+     */
+    private function flushPoolsIfStreaming(): void
+    {
+        if (
+            $this->streaming_memo === null
+            || $this->streaming_context_pools === null
+        ) {
+            return;
+        }
+        $this->streaming_context_pools->convertToSentinels($this->streaming_memo);
+        $this->streaming_context_pools->clear();
+    }
+
+    /**
      * In streaming mode, register a parent node in the analyzer's memo
      * and emit it to the sink, so that children can be emitted as
      * sub-nodes during collection. Returns the assigned node_id, or
@@ -1109,6 +1127,7 @@ final class MemoryLocationsCollector
                     $call_frame_context,
                     $parent_node_id,
                 );
+                $this->flushPoolsIfStreaming();
             }
             $call_frames_context->add((string)$key, $call_frame_context);
         }
@@ -2049,6 +2068,7 @@ final class MemoryLocationsCollector
                     $function_context,
                     $parent_node_id,
                 );
+                $this->flushPoolsIfStreaming();
             }
             $defined_functions_context->add($function_name, $function_context);
         }
@@ -2400,6 +2420,7 @@ final class MemoryLocationsCollector
                         $class_definition_context,
                         $parent_node_id,
                     );
+                    $this->flushPoolsIfStreaming();
                 }
                 $defined_classes_context->add((string)$class_name, $class_definition_context);
             }
@@ -2759,6 +2780,7 @@ final class MemoryLocationsCollector
                     $objects_store_bucket_context,
                     $parent_node_id,
                 );
+                $this->flushPoolsIfStreaming();
             }
             $objects_store_context->add((string)$key, $objects_store_bucket_context);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -283,18 +283,20 @@ final class MemoryLocationsCollector
     /**
      * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      */
-    private function getDereferencer(int $pid, string $php_version): Dereferencer
+    private function getDereferencer(int $pid, string $php_version, bool $enable_cache = false): Dereferencer
     {
-        return new CachingDereferencer(
-            new RemoteProcessDereferencer(
-                $this->memory_reader,
-                new ProcessSpecifier($pid),
-                new ZendCastedTypeProvider(
-                    $this->getTypeReader($php_version),
-                ),
-                new VersionedPointedTypeResolver($php_version)
+        $inner = new RemoteProcessDereferencer(
+            $this->memory_reader,
+            new ProcessSpecifier($pid),
+            new ZendCastedTypeProvider(
+                $this->getTypeReader($php_version),
             ),
+            new VersionedPointedTypeResolver($php_version)
         );
+        if ($enable_cache) {
+            return new CachingDereferencer($inner);
+        }
+        return $inner;
     }
 
     /** @param TargetPhpSettings<VersionDecided> $target_php_settings */
@@ -328,7 +330,7 @@ final class MemoryLocationsCollector
     ): CollectedMemories {
         $pid = $process_specifier->pid;
         $php_version = $target_php_settings->php_version;
-        $dereferencer = $this->getDereferencer($pid, $php_version);
+        $dereferencer = $this->getDereferencer($pid, $php_version, enable_cache: $sink !== null);
         $zend_type_reader = $this->zend_type_reader_creator->create($php_version);
 
         $main_chunk_header_pointer = new Pointer(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -128,6 +128,8 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\TopReferenceConte
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\WeakMapContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\WeakReferenceContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -203,6 +205,7 @@ final class MemoryLocationsCollector
         int $cg_address,
         ?MemoryLimitErrorDetails $memory_limit_error_details = null,
         ?int $bg_address = null,
+        ?ContextTreeSink $sink = null,
     ): CollectedMemories {
         $pid = $process_specifier->pid;
         $php_version = $target_php_settings->php_version;
@@ -419,6 +422,47 @@ final class MemoryLocationsCollector
                 $zend_type_reader,
                 $memory_locations,
                 $context_pools,
+            );
+        }
+
+        if ($sink !== null) {
+            // Streaming mode: emit each branch to the sink immediately,
+            // then release it. Shared contexts (via pools) are tracked
+            // by the memo WeakMap across all branches, ensuring proper
+            // reference deduplication.
+            $analyzer = new ContextAnalyzer();
+            /** @var \WeakMap<ReferenceContext, int> $memo */
+            $memo = new \WeakMap();
+
+            /** @var array<string, ReferenceContext> $branches */
+            $branches = [
+                'call_frames' => $call_frames_context,
+                'global_variables' => $global_variables_context,
+                'function_table' => $defined_functions_context,
+                'class_table' => $defined_classes_context,
+                'global_constants' => $global_constants_context,
+                'included_files' => $included_files_context,
+                'interned_strings' => $interned_strings_context,
+                'global_callbacks' => $global_callbacks_context,
+                'modules' => $modules_context,
+                'objects_store' => $objects_store_context,
+            ];
+            foreach ($branches as $link_name => $branch_context) {
+                $analyzer->analyzeSingleLink($link_name, $branch_context, $sink, null, $memo);
+            }
+
+            $context_pools->clear();
+
+            return new CollectedMemories(
+                $chunk_memory_locations,
+                $huge_memory_locations,
+                $vm_stack_memory_locations,
+                $compiler_arena_memory_locations,
+                $cached_chunks_size,
+                $memory_locations,
+                null,
+                $memory_get_usage_size,
+                $memory_get_usage_real_size,
             );
         }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -160,6 +160,28 @@ final class MemoryLocationsCollector
      */
     private bool $defer_unseen_objects = false;
 
+    /**
+     * Edges deferred during objects_store collection. Each entry records
+     * a property reference to an object that was not yet collected.
+     * After all objects are collected, these are resolved via the sentinel
+     * map and emitted as reference edges.
+     *
+     * @var list<array{int, int, string}> [parent_node_id, child_address, link_name]
+     */
+    private array $deferred_object_edges = [];
+
+    /**
+     * The node_id of the innermost streaming parent that is currently
+     * being populated. Used by defer logic to record edges.
+     */
+    private ?int $current_streaming_parent_node_id = null;
+
+    /**
+     * The link name under which the current child is being collected.
+     * Used by defer logic to record the correct edge name.
+     */
+    private ?string $current_streaming_link_name = null;
+
     public function __construct(
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
@@ -459,6 +481,17 @@ final class MemoryLocationsCollector
             $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
             unset($objects_store_context);
             $context_pools->convertToSentinels($memo);
+
+            // Emit deferred edges: property references to objects that
+            // were skipped during objects_store (defer_unseen_objects mode).
+            // Now all objects have sentinels, so we can resolve addresses.
+            foreach ($this->deferred_object_edges as [$parent_node_id, $child_address, $link_name]) {
+                $child_sentinel = $context_pools->getSentinel($child_address);
+                if ($child_sentinel !== null) {
+                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
+                }
+            }
+            $this->deferred_object_edges = [];
         }
 
         $defined_functions_context = $this->collectFunctionTable(
@@ -1050,8 +1083,15 @@ final class MemoryLocationsCollector
             }
         } elseif ($this->defer_unseen_objects) {
             // During objects_store collection: don't recurse into unseen
-            // objects via property traversal. The object will be collected
-            // when its objects_store bucket is reached.
+            // objects via property traversal. Record the edge so it can
+            // be emitted after all objects are collected.
+            if ($this->current_streaming_parent_node_id !== null) {
+                $this->deferred_object_edges[] = [
+                    $this->current_streaming_parent_node_id,
+                    $pointer->address,
+                    $this->current_streaming_link_name ?? 'deferred_object',
+                ];
+            }
             return null;
         }
         $obj = $dereferencer->deref($pointer);
@@ -1488,12 +1528,17 @@ final class MemoryLocationsCollector
         $properties_exists = false;
         $object_properties_context = new ObjectPropertiesContext();
         $properties_parent_node_id = $this->registerParentIfStreaming($object_properties_context);
+        $saved_parent_node_id = $this->current_streaming_parent_node_id;
+        if ($properties_parent_node_id !== null) {
+            $this->current_streaming_parent_node_id = $properties_parent_node_id;
+        }
         $properties_iterator = $object->getPropertiesIterator(
             $dereferencer,
             $zend_type_reader,
         );
         foreach ($properties_iterator as $name => $property) {
             assert(is_string($name));
+            $this->current_streaming_link_name = $name;
             $property_context = $this->collectZval(
                 $property,
                 $map_ptr_base,
@@ -1516,6 +1561,7 @@ final class MemoryLocationsCollector
                 $properties_exists = true;
             }
         }
+        $this->current_streaming_parent_node_id = $saved_parent_node_id;
         if ($properties_exists) {
             $object_context->add('object_properties', $object_properties_context);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -468,110 +468,114 @@ final class MemoryLocationsCollector
         $class_table = $dereferencer->deref($eg->class_table);
         $zend_constants = $dereferencer->deref($eg->zend_constants);
 
-        // Collect objects_store, function_table, and class_table first.
-        // This populates the sentinel map with all objects, arrays, and
-        // strings. When global_variables and call_frames are collected
-        // later, collectZval hits sentinels for most data, avoiding deep
-        // recursive expansion of the entire object graph.
-        $objects_store_context = $this->collectObjectsStore(
-            $eg->objects_store,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
         if ($sink !== null && $analyzer !== null && $memo !== null) {
+            // Streaming mode: collect objects_store, function_table, and
+            // class_table BEFORE global_variables and call_frames. This
+            // populates the sentinel map so later phases hit sentinels
+            // instead of recursively expanding the object graph.
+            $objects_store_context = $this->collectObjectsStore(
+                $eg->objects_store,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
             $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
             unset($objects_store_context);
             $context_pools->convertToSentinels($memo);
-            // Deferred edges are resolved later, after all phases complete.
-        }
 
-        $defined_functions_context = $this->collectFunctionTable(
-            $function_table,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $defined_functions_context = $this->collectFunctionTable(
+                $function_table,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
             $analyzer->analyzeSingleLink('function_table', $defined_functions_context, $sink, null, $memo);
             unset($defined_functions_context);
             $context_pools->convertToSentinels($memo);
-        }
 
-        $defined_classes_context = $this->collectClassTable(
-            $class_table,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $defined_classes_context = $this->collectClassTable(
+                $class_table,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
             $analyzer->analyzeSingleLink('class_table', $defined_classes_context, $sink, null, $memo);
             unset($defined_classes_context);
             $context_pools->convertToSentinels($memo);
-        }
 
-        $global_variables_context = $this->collectGlobalVariables(
-            $eg->symbol_table,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $global_variables_context = $this->collectGlobalVariables(
+                $eg->symbol_table,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
             $analyzer->analyzeSingleLink('global_variables', $global_variables_context, $sink, null, $memo);
             unset($global_variables_context);
             $context_pools->convertToSentinels($memo);
-        }
 
-        $global_constants_context = $this->collectGlobalConstants(
-            $zend_constants,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $global_constants_context = $this->collectGlobalConstants(
+                $zend_constants,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
             $analyzer->analyzeSingleLink('global_constants', $global_constants_context, $sink, null, $memo);
             unset($global_constants_context);
             $context_pools->convertToSentinels($memo);
-        }
 
-        try {
-            $global_callbacks_context = $this->collectGlobalCallbacks(
-                $eg,
-                $cg->map_ptr_base,
-                $dereferencer,
-                $zend_type_reader,
-                $memory_locations,
-                $context_pools,
-                $memory_limit_error_details,
-            );
-        } catch (\Throwable $e) {
-            Log::info('failed to collect global callbacks', ['error' => $e->getMessage()]);
-            $global_callbacks_context = new GlobalCallbacksContext();
-        }
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            try {
+                $global_callbacks_context = $this->collectGlobalCallbacks(
+                    $eg,
+                    $cg->map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+            } catch (\Throwable $e) {
+                Log::info('failed to collect global callbacks', ['error' => $e->getMessage()]);
+                $global_callbacks_context = new GlobalCallbacksContext();
+            }
             $analyzer->analyzeSingleLink('global_callbacks', $global_callbacks_context, $sink, null, $memo);
             unset($global_callbacks_context);
             $context_pools->convertToSentinels($memo);
-        }
 
-        try {
-            $modules_context = $this->collectModules(
-                $bg_address,
+            try {
+                $modules_context = $this->collectModules(
+                    $bg_address,
+                    $cg->map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                    $memory_limit_error_details,
+                );
+            } catch (\Throwable $e) {
+                Log::info('failed to collect modules', ['error' => $e->getMessage()]);
+                $modules_context = new ModulesContext();
+            }
+            $analyzer->analyzeSingleLink('modules', $modules_context, $sink, null, $memo);
+            unset($modules_context);
+            $context_pools->convertToSentinels($memo);
+
+            $call_frames_context = $this->collectCallFrames(
+                $eg,
                 $cg->map_ptr_base,
                 $dereferencer,
                 $zend_type_reader,
@@ -579,43 +583,21 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
-        } catch (\Throwable $e) {
-            Log::info('failed to collect modules', ['error' => $e->getMessage()]);
-            $modules_context = new ModulesContext();
-        }
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
-            $analyzer->analyzeSingleLink('modules', $modules_context, $sink, null, $memo);
-            unset($modules_context);
-            $context_pools->convertToSentinels($memo);
-        }
 
-        $call_frames_context = $this->collectCallFrames(
-            $eg,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        // call_frames emission is deferred — memory_limit_error may replace it below
+            if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
+                $call_frames_context = $this->collectRealCallStackOnMemoryLimitViolation(
+                    $this->memory_limit_error_function_context,
+                    $memory_limit_error_details->max_challenge_depth,
+                    $call_frames_context,
+                    $eg,
+                    $cg->map_ptr_base,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $memory_locations,
+                    $context_pools,
+                );
+            }
 
-        if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
-            $call_frames_context = $this->collectRealCallStackOnMemoryLimitViolation(
-                $this->memory_limit_error_function_context,
-                $memory_limit_error_details->max_challenge_depth,
-                $call_frames_context,
-                $eg,
-                $cg->map_ptr_base,
-                $dereferencer,
-                $zend_type_reader,
-                $memory_locations,
-                $context_pools,
-            );
-        }
-
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
-            // Emit the deferred call_frames branch (may have been replaced above)
             $analyzer->analyzeSingleLink('call_frames', $call_frames_context, $sink, null, $memo);
             unset($call_frames_context);
             $context_pools->convertToSentinels($memo);
@@ -689,6 +671,112 @@ final class MemoryLocationsCollector
                 null,
                 $memory_get_usage_size,
                 $memory_get_usage_real_size,
+            );
+        }
+
+        // Non-streaming path: original collection order (0.12.x compatible).
+        // call_frames → function_table → class_table → ... → objects_store
+        $global_variables_context = $this->collectGlobalVariables(
+            $eg->symbol_table,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        $call_frames_context = $this->collectCallFrames(
+            $eg,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        $defined_functions_context = $this->collectFunctionTable(
+            $function_table,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        $defined_classes_context = $this->collectClassTable(
+            $class_table,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        $global_constants_context = $this->collectGlobalConstants(
+            $zend_constants,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        try {
+            $global_callbacks_context = $this->collectGlobalCallbacks(
+                $eg,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
+        } catch (\Throwable $e) {
+            Log::info('failed to collect global callbacks', ['error' => $e->getMessage()]);
+            $global_callbacks_context = new GlobalCallbacksContext();
+        }
+
+        try {
+            $modules_context = $this->collectModules(
+                $bg_address,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
+                $memory_limit_error_details,
+            );
+        } catch (\Throwable $e) {
+            Log::info('failed to collect modules', ['error' => $e->getMessage()]);
+            $modules_context = new ModulesContext();
+        }
+
+        $objects_store_context = $this->collectObjectsStore(
+            $eg->objects_store,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+
+        if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
+            $call_frames_context = $this->collectRealCallStackOnMemoryLimitViolation(
+                $this->memory_limit_error_function_context,
+                $memory_limit_error_details->max_challenge_depth,
+                $call_frames_context,
+                $eg,
+                $cg->map_ptr_base,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+                $context_pools,
             );
         }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -449,8 +449,13 @@ final class MemoryLocationsCollector
             $context_pools->convertToSentinels($memo);
         }
 
-        $call_frames_context = $this->collectCallFrames(
-            $eg,
+        // Collect objects_store, function_table, and class_table BEFORE
+        // call_frames. This populates the sentinel map with all objects,
+        // arrays, and strings. When call_frames is collected later,
+        // collectZval hits sentinels for most data, avoiding deep
+        // recursive expansion of the entire object graph.
+        $objects_store_context = $this->collectObjectsStore(
+            $eg->objects_store,
             $cg->map_ptr_base,
             $dereferencer,
             $zend_type_reader,
@@ -458,7 +463,11 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
-        // call_frames emission is deferred — memory_limit_error may replace it below
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
+            unset($objects_store_context);
+            $context_pools->convertToSentinels($memo);
+        }
 
         $defined_functions_context = $this->collectFunctionTable(
             $function_table,
@@ -545,8 +554,8 @@ final class MemoryLocationsCollector
             $context_pools->convertToSentinels($memo);
         }
 
-        $objects_store_context = $this->collectObjectsStore(
-            $eg->objects_store,
+        $call_frames_context = $this->collectCallFrames(
+            $eg,
             $cg->map_ptr_base,
             $dereferencer,
             $zend_type_reader,
@@ -554,11 +563,7 @@ final class MemoryLocationsCollector
             $context_pools,
             $memory_limit_error_details,
         );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
-            $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
-            unset($objects_store_context);
-            $context_pools->convertToSentinels($memo);
-        }
+        // call_frames emission is deferred — memory_limit_error may replace it below
 
         if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
             $call_frames_context = $this->collectRealCallStackOnMemoryLimitViolation(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -434,25 +434,10 @@ final class MemoryLocationsCollector
         $class_table = $dereferencer->deref($eg->class_table);
         $zend_constants = $dereferencer->deref($eg->zend_constants);
 
-        $global_variables_context = $this->collectGlobalVariables(
-            $eg->symbol_table,
-            $cg->map_ptr_base,
-            $dereferencer,
-            $zend_type_reader,
-            $memory_locations,
-            $context_pools,
-            $memory_limit_error_details,
-        );
-        if ($sink !== null && $analyzer !== null && $memo !== null) {
-            $analyzer->analyzeSingleLink('global_variables', $global_variables_context, $sink, null, $memo);
-            unset($global_variables_context);
-            $context_pools->convertToSentinels($memo);
-        }
-
-        // Collect objects_store, function_table, and class_table BEFORE
-        // call_frames. This populates the sentinel map with all objects,
-        // arrays, and strings. When call_frames is collected later,
-        // collectZval hits sentinels for most data, avoiding deep
+        // Collect objects_store, function_table, and class_table first.
+        // This populates the sentinel map with all objects, arrays, and
+        // strings. When global_variables and call_frames are collected
+        // later, collectZval hits sentinels for most data, avoiding deep
         // recursive expansion of the entire object graph.
         $objects_store_context = $this->collectObjectsStore(
             $eg->objects_store,
@@ -496,6 +481,21 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('class_table', $defined_classes_context, $sink, null, $memo);
             unset($defined_classes_context);
+            $context_pools->convertToSentinels($memo);
+        }
+
+        $global_variables_context = $this->collectGlobalVariables(
+            $eg->symbol_table,
+            $cg->map_ptr_base,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+            $context_pools,
+            $memory_limit_error_details,
+        );
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $analyzer->analyzeSingleLink('global_variables', $global_variables_context, $sink, null, $memo);
+            unset($global_variables_context);
             $context_pools->convertToSentinels($memo);
         }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -123,6 +123,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\RuntimeCacheContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ScalarValueContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\TopReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContext;
@@ -312,6 +313,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('included_files', $included_files_context, $sink, null, $memo);
             unset($included_files_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         $interned_strings_context = $this->collectInternedStrings(
@@ -325,6 +327,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('interned_strings', $interned_strings_context, $sink, null, $memo);
             unset($interned_strings_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         assert(!is_null($eg->function_table));
@@ -347,6 +350,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('global_variables', $global_variables_context, $sink, null, $memo);
             unset($global_variables_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         $call_frames_context = $this->collectCallFrames(
@@ -372,6 +376,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('function_table', $defined_functions_context, $sink, null, $memo);
             unset($defined_functions_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         $defined_classes_context = $this->collectClassTable(
@@ -386,6 +391,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('class_table', $defined_classes_context, $sink, null, $memo);
             unset($defined_classes_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         $global_constants_context = $this->collectGlobalConstants(
@@ -400,6 +406,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('global_constants', $global_constants_context, $sink, null, $memo);
             unset($global_constants_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         try {
@@ -419,6 +426,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('global_callbacks', $global_callbacks_context, $sink, null, $memo);
             unset($global_callbacks_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         try {
@@ -438,6 +446,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('modules', $modules_context, $sink, null, $memo);
             unset($modules_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         $objects_store_context = $this->collectObjectsStore(
@@ -452,6 +461,7 @@ final class MemoryLocationsCollector
         if ($sink !== null && $analyzer !== null && $memo !== null) {
             $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
             unset($objects_store_context);
+            $context_pools->convertToSentinels($memo);
         }
 
         if ($memory_limit_error_details and !is_null($this->memory_limit_error_function_context)) {
@@ -615,8 +625,12 @@ final class MemoryLocationsCollector
         Dereferencer $dereferencer,
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools
-    ): ResourceContext {
+    ): ResourceContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendResourceMemoryLocation) {
                 return $context_pools
@@ -839,8 +853,12 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): PhpReferenceContext {
+    ): PhpReferenceContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendReferenceMemoryLocation) {
                 return $context_pools
@@ -880,8 +898,12 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ArrayHeaderContext {
+    ): ArrayHeaderContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendArrayMemoryLocation) {
                 return $context_pools
@@ -911,8 +933,12 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ObjectContext {
+    ): ObjectContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
                 unset($memory_location);
@@ -942,8 +968,12 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         Dereferencer $dereferencer,
         ContextPools $context_pools
-    ): StringContext {
+    ): StringContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
                 $memory_location = null;
@@ -1936,8 +1966,12 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): FunctionDefinitionContext {
+    ): FunctionDefinitionContext|SentinelContext {
         if ($memory_locations->has($pointer->address)) {
+            $sentinel = $context_pools->getSentinel($pointer->address);
+            if ($sentinel !== null) {
+                return $sentinel;
+            }
             $memory_location = $memory_locations->get($pointer->address);
             if ($memory_location instanceof ZendOpArrayHeaderMemoryLocation) {
                 return $context_pools

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -135,6 +135,7 @@ use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\CachingDereferencer;
 use Reli\Lib\Process\Pointer\RemoteProcessDereferencer;
 use Reli\Lib\Process\ProcessSpecifier;
 
@@ -284,13 +285,15 @@ final class MemoryLocationsCollector
      */
     private function getDereferencer(int $pid, string $php_version): Dereferencer
     {
-        return new RemoteProcessDereferencer(
-            $this->memory_reader,
-            new ProcessSpecifier($pid),
-            new ZendCastedTypeProvider(
-                $this->getTypeReader($php_version),
+        return new CachingDereferencer(
+            new RemoteProcessDereferencer(
+                $this->memory_reader,
+                new ProcessSpecifier($pid),
+                new ZendCastedTypeProvider(
+                    $this->getTypeReader($php_version),
+                ),
+                new VersionedPointedTypeResolver($php_version)
             ),
-            new VersionedPointedTypeResolver($php_version)
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1525,6 +1525,15 @@ final class MemoryLocationsCollector
         ;
         $object_context->add('object_handlers', $object_handlers_context);
 
+        // In streaming mode, enable defer for all nested object references
+        // within this object. This prevents deep recursion through the
+        // object graph — referenced objects will be collected later from
+        // their own objects_store bucket.
+        $saved_defer = $this->defer_unseen_objects;
+        if ($this->streaming_sink !== null) {
+            $this->defer_unseen_objects = true;
+        }
+
         $properties_exists = false;
         $object_properties_context = new ObjectPropertiesContext();
         $properties_parent_node_id = $this->registerParentIfStreaming($object_properties_context);
@@ -1699,6 +1708,7 @@ final class MemoryLocationsCollector
             }
         }
 
+        $this->defer_unseen_objects = $saved_defer;
         return $object_context;
     }
 
@@ -2832,15 +2842,6 @@ final class MemoryLocationsCollector
             $zend_type_reader,
         );
 
-        // Defer unseen object traversal during objects_store collection.
-        // Property references to other objects return null instead of
-        // recursing. Those objects will be collected when their own
-        // bucket is reached, keeping memory bounded per-object.
-        $was_deferring = $this->defer_unseen_objects;
-        if ($this->streaming_sink !== null) {
-            $this->defer_unseen_objects = true;
-        }
-
         foreach ($bucket_iterator as $key => $bucket) {
             if ($key === 0) {
                 continue;
@@ -2854,6 +2855,10 @@ final class MemoryLocationsCollector
             if ($key >= $objects_store->top) {
                 break;
             }
+            // Disable defer for the top-level bucket call so the object
+            // itself is collected. It will be re-enabled inside
+            // collectZendObject's property loop.
+            $this->defer_unseen_objects = false;
             $objects_store_bucket_context = $this->collectZendObjectPointer(
                 $bucket,
                 $map_ptr_base,
@@ -2876,7 +2881,7 @@ final class MemoryLocationsCollector
             }
             $objects_store_context->add((string)$key, $objects_store_bucket_context);
         }
-        $this->defer_unseen_objects = $was_deferring;
+        $this->defer_unseen_objects = false;
         return $objects_store_context;
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -146,11 +146,79 @@ final class MemoryLocationsCollector
     private ?MemoryLocations $fiber_vm_stack_memory_locations = null;
     private ?MemoryLocations $chunk_memory_locations = null;
 
+    /** Set during streaming collection for sub-tree level emit+release */
+    private ?ContextTreeSink $streaming_sink = null;
+    private ?ContextAnalyzer $streaming_analyzer = null;
+    /** @var \WeakMap<ReferenceContext, int>|null */
+    private ?\WeakMap $streaming_memo = null;
+    private ?ContextPools $streaming_context_pools = null;
+
     public function __construct(
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private PhpZendMemoryManagerChunkFinder $chunk_finder,
     ) {
+    }
+
+    /**
+     * In streaming mode, register a parent node in the analyzer's memo
+     * and emit it to the sink, so that children can be emitted as
+     * sub-nodes during collection. Returns the assigned node_id, or
+     * null if not in streaming mode.
+     */
+    private function registerParentIfStreaming(
+        ReferenceContext $parent,
+    ): ?int {
+        if (
+            $this->streaming_sink === null
+            || $this->streaming_analyzer === null
+            || $this->streaming_memo === null
+        ) {
+            return null;
+        }
+        $existing = $this->streaming_memo[$parent] ?? null;
+        if ($existing !== null) {
+            return $existing;
+        }
+        $node_id = $this->streaming_analyzer->assignNodeId($parent, $this->streaming_memo);
+        return $node_id;
+    }
+
+    /**
+     * In streaming mode, emit a child context that was just collected,
+     * and return a SentinelContext so the parent holds only node_id.
+     * In non-streaming mode, return the child as-is for normal tree building.
+     */
+    private function emitChildIfStreaming(
+        string $link_name,
+        ReferenceContext $child,
+        int $parent_node_id,
+    ): ReferenceContext {
+        if (
+            $this->streaming_sink === null
+            || $this->streaming_analyzer === null
+            || $this->streaming_memo === null
+        ) {
+            return $child;
+        }
+        // Already a sentinel — no need to emit again
+        if ($child instanceof SentinelContext) {
+            return $child;
+        }
+        // Emit the child subtree to DB
+        $this->streaming_analyzer->analyzeSingleLink(
+            $link_name,
+            $child,
+            $this->streaming_sink,
+            $parent_node_id,
+            $this->streaming_memo,
+        );
+        // Look up the node_id that was assigned
+        $node_id = $this->streaming_memo[$child] ?? null;
+        if ($node_id !== null) {
+            return new SentinelContext($node_id);
+        }
+        return $child;
     }
 
     /**
@@ -300,9 +368,17 @@ final class MemoryLocationsCollector
 
         // In streaming mode, set up the analyzer and memo early so we can
         // emit each branch right after collection and release it.
+        // Also set instance properties so collect* methods can emit sub-trees.
         $analyzer = $sink !== null ? new ContextAnalyzer() : null;
         /** @var \WeakMap<ReferenceContext, int>|null $memo */
         $memo = $sink !== null ? new \WeakMap() : null;
+
+        if ($sink !== null && $analyzer !== null && $memo !== null) {
+            $this->streaming_sink = $sink;
+            $this->streaming_analyzer = $analyzer;
+            $this->streaming_memo = $memo;
+            $this->streaming_context_pools = $context_pools;
+        }
 
         $included_files_context = $this->collectIncludedFiles(
             $eg->included_files,
@@ -484,6 +560,12 @@ final class MemoryLocationsCollector
             unset($call_frames_context);
 
             $context_pools->clear();
+
+            // Clear streaming state
+            $this->streaming_sink = null;
+            $this->streaming_analyzer = null;
+            $this->streaming_memo = null;
+            $this->streaming_context_pools = null;
 
             return new CollectedMemories(
                 $chunk_memory_locations,
@@ -1006,6 +1088,7 @@ final class MemoryLocationsCollector
         ?MemoryLimitErrorDetails $memory_limit_error_details,
     ): CallFramesContext {
         $call_frames_context = new CallFramesContext();
+        $parent_node_id = $this->registerParentIfStreaming($call_frames_context);
         if (is_null($eg->current_execute_data)) {
             return $call_frames_context;
         }
@@ -1020,6 +1103,13 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
+            if ($parent_node_id !== null) {
+                $call_frame_context = $this->emitChildIfStreaming(
+                    (string)$key,
+                    $call_frame_context,
+                    $parent_node_id,
+                );
+            }
             $call_frames_context->add((string)$key, $call_frame_context);
         }
         return $call_frames_context;
@@ -1939,6 +2029,7 @@ final class MemoryLocationsCollector
             $array_header_location,
             $array_table_location,
         );
+        $parent_node_id = $this->registerParentIfStreaming($defined_functions_context);
 
         foreach ($array->getItemIterator($dereferencer) as $function_name => $zval) {
             assert(is_string($function_name));
@@ -1952,6 +2043,13 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
+            if ($parent_node_id !== null) {
+                $function_context = $this->emitChildIfStreaming(
+                    $function_name,
+                    $function_context,
+                    $parent_node_id,
+                );
+            }
             $defined_functions_context->add($function_name, $function_context);
         }
         return $defined_functions_context;
@@ -2283,6 +2381,7 @@ final class MemoryLocationsCollector
         ?MemoryLimitErrorDetails $memory_limit_error_details,
     ): DefinedClassesContext {
         $defined_classes_context = new DefinedClassesContext();
+        $parent_node_id = $this->registerParentIfStreaming($defined_classes_context);
         foreach ($array->getItemIterator($dereferencer) as $class_name => $zval) {
             assert(!is_null($zval->value->ce));
             $class_definition_context = $this->collectClassDefinitionPointer(
@@ -2295,6 +2394,13 @@ final class MemoryLocationsCollector
                 $memory_limit_error_details,
             );
             if (!is_null($class_definition_context)) {
+                if ($parent_node_id !== null) {
+                    $class_definition_context = $this->emitChildIfStreaming(
+                        (string)$class_name,
+                        $class_definition_context,
+                        $parent_node_id,
+                    );
+                }
                 $defined_classes_context->add((string)$class_name, $class_definition_context);
             }
         }
@@ -2616,6 +2722,7 @@ final class MemoryLocationsCollector
         );
         $objects_store_context = new ObjectsStoreContext($objects_store_memory_location);
         $memory_locations->add($objects_store_memory_location);
+        $parent_node_id = $this->registerParentIfStreaming($objects_store_context);
 
         assert($objects_store->object_buckets instanceof Pointer);
         $buckets = $dereferencer->deref($objects_store->object_buckets);
@@ -2646,6 +2753,13 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
+            if ($parent_node_id !== null) {
+                $objects_store_bucket_context = $this->emitChildIfStreaming(
+                    (string)$key,
+                    $objects_store_bucket_context,
+                    $parent_node_id,
+                );
+            }
             $objects_store_context->add((string)$key, $objects_store_bucket_context);
         }
         return $objects_store_context;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1644,6 +1644,16 @@ final class MemoryLocationsCollector
             $object_context->add('object_properties', $object_properties_context);
         }
 
+        // When defer is active (shallow collection for objects_store),
+        // skip dynamic properties, closures, generators, and fibers.
+        // These can trigger deep recursive expansion. They will be
+        // collected when the object is reached from another phase, or
+        // via deferred edge resolution.
+        if ($this->defer_unseen_objects) {
+            $this->defer_unseen_objects = $saved_defer;
+            return $object_context;
+        }
+
         if (
             !is_null($object->properties)
             and !is_null($object->ce)

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -997,7 +997,7 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): PhpReferenceContext|SentinelContext {
+    ): PhpReferenceContext|SentinelContext|null {
         if ($memory_locations->has($pointer->address)) {
             $sentinel = $context_pools->getSentinel($pointer->address);
             if ($sentinel !== null) {
@@ -1007,6 +1007,15 @@ final class MemoryLocationsCollector
             if ($cached !== null) {
                 return $cached;
             }
+        } elseif ($this->defer_unseen_objects) {
+            if ($this->current_streaming_parent_node_id !== null) {
+                $this->deferred_object_edges[] = [
+                    $this->current_streaming_parent_node_id,
+                    $pointer->address,
+                    $this->current_streaming_link_name ?? 'deferred_reference',
+                ];
+            }
+            return null;
         }
         $php_reference = $dereferencer->deref($pointer);
         $memory_location = ZendReferenceMemoryLocation::fromZendReference($php_reference);
@@ -1039,7 +1048,7 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ArrayHeaderContext|SentinelContext {
+    ): ArrayHeaderContext|SentinelContext|null {
         if ($memory_locations->has($pointer->address)) {
             $sentinel = $context_pools->getSentinel($pointer->address);
             if ($sentinel !== null) {
@@ -1049,6 +1058,17 @@ final class MemoryLocationsCollector
             if ($cached !== null) {
                 return $cached;
             }
+        } elseif ($this->defer_unseen_objects) {
+            // During shallow collection: don't recurse into unseen arrays.
+            // Record a deferred edge if we have a parent context.
+            if ($this->current_streaming_parent_node_id !== null) {
+                $this->deferred_object_edges[] = [
+                    $this->current_streaming_parent_node_id,
+                    $pointer->address,
+                    $this->current_streaming_link_name ?? 'deferred_array',
+                ];
+            }
+            return null;
         }
         $array = $dereferencer->deref($pointer);
         return $this->collectZendArray(
@@ -1374,7 +1394,9 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
-            $call_frame_context->add('symbol_table', $symbol_table_context);
+            if ($symbol_table_context !== null) {
+                $call_frame_context->add('symbol_table', $symbol_table_context);
+            }
         }
         if ($execute_data->hasExtraNamedParams() and !is_null($execute_data->extra_named_params)) {
             $extra_named_params_context = $this->collectZendArrayPointer(
@@ -1386,7 +1408,9 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
-            $call_frame_context->add('extra_named_params', $extra_named_params_context);
+            if ($extra_named_params_context !== null) {
+                $call_frame_context->add('extra_named_params', $extra_named_params_context);
+            }
         }
         return $call_frame_context;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1263,12 +1263,22 @@ final class MemoryLocationsCollector
                 $memory_limit_error_details,
             );
             if (!is_null($this_context)) {
+                $call_frame_parent_node_id = $this->registerParentIfStreaming($call_frame_context);
+                if ($call_frame_parent_node_id !== null) {
+                    $this_context = $this->emitChildIfStreaming(
+                        'this',
+                        $this_context,
+                        $call_frame_parent_node_id,
+                    );
+                    $this->flushPoolsIfStreaming();
+                }
                 $call_frame_context->add('this', $this_context);
             }
         }
 
         $has_local_variables = false;
         $variable_table_context = new CallFrameVariableTableContext();
+        $variable_table_parent_node_id = $this->registerParentIfStreaming($variable_table_context);
         $local_variables_iterator = $execute_data->getVariables($dereferencer, $zend_type_reader);
         foreach ($local_variables_iterator as $name => $value) {
             $local_variable_context = $this->collectZval(
@@ -1281,6 +1291,14 @@ final class MemoryLocationsCollector
                 $memory_limit_error_details,
             );
             if (!is_null($local_variable_context)) {
+                if ($variable_table_parent_node_id !== null) {
+                    $local_variable_context = $this->emitChildIfStreaming(
+                        $name,
+                        $local_variable_context,
+                        $variable_table_parent_node_id,
+                    );
+                    $this->flushPoolsIfStreaming();
+                }
                 $variable_table_context->add($name, $local_variable_context);
                 $has_local_variables = true;
             }
@@ -1368,6 +1386,7 @@ final class MemoryLocationsCollector
 
         $array_context = new ArrayElementsContext($array_table_location);
         $overhead_context = new ArrayPossibleOverheadContext($array_table_overhead_location);
+        $array_elements_parent_node_id = $this->registerParentIfStreaming($array_context);
 
         foreach ($array->getItemIteratorWithZendStringKeyIfAssoc($dereferencer) as $key => $zval) {
             $element_context = new ArrayElementContext();
@@ -1384,7 +1403,6 @@ final class MemoryLocationsCollector
             } else {
                 $key_string = (string)$key;
             }
-            $array_context->add($key_string, $element_context);
             $value_context = $this->collectZval(
                 $zval,
                 $map_ptr_base,
@@ -1397,6 +1415,15 @@ final class MemoryLocationsCollector
             if (!is_null($value_context)) {
                 $element_context->add('value', $value_context);
             }
+            if ($array_elements_parent_node_id !== null) {
+                $element_context = $this->emitChildIfStreaming(
+                    $key_string,
+                    $element_context,
+                    $array_elements_parent_node_id,
+                );
+                $this->flushPoolsIfStreaming();
+            }
+            $array_context->add($key_string, $element_context);
         }
         $array_header_context->add('possible_unused_area', $overhead_context);
         $array_header_context->add('array_elements', $array_context);
@@ -1443,6 +1470,7 @@ final class MemoryLocationsCollector
 
         $properties_exists = false;
         $object_properties_context = new ObjectPropertiesContext();
+        $properties_parent_node_id = $this->registerParentIfStreaming($object_properties_context);
         $properties_iterator = $object->getPropertiesIterator(
             $dereferencer,
             $zend_type_reader,
@@ -1459,6 +1487,14 @@ final class MemoryLocationsCollector
                 $memory_limit_error_details,
             );
             if (!is_null($property_context)) {
+                if ($properties_parent_node_id !== null) {
+                    $property_context = $this->emitChildIfStreaming(
+                        $name,
+                        $property_context,
+                        $properties_parent_node_id,
+                    );
+                    $this->flushPoolsIfStreaming();
+                }
                 $object_properties_context->add($name, $property_context);
                 $properties_exists = true;
             }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -310,7 +310,9 @@ final class MemoryLocationsCollector
             $zend_type_reader->sizeOf('zend_mm_chunk'),
         );
 
-        $memory_locations = new MemoryLocations();
+        $memory_locations = $sink !== null
+            ? MemoryLocations::createLightweight()
+            : new MemoryLocations();
         $chunk_memory_locations = new MemoryLocations();
         $this->chunk_memory_locations = $chunk_memory_locations;
 
@@ -731,12 +733,11 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendResourceMemoryLocation) {
-                return $context_pools
-                    ->resource_context_pool
-                    ->getContextForLocation($memory_location)
-                ;
+            if ($memory_locations->getClass($pointer->address) === ZendResourceMemoryLocation::class) {
+                $cached = $context_pools->resource_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
         $resource = $dereferencer->deref($pointer);
@@ -959,12 +960,11 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendReferenceMemoryLocation) {
-                return $context_pools
-                    ->php_reference_context_pool
-                    ->getContextForLocation($memory_location)
-                ;
+            if ($memory_locations->getClass($pointer->address) === ZendReferenceMemoryLocation::class) {
+                $cached = $context_pools->php_reference_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
         $php_reference = $dereferencer->deref($pointer);
@@ -1004,12 +1004,11 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendArrayMemoryLocation) {
-                return $context_pools
-                    ->array_context_pool
-                    ->getContextForLocation($memory_location)
-                ;
+            if ($memory_locations->getClass($pointer->address) === ZendArrayMemoryLocation::class) {
+                $cached = $context_pools->array_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
         $array = $dereferencer->deref($pointer);
@@ -1039,15 +1038,12 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
-                unset($memory_location);
-            } else {
-                assert($memory_location instanceof ZendObjectMemoryLocation);
-                return $context_pools
-                    ->object_context_pool
-                    ->getContextForLocation($memory_location)
-                    ;
+            $location_class = $memory_locations->getClass($pointer->address);
+            if ($location_class !== ZendArrayTableOverheadMemoryLocation::class) {
+                $cached = $context_pools->object_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
         $obj = $dereferencer->deref($pointer);
@@ -1074,22 +1070,20 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendArrayTableOverheadMemoryLocation) {
-                $memory_location = null;
-            } else {
-                assert($memory_location instanceof ZendStringMemoryLocation);
+            $location_class = $memory_locations->getClass($pointer->address);
+            if ($location_class !== ZendArrayTableOverheadMemoryLocation::class) {
+                $cached = $context_pools->string_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
-        if (!isset($memory_location)) {
-            $str = $dereferencer->deref($pointer);
-            $memory_location = ZendStringMemoryLocation::fromZendString(
-                $str,
-                $dereferencer,
-            );
-            $memory_locations->add($memory_location);
-        }
-        assert($memory_location instanceof ZendStringMemoryLocation);
+        $str = $dereferencer->deref($pointer);
+        $memory_location = ZendStringMemoryLocation::fromZendString(
+            $str,
+            $dereferencer,
+        );
+        $memory_locations->add($memory_location);
         return $context_pools
             ->string_context_pool
             ->getContextForLocation($memory_location)
@@ -2090,12 +2084,11 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $memory_location = $memory_locations->get($pointer->address);
-            if ($memory_location instanceof ZendOpArrayHeaderMemoryLocation) {
-                return $context_pools
-                    ->user_function_definition_context_pool
-                    ->getContextForLocation($memory_location)
-                ;
+            if ($memory_locations->getClass($pointer->address) === ZendOpArrayHeaderMemoryLocation::class) {
+                $cached = $context_pools->user_function_definition_context_pool->getContextByAddress($pointer->address);
+                if ($cached !== null) {
+                    return $cached;
+                }
             }
         }
         $func = $dereferencer->deref($pointer);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -166,7 +166,7 @@ final class MemoryLocationsCollector
      * After all objects are collected, these are resolved via the sentinel
      * map and emitted as reference edges.
      *
-     * @var list<array{int, int, string}> [parent_node_id, child_address, link_name]
+     * @var list<array{int, int, string, string}> [parent_node_id, child_address, link_name, pointer_type]
      */
     private array $deferred_object_edges = [];
 
@@ -481,17 +481,7 @@ final class MemoryLocationsCollector
             $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
             unset($objects_store_context);
             $context_pools->convertToSentinels($memo);
-
-            // Emit deferred edges: property references to objects that
-            // were skipped during objects_store (defer_unseen_objects mode).
-            // Now all objects have sentinels, so we can resolve addresses.
-            foreach ($this->deferred_object_edges as [$parent_node_id, $child_address, $link_name]) {
-                $child_sentinel = $context_pools->getSentinel($child_address);
-                if ($child_sentinel !== null) {
-                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
-                }
-            }
-            $this->deferred_object_edges = [];
+            // Deferred edges are resolved later, after all phases complete.
         }
 
         $defined_functions_context = $this->collectFunctionTable(
@@ -623,6 +613,58 @@ final class MemoryLocationsCollector
             // Emit the deferred call_frames branch (may have been replaced above)
             $analyzer->analyzeSingleLink('call_frames', $call_frames_context, $sink, null, $memo);
             unset($call_frames_context);
+            $context_pools->convertToSentinels($memo);
+
+            // Resolve deferred edges from objects_store shallow collection.
+            // By now most addresses have sentinels from all phases.
+            // For remaining unresolved addresses (only reachable from
+            // objects_store properties), collect them now with defer off.
+            $this->defer_unseen_objects = false;
+            $remaining_deferred = [];
+            foreach ($this->deferred_object_edges as [$parent_node_id, $child_address, $link_name, $pointer_type]) {
+                $child_sentinel = $context_pools->getSentinel($child_address);
+                if ($child_sentinel !== null) {
+                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
+                    continue;
+                }
+                // Not resolved — collect it now
+                $remaining_deferred[] = [$parent_node_id, $child_address, $link_name, $pointer_type];
+            }
+            $this->deferred_object_edges = [];
+
+            // Collect unresolved deferred targets (arrays/objects/references
+            // only reachable from object properties). Defer is off, so they
+            // will be fully expanded. Each is emitted as a child of the
+            // original parent.
+            foreach ($remaining_deferred as [$parent_node_id, $child_address, $link_name, $pointer_type]) {
+                $child_sentinel = $context_pools->getSentinel($child_address);
+                if ($child_sentinel !== null) {
+                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
+                    continue;
+                }
+                $child_context = match ($pointer_type) {
+                    'array' => $this->collectZendArrayPointer(
+                        new Pointer(ZendArray::class, $child_address, $zend_type_reader->sizeOf('zend_array')),
+                        $cg->map_ptr_base, $memory_locations, $dereferencer,
+                        $zend_type_reader, $context_pools, $memory_limit_error_details,
+                    ),
+                    'object' => $this->collectZendObjectPointer(
+                        new Pointer(ZendObject::class, $child_address, $zend_type_reader->sizeOf('zend_object')),
+                        $cg->map_ptr_base, $memory_locations, $dereferencer,
+                        $zend_type_reader, $context_pools, $memory_limit_error_details,
+                    ),
+                    'reference' => $this->collectPhpReferencePointer(
+                        new Pointer(ZendReference::class, $child_address, $zend_type_reader->sizeOf('zend_reference')),
+                        $cg->map_ptr_base, $memory_locations, $dereferencer,
+                        $zend_type_reader, $context_pools, $memory_limit_error_details,
+                    ),
+                    default => null,
+                };
+                if ($child_context !== null) {
+                    $analyzer->analyzeSingleLink($link_name, $child_context, $sink, $parent_node_id, $memo);
+                    $context_pools->convertToSentinels($memo);
+                }
+            }
 
             $context_pools->clear();
 
@@ -1013,6 +1055,7 @@ final class MemoryLocationsCollector
                     $this->current_streaming_parent_node_id,
                     $pointer->address,
                     $this->current_streaming_link_name ?? 'deferred_reference',
+                    'reference',
                 ];
             }
             return null;
@@ -1066,6 +1109,7 @@ final class MemoryLocationsCollector
                     $this->current_streaming_parent_node_id,
                     $pointer->address,
                     $this->current_streaming_link_name ?? 'deferred_array',
+                    'array',
                 ];
             }
             return null;
@@ -1110,6 +1154,7 @@ final class MemoryLocationsCollector
                     $this->current_streaming_parent_node_id,
                     $pointer->address,
                     $this->current_streaming_link_name ?? 'deferred_object',
+                    'object',
                 ];
             }
             return null;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -153,6 +153,13 @@ final class MemoryLocationsCollector
     private ?\WeakMap $streaming_memo = null;
     private ?ContextPools $streaming_context_pools = null;
 
+    /**
+     * When true, collectZendObjectPointer skips deep recursion for unseen
+     * objects, deferring them to the objects_store bucket loop. This prevents
+     * deep object graph traversal from within a single bucket.
+     */
+    private bool $defer_unseen_objects = false;
+
     public function __construct(
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
@@ -1031,7 +1038,7 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ObjectContext|SentinelContext {
+    ): ObjectContext|SentinelContext|null {
         if ($memory_locations->has($pointer->address)) {
             $sentinel = $context_pools->getSentinel($pointer->address);
             if ($sentinel !== null) {
@@ -1041,6 +1048,11 @@ final class MemoryLocationsCollector
             if ($cached !== null) {
                 return $cached;
             }
+        } elseif ($this->defer_unseen_objects) {
+            // During objects_store collection: don't recurse into unseen
+            // objects via property traversal. The object will be collected
+            // when its objects_store bucket is reached.
+            return null;
         }
         $obj = $dereferencer->deref($pointer);
         return $this->collectZendObject(
@@ -2011,7 +2023,9 @@ final class MemoryLocationsCollector
                     $context_pools,
                     $memory_limit_error_details,
                 );
-                $weak_reference_context->add('referent', $referent_context);
+                if ($referent_context !== null) {
+                    $weak_reference_context->add('referent', $referent_context);
+                }
             } catch (\Throwable) {
             }
         }
@@ -2772,6 +2786,15 @@ final class MemoryLocationsCollector
             $zend_type_reader,
         );
 
+        // Defer unseen object traversal during objects_store collection.
+        // Property references to other objects return null instead of
+        // recursing. Those objects will be collected when their own
+        // bucket is reached, keeping memory bounded per-object.
+        $was_deferring = $this->defer_unseen_objects;
+        if ($this->streaming_sink !== null) {
+            $this->defer_unseen_objects = true;
+        }
+
         foreach ($bucket_iterator as $key => $bucket) {
             if ($key === 0) {
                 continue;
@@ -2794,6 +2817,9 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
+            if ($objects_store_bucket_context === null) {
+                continue;
+            }
             if ($parent_node_id !== null) {
                 $objects_store_bucket_context = $this->emitChildIfStreaming(
                     (string)$key,
@@ -2804,6 +2830,7 @@ final class MemoryLocationsCollector
             }
             $objects_store_context->add((string)$key, $objects_store_bucket_context);
         }
+        $this->defer_unseen_objects = $was_deferring;
         return $objects_store_context;
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -733,11 +733,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            if ($memory_locations->getClass($pointer->address) === ZendResourceMemoryLocation::class) {
-                $cached = $context_pools->resource_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->resource_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $resource = $dereferencer->deref($pointer);
@@ -960,11 +958,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            if ($memory_locations->getClass($pointer->address) === ZendReferenceMemoryLocation::class) {
-                $cached = $context_pools->php_reference_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->php_reference_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $php_reference = $dereferencer->deref($pointer);
@@ -1004,11 +1000,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            if ($memory_locations->getClass($pointer->address) === ZendArrayMemoryLocation::class) {
-                $cached = $context_pools->array_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->array_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $array = $dereferencer->deref($pointer);
@@ -1038,12 +1032,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $location_class = $memory_locations->getClass($pointer->address);
-            if ($location_class !== ZendArrayTableOverheadMemoryLocation::class) {
-                $cached = $context_pools->object_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->object_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $obj = $dereferencer->deref($pointer);
@@ -1070,12 +1061,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            $location_class = $memory_locations->getClass($pointer->address);
-            if ($location_class !== ZendArrayTableOverheadMemoryLocation::class) {
-                $cached = $context_pools->string_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->string_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $str = $dereferencer->deref($pointer);
@@ -2084,11 +2072,9 @@ final class MemoryLocationsCollector
             if ($sentinel !== null) {
                 return $sentinel;
             }
-            if ($memory_locations->getClass($pointer->address) === ZendOpArrayHeaderMemoryLocation::class) {
-                $cached = $context_pools->user_function_definition_context_pool->getContextByAddress($pointer->address);
-                if ($cached !== null) {
-                    return $cached;
-                }
+            $cached = $context_pools->user_function_definition_context_pool->getContextByAddress($pointer->address);
+            if ($cached !== null) {
+                return $cached;
             }
         }
         $func = $dereferencer->deref($pointer);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1052,6 +1052,17 @@ final class MemoryLocationsCollector
             if ($cached !== null) {
                 return $cached;
             }
+            if ($this->defer_unseen_objects) {
+                if ($this->current_streaming_parent_node_id !== null) {
+                    $this->deferred_object_edges[] = [
+                        $this->current_streaming_parent_node_id,
+                        $pointer->address,
+                        $this->current_streaming_link_name ?? 'deferred_reference',
+                        'reference',
+                    ];
+                }
+                return null;
+            }
         } elseif ($this->defer_unseen_objects) {
             if ($this->current_streaming_parent_node_id !== null) {
                 $this->deferred_object_edges[] = [
@@ -1104,6 +1115,17 @@ final class MemoryLocationsCollector
             if ($cached !== null) {
                 return $cached;
             }
+            if ($this->defer_unseen_objects) {
+                if ($this->current_streaming_parent_node_id !== null) {
+                    $this->deferred_object_edges[] = [
+                        $this->current_streaming_parent_node_id,
+                        $pointer->address,
+                        $this->current_streaming_link_name ?? 'deferred_array',
+                        'array',
+                    ];
+                }
+                return null;
+            }
         } elseif ($this->defer_unseen_objects) {
             // During shallow collection: don't recurse into unseen arrays.
             // Record a deferred edge if we have a parent context.
@@ -1147,6 +1169,17 @@ final class MemoryLocationsCollector
             $cached = $context_pools->object_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
                 return $cached;
+            }
+            if ($this->defer_unseen_objects) {
+                if ($this->current_streaming_parent_node_id !== null) {
+                    $this->deferred_object_edges[] = [
+                        $this->current_streaming_parent_node_id,
+                        $pointer->address,
+                        $this->current_streaming_link_name ?? 'deferred_object',
+                        'object',
+                    ];
+                }
+                return null;
             }
         } elseif ($this->defer_unseen_objects) {
             // During objects_store collection: don't recurse into unseen

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -435,6 +435,9 @@ final class MemoryLocationsCollector
             $modules_context,
         );
 
+        // Release pool references so ContextAnalyzer's releaseLinks() can trigger GC
+        $context_pools->clear();
+
         return new CollectedMemories(
             $chunk_memory_locations,
             $huge_memory_locations,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
@@ -31,6 +31,11 @@ final class ArrayContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?ArrayHeaderContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
@@ -35,4 +35,13 @@ final class ArrayContextPool
     {
         $this->contexts = [];
     }
+
+    /** @return \Generator<int, ArrayHeaderContext> */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayContextPool.php
@@ -30,4 +30,9 @@ final class ArrayContextPool
         $this->contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
@@ -53,4 +53,17 @@ final class ObjectContextPool
         $this->contexts = [];
         $this->handlers_contexts = [];
     }
+
+    /** @return \Generator<int, ObjectContext|ObjectHandlersContext> */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+        foreach ($this->handlers_contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->handlers_contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
@@ -47,4 +47,10 @@ final class ObjectContextPool
         $this->handlers_contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+        $this->handlers_contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ObjectContextPool.php
@@ -48,6 +48,11 @@ final class ObjectContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?ObjectContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
@@ -35,4 +35,13 @@ final class PhpReferenceContextPool
     {
         $this->contexts = [];
     }
+
+    /** @return \Generator<int, PhpReferenceContext> */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
@@ -30,4 +30,9 @@ final class PhpReferenceContextPool
         $this->contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/PhpReferenceContextPool.php
@@ -31,6 +31,11 @@ final class PhpReferenceContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?PhpReferenceContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
@@ -30,4 +30,9 @@ final class ResourceContextPool
         $this->contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
@@ -35,4 +35,13 @@ final class ResourceContextPool
     {
         $this->contexts = [];
     }
+
+    /** @return \Generator<int, ResourceContext> */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContextPool.php
@@ -31,6 +31,11 @@ final class ResourceContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?ResourceContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
@@ -23,7 +23,7 @@ use Reli\Lib\Process\MemoryLocation;
 final class SentinelContext implements ReferenceContext
 {
     public function __construct(
-        public readonly int $node_id,
+        public int $node_id,
     ) {
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use Reli\Lib\Process\MemoryLocation;
+
+/**
+ * Lightweight placeholder for a context that was already emitted to DB.
+ * Holds only the node_id so the analyzer can emit a reference edge
+ * without keeping the full context object in memory.
+ */
+final class SentinelContext implements ReferenceContext
+{
+    public function __construct(
+        public readonly int $node_id,
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'SentinelContext';
+    }
+
+    #[\Override]
+    public function add(string $link_name, ReferenceContext $reference_context): void
+    {
+        throw new \LogicException('SentinelContext cannot have children');
+    }
+
+    /** @return array<string, ReferenceContext> */
+    #[\Override]
+    public function getLinks(): iterable
+    {
+        return [];
+    }
+
+    /** @return iterable<array-key, MemoryLocation> */
+    #[\Override]
+    public function getLocations(): iterable
+    {
+        return [];
+    }
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        return [];
+    }
+
+    #[\Override]
+    public function releaseLinks(): void
+    {
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
@@ -31,6 +31,11 @@ final class StringContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?StringContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
@@ -30,4 +30,9 @@ final class StringContextPool
         $this->contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContextPool.php
@@ -35,4 +35,16 @@ final class StringContextPool
     {
         $this->contexts = [];
     }
+
+    /**
+     * Yield all entries as address => context, then clear the pool.
+     * @return \Generator<int, StringContext>
+     */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
@@ -32,6 +32,11 @@ final class UserFunctionDefinitionContextPool
         return $context;
     }
 
+    public function getContextByAddress(int $address): ?UserFunctionDefinitionContext
+    {
+        return $this->contexts[$address] ?? null;
+    }
+
     public function clear(): void
     {
         $this->contexts = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
@@ -36,4 +36,13 @@ final class UserFunctionDefinitionContextPool
     {
         $this->contexts = [];
     }
+
+    /** @return \Generator<int, UserFunctionDefinitionContext> */
+    public function drainWithAddresses(): \Generator
+    {
+        foreach ($this->contexts as $address => $context) {
+            yield $address => $context;
+        }
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/UserFunctionDefinitionContextPool.php
@@ -31,4 +31,9 @@ final class UserFunctionDefinitionContextPool
         $this->contexts[$memory_location->address] = $context;
         return $context;
     }
+
+    public function clear(): void
+    {
+        $this->contexts = [];
+    }
 }

--- a/src/Lib/Process/Pointer/CachingDereferencer.php
+++ b/src/Lib/Process/Pointer/CachingDereferencer.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+/**
+ * Caching decorator for Dereferencer.
+ *
+ * Caches deref results by (address, type) so that repeated dereferences
+ * of the same pointer (e.g. 94K objects of the same class all dereffing
+ * the same zend_class_entry address) return the same PHP object without
+ * re-reading memory or re-allocating FFI buffers.
+ */
+final class CachingDereferencer implements Dereferencer
+{
+    /** @var array<string, mixed> "type:address" → result */
+    private array $cache = [];
+
+    public function __construct(
+        private Dereferencer $inner,
+        private int $max_entries = 4096,
+    ) {
+    }
+
+    /**
+     * @template T of Dereferencable
+     * @param Pointer<T> $pointer
+     * @return T
+     */
+    #[\Override]
+    public function deref(Pointer $pointer): mixed
+    {
+        $key = $pointer->type . ':' . $pointer->address;
+        if (isset($this->cache[$key])) {
+            /** @var T */
+            return $this->cache[$key];
+        }
+        $result = $this->inner->deref($pointer);
+        if (count($this->cache) >= $this->max_entries) {
+            // Evict oldest quarter to avoid unbounded growth
+            $this->cache = array_slice($this->cache, (int)($this->max_entries / 4), preserve_keys: true);
+        }
+        $this->cache[$key] = $result;
+        return $result;
+    }
+
+    public function clearCache(): void
+    {
+        $this->cache = [];
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/StreamingJsonFromDbExporterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ArrayHeaderContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayMemoryLocation;
+use Reli\Lib\Process\MemoryLocation;
+
+class StreamingJsonFromDbExporterTest extends BaseTestCase
+{
+    private string $db_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db_path = tempnam(sys_get_temp_dir(), 'reli_test_') . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    public function testExportProducesValidJson(): void
+    {
+        $pdo_output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $context = $this->createTreeContext();
+        $result = new MemoryAnalysisResult(
+            [['memory_get_usage' => 1024]],
+            $context,
+        );
+        $pdo_output->output($result);
+
+        $db = new \PDO("sqlite:{$this->db_path}");
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $run_id = (int)$db->query('SELECT MAX(run_id) FROM runs')->fetchColumn();
+
+        $exporter = new StreamingJsonFromDbExporter($db, $run_id);
+        $fp = fopen('php://memory', 'w+');
+        assert($fp !== false);
+        $exporter->export(
+            [['memory_get_usage' => 1024]],
+            ['TestLocation' => ['count' => 1, 'memory_usage' => 32]],
+            null,
+            $fp,
+        );
+
+        rewind($fp);
+        $json = stream_get_contents($fp);
+        fclose($fp);
+
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertNotNull($decoded, 'Output must be valid JSON: ' . json_last_error_msg());
+        $this->assertArrayHasKey('summary', $decoded);
+        $this->assertArrayHasKey('context', $decoded);
+        $this->assertArrayHasKey('location_types_summary', $decoded);
+        $this->assertArrayHasKey('class_objects_summary', $decoded);
+    }
+
+    public function testExportContainsNodeData(): void
+    {
+        $pdo_output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $str_loc = new ZendStringMemoryLocation(0x1000, 32, 1, 0, 'hello');
+        $str_ctx = new StringContext($str_loc);
+
+        $root = \Mockery::mock(ReferenceContext::class);
+        $root->allows('getName')->andReturn('Root');
+        $root->allows('getLinks')->andReturn(['child' => $str_ctx]);
+        $root->allows('getLocations')->andReturn([]);
+        $root->allows('getContexts')->andReturn([]);
+        $root->allows('releaseLinks');
+
+        $wrapper = \Mockery::mock(ReferenceContext::class);
+        $wrapper->allows('getName')->andReturn('Wrapper');
+        $wrapper->allows('getLinks')->andReturn(['root' => $root]);
+        $wrapper->allows('getLocations')->andReturn([]);
+        $wrapper->allows('getContexts')->andReturn([]);
+        $wrapper->allows('releaseLinks');
+
+        $result = new MemoryAnalysisResult([['test' => 1]], $wrapper);
+        $pdo_output->output($result);
+
+        $db = new \PDO("sqlite:{$this->db_path}");
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $run_id = (int)$db->query('SELECT MAX(run_id) FROM runs')->fetchColumn();
+
+        $exporter = new StreamingJsonFromDbExporter($db, $run_id);
+        $fp = fopen('php://memory', 'w+');
+        assert($fp !== false);
+        $exporter->export([['test' => 1]], null, null, $fp);
+
+        rewind($fp);
+        $json = stream_get_contents($fp);
+        fclose($fp);
+
+        $decoded = json_decode($json, true);
+        $this->assertNotNull($decoded);
+        // The context tree should contain the root node
+        $this->assertArrayHasKey('context', $decoded);
+        $this->assertNotEmpty($decoded['context']);
+    }
+
+    public function testExportWithPrettyPrint(): void
+    {
+        $pdo_output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        $result = new MemoryAnalysisResult(
+            [['key' => 'value']],
+            $this->createTreeContext(),
+        );
+        $pdo_output->output($result);
+
+        $db = new \PDO("sqlite:{$this->db_path}");
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $run_id = (int)$db->query('SELECT MAX(run_id) FROM runs')->fetchColumn();
+
+        $exporter = new StreamingJsonFromDbExporter($db, $run_id, pretty_print: true);
+        $fp = fopen('php://memory', 'w+');
+        assert($fp !== false);
+        $exporter->export([['key' => 'value']], null, null, $fp);
+
+        rewind($fp);
+        $json = stream_get_contents($fp);
+        fclose($fp);
+
+        $this->assertStringContainsString("\n", $json);
+        $this->assertNotNull(json_decode($json, true));
+    }
+
+    private function createTreeContext(): ReferenceContext
+    {
+        $context = \Mockery::mock(ReferenceContext::class);
+        $context->allows('getName')->andReturn('TestContext');
+        $context->allows('getLinks')->andReturn([]);
+        $context->allows('getLocations')->andReturn([]);
+        $context->allows('getContexts')->andReturn([]);
+        $context->allows('releaseLinks');
+        return $context;
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocationsLightweightTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MemoryLocationsLightweightTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\BaseTestCase;
+use Reli\Lib\Process\MemoryLocation;
+
+class MemoryLocationsLightweightTest extends BaseTestCase
+{
+    public function testCreateLightweight(): void
+    {
+        $locations = MemoryLocations::createLightweight();
+        $this->assertInstanceOf(MemoryLocations::class, $locations);
+    }
+
+    public function testHasReturnsFalseForUnknownAddress(): void
+    {
+        $locations = MemoryLocations::createLightweight();
+        $this->assertFalse($locations->has(0x1000));
+    }
+
+    public function testAddAndHas(): void
+    {
+        $locations = MemoryLocations::createLightweight();
+        $locations->add(new MemoryLocation(0x1000, 32));
+        $this->assertTrue($locations->has(0x1000));
+        $this->assertFalse($locations->has(0x2000));
+    }
+
+    public function testMultipleAdds(): void
+    {
+        $locations = MemoryLocations::createLightweight();
+        $locations->add(new MemoryLocation(0x1000, 32));
+        $locations->add(new MemoryLocation(0x2000, 64));
+        $locations->add(new MemoryLocation(0x3000, 16));
+
+        $this->assertTrue($locations->has(0x1000));
+        $this->assertTrue($locations->has(0x2000));
+        $this->assertTrue($locations->has(0x3000));
+        $this->assertFalse($locations->has(0x4000));
+    }
+
+    public function testDuplicateAddDoesNotError(): void
+    {
+        $locations = MemoryLocations::createLightweight();
+        $locations->add(new MemoryLocation(0x1000, 32));
+        $locations->add(new MemoryLocation(0x1000, 64));
+        $this->assertTrue($locations->has(0x1000));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContextTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContextTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use Reli\BaseTestCase;
+
+class SentinelContextTest extends BaseTestCase
+{
+    public function testGetName(): void
+    {
+        $sentinel = new SentinelContext(42);
+        $this->assertSame('SentinelContext', $sentinel->getName());
+    }
+
+    public function testNodeIdIsAccessible(): void
+    {
+        $sentinel = new SentinelContext(99);
+        $this->assertSame(99, $sentinel->node_id);
+    }
+
+    public function testNodeIdIsMutable(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $sentinel->node_id = 2;
+        $this->assertSame(2, $sentinel->node_id);
+    }
+
+    public function testAddThrowsLogicException(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $this->expectException(\LogicException::class);
+        $sentinel->add('child', new SentinelContext(2));
+    }
+
+    public function testGetLinksReturnsEmpty(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $this->assertSame([], iterator_to_array($sentinel->getLinks()));
+    }
+
+    public function testGetLocationsReturnsEmpty(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $this->assertSame([], iterator_to_array($sentinel->getLocations()));
+    }
+
+    public function testGetContextsReturnsEmpty(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $this->assertSame([], iterator_to_array($sentinel->getContexts()));
+    }
+
+    public function testReleaseLinksDoesNothing(): void
+    {
+        $sentinel = new SentinelContext(1);
+        $sentinel->releaseLinks();
+        $this->assertSame(1, $sentinel->node_id);
+    }
+}

--- a/tests/Lib/Process/Pointer/CachingDereferencerTest.php
+++ b/tests/Lib/Process/Pointer/CachingDereferencerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\Pointer;
+
+use Reli\BaseTestCase;
+
+class CachingDereferencerTest extends BaseTestCase
+{
+    public function testCacheHitReturnsSameObject(): void
+    {
+        $result = new \stdClass();
+        $result->value = 42;
+
+        $inner = \Mockery::mock(Dereferencer::class);
+        $inner->expects('deref')->once()->andReturn($result);
+
+        $caching = new CachingDereferencer($inner);
+
+        /** @var Pointer<Dereferencable> $pointer */
+        $pointer = new Pointer('TestType', 0x1000, 64);
+
+        $first = $caching->deref($pointer);
+        $second = $caching->deref($pointer);
+
+        $this->assertSame($first, $second);
+        $this->assertSame(42, $first->value);
+    }
+
+    public function testDifferentAddressesCallInner(): void
+    {
+        $result1 = new \stdClass();
+        $result1->id = 1;
+        $result2 = new \stdClass();
+        $result2->id = 2;
+
+        $inner = \Mockery::mock(Dereferencer::class);
+        $inner->expects('deref')->twice()->andReturnUsing(function (Pointer $p) use ($result1, $result2) {
+            return $p->address === 0x1000 ? $result1 : $result2;
+        });
+
+        $caching = new CachingDereferencer($inner);
+
+        /** @var Pointer<Dereferencable> $p1 */
+        $p1 = new Pointer('TestType', 0x1000, 64);
+        /** @var Pointer<Dereferencable> $p2 */
+        $p2 = new Pointer('TestType', 0x2000, 64);
+
+        $this->assertSame(1, $caching->deref($p1)->id);
+        $this->assertSame(2, $caching->deref($p2)->id);
+    }
+
+    public function testEvictsOldEntriesWhenFull(): void
+    {
+        $inner = \Mockery::mock(Dereferencer::class);
+        $call_count = 0;
+        $inner->allows('deref')->andReturnUsing(function () use (&$call_count) {
+            return new \stdClass();
+        });
+
+        $caching = new CachingDereferencer($inner, max_entries: 4);
+
+        for ($i = 0; $i < 6; $i++) {
+            /** @var Pointer<Dereferencable> $p */
+            $p = new Pointer('Type', $i * 0x1000, 64);
+            $caching->deref($p);
+        }
+
+        // After eviction, early entries should miss cache
+        /** @var Pointer<Dereferencable> $p0 */
+        $p0 = new Pointer('Type', 0x0000, 64);
+        $a = $caching->deref($p0);
+        $b = $caching->deref($p0);
+        // $a was re-fetched (cache miss after eviction), $b is cached
+        $this->assertSame($a, $b);
+    }
+
+    public function testClearCacheRemovesAllEntries(): void
+    {
+        $inner = \Mockery::mock(Dereferencer::class);
+        $inner->allows('deref')->andReturnUsing(fn () => new \stdClass());
+
+        $caching = new CachingDereferencer($inner);
+
+        /** @var Pointer<Dereferencable> $p */
+        $p = new Pointer('Type', 0x1000, 64);
+
+        $first = $caching->deref($p);
+        $caching->clearCache();
+        $second = $caching->deref($p);
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testDifferentTypeSameAddressAreSeparateEntries(): void
+    {
+        $inner = \Mockery::mock(Dereferencer::class);
+        $inner->allows('deref')->andReturnUsing(fn () => new \stdClass());
+
+        $caching = new CachingDereferencer($inner);
+
+        /** @var Pointer<Dereferencable> $p1 */
+        $p1 = new Pointer('TypeA', 0x1000, 64);
+        /** @var Pointer<Dereferencable> $p2 */
+        $p2 = new Pointer('TypeB', 0x1000, 64);
+
+        $a = $caching->deref($p1);
+        $b = $caching->deref($p2);
+
+        $this->assertNotSame($a, $b);
+    }
+}


### PR DESCRIPTION
## Summary

Streaming memory analysis architecture that reduces peak memory from O(total nodes) toward O(tree depth). Enables analysis of multi-GB PHP processes (tested with 5.6 GB self-dump) that previously OOMed at 8 GB.

## Key Changes

### Streaming collection pipeline
- `collectAll()` accepts optional `ContextTreeSink` — each branch is emitted to SQLite immediately after collection and released for GC
- Inner loops (array elements, object properties, local variables) also emit per-iteration via `emitChildIfStreaming()` + `flushPoolsIfStreaming()`
- Collection order optimized for streaming: `objects_store` → `function_table` → `class_table` → `global_variables` → `call_frames` (non-streaming preserves original order)

### Shallow object collection with deferred edges
- During `objects_store`, `defer_unseen_objects` prevents recursive expansion through property chains
- Arrays, objects, and PHP references to unseen addresses are deferred with edge recording
- Dynamic properties, closures, generators, fibers skipped in defer mode
- Deferred edges resolved after all phases complete — sentinel hits emit reference edges, remaining targets are fully collected

### Sentinel-based deduplication
- `ContextPools` maintains `array<int, int>` sentinel map (address → node_id) with shared `SentinelContext` instance
- `convertToSentinels()` + `clear()` called per-iteration in loops, releasing pool contexts immediately
- `ContextAnalyzer` recognizes `SentinelContext` and emits reference edge without traversal

### Lightweight MemoryLocations
- `MemoryLocations::createLightweight()` stores `array<int, true>` seen set instead of full objects
- Collector cache-hit paths use `getContextByAddress()` on pools directly, no `instanceof` checks needed

### CachingDereferencer
- Wraps `RemoteProcessDereferencer` with `(type, address) → result` LRU cache (4096 entries)
- 94K objects of same class: class_entry deref drops from 94K FFI allocations to ~1
- Enabled in streaming mode only to avoid stale-cache issues

### Output pipeline
- `StreamingJsonFromDbExporter`: DFS walk of SQLite, `fwrite` per node — O(depth) memory
- `JsonMemoryOutput` / `ReportMemoryOutput`: detect `pre_populated_db` and stream from it
- `MemoryOutputFactory::createStreamingSink()`: DB formats write directly to output DB, non-DB formats use temp SQLite
- `PdoMemoryOutput::copyFromPrePopulatedDb()`: fallback for temp→target DB copy

### Lazy dump file loading
- `MemoryDumpReaderFactory` builds region index (address, size, file_offset) without loading data
- `read()` uses `fseek` + `fread` on demand — O(1) memory per read vs O(dump size)

## Test plan
- [x] Psalm clean (0 errors)
- [x] phpcs clean (PSR12)
- [x] Unit tests pass (120 tests, 302 assertions)
- [x] Integration tests pass (234 tests, Docker-based, all PHP versions)
- [x] New tests: CachingDereferencerTest, SentinelContextTest, MemoryLocationsLightweightTest
- [x] 5.6 GB self-dump: completes without OOM (previously crashed at 8 GB)

https://claude.ai/code/session_01Ut7jcstJVKYybPuYw3RrsH