### PR TITLE
Rewrite StructuralDedupPass and TopArraysPass to use graph substrate

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class StructuralDedupPass implements PassInterface
@@ -23,18 +24,160 @@ final class StructuralDedupPass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
+        private ?GraphSubstrate $substrate = null,
     ) {
     }
 
     /**
      * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress MixedOperand, InvalidOperand
      * @psalm-suppress PossiblyInvalidArgument, InvalidArgument
      */
     #[\Override]
     public function analyze(): array
     {
-        // Compute shape signatures: class + size + property list
+        $shape_groups = $this->substrate !== null
+            ? $this->analyzeWithGraph()
+            : $this->analyzeWithSql();
+
+        $findings = [];
+
+        $dedup_candidates = array_filter(
+            $shape_groups,
+            fn($g) => $g['count'] >= 50
+        );
+        usort(
+            $dedup_candidates,
+            fn($a, $b) => $b['total_size'] <=> $a['total_size']
+        );
+
+        foreach (array_slice($dedup_candidates, 0, 10) as $g) {
+            $short = $g['class'];
+            $is_empty = $g['props'] === '';
+            $waste = ($g['count'] - 1) * $g['size'];
+
+            if ($is_empty) {
+                $findings[] = new Finding(
+                    kind: 'empty_object',
+                    severity: $g['total_size'] > 102400
+                        ? FindingSeverity::Medium
+                        : FindingSeverity::Low,
+                    confidence: FindingConfidence::High,
+                    summary: sprintf(
+                        '%s: %s instances x %s, no properties (%s)',
+                        $short,
+                        number_format($g['count']),
+                        SizeFormatter::format($g['size']),
+                        SizeFormatter::format($g['total_size']),
+                    ),
+                    facts: [
+                        'class_name' => $g['class'],
+                        'count' => $g['count'],
+                        'each_size' => $g['size'],
+                        'total_size' => $g['total_size'],
+                    ],
+                    hypothesis: 'Objects with no stored properties'
+                        . ' — pure overhead, may be replaceable',
+                    impact_bytes: $waste,
+                    evidence_node_ids: [$g['example_id']],
+                );
+            } else {
+                $findings[] = new Finding(
+                    kind: 'structural_duplicate',
+                    severity: $waste > 102400
+                        ? FindingSeverity::Medium
+                        : FindingSeverity::Low,
+                    confidence: FindingConfidence::Medium,
+                    summary: sprintf(
+                        '%s: %s identical shapes x %s = %s'
+                        . ' (saving: %s)',
+                        $short,
+                        number_format($g['count']),
+                        SizeFormatter::format($g['size']),
+                        SizeFormatter::format($g['total_size']),
+                        SizeFormatter::format($waste),
+                    ),
+                    facts: [
+                        'class_name' => $g['class'],
+                        'count' => $g['count'],
+                        'each_size' => $g['size'],
+                        'total_size' => $g['total_size'],
+                        'theoretical_saving' => $waste,
+                        'properties' => $g['props'],
+                    ],
+                    hypothesis: 'Identical object shapes'
+                        . ' — candidates for flyweight/sharing',
+                    impact_bytes: $waste,
+                    evidence_node_ids: [$g['example_id']],
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * In-memory analysis using GraphSubstrate. O(nodes).
+     * @return list<array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}>
+     * @psalm-suppress MixedReturnTypeCoercion
+     */
+    private function analyzeWithGraph(): array
+    {
+        assert($this->substrate !== null);
+
+        $link_names = $this->loadLinkNames();
+
+        /** @var array<string, array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}> */
+        $shape_groups = [];
+
+        foreach ($this->substrate->iterateNodeClasses() as $node_id => $class_name) {
+            $size = $this->substrate->getNodeSize($node_id);
+
+            // Find object_properties child, collect property names
+            $props = [];
+            foreach ($this->substrate->getChildren($node_id) as $child) {
+                if (($link_names[$child] ?? '') !== 'object_properties') {
+                    continue;
+                }
+                foreach ($this->substrate->getChildren($child) as $prop_child) {
+                    $prop_name = $link_names[$prop_child] ?? null;
+                    if ($prop_name !== null) {
+                        $props[] = $prop_name;
+                    }
+                }
+                break;
+            }
+
+            sort($props);
+            $prop_sig = implode(',', $props);
+            $hash = $class_name . '|' . $size . '|' . $prop_sig;
+
+            if (!isset($shape_groups[$hash])) {
+                $shape_groups[$hash] = [
+                    'class' => $class_name,
+                    'size' => $size,
+                    'props' => $prop_sig,
+                    'count' => 0,
+                    'total_size' => 0,
+                    'example_id' => $node_id,
+                ];
+            }
+            $shape_groups[$hash]['count']++;
+            $shape_groups[$hash]['total_size'] += $size;
+        }
+
+        return array_values($shape_groups);
+    }
+
+    /**
+     * SQL-based analysis (fallback when no substrate).
+     * @return list<array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedReturnTypeCoercion
+     * @psalm-suppress MixedArgument, MixedOperand
+     */
+    private function analyzeWithSql(): array
+    {
         $rows = $this->db->query("
             SELECT
                 cnl.node_id,
@@ -42,20 +185,27 @@ final class StructuralDedupPass implements PassInterface
                 cnl.size,
                 group_concat(e_prop.link_name, '|') as property_names
             FROM context_node_locations cnl
-            JOIN context_edges e_to_obj ON e_to_obj.parent_node_id = cnl.node_id
-                AND e_to_obj.link_name = 'object_properties' AND e_to_obj.is_tree = 1
+            JOIN context_edges e_to_obj
+                ON e_to_obj.parent_node_id = cnl.node_id
+                AND e_to_obj.link_name = 'object_properties'
+                AND e_to_obj.is_tree = 1
                 AND e_to_obj.run_id = {$this->run_id}
-            LEFT JOIN context_edges e_prop ON e_prop.parent_node_id = e_to_obj.child_node_id
-                AND e_prop.is_tree = 1 AND e_prop.run_id = {$this->run_id}
+            LEFT JOIN context_edges e_prop
+                ON e_prop.parent_node_id = e_to_obj.child_node_id
+                AND e_prop.is_tree = 1
+                AND e_prop.run_id = {$this->run_id}
             WHERE cnl.location_type = 'ZendObjectMemoryLocation'
                 AND cnl.class_name IS NOT NULL
                 AND cnl.run_id = {$this->run_id}
             GROUP BY cnl.node_id
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
+        /** @var array<string, array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}> */
         $shape_groups = [];
         foreach ($rows as $s) {
-            $props = $s['property_names'] ? explode('|', $s['property_names']) : [];
+            $props = $s['property_names']
+                ? explode('|', $s['property_names'])
+                : [];
             sort($props);
             $prop_sig = implode(',', $props);
             $hash = $s['class_name'] . '|' . $s['size'] . '|' . $prop_sig;
@@ -75,67 +225,25 @@ final class StructuralDedupPass implements PassInterface
         }
         unset($rows);
 
-        $findings = [];
+        return array_values($shape_groups);
+    }
 
-        // Structural duplicates (>= 50 identical shapes)
-        $dedup_candidates = array_filter($shape_groups, fn($g) => $g['count'] >= 50);
-        usort($dedup_candidates, fn($a, $b) => $b['total_size'] <=> $a['total_size']);
+    /**
+     * @return array<int, string>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadLinkNames(): array
+    {
+        $rows = $this->db->query(
+            "SELECT child_node_id, link_name FROM context_edges"
+            . " WHERE is_tree = 1 AND run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
 
-        foreach (array_slice($dedup_candidates, 0, 10) as $g) {
-            $short = $g['class'];
-            $is_empty = $g['props'] === '';
-            $waste = ($g['count'] - 1) * $g['size'];
-
-            if ($is_empty) {
-                $findings[] = new Finding(
-                    kind: 'empty_object',
-                    severity: $g['total_size'] > 102400 ? FindingSeverity::Medium : FindingSeverity::Low,
-                    confidence: FindingConfidence::High,
-                    summary: sprintf(
-                        '%s: %s instances x %s, no properties stored (%s)',
-                        $short,
-                        number_format($g['count']),
-                        SizeFormatter::format($g['size']),
-                        SizeFormatter::format($g['total_size']),
-                    ),
-                    facts: [
-                        'class_name' => $g['class'],
-                        'count' => $g['count'],
-                        'each_size' => $g['size'],
-                        'total_size' => $g['total_size'],
-                    ],
-                    hypothesis: 'Objects with no stored properties — pure overhead, may be replaceable',
-                    impact_bytes: $waste,
-                    evidence_node_ids: [$g['example_id']],
-                );
-            } else {
-                $findings[] = new Finding(
-                    kind: 'structural_duplicate',
-                    severity: $waste > 102400 ? FindingSeverity::Medium : FindingSeverity::Low,
-                    confidence: FindingConfidence::Medium,
-                    summary: sprintf(
-                        '%s: %s identical shapes x %s = %s (theoretical saving: %s)',
-                        $short,
-                        number_format($g['count']),
-                        SizeFormatter::format($g['size']),
-                        SizeFormatter::format($g['total_size']),
-                        SizeFormatter::format($waste),
-                    ),
-                    facts: [
-                        'class_name' => $g['class'],
-                        'count' => $g['count'],
-                        'each_size' => $g['size'],
-                        'total_size' => $g['total_size'],
-                        'theoretical_saving' => $waste,
-                        'properties' => $g['props'],
-                    ],
-                    hypothesis: 'Identical object shapes — candidates for flyweight/sharing optimization',
-                    impact_bytes: $waste,
-                    evidence_node_ids: [$g['example_id']],
-                );
-            }
+        $map = [];
+        foreach ($rows as $r) {
+            $map[(int)$r[0]] = (string)$r[1];
         }
-
-        return $findings;
+        unset($rows);
+        return $map;
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -43,7 +43,115 @@ final class TopArraysPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        // 3-hop ancestor: gp_link -> parent_link -> owner -> array
+        if ($this->substrate !== null) {
+            return $this->analyzeWithGraph();
+        }
+        return $this->analyzeWithSql();
+    }
+
+    /**
+     * In-memory analysis using GraphSubstrate.
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess
+     */
+    private function analyzeWithGraph(): array
+    {
+        assert($this->substrate !== null);
+        $link_names = $this->loadLinkNames();
+        $labeler = new NodeLabeler($this->db, $this->run_id);
+        $use_retained = $this->substrate->hasSubtreeSizes();
+
+        $arrays = [];
+        foreach ($this->substrate->iterateNodeSizes() as $node => $shallow) {
+            foreach ($this->substrate->getChildren($node) as $child) {
+                if (($link_names[$child] ?? '') === 'array_elements') {
+                    $retained = $use_retained
+                        ? $this->substrate->getSubtreeSize($node)
+                        : $shallow;
+                    $elem_count = count(
+                        $this->substrate->getChildren($child)
+                    );
+                    $arrays[] = [
+                        'node_id' => $node,
+                        'shallow' => $shallow,
+                        'retained' => $retained ?: $shallow,
+                        'element_count' => $elem_count,
+                    ];
+                    break;
+                }
+            }
+        }
+
+        usort($arrays, fn($a, $b) => $b['retained'] <=> $a['retained']);
+
+        $findings = [];
+        foreach (array_slice($arrays, 0, 10) as $arr) {
+            $retained = $arr['retained'];
+            $shallow = $arr['shallow'];
+            $node_id = $arr['node_id'];
+
+            if ($retained < 10240 && $shallow < 10240) {
+                continue;
+            }
+
+            $elements = $arr['element_count'];
+            $path = $this->buildFullPath($node_id, $labeler);
+
+            if ($use_retained && $retained > $shallow) {
+                $summary = sprintf(
+                    '%s retained (table: %s), %s elements — %s',
+                    SizeFormatter::format($retained),
+                    SizeFormatter::format($shallow),
+                    number_format($elements),
+                    $path ?: '(root)',
+                );
+            } else {
+                $summary = sprintf(
+                    '%s array, %s elements — %s',
+                    SizeFormatter::format($shallow),
+                    number_format($elements),
+                    $path ?: '(root)',
+                );
+            }
+
+            $findings[] = new Finding(
+                kind: 'large_array',
+                severity: $retained > 1024 * 1024
+                    ? FindingSeverity::Medium
+                    : FindingSeverity::Low,
+                confidence: FindingConfidence::High,
+                summary: $summary,
+                facts: [
+                    'node_id' => $node_id,
+                    'table_size' => $shallow,
+                    'retained_size' => $retained,
+                    'element_count' => $elements,
+                    'owner_path' => $path,
+                ],
+                hypothesis: 'Large array allocation;'
+                    . ' may be a cache, buffer, or accumulator',
+                next_checks: [
+                    'Check if array size is bounded',
+                    'Consider SplFixedArray for known-size collections',
+                ],
+                impact_bytes: $retained,
+                evidence_node_ids: [$node_id],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * SQL-based analysis (fallback when no substrate).
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     * @psalm-suppress InvalidOperand
+     */
+    private function analyzeWithSql(): array
+    {
+        $labeler = new NodeLabeler($this->db, $this->run_id);
+
         $rows = $this->db->query("
             SELECT
                 va.node_id,
@@ -76,71 +184,32 @@ final class TopArraysPass implements PassInterface
             LIMIT 10
         ")->fetchAll(\PDO::FETCH_ASSOC);
 
-        $labeler = new NodeLabeler($this->db, $this->run_id);
-        $use_retained = $this->substrate !== null
-            && $this->substrate->hasSubtreeSizes();
-
-        // If substrate available, sort by retained size instead
-        $entries = [];
-        foreach ($rows as $row) {
-            $table_size = (int)$row['total_size'];
-            $node_id = (int)$row['node_id'];
-            $retained = $use_retained
-                ? ($this->substrate->getSubtreeSize($node_id) ?: $table_size)
-                : $table_size;
-            $entries[] = [
-                'row' => $row,
-                'table_size' => $table_size,
-                'retained' => $retained,
-                'node_id' => $node_id,
-            ];
-        }
-        usort($entries, fn($a, $b) => $b['retained'] <=> $a['retained']);
-
         $findings = [];
-        foreach (array_slice($entries, 0, 10) as $entry) {
-            $row = $entry['row'];
-            $table_size = $entry['table_size'];
-            $retained = $entry['retained'];
-            $node_id = $entry['node_id'];
-
-            if ($retained < 10240 && $table_size < 10240) {
+        foreach ($rows as $row) {
+            $total = (int)$row['total_size'];
+            if ($total < 10240) {
                 continue;
             }
 
             $elements = (int)($row['element_count'] ?? 0);
-            $path = $this->substrate !== null
-                ? $this->buildFullPath($node_id, $labeler)
-                : $this->buildOwnerPath($row, $labeler);
-
-            if ($use_retained && $retained > $table_size) {
-                $summary = sprintf(
-                    '%s retained (table: %s), %s elements — %s',
-                    SizeFormatter::format($retained),
-                    SizeFormatter::format($table_size),
-                    number_format($elements),
-                    $path ?: '(root)',
-                );
-            } else {
-                $summary = sprintf(
-                    '%s array, %s elements — %s',
-                    SizeFormatter::format($table_size),
-                    number_format($elements),
-                    $path ?: '(root)',
-                );
-            }
+            $path = $this->buildOwnerPath($row, $labeler);
 
             $findings[] = new Finding(
                 kind: 'large_array',
-                severity: $retained > 1024 * 1024
+                severity: $total > 1024 * 1024
                     ? FindingSeverity::Medium
                     : FindingSeverity::Low,
                 confidence: FindingConfidence::High,
-                summary: $summary,
+                summary: sprintf(
+                    '%s array, %s elements — %s',
+                    SizeFormatter::format($total),
+                    number_format($elements),
+                    $path ?: '(root)',
+                ),
                 facts: [
-                    'node_id' => $node_id,
-                    'table_size' => $table_size,
-                    'retained_size' => $retained,
+                    'node_id' => (int)$row['node_id'],
+                    'table_size' => $total,
+                    'retained_size' => $total,
                     'element_count' => $elements,
                     'owner_path' => $path,
                 ],
@@ -150,16 +219,12 @@ final class TopArraysPass implements PassInterface
                     'Check if array size is bounded',
                     'Consider SplFixedArray for known-size collections',
                 ],
-                impact_bytes: $retained,
-                evidence_node_ids: [$node_id],
-                replay_query: "SELECT * FROM v_arrays"
-                    . " WHERE run_id = {$this->run_id}"
-                    . " ORDER BY total_size DESC LIMIT 10",
+                impact_bytes: $total,
+                evidence_node_ids: [(int)$row['node_id']],
             );
         }
 
-        // Sparse array detection: table_size >> element_count
-        // table_size (bytes) = nTableSize * 32 (sizeof Bucket)
+        // Sparse array detection
         $sparse_rows = $this->db->query("
             SELECT
                 va.node_id,
@@ -183,21 +248,17 @@ final class TopArraysPass implements PassInterface
             $utilization = $s_capacity > 0
                 ? $s_count / $s_capacity * 100.0
                 : 0;
-            $s_path = $this->substrate !== null
-                ? $this->buildFullPath($s_node, $labeler)
-                : '(use --full-analysis for path)';
 
             $findings[] = new Finding(
                 kind: 'sparse_array',
                 severity: FindingSeverity::Medium,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    '%s table, %s/%s slots used (%.1f%%) — %s',
+                    '%s table, %s/%s slots used (%.1f%%)',
                     SizeFormatter::format($s_table),
                     number_format($s_count),
                     number_format($s_capacity),
                     $utilization,
-                    $s_path,
                 ),
                 facts: [
                     'node_id' => $s_node,
@@ -221,11 +282,32 @@ final class TopArraysPass implements PassInterface
     }
 
     /**
+     * @return array<int, string>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadLinkNames(): array
+    {
+        $rows = $this->db->query(
+            "SELECT child_node_id, link_name FROM context_edges"
+            . " WHERE is_tree = 1 AND run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        $map = [];
+        foreach ($rows as $r) {
+            $map[(int)$r[0]] = (string)$r[1];
+        }
+        unset($rows);
+        return $map;
+    }
+
+    /**
      * Walk from node to root via tree parent edges.
      * @psalm-suppress MixedArrayAccess, MixedAssignment
      */
-    private function buildFullPath(int $node_id, NodeLabeler $labeler): string
-    {
+    private function buildFullPath(
+        int $node_id,
+        NodeLabeler $labeler,
+    ): string {
         assert($this->substrate !== null);
 
         if ($this->parentMapCache === null) {
@@ -236,7 +318,8 @@ final class TopArraysPass implements PassInterface
                 . " AND run_id = {$this->run_id}"
             )->fetchAll(\PDO::FETCH_NUM);
             foreach ($rows as $r) {
-                $this->parentMapCache[(int)$r[0]] = [(int)($r[1] ?? -1), (string)$r[2]];
+                $this->parentMapCache[(int)$r[0]]
+                    = [(int)($r[1] ?? -1), (string)$r[2]];
             }
             unset($rows);
 
@@ -310,7 +393,6 @@ final class TopArraysPass implements PassInterface
             $raw_parts[] = (string)$row['link1'];
         }
 
-        // Filter structural intermediaries and join with ->
         $filtered = array_values(array_filter(
             $raw_parts,
             fn(string $p) => !in_array($p, self::STRUCTURAL_LINKS, true)

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -89,8 +89,8 @@ final class ReportGenerator
                 $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
                 $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
                 $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
+                $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id)));
             }
-            $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id)));
         }
 
         // Phase 3: Graph-based passes (< 500K edges, or --full-analysis)
@@ -107,6 +107,7 @@ final class ReportGenerator
             $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id, $substrate)));
+            $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id, $substrate)));
             $findings = array_merge($findings, $this->runPass(new DrillDownPass($substrate, $db, $run_id)));
             $findings = array_merge($findings, $this->runPass(
                 new ChokePointPass($substrate, $db, $run_id, $heap_usage)


### PR DESCRIPTION
## Summary

Rewrites both StructuralDedupPass and TopArraysPass to use graph substrate for in-memory analysis, eliminating heavy SQL queries that hung on large datasets.

### StructuralDedupPass
**Problem**: `GROUP BY cnl.node_id` with 3-stage JOIN (`context_node_locations → context_edges (object_properties) → context_edges (properties)`) + `group_concat` never finished on large datasets.

**Solution**: When substrate available, walks `children` and `link_names` in-memory O(nodes). For each object node: find `object_properties` child → collect property link_names → sort and hash as shape signature → group by hash.

### TopArraysPass
**Problem**: `v_arrays` view + 3-hop ancestor JOIN hung on large datasets. Even with substrate available, the SQL was always executed.

**Solution**: When substrate available, finds arrays by looking for nodes with an `array_elements` child in the graph. Uses `subtree_sizes` for retained size, `buildFullPath` for PHP-syntax paths. No SQL at all in graph mode.

SQL fallback kept for Phase 2 (no substrate). Sparse array detection kept in SQL fallback only (requires `v_arrays` view data).

Both passes deferred to Phase 3 when substrate exists, same pattern as PropertyScaling, NonTreeEdge, etc.

## Test plan
- [x] 56 tests, 124 assertions pass
- [x] Psalm: 0 errors
- [x] PHPCS: clean

https://claude.ai/code/session_019KcwwVKtwbCnftXG9NRyNf