### PR TITLE
Add --memory-limit option to inspector commands

### DIFF
--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -57,6 +57,12 @@ psql reli_memory -c "SELECT * FROM location_types_summary ORDER BY memory_usage 
 | `--db-user` | (required) | Database user |
 | `--db-password` | (empty) | Database password |
 
+### PHP memory limit
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--memory-limit` | — | Set PHP memory_limit for analysis (e.g. 2G, 512M) |
+
 All other options of `inspector:memory` work the same regardless of output format.
 
 ## Database Schema

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -75,6 +75,7 @@ Options:
   -V, --version                                                      Display this application version
       --ansi|--no-ansi                                               Force (or disable --no-ansi) ANSI output
   -n, --no-interaction                                               Do not ask any interactive question
+      --memory-limit=MEMORY-LIMIT                                     set PHP memory_limit for analysis (e.g. 2G, 512M)
   -v|vv|vvv, --verbose                                               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 ```

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -273,7 +273,7 @@ reli inspector:watch --target-regex="php-fpm" \
   --log-file=/var/log/reli-watch.log
 ```
 
-Each discovered process gets its own worker that independently reads heap stats, evaluates triggers, and applies cooldown. Only trigger events are sent back to the controller.
+Each discovered process gets its own worker that independently reads heap stats, evaluates triggers, and applies cooldown. Only trigger events are sent back to the controller. The `--memory-limit` option is propagated to each worker process.
 
 Global `--max-triggers` (or `--oneshot`) is a single counter across all workers.
 
@@ -311,6 +311,7 @@ Global `--max-triggers` (or `--oneshot`) is a single counter across all workers.
 | `--max-dump-size` | `1G` | Cumulative dump file size limit |
 | `--max-triggers` | `0` | Total trigger limit (0=unlimited) |
 | `--oneshot` | — | Alias for --max-triggers |
+| `--memory-limit` | — | Set PHP memory_limit (e.g. 2G, 512M) |
 | `--quiet-watch` | off | Suppress terminal status output |
 | `-S, --stop-process` | off | Stop target with ptrace during reads |
 | `-T, --threads` | `8` | Worker count (daemon mode) |

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -71,11 +71,22 @@ final class CoreDumpCommand extends Command
             'dependency root directory'
         );
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -53,11 +53,22 @@ final class MemoryAnalyzeCommand extends Command
             'dependency root directory (for read-only segment fallback)'
         );
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -63,11 +63,22 @@ final class MemoryCommand extends Command
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -38,12 +38,24 @@ final class MemoryDbOptimizeCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'run ID to materialize (default: all runs)',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
+
         $db_path = $input->getArgument('db-path');
         assert(is_string($db_path));
 

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -64,6 +64,12 @@ final class MemoryDumpCommand extends Command
             InputOption::VALUE_NONE,
             'disable the binary analysis cache',
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
@@ -71,6 +77,11 @@ final class MemoryDumpCommand extends Command
         InputInterface $input,
         OutputInterface $output,
     ): int {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -115,28 +115,20 @@ final class WatchCommand extends Command
         $this->output_settings_from_console_input->setOptions($this);
         $this->daemon_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
         $no_cache = (bool)$input->getOption('no-cache');
         if ($no_cache) {
             $this->binary_analysis_cache->disable();
         }
 
         $watch_settings = $this->watch_settings_from_console_input->createSettings($input);
+        if ($watch_settings->memory_limit !== null) {
+            ini_set('memory_limit', $watch_settings->memory_limit);
+        }
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $output_settings = $this->output_settings_from_console_input->createSettings($input);
 

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -115,11 +115,22 @@ final class WatchCommand extends Command
         $this->output_settings_from_console_input->setOptions($this);
         $this->daemon_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $no_cache = (bool)$input->getOption('no-cache');
         if ($no_cache) {
             $this->binary_analysis_cache->disable();

--- a/src/Inspector/Settings/WatchSettings/WatchSettings.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettings.php
@@ -51,6 +51,7 @@ final class WatchSettings
         public ?string $log_file,
         public ?string $memory_output_format,
         public bool $include_binary = false,
+        public ?string $memory_limit = null,
     ) {
     }
 }

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -173,6 +173,12 @@ final class WatchSettingsFromConsoleInput
                 InputOption::VALUE_NONE,
                 'suppress terminal status output',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
@@ -257,6 +263,7 @@ final class WatchSettingsFromConsoleInput
             ),
             memory_output_format: NullableCast::toString($input->getOption('memory-output-format')),
             include_binary: (bool)$input->getOption('include-binary'),
+            memory_limit: NullableCast::toString($input->getOption('memory-limit')),
         );
     }
 

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -58,6 +58,9 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         Log::debug('watch worker: settings received');
 
         $watch_settings = $settings_message->watch_settings;
+        if ($watch_settings->memory_limit !== null) {
+            ini_set('memory_limit', $watch_settings->memory_limit);
+        }
         $get_trace_settings = $settings_message->get_trace_settings;
 
         // Build triggers from settings

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -46,6 +46,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'status-interval' => null,
             'quiet-watch' => false,
             'include-binary' => false,
+            'memory-limit' => null,
         ];
         $merged = array_merge($defaults, $overrides);
         $input = Mockery::mock(InputInterface::class);


### PR DESCRIPTION
## Summary
Add a `--memory-limit` command-line option to all inspector commands that allows users to configure PHP's memory limit during analysis execution. This enables running memory-intensive analysis operations with custom memory allocations.

## Key Changes
- Added `--memory-limit` option to 5 inspector commands:
  - `MemoryDbOptimizeCommand`
  - `CoreDumpCommand`
  - `MemoryAnalyzeCommand`
  - `MemoryCommand`
  - `MemoryDumpCommand`

- Each command now:
  - Accepts an optional `--memory-limit` parameter (e.g., `2G`, `512M`)
  - Retrieves the option value in the `execute()` method
  - Applies the memory limit via `ini_set('memory_limit', $memory_limit)` if provided

## Implementation Details
- The option is defined as `InputOption::VALUE_REQUIRED` to accept memory size values
- Implementation includes type safety with `@var string|null` annotations
- Memory limit is only applied if the option is provided and non-empty
- Consistent implementation pattern across all affected commands

https://claude.ai/code/session_01Dg27bT9eoxAqHFLws88FEF