### PR TITLE
Add RSS usage monitoring trigger for watch command

### DIFF
--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -42,9 +42,11 @@ use Reli\Inspector\Watch\CooldownManager;
 use Reli\Inspector\Watch\DiskUsageTracker;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\HeapStatsReader;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Inspector\Watch\TriggerFactory;
 use Reli\Inspector\Watch\VariableReader;
 use Reli\Inspector\Watch\VariableSpec;
+use Reli\Inspector\Watch\Trigger\RssUsageTrigger;
 use Reli\Inspector\Watch\Trigger\TriggerInterface;
 use Reli\Inspector\Watch\Trigger\VariableValueTrigger;
 use Reli\Inspector\Watch\TriggerEvent;
@@ -73,6 +75,7 @@ final class WatchCommand extends Command
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,
         private HeapStatsReader $heap_stats_reader,
+        private RssReader $rss_reader,
         private VariableReader $variable_reader,
         private CallTraceReader $call_trace_reader,
         private TriggerFactory $trigger_factory,
@@ -176,11 +179,15 @@ final class WatchCommand extends Command
 
         // Check what each trigger needs
         $needs_call_trace = false;
+        $needs_rss = false;
         /** @var list<VariableSpec> $var_specs */
         $var_specs = [];
         foreach ($triggers as $trigger) {
             if ($trigger->requiresCallTrace()) {
                 $needs_call_trace = true;
+            }
+            if ($trigger instanceof RssUsageTrigger) {
+                $needs_rss = true;
             }
             if ($trigger instanceof VariableValueTrigger) {
                 $var_specs[] = new VariableSpec(
@@ -264,6 +271,7 @@ final class WatchCommand extends Command
                 $depth,
                 $stop_process,
                 $needs_call_trace,
+                $needs_rss,
                 $var_specs,
                 $triggers,
                 $actions,
@@ -335,6 +343,11 @@ final class WatchCommand extends Command
                                 $cg_address,
                             );
                     }
+
+                    $rss_bytes = null;
+                    if ($needs_rss) {
+                        $rss_bytes = $this->rss_reader->read($process_specifier->pid);
+                    }
                 } catch (\Throwable) {
                     // Target may be between requests or temporarily
                     // unreadable. Skip this poll, try next cycle.
@@ -349,6 +362,7 @@ final class WatchCommand extends Command
                     timestamp: $now,
                     previous: $previous_context,
                     variable_values: $variable_values,
+                    rss_bytes: $rss_bytes,
                 );
 
                 // Evaluate triggers — collect all fired events in this poll

--- a/src/Inspector/Settings/WatchSettings/WatchSettings.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettings.php
@@ -39,6 +39,7 @@ final class WatchSettings
         public ?int $memory_usage_bytes,
         public ?string $memory_growth_rate,
         public bool $memory_peak_watch,
+        public ?int $rss_usage_bytes,
         public ?string $watch_function,
         public ?int $trace_depth_limit,
         /** @var list<string> Variable watch expressions (scope::name:op:value) */

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -47,6 +47,12 @@ final class WatchSettingsFromConsoleInput
                 'trigger when memory peak is updated',
             )
             ->addOption(
+                'rss-usage',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'trigger when RSS (Resident Set Size) exceeds this limit (e.g., 512M)',
+            )
+            ->addOption(
                 'watch-function',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -175,6 +181,9 @@ final class WatchSettingsFromConsoleInput
         $memory_usage_str = NullableCast::toString($input->getOption('memory-usage'));
         $memory_usage_bytes = $memory_usage_str !== null ? HeapStats::parseSize($memory_usage_str) : null;
 
+        $rss_usage_str = NullableCast::toString($input->getOption('rss-usage'));
+        $rss_usage_bytes = $rss_usage_str !== null ? HeapStats::parseSize($rss_usage_str) : null;
+
         $memory_growth_rate = NullableCast::toString($input->getOption('memory-growth-rate'));
         if ($memory_growth_rate !== null) {
             // Validate the format early
@@ -230,6 +239,7 @@ final class WatchSettingsFromConsoleInput
             memory_usage_bytes: $memory_usage_bytes,
             memory_growth_rate: $memory_growth_rate,
             memory_peak_watch: (bool)$input->getOption('memory-peak-watch'),
+            rss_usage_bytes: $rss_usage_bytes,
             watch_function: NullableCast::toString($input->getOption('watch-function')),
             trace_depth_limit: $trace_depth_limit,
             watch_var: array_values(array_filter(

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -119,6 +119,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                 while ($this->loop_condition->shouldContinue()) {
                     $now = microtime(true);
                     $call_trace = null;
+                    $rss_bytes = null;
 
                     // Read process state. Skip poll on failure
                     // (target may be between requests).
@@ -152,7 +153,6 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                                 );
                         }
 
-                        $rss_bytes = null;
                         if ($needs_rss) {
                             $rss_bytes = $this->rss_reader->read($descriptor->pid);
                         }

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -19,12 +19,14 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\HeapStatsReader;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Inspector\Watch\VariableReader;
 use Reli\Inspector\Watch\VariableSpec;
 use Reli\Inspector\Watch\Trigger\FunctionDetectionTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryGrowthRateTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryUsageTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryPeakTrigger;
+use Reli\Inspector\Watch\Trigger\RssUsageTrigger;
 use Reli\Inspector\Watch\Trigger\TraceDepthTrigger;
 use Reli\Inspector\Watch\Trigger\TriggerInterface;
 use Reli\Inspector\Watch\Trigger\VariableValueTrigger;
@@ -41,6 +43,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
 {
     public function __construct(
         private HeapStatsReader $heap_stats_reader,
+        private RssReader $rss_reader,
         private CallTraceReader $call_trace_reader,
         private VariableReader $variable_reader,
         private PhpWatchWorkerProtocolInterface $protocol,
@@ -60,11 +63,15 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         // Build triggers from settings
         $triggers = $this->buildTriggers($watch_settings);
         $needs_call_trace = false;
+        $needs_rss = false;
         /** @var list<VariableSpec> $var_specs */
         $var_specs = [];
         foreach ($triggers as $trigger) {
             if ($trigger->requiresCallTrace()) {
                 $needs_call_trace = true;
+            }
+            if ($trigger instanceof RssUsageTrigger) {
+                $needs_rss = true;
             }
             if ($trigger instanceof VariableValueTrigger) {
                 $var_specs[] = new VariableSpec(
@@ -144,6 +151,11 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                                     $descriptor->eg_address,
                                 );
                         }
+
+                        $rss_bytes = null;
+                        if ($needs_rss) {
+                            $rss_bytes = $this->rss_reader->read($descriptor->pid);
+                        }
                     } catch (\Throwable) {
                         $consecutive_failures++;
                         if ($consecutive_failures >= $max_consecutive_failures) {
@@ -169,6 +181,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                         timestamp: $now,
                         previous: $previous_context,
                         variable_values: $variable_values,
+                        rss_bytes: $rss_bytes,
                     );
 
                     // Evaluate triggers (with cooldown/rate limiting in worker)
@@ -224,6 +237,9 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         }
         if ($settings->memory_peak_watch) {
             $triggers[] = new MemoryPeakTrigger();
+        }
+        if ($settings->rss_usage_bytes !== null) {
+            $triggers[] = new RssUsageTrigger($settings->rss_usage_bytes);
         }
         if ($settings->watch_function !== null) {
             $triggers[] = new FunctionDetectionTrigger($settings->watch_function);

--- a/src/Inspector/Watch/RssReader.php
+++ b/src/Inspector/Watch/RssReader.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Reads RSS (Resident Set Size) from /proc/[pid]/statm.
+ *
+ * /proc/[pid]/statm fields (all in pages):
+ *   0: total program size
+ *   1: resident set size (RSS)
+ *   2: shared pages
+ *   3: text (code)
+ *   4: lib (unused since Linux 2.6)
+ *   5: data + stack
+ *   6: dirty pages (unused since Linux 2.6)
+ */
+final class RssReader
+{
+    private int $page_size;
+
+    public function __construct()
+    {
+        $page_size = \posix_sysconf(\POSIX_SC_PAGESIZE);
+        if ($page_size === false || $page_size <= 0) {
+            $page_size = 4096;
+        }
+        $this->page_size = $page_size;
+    }
+
+    /**
+     * Read RSS in bytes for the given PID.
+     *
+     * @return int|null RSS in bytes, or null if unreadable
+     */
+    public function read(int $pid): ?int
+    {
+        $content = @\file_get_contents("/proc/{$pid}/statm");
+        if ($content === false) {
+            return null;
+        }
+        $fields = \explode(' ', \trim($content));
+        if (!isset($fields[1])) {
+            return null;
+        }
+        return (int)$fields[1] * $this->page_size;
+    }
+}

--- a/src/Inspector/Watch/RssReader.php
+++ b/src/Inspector/Watch/RssReader.php
@@ -32,7 +32,8 @@ final class RssReader
     public function __construct()
     {
         $page_size = \posix_sysconf(\POSIX_SC_PAGESIZE);
-        if ($page_size === false || $page_size <= 0) {
+        /** @psalm-suppress TypeDoesNotContainType posix_sysconf can return -1 on error */
+        if ($page_size <= 0) {
             $page_size = 4096;
         }
         $this->page_size = $page_size;

--- a/src/Inspector/Watch/RssReader.php
+++ b/src/Inspector/Watch/RssReader.php
@@ -31,12 +31,19 @@ final class RssReader
 
     public function __construct()
     {
-        $page_size = \posix_sysconf(\POSIX_SC_PAGESIZE);
-        /** @psalm-suppress TypeDoesNotContainType posix_sysconf can return -1 on error */
-        if ($page_size <= 0) {
-            $page_size = 4096;
+        $this->page_size = self::detectPageSize();
+    }
+
+    private static function detectPageSize(): int
+    {
+        if (\function_exists('posix_sysconf') && \defined('POSIX_SC_PAGESIZE')) {
+            /** @var int $page_size */
+            $page_size = \posix_sysconf(\POSIX_SC_PAGESIZE);
+            if ($page_size > 0) {
+                return $page_size;
+            }
         }
-        $this->page_size = $page_size;
+        return 4096;
     }
 
     /**

--- a/src/Inspector/Watch/Trigger/RssUsageTrigger.php
+++ b/src/Inspector/Watch/Trigger/RssUsageTrigger.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Trigger;
+
+use Reli\Inspector\Watch\HeapStats;
+use Reli\Inspector\Watch\TriggerEvent;
+use Reli\Inspector\Watch\WatchContext;
+
+final class RssUsageTrigger implements TriggerInterface
+{
+    public function __construct(
+        private int $limit_bytes,
+    ) {
+    }
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'rss-usage';
+    }
+
+    #[\Override]
+    public function requiresCallTrace(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function requiresDeepInspection(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function evaluate(WatchContext $context): ?TriggerEvent
+    {
+        if ($context->rss_bytes === null) {
+            return null;
+        }
+        if ($context->rss_bytes > $this->limit_bytes) {
+            return new TriggerEvent(
+                trigger_name: $this->name(),
+                description: sprintf(
+                    'rss=%s>%s',
+                    HeapStats::humanReadableBytes($context->rss_bytes),
+                    HeapStats::humanReadableBytes($this->limit_bytes),
+                ),
+                timestamp: $context->timestamp,
+                value: (float)$context->rss_bytes,
+            );
+        }
+        return null;
+    }
+}

--- a/src/Inspector/Watch/TriggerFactory.php
+++ b/src/Inspector/Watch/TriggerFactory.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Watch\Trigger\FunctionDetectionTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryGrowthRateTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryUsageTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryPeakTrigger;
+use Reli\Inspector\Watch\Trigger\RssUsageTrigger;
 use Reli\Inspector\Watch\Trigger\TraceDepthTrigger;
 use Reli\Inspector\Watch\Trigger\TriggerInterface;
 use Reli\Inspector\Watch\Trigger\VariableValueTrigger;
@@ -45,6 +46,11 @@ final class TriggerFactory
         }
         if ($settings->memory_peak_watch) {
             $triggers[] = new MemoryPeakTrigger();
+        }
+        if ($settings->rss_usage_bytes !== null) {
+            $triggers[] = new RssUsageTrigger(
+                $settings->rss_usage_bytes,
+            );
         }
 
         // Tier 2 triggers

--- a/src/Inspector/Watch/WatchContext.php
+++ b/src/Inspector/Watch/WatchContext.php
@@ -28,6 +28,8 @@ final class WatchContext
         public readonly float $timestamp,
         public readonly ?self $previous,
         public readonly array $variable_values = [],
+        /** RSS (Resident Set Size) in bytes, read from /proc/[pid]/statm */
+        public readonly ?int $rss_bytes = null,
         /** Daemon mode: EG address from WatchTriggerMessage */
         public readonly int $daemon_eg_address = 0,
         /** Daemon mode: CG address from WatchTriggerMessage */

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -26,6 +26,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'memory-usage' => null,
             'memory-growth-rate' => null,
             'memory-peak-watch' => false,
+            'rss-usage' => null,
             'watch-function' => null,
             'trace-depth-limit' => null,
             'watch-var' => [],

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsTest.php
@@ -33,6 +33,7 @@ class WatchSettingsTest extends TestCase
             memory_usage_bytes: 256 * 1024 * 1024,
             memory_growth_rate: '10M/min',
             memory_peak_watch: true,
+            rss_usage_bytes: null,
             watch_function: 'sleep',
             trace_depth_limit: 200,
             watch_var: ['global::x:gt:0'],

--- a/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
+++ b/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
@@ -48,6 +48,7 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
             'memory_usage_bytes' => null,
             'memory_growth_rate' => null,
             'memory_peak_watch' => false,
+            'rss_usage_bytes' => null,
             'watch_function' => null,
             'trace_depth_limit' => null,
             'watch_var' => [],

--- a/tests/Inspector/Watch/ActionFactoryTest.php
+++ b/tests/Inspector/Watch/ActionFactoryTest.php
@@ -45,6 +45,7 @@ class ActionFactoryTest extends BaseTestCase
             'memory_usage_bytes' => null,
             'memory_growth_rate' => null,
             'memory_peak_watch' => false,
+            'rss_usage_bytes' => null,
             'watch_function' => null,
             'trace_depth_limit' => null,
             'watch_var' => [],

--- a/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
+++ b/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
@@ -191,6 +191,7 @@ final class PhpWatchControllerTest extends BaseTestCase
             memory_usage_bytes: null,
             memory_growth_rate: null,
             memory_peak_watch: false,
+            rss_usage_bytes: null,
             watch_function: null,
             trace_depth_limit: null,
             watch_var: [],

--- a/tests/Inspector/Watch/Daemon/Protocol/Message/WatchMessagesTest.php
+++ b/tests/Inspector/Watch/Daemon/Protocol/Message/WatchMessagesTest.php
@@ -97,6 +97,7 @@ class WatchMessagesTest extends TestCase
             memory_usage_bytes: null,
             memory_growth_rate: null,
             memory_peak_watch: false,
+            rss_usage_bytes: null,
             watch_function: null,
             trace_depth_limit: null,
             watch_var: [],

--- a/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
+++ b/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
@@ -49,6 +49,7 @@ class PhpWatchEntryPointRunTest extends TestCase
                 memory_usage_bytes: 1024 * 1024,
                 memory_growth_rate: null,
                 memory_peak_watch: false,
+                rss_usage_bytes: null,
                 watch_function: null,
                 trace_depth_limit: null,
                 watch_var: [],
@@ -126,6 +127,7 @@ class PhpWatchEntryPointRunTest extends TestCase
 
         $entry_point = new PhpWatchEntryPoint(
             heap_stats_reader: $this->createFailingHeapStatsReader(),
+            rss_reader: new \Reli\Inspector\Watch\RssReader(),
             call_trace_reader: $this->createCallTraceReader(),
             variable_reader: $this->createVariableReader(),
             protocol: $protocol,
@@ -150,6 +152,7 @@ class PhpWatchEntryPointRunTest extends TestCase
 
         $entry_point = new PhpWatchEntryPoint(
             heap_stats_reader: $this->createFailingHeapStatsReader(),
+            rss_reader: new \Reli\Inspector\Watch\RssReader(),
             call_trace_reader: $this->createCallTraceReader(),
             variable_reader: $this->createVariableReader(),
             protocol: $protocol,

--- a/tests/Inspector/Watch/Trigger/RssUsageTriggerTest.php
+++ b/tests/Inspector/Watch/Trigger/RssUsageTriggerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Trigger;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\Watch\HeapStats;
+use Reli\Inspector\Watch\WatchContext;
+
+class RssUsageTriggerTest extends TestCase
+{
+    public function testFiresWhenAboveLimit(): void
+    {
+        $trigger = new RssUsageTrigger(100 * 1024 * 1024); // 100M
+        $context = $this->makeContext(150 * 1024 * 1024);
+
+        $event = $trigger->evaluate($context);
+        $this->assertNotNull($event);
+        $this->assertSame('rss-usage', $event->trigger_name);
+        $this->assertSame((float)(150 * 1024 * 1024), $event->value);
+    }
+
+    public function testDoesNotFireWhenBelowLimit(): void
+    {
+        $trigger = new RssUsageTrigger(100 * 1024 * 1024);
+        $context = $this->makeContext(50 * 1024 * 1024);
+
+        $this->assertNull($trigger->evaluate($context));
+    }
+
+    public function testDoesNotFireWhenExactlyAtLimit(): void
+    {
+        $trigger = new RssUsageTrigger(100 * 1024 * 1024);
+        $context = $this->makeContext(100 * 1024 * 1024);
+
+        $this->assertNull($trigger->evaluate($context));
+    }
+
+    public function testDoesNotFireWhenRssIsNull(): void
+    {
+        $trigger = new RssUsageTrigger(100 * 1024 * 1024);
+        $context = new WatchContext(
+            pid: 1234,
+            heap_stats: new HeapStats(0, 0, 0, 0),
+            call_trace: null,
+            timestamp: microtime(true),
+            previous: null,
+            rss_bytes: null,
+        );
+
+        $this->assertNull($trigger->evaluate($context));
+    }
+
+    public function testProperties(): void
+    {
+        $trigger = new RssUsageTrigger(1024);
+        $this->assertSame('rss-usage', $trigger->name());
+        $this->assertFalse($trigger->requiresCallTrace());
+        $this->assertFalse($trigger->requiresDeepInspection());
+    }
+
+    private function makeContext(int $rss_bytes): WatchContext
+    {
+        return new WatchContext(
+            pid: 1234,
+            heap_stats: new HeapStats(0, 0, 0, 0),
+            call_trace: null,
+            timestamp: microtime(true),
+            previous: null,
+            rss_bytes: $rss_bytes,
+        );
+    }
+}

--- a/tests/Inspector/Watch/TriggerFactoryTest.php
+++ b/tests/Inspector/Watch/TriggerFactoryTest.php
@@ -40,6 +40,7 @@ class TriggerFactoryTest extends TestCase
             'memory_usage_bytes' => null,
             'memory_growth_rate' => null,
             'memory_peak_watch' => false,
+            'rss_usage_bytes' => null,
             'watch_function' => null,
             'trace_depth_limit' => null,
             'watch_var' => [],

--- a/tests/Inspector/Watch/WatchPipelineTest.php
+++ b/tests/Inspector/Watch/WatchPipelineTest.php
@@ -175,6 +175,7 @@ class WatchPipelineTest extends TestCase
             memory_usage_bytes: 1024,
             memory_growth_rate: null,
             memory_peak_watch: true,
+            rss_usage_bytes: null,
             watch_function: null,
             trace_depth_limit: null,
             watch_var: [],


### PR DESCRIPTION
## Summary
This PR adds RSS (Resident Set Size) memory monitoring capabilities to the watch command, allowing users to trigger profiling when a process's resident memory exceeds a specified threshold.

## Key Changes
- **New `RssReader` class**: Reads RSS memory usage from `/proc/[pid]/statm` on Linux systems, converting page counts to bytes using the system page size
- **New `RssUsageTrigger` class**: Implements a trigger that fires when RSS memory exceeds a configured limit, with human-readable descriptions of memory usage
- **CLI option `--rss-usage`**: Added to `WatchCommand` and `WatchSettingsFromConsoleInput` to accept RSS threshold values (e.g., "512M")
- **Integration with watch infrastructure**: 
  - Updated `WatchContext` to include optional `rss_bytes` field
  - Updated `WatchSettings` to include `rss_usage_bytes` configuration
  - Modified `PhpWatchEntryPoint` and `WatchCommand` to conditionally read RSS when needed
  - Updated `TriggerFactory` to instantiate `RssUsageTrigger` from settings
- **Comprehensive test coverage**: Added `RssUsageTriggerTest` with tests for threshold behavior, null handling, and trigger properties

## Implementation Details
- RSS reading is only performed when an `RssUsageTrigger` is active (lazy evaluation)
- The trigger uses `>` comparison (strict greater than), so exact threshold values don't trigger
- Null RSS values are safely handled (returns null event)
- Uses existing `HeapStats::humanReadableBytes()` for consistent memory formatting in descriptions
- Follows the existing trigger interface pattern with `requiresCallTrace()` and `requiresDeepInspection()` returning false

https://claude.ai/code/session_01PTaB3vHWPSZXfPiuExrsYh