### PR TITLE
Add RSS usage trigger to watch command documentation

### DIFF
--- a/docs/internals/watch-command-architecture.md
+++ b/docs/internals/watch-command-architecture.md
@@ -22,6 +22,7 @@ WatchCommand::execute()
   ├── PhpGlobalsFinder → EG, SG, CG addresses
   └── LoopBuilder middleware chain:
        ├── HeapStatsReader::read()              (always, Tier 1)
+       ├── RssReader::read()                    (if RssUsageTrigger)
        ├── CallTraceReader::readCallTrace()     (if Tier 2 trigger)
        ├── HeapStatsReader::hasException()      (if ExceptionDetectionTrigger)
        ├── VariableReader::readVariables()      (if VariableValueTrigger)
@@ -56,7 +57,7 @@ WatchCommand::executeDaemonMode()
 
 | Tier | What's Read | Cost | Triggers |
 |------|-------------|------|----------|
-| 1 | ZendMmHeap stats only | < 1ms | MemoryLimit, GrowthRate, PeakWatch |
+| 1 | ZendMmHeap stats only | < 1ms | MemoryLimit, GrowthRate, PeakWatch, RssUsage |
 | 2 | + Call trace | ~ms | FunctionDetection, TraceDepth |
 | 3 | + EG exception, variables | ~10ms | ExceptionDetection, VariableValue |
 

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -60,6 +60,17 @@ reli inspector:watch -p <pid> --memory-peak-watch
 
 Note: with exponential backoff cooldown, frequent peak updates are naturally throttled.
 
+### RSS Usage (`--rss-usage=<size>`)
+
+Fires when the process's RSS (Resident Set Size) exceeds the threshold. Unlike `--memory-usage` which monitors PHP's internal heap, this monitors the actual physical memory used by the process as reported by the OS (`/proc/[pid]/statm`).
+
+```bash
+reli inspector:watch -p <pid> --rss-usage=512M
+reli inspector:watch -p <pid> --rss-usage=1G
+```
+
+This is useful for detecting memory usage that occurs outside the Zend heap (e.g., FFI allocations, shared memory, memory-mapped files, or native extensions).
+
 ### Function Detection (`--watch-function=<name>`)
 
 Fires when the specified function appears in the call stack. Requires the **fully qualified function name** (exact match).
@@ -296,6 +307,7 @@ Global `--max-triggers` (or `--oneshot`) is a single counter across all workers.
 | `--memory-usage` | — | Trigger on heap usage threshold |
 | `--memory-growth-rate` | — | Trigger on memory growth rate |
 | `--memory-peak-watch` | off | Trigger on peak memory update |
+| `--rss-usage` | — | Trigger on RSS (Resident Set Size) threshold |
 | `--watch-function` | — | Trigger on function in call stack |
 | `--trace-depth-limit` | — | Trigger on call stack depth |
 | `--watch-var` | — | Trigger on variable value condition (repeatable) |


### PR DESCRIPTION
## Summary
- Add `--rss-usage` section to `docs/watch-command.md` with usage examples and explanation of RSS vs heap monitoring
- Add `--rss-usage` to the All Options table
- Update `docs/internals/watch-command-architecture.md`: add `RssUsage` to Tier 1 trigger table and `RssReader::read()` to the data flow diagram

Follow-up to #573 which added the RSS monitoring implementation.

https://claude.ai/code/session_01PTaB3vHWPSZXfPiuExrsYh