### PR TITLE
Fix assignNodeId causing parent nodes to be missing from DB

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -51,6 +51,10 @@ final class ContextAnalyzer
      * without emitting it yet. Used by the collector to register parent
      * nodes before their children are collected and emitted.
      *
+     * The node_id is stored as negative in the memo to distinguish it
+     * from fully-emitted nodes. analyzeContext will detect this and
+     * emit the node properly.
+     *
      * @param WeakMap<ReferenceContext, int> $memo
      */
     public function assignNodeId(
@@ -59,10 +63,11 @@ final class ContextAnalyzer
     ): int {
         $existing = $memo[$context] ?? null;
         if ($existing !== null) {
-            return $existing;
+            return $existing < 0 ? -$existing - 1 : $existing;
         }
         $node_id = $this->node_id++;
-        $memo[$context] = $node_id;
+        // Store as negative-minus-1 to indicate "reserved but not emitted"
+        $memo[$context] = -$node_id - 1;
         return $node_id;
     }
 
@@ -104,12 +109,18 @@ final class ContextAnalyzer
         }
 
         $existing_node_id = $memo[$linked_context] ?? null;
-        if ($existing_node_id !== null) {
+        if ($existing_node_id !== null && $existing_node_id >= 0) {
+            // Fully emitted — just add a reference edge
             $sink->emitReference($existing_node_id, $parent_node_id, $link_name);
             return;
         }
 
-        $current_node_id = $this->node_id++;
+        if ($existing_node_id !== null && $existing_node_id < 0) {
+            // Reserved by assignNodeId but not yet emitted — use the reserved id
+            $current_node_id = -$existing_node_id - 1;
+        } else {
+            $current_node_id = $this->node_id++;
+        }
         $memo[$linked_context] = $current_node_id;
 
         $contexts = $linked_context->getContexts();


### PR DESCRIPTION
## Summary

Fixes a bug where parent nodes (ObjectsStoreContext, DefinedFunctionsContext, etc.) registered via `registerParentIfStreaming` → `assignNodeId` were missing from the DB in streaming mode.

## Root cause

`assignNodeId()` stored the node_id in the analyzer's `WeakMap` memo. When `analyzeSingleLink()` later processed the same context, `analyzeContext()` found the memo entry and treated it as "already fully emitted" — emitting only a reference edge and skipping `emitNode()` entirely. The node's type, locations, and attributes were never written to the DB.

## Fix

`assignNodeId()` now stores the node_id encoded as `-node_id - 1` (negative) to distinguish "reserved but not yet emitted" from "fully emitted" (positive). `analyzeContext()` detects the negative value, recovers the reserved node_id, and proceeds with full `emitNode()` + subtree traversal.

## Test plan

- [x] Psalm clean
- [x] phpcs clean
- [x] Unit tests pass (123 tests)
- [x] Verified with manual test: ObjectsStoreContext node now appears in DB after `registerParentIfStreaming` + `analyzeSingleLink`

https://claude.ai/code/session_01Ut7jcstJVKYybPuYw3RrsH