### PR TITLE
Implement SCC address unification and canonical-aware report passes

### DIFF
--- a/docs/memory-profiler-database.md
+++ b/docs/memory-profiler-database.md
@@ -136,6 +136,7 @@ Each node represents a unique context (object, array, string, etc.) in the memor
 | `run_id` | INTEGER (PK) | References `runs.run_id` |
 | `node_id` | INTEGER (PK) | Unique node identifier within this run (same as `#node_id` in JSON) |
 | `type` | TEXT | Context type (e.g. `ObjectContext`, `ArrayHeaderContext`) |
+| `canonical_node_id` | INTEGER | Representative node_id for nodes sharing the same memory address. NULL if this node's address is unique. When non-NULL, groups nodes that represent the same PHP value observed from different collection phases (e.g. objects_store vs call_frames in streaming mode). Used for SCC (cycle) detection across collection phases. |
 
 #### `context_edges`
 Edges represent parent-child relationships in the reference graph. A node may have multiple incoming edges (shared references).
@@ -147,6 +148,7 @@ Edges represent parent-child relationships in the reference graph. A node may ha
 | `child_node_id` | INTEGER | Child node (references `context_nodes.node_id`) |
 | `link_name` | TEXT | Name of the link (e.g. property name, variable name, array key) |
 | `is_tree` | INTEGER | `1` = DFS first-visit (spanning tree edge), `0` = back-reference (shared/circular) |
+| `strength` | TEXT | Reference strength: `strong` (default, increments refcount), `weak` (objects_store bucket, no refcount), `structural` (VM internals like object_handlers, class_entry) |
 
 The `is_tree` flag distinguishes the DFS spanning tree from back-references:
 - `is_tree = 1` edges form a tree where each node has exactly one parent — use these for canonical path queries
@@ -157,6 +159,15 @@ The `is_tree` flag distinguishes the DFS spanning tree from back-references:
 SELECT parent_node_id, link_name, is_tree
 FROM context_edges
 WHERE run_id = 1 AND child_node_id = 42;
+
+-- Find strong non-tree edges (true shared references, excluding VM internals)
+SELECT parent_node_id, child_node_id, link_name
+FROM context_edges
+WHERE run_id = 1 AND is_tree = 0 AND strength = 'strong';
+
+-- Find all graph nodes that represent the same PHP object
+SELECT node_id, type FROM context_nodes
+WHERE run_id = 1 AND canonical_node_id = 100;
 ```
 
 #### `context_node_locations`
@@ -196,6 +207,10 @@ The following indexes are created after bulk insertion for query performance:
 - `idx_context_node_locations_run_node` on `context_node_locations(run_id, node_id)` -- essential for joining locations to nodes
 - `idx_context_node_locations_run_class` on `context_node_locations(run_id, class_name)` -- speeds up class-based queries
 - `idx_context_node_attributes_run_node` on `context_node_attributes(run_id, node_id)` -- for attribute lookups
+- `idx_context_node_locations_run_type` on `context_node_locations(run_id, location_type)` -- type-based filtering
+- `idx_context_edges_run_link_parent_tree` on `context_edges(run_id, link_name, parent_node_id, is_tree)` -- link-based queries
+- `idx_context_edges_run_strength` on `context_edges(run_id, strength)` -- strength-based filtering
+- `idx_context_nodes_canonical` on `context_nodes(run_id, canonical_node_id)` -- canonical node lookups for SCC
 
 ### Views
 

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -74,6 +74,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
             $this->insertLocationTypesSummaryFromDb($db, $run_id);
             $this->insertClassObjectsSummaryFromDb($db, $run_id);
+            $this->computeCanonicalNodeIds($db, $run_id);
 
             $db->commit();
         } catch (\Throwable $e) {
@@ -116,6 +117,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $this->insertSummary($db, $run_id, $summary);
         $this->insertLocationTypesSummaryFromDb($db, $run_id);
         $this->insertClassObjectsSummaryFromDb($db, $run_id);
+        $this->computeCanonicalNodeIds($db, $run_id);
         $db->commit();
         $this->driver->afterBulkInsert($db);
         $this->createIndexes($db);
@@ -169,6 +171,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 run_id INTEGER NOT NULL,
                 node_id INTEGER NOT NULL,
                 type TEXT NOT NULL,
+                canonical_node_id INTEGER,
                 PRIMARY KEY (run_id, node_id)
             )
         ');
@@ -244,6 +247,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $db->exec(
             'CREATE INDEX IF NOT EXISTS idx_context_edges_run_strength'
             . ' ON context_edges(run_id, strength)'
+        );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_nodes_canonical'
+            . ' ON context_nodes(run_id, canonical_node_id)'
         );
     }
 
@@ -365,6 +372,43 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     }
 
     /**
+     * Compute canonical_node_id for nodes that share the same memory address.
+     *
+     * When the same PHP object is observed from multiple collection phases
+     * (e.g. objects_store and call_frames in streaming mode), each phase
+     * creates a separate graph node. This method groups those nodes by their
+     * memory address and assigns the smallest node_id in each group as the
+     * canonical representative.
+     *
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     */
+    private function computeCanonicalNodeIds(\PDO $db, int $run_id): void
+    {
+        $rows = $db->query(
+            "SELECT address, GROUP_CONCAT(DISTINCT node_id) AS node_ids"
+            . " FROM context_node_locations"
+            . " WHERE run_id = {$run_id} AND address IS NOT NULL"
+            . " GROUP BY address"
+            . " HAVING COUNT(DISTINCT node_id) > 1"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        if (!$rows) {
+            return;
+        }
+
+        $stmt = $db->prepare(
+            "UPDATE context_nodes SET canonical_node_id = ? WHERE run_id = ? AND node_id = ?"
+        );
+        foreach ($rows as $r) {
+            $node_ids = array_map('intval', explode(',', (string)$r[1]));
+            $canon = min($node_ids);
+            foreach ($node_ids as $nid) {
+                $stmt->execute([$canon, $run_id, $nid]);
+            }
+        }
+    }
+
+    /**
      * Copy all data from a pre-populated (temp) SQLite DB to the target DB.
      */
     private function copyFromPrePopulatedDb(\PDO $source, int $source_run_id, \PDO $target): void
@@ -386,15 +430,21 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         }
 
         // Copy context_nodes
-        $rows = $source->prepare('SELECT node_id, type FROM context_nodes WHERE run_id = ?');
+        $rows = $source->prepare(
+            'SELECT node_id, type, canonical_node_id FROM context_nodes WHERE run_id = ?'
+        );
         $rows->execute([$source_run_id]);
         $insert = $target->prepare(
-            $this->driver->insertIgnoreSql('context_nodes', 'run_id, node_id, type', '?, ?, ?')
+            $this->driver->insertIgnoreSql(
+                'context_nodes',
+                'run_id, node_id, type, canonical_node_id',
+                '?, ?, ?, ?'
+            )
         );
         /** @psalm-suppress MixedAssignment */
         while ($row = $rows->fetch(\PDO::FETCH_ASSOC)) {
             /** @psalm-suppress MixedArrayAccess */
-            $insert->execute([$run_id, $row['node_id'], $row['type']]);
+            $insert->execute([$run_id, $row['node_id'], $row['type'], $row['canonical_node_id']]);
         }
 
         // Copy context_edges

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
@@ -77,10 +77,28 @@ final class BlameAllocationPass implements PassInterface
             $blame[$root] = ['exclusive' => 0, 'shared' => 0, 'nodes' => 0];
         }
 
+        // Track which canonicals have been blamed to avoid double-counting
+        $blamed_canonicals = [];
+
         foreach ($this->substrate->iterateNodeSizes() as $node => $size) {
             if ($size === 0) {
                 continue;
             }
+
+            // Skip non-canonical duplicates to avoid double-counting
+            $canon = $this->substrate->getCanonical($node);
+            if (isset($blamed_canonicals[$canon])) {
+                continue;
+            }
+            $blamed_canonicals[$canon] = true;
+
+            // Sum sizes across all nodes in the canonical group
+            $group = $this->substrate->getCanonicalGroup($node);
+            $group_size = 0;
+            foreach ($group as $gnode) {
+                $group_size += $this->substrate->getNodeSize($gnode);
+            }
+
             $owner = $node_root_owner[$node] ?? null;
             if ($owner === null) {
                 continue;
@@ -89,7 +107,7 @@ final class BlameAllocationPass implements PassInterface
             $in_count = $incoming_count[$node] ?? 1;
 
             if ($in_count <= 1) {
-                $blame[$owner]['exclusive'] += $size;
+                $blame[$owner]['exclusive'] += $group_size;
                 $blame[$owner]['nodes']++;
             } else {
                 $owner_shares = [];
@@ -104,10 +122,10 @@ final class BlameAllocationPass implements PassInterface
                 }
                 $total_shares = array_sum($owner_shares);
                 if ($total_shares === 0) {
-                    $blame[$owner]['exclusive'] += $size;
+                    $blame[$owner]['exclusive'] += $group_size;
                 } else {
                     foreach ($owner_shares as $share_owner => $share_count) {
-                        $fraction = $size * $share_count / $total_shares;
+                        $fraction = $group_size * $share_count / $total_shares;
                         if (!isset($blame[$share_owner])) {
                             $blame[$share_owner] = ['exclusive' => 0, 'shared' => 0, 'nodes' => 0];
                         }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -41,6 +41,10 @@ final class ChokePointPass implements PassInterface
     {
         $chokepoints = [];
         foreach ($this->substrate->iterateSubtreeSizes() as $node => $subtree) {
+            // Skip non-canonical duplicates to avoid double-counting
+            if (!$this->substrate->isCanonicalOrUnique($node)) {
+                continue;
+            }
             $shallow = $this->substrate->getNodeSize($node);
             if ($subtree < 1024 * 1024) {
                 continue;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -53,6 +53,7 @@ final class DrillDownPass implements PassInterface
         $path_types = [];
         $path_sizes = [];
         $current_children = $this->substrate->getRoots();
+        $visited_canonicals = [];
 
         for ($depth = 0; $depth < 12; $depth++) {
             if (empty($current_children)) {
@@ -61,12 +62,20 @@ final class DrillDownPass implements PassInterface
 
             $branches = [];
             foreach ($current_children as $child_id) {
+                $canon = $this->substrate->getCanonical($child_id);
+                if (isset($visited_canonicals[$canon])) {
+                    continue;
+                }
                 $size = $this->substrate->getSubtreeSize($child_id);
-                $branches[] = [$child_id, $size];
+                $branches[] = [$child_id, $size, $canon];
+            }
+            if (empty($branches)) {
+                break;
             }
             usort($branches, fn($a, $b) => $b[1] <=> $a[1]);
 
             $heaviest = $branches[0];
+            $visited_canonicals[$heaviest[2]] = true;
             $link_stmt->execute([$heaviest[0]]);
             $r = $link_stmt->fetch(\PDO::FETCH_NUM);
             /** @var string $raw_name */

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/OwnershipPatternPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/OwnershipPatternPass.php
@@ -46,10 +46,13 @@ final class OwnershipPatternPass implements PassInterface
     {
         $link_names = $this->loadLinkNames();
 
-        // Build class instance counts
+        // Build class instance counts (canonical-or-unique only)
         /** @var array<string, int> */
         $class_counts = [];
-        foreach ($this->substrate->iterateNodeClasses() as $cls) {
+        foreach ($this->substrate->iterateNodeClasses() as $node_id => $cls) {
+            if (!$this->substrate->isCanonicalOrUnique($node_id)) {
+                continue;
+            }
             $class_counts[$cls] = ($class_counts[$cls] ?? 0) + 1;
         }
 
@@ -59,6 +62,10 @@ final class OwnershipPatternPass implements PassInterface
         $ownership = [];
 
         foreach ($this->substrate->iterateNodeClasses() as $node_id => $owner_class) {
+            // Skip non-canonical duplicates
+            if (!$this->substrate->isCanonicalOrUnique($node_id)) {
+                continue;
+            }
             foreach ($this->substrate->getChildren($node_id) as $child) {
                 if (($link_names[$child] ?? '') !== 'object_properties') {
                     continue;
@@ -195,7 +202,7 @@ final class OwnershipPatternPass implements PassInterface
         $total = 0;
         $count = 0;
         foreach ($this->substrate->iterateNodeClasses() as $nid => $cls) {
-            if ($cls === $class_name) {
+            if ($cls === $class_name && $this->substrate->isCanonicalOrUnique($nid)) {
                 $total += $this->substrate->getNodeSize($nid);
                 $count++;
                 if ($count >= 10) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -206,16 +206,28 @@ final class PropertyScalingPass implements PassInterface
             if ($cls !== $dominant_class) {
                 continue;
             }
+            // Skip non-canonical duplicates to avoid double-counting instances
+            if (!$this->substrate->isCanonicalOrUnique($node_id)) {
+                continue;
+            }
             foreach ($this->substrate->getChildren($node_id) as $child) {
                 if (($link_names[$child] ?? '') !== 'object_properties') {
                     continue;
                 }
                 // child = ObjectPropertiesContext
+                // Deduplicate property children by canonical
+                $seen_prop_canonicals = [];
                 foreach ($this->substrate->getChildren($child) as $prop_child) {
                     $prop_name = $link_names[$prop_child] ?? null;
                     if ($prop_name === null) {
                         continue;
                     }
+                    $prop_canon = $this->substrate->getCanonical($prop_child);
+                    if (isset($seen_prop_canonicals[$prop_canon])) {
+                        continue;
+                    }
+                    $seen_prop_canonicals[$prop_canon] = true;
+
                     if (!isset($prop_stats[$prop_name])) {
                         $prop_stats[$prop_name] = [
                             'distinct' => [],
@@ -223,7 +235,7 @@ final class PropertyScalingPass implements PassInterface
                             'size' => 0,
                         ];
                     }
-                    $prop_stats[$prop_name]['distinct'][$prop_child] = true;
+                    $prop_stats[$prop_name]['distinct'][$prop_canon] = true;
                     $prop_stats[$prop_name]['total_refs']++;
                     // Use retained if available, else shallow
                     if ($use_retained) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -132,6 +132,11 @@ final class StructuralDedupPass implements PassInterface
         $shape_groups = [];
 
         foreach ($this->substrate->iterateNodeClasses() as $node_id => $class_name) {
+            // Skip non-canonical duplicates: same object from different
+            // collection phases should not count as separate instances
+            if (!$this->substrate->isCanonicalOrUnique($node_id)) {
+                continue;
+            }
             $size = $this->substrate->getNodeSize($node_id);
 
             // Find object_properties child, collect property names

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -79,6 +79,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $substrate = new self();
         $substrate->loadNodeSizesFfi($db, $run_id);
         $substrate->loadEdgesFfi($db, $run_id);
+        $substrate->loadAddressMapping($db, $run_id);
+        $substrate->buildSccAdjacency();
         $substrate->computeSubtreeSizesFfi();
         $substrate->computeSccFfi();
         return $substrate;
@@ -541,6 +543,15 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     /** @psalm-suppress UnsupportedReferenceUsage, MixedArgument */
     private function computeSccFfi(): void
     {
+        $use_unified = $this->scc_adjacency !== [];
+
+        // When using unified adjacency, run Tarjan on canonical node_ids
+        // (not CSR indices) since scc_adjacency uses node_ids.
+        if ($use_unified) {
+            $this->computeSccFfiUnified();
+            return;
+        }
+
         $index_counter = 0;
         $stack = [];
         $on_stack = [];
@@ -609,6 +620,132 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             }
         }
 
+        $this->buildSccProfilesFfi($sccs);
+    }
+
+    /**
+     * SCC computation using unified adjacency (canonical node_ids).
+     * Used when address unification is active.
+     *
+     * @psalm-suppress UnsupportedReferenceUsage, MixedArgument
+     */
+    private function computeSccFfiUnified(): void
+    {
+        // Collect canonical node_ids to visit
+        $canonical_nodes = [];
+        for ($v = 0; $v < $this->nodeCount; $v++) {
+            $nid = (int)$this->indexToNodeFfi[$v];
+            if ($nid === -1) {
+                continue;
+            }
+            $canon = $this->findCanonical($nid);
+            $canonical_nodes[$canon] = true;
+        }
+
+        $index_counter = 0;
+        $stack = [];
+        $on_stack = [];
+        $index = [];
+        $lowlink = [];
+        $sccs = [];
+
+        foreach ($canonical_nodes as $v => $_) {
+            if (isset($index[$v])) {
+                continue;
+            }
+
+            $call_stack = [[$v, 0]];
+            $index[$v] = $lowlink[$v] = $index_counter++;
+            $stack[] = $v;
+            $on_stack[$v] = true;
+
+            while ($call_stack) {
+                [$node, $ci] = array_pop($call_stack);
+                $node_children = $this->scc_adjacency[$node] ?? [];
+                $count = count($node_children);
+
+                $found_unvisited = false;
+                for ($i = $ci; $i < $count; $i++) {
+                    $w = $node_children[$i];
+                    if (!isset($index[$w])) {
+                        $call_stack[] = [$node, $i + 1];
+                        $index[$w] = $lowlink[$w] = $index_counter++;
+                        $stack[] = $w;
+                        $on_stack[$w] = true;
+                        $call_stack[] = [$w, 0];
+                        $found_unvisited = true;
+                        break;
+                    } elseif (isset($on_stack[$w])) {
+                        $lowlink[$node] = min($lowlink[$node], $index[$w]);
+                    }
+                }
+
+                if (!$found_unvisited) {
+                    if ($lowlink[$node] === $index[$node]) {
+                        /** @var list<int> $scc canonical node_ids */
+                        $scc = [];
+                        do {
+                            /** @var int $w */
+                            $w = array_pop($stack);
+                            unset($on_stack[$w]);
+                            $scc[] = $w;
+                        } while ($w !== $node);
+                        if (count($scc) > 1) {
+                            $sccs[] = $scc;
+                        }
+                    }
+                    if ($call_stack) {
+                        $parent_frame = &$call_stack[count($call_stack) - 1];
+                        $lowlink[$parent_frame[0]] = min(
+                            $lowlink[$parent_frame[0]],
+                            $lowlink[$node]
+                        );
+                    }
+                }
+            }
+        }
+
+        // Expand canonical nodes to all originals
+        foreach ($sccs as &$scc) {
+            $expanded = [];
+            foreach ($scc as $canonical) {
+                if (isset($this->canonicalToOriginals[$canonical])) {
+                    foreach ($this->canonicalToOriginals[$canonical] as $orig) {
+                        $expanded[] = $orig;
+                    }
+                } else {
+                    $expanded[] = $canonical;
+                }
+            }
+            $scc = array_values(array_unique($expanded));
+        }
+        unset($scc);
+
+        // Convert node_ids to CSR indices for profile building
+        $csr_sccs = [];
+        foreach ($sccs as $scc_nodes) {
+            $scc_indices = [];
+            foreach ($scc_nodes as $nid) {
+                $idx = $this->nodeIdToIndex($nid);
+                if ($idx >= 0) {
+                    $scc_indices[] = $idx;
+                }
+            }
+            if (count($scc_indices) > 1) {
+                $csr_sccs[] = $scc_indices;
+            }
+        }
+
+        $this->buildSccProfilesFfi($csr_sccs);
+    }
+
+    /**
+     * Build SCC profiles from CSR index-based SCCs.
+     *
+     * @param list<list<int>> $sccs Each SCC is a list of CSR indices
+     */
+    private function buildSccProfilesFfi(array $sccs): void
+    {
         // Build SCC profiles (convert CSR indices back to node IDs)
         foreach ($sccs as $scc_id => $scc_indices) {
             $scc_nodes = [];

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -232,6 +232,37 @@ class GraphSubstrate
         return $this->node_to_scc;
     }
 
+    /**
+     * Whether this node is the canonical representative or has no duplicates.
+     */
+    public function isCanonicalOrUnique(int $nodeId): bool
+    {
+        if (!isset($this->canonical[$nodeId])) {
+            return true;
+        }
+        return $this->findCanonical($nodeId) === $nodeId;
+    }
+
+    /**
+     * Get the canonical node_id for a given node.
+     * Returns the node itself if it has no duplicates.
+     */
+    public function getCanonical(int $nodeId): int
+    {
+        return $this->findCanonical($nodeId);
+    }
+
+    /**
+     * Get all original node_ids that share the same canonical.
+     * Returns [$nodeId] if no duplicates.
+     * @return list<int>
+     */
+    public function getCanonicalGroup(int $nodeId): array
+    {
+        $canon = $this->findCanonical($nodeId);
+        return $this->canonicalToOriginals[$canon] ?? [$canon];
+    }
+
     protected function findCanonical(int $node): int
     {
         if (!isset($this->canonical[$node])) {

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -62,6 +62,15 @@ class GraphSubstrate
 
     public int $edge_count = 0;
 
+    /** @var array<int, int> node_id => canonical node_id (Union-Find parent) */
+    protected array $canonical = [];
+
+    /** @var array<int, list<int>> canonical_node_id => [original_node_id, ...] */
+    protected array $canonicalToOriginals = [];
+
+    /** @var array<int, list<int>> canonical_parent => [canonical_child, ...] for SCC */
+    protected array $scc_adjacency = [];
+
     private const FFI_CSR_THRESHOLD = 2_000_000;
 
     /** @psalm-suppress UnsafeInstantiation */
@@ -70,6 +79,8 @@ class GraphSubstrate
         $substrate = new static();
         $substrate->loadNodeSizes($db, $run_id);
         $substrate->loadEdges($db, $run_id);
+        $substrate->loadAddressMapping($db, $run_id);
+        $substrate->buildSccAdjacency();
         $substrate->computeSubtreeSizes();
         $substrate->computeScc();
         return $substrate;
@@ -221,6 +232,94 @@ class GraphSubstrate
         return $this->node_to_scc;
     }
 
+    protected function findCanonical(int $node): int
+    {
+        if (!isset($this->canonical[$node])) {
+            return $node;
+        }
+        // Path compression
+        while ($this->canonical[$node] !== $node) {
+            $this->canonical[$node] = $this->canonical[$this->canonical[$node]] ?? $this->canonical[$node];
+            $node = $this->canonical[$node];
+        }
+        return $node;
+    }
+
+    protected function union(int $a, int $b): void
+    {
+        $ca = $this->findCanonical($a);
+        $cb = $this->findCanonical($b);
+        if ($ca !== $cb) {
+            // Use smaller node_id as canonical
+            if ($ca > $cb) {
+                [$ca, $cb] = [$cb, $ca];
+            }
+            $this->canonical[$cb] = $ca;
+            $this->canonical[$ca] = $ca;
+        }
+    }
+
+    /**
+     * Load canonical_node_id from DB and build Union-Find structure.
+     *
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
+     */
+    protected function loadAddressMapping(\PDO $db, int $run_id): void
+    {
+        $rows = $db->query(
+            "SELECT node_id, canonical_node_id"
+            . " FROM context_nodes"
+            . " WHERE run_id = {$run_id} AND canonical_node_id IS NOT NULL"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        if (!$rows) {
+            return;
+        }
+
+        foreach ($rows as $r) {
+            $node_id = (int)$r[0];
+            $canon = (int)$r[1];
+            $this->canonical[$node_id] = $canon;
+            $this->canonical[$canon] = $canon;
+        }
+
+        // Build reverse mapping: canonical → [original_node_ids]
+        $this->canonicalToOriginals = [];
+        foreach ($this->canonical as $node => $parent) {
+            $canon = $this->findCanonical($node);
+            $this->canonicalToOriginals[$canon][] = $node;
+        }
+        // Deduplicate
+        foreach ($this->canonicalToOriginals as $canon => $nodes) {
+            $this->canonicalToOriginals[$canon] = array_values(array_unique($nodes));
+        }
+    }
+
+    /**
+     * Build a unified adjacency list for SCC that maps through canonical IDs.
+     */
+    protected function buildSccAdjacency(): void
+    {
+        if ($this->canonical === []) {
+            // No unification needed, SCC uses strong_all_children directly
+            return;
+        }
+
+        foreach ($this->strong_all_children as $parent => $children) {
+            $cp = $this->findCanonical($parent);
+            foreach ($children as $child) {
+                $cc = $this->findCanonical($child);
+                if ($cp !== $cc) {
+                    $this->scc_adjacency[$cp][] = $cc;
+                }
+            }
+        }
+        // Deduplicate
+        foreach ($this->scc_adjacency as $node => $children) {
+            $this->scc_adjacency[$node] = array_values(array_unique($children));
+        }
+    }
+
     /** @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedPropertyTypeCoercion */
     protected function loadNodeSizes(\PDO $db, int $run_id): void
     {
@@ -304,6 +403,18 @@ class GraphSubstrate
     /** @psalm-suppress PossiblyNullArrayOffset, MixedArgument, UnsupportedReferenceUsage */
     protected function computeScc(): void
     {
+        $use_unified = $this->scc_adjacency !== [];
+
+        // When using unified adjacency, iterate over canonical nodes only
+        if ($use_unified) {
+            $nodes_to_visit = array_unique(array_map(
+                fn (int $n): int => $this->findCanonical($n),
+                array_keys($this->node_sizes)
+            ));
+        } else {
+            $nodes_to_visit = array_keys($this->node_sizes);
+        }
+
         $index_counter = 0;
         $stack = [];
         $on_stack = [];
@@ -311,7 +422,7 @@ class GraphSubstrate
         $lowlink = [];
         $sccs = [];
 
-        foreach (array_keys($this->node_sizes) as $v) {
+        foreach ($nodes_to_visit as $v) {
             if (isset($index[$v])) {
                 continue;
             }
@@ -323,7 +434,9 @@ class GraphSubstrate
 
             while ($call_stack) {
                 [$node, $ci] = array_pop($call_stack);
-                $node_children = $this->strong_all_children[$node] ?? [];
+                $node_children = $use_unified
+                    ? ($this->scc_adjacency[$node] ?? [])
+                    : ($this->strong_all_children[$node] ?? []);
 
                 $found_unvisited = false;
                 $count = count($node_children);
@@ -362,6 +475,24 @@ class GraphSubstrate
                     }
                 }
             }
+        }
+
+        // When using unified adjacency, expand canonical nodes back to all originals
+        if ($use_unified) {
+            foreach ($sccs as &$scc) {
+                $expanded = [];
+                foreach ($scc as $canonical) {
+                    if (isset($this->canonicalToOriginals[$canonical])) {
+                        foreach ($this->canonicalToOriginals[$canonical] as $orig) {
+                            $expanded[] = $orig;
+                        }
+                    } else {
+                        $expanded[] = $canonical;
+                    }
+                }
+                $scc = array_values(array_unique($expanded));
+            }
+            unset($scc);
         }
 
         // Build SCC profiles

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
@@ -280,7 +280,8 @@ class GraphSubstrateTest extends BaseTestCase
         // Insert edges: A->B (tree, strong) and B->A (non-tree, strong)
         // In objects_store phase: 100 -> 200
         // In call_frames phase: 600 -> 500
-        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
             (1, NULL, 100, 'objects_store', 1, 'strong'),
             (1, 100, 200, 'next', 1, 'strong'),
             (1, NULL, 500, 'call_frames', 1, 'strong'),
@@ -317,7 +318,8 @@ class GraphSubstrateTest extends BaseTestCase
         ");
 
         // Linear chain: 1 -> 2 -> 3 (no cycle)
-        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
             (1, NULL, 1, 'root', 1, 'strong'),
             (1, 1, 2, 'a', 1, 'strong'),
             (1, 2, 3, 'b', 1, 'strong')
@@ -350,7 +352,8 @@ class GraphSubstrateTest extends BaseTestCase
         ");
 
         // Cycle: 10 -> 20 (tree), 40 -> 30 (non-tree, creates cycle via unification)
-        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
             (1, NULL, 10, 'root', 1, 'strong'),
             (1, 10, 20, 'link', 1, 'strong'),
             (1, NULL, 30, 'root2', 1, 'strong'),
@@ -382,7 +385,8 @@ class GraphSubstrateTest extends BaseTestCase
             (1, 1, 1000, 64, 'ZendObjectMemoryLocation'),
             (1, 2, 2000, 64, 'ZendObjectMemoryLocation')
         ");
-        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
             (1, NULL, 1, 'root', 1, 'strong'),
             (1, 1, 2, 'a', 1, 'strong')
         ");
@@ -411,7 +415,8 @@ class GraphSubstrateTest extends BaseTestCase
             (1, 20, 2000, 64, 'ZendObjectMemoryLocation'),
             (1, 30, 1000, 64, 'ZendObjectMemoryLocation')
         ");
-        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
             (1, NULL, 10, 'root', 1, 'strong'),
             (1, 10, 20, 'a', 1, 'strong'),
             (1, NULL, 30, 'root2', 1, 'strong')

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
@@ -368,6 +368,71 @@ class GraphSubstrateTest extends BaseTestCase
         $this->assertArrayHasKey('App\\Bar', $scc['class_counts']);
     }
 
+    // ---- Phase 2: Canonical helper methods ----
+
+    public function testIsCanonicalOrUniqueReturnsTrueForUniqueNodes(): void
+    {
+        $db = $this->createDirectDb();
+
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 1, 'ObjectContext'),
+            (1, 2, 'ObjectContext')
+        ");
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type) VALUES
+            (1, 1, 1000, 64, 'ZendObjectMemoryLocation'),
+            (1, 2, 2000, 64, 'ZendObjectMemoryLocation')
+        ");
+        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 1, 'root', 1, 'strong'),
+            (1, 1, 2, 'a', 1, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        // No canonical mapping → all nodes are unique
+        $this->assertTrue($substrate->isCanonicalOrUnique(1));
+        $this->assertTrue($substrate->isCanonicalOrUnique(2));
+        $this->assertSame(1, $substrate->getCanonical(1));
+        $this->assertSame([1], $substrate->getCanonicalGroup(1));
+    }
+
+    public function testIsCanonicalOrUniqueWithDuplicates(): void
+    {
+        $db = $this->createDirectDb();
+
+        // Node 10 and 30 share the same address (canonical 10)
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type, canonical_node_id) VALUES
+            (1, 10, 'ObjectContext', 10),
+            (1, 20, 'ObjectContext', NULL),
+            (1, 30, 'ObjectContext', 10)
+        ");
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type) VALUES
+            (1, 10, 1000, 64, 'ZendObjectMemoryLocation'),
+            (1, 20, 2000, 64, 'ZendObjectMemoryLocation'),
+            (1, 30, 1000, 64, 'ZendObjectMemoryLocation')
+        ");
+        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 10, 'root', 1, 'strong'),
+            (1, 10, 20, 'a', 1, 'strong'),
+            (1, NULL, 30, 'root2', 1, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        $this->assertTrue($substrate->isCanonicalOrUnique(10));   // canonical representative
+        $this->assertTrue($substrate->isCanonicalOrUnique(20));   // unique (no duplicates)
+        $this->assertFalse($substrate->isCanonicalOrUnique(30));  // duplicate of 10
+
+        $this->assertSame(10, $substrate->getCanonical(10));
+        $this->assertSame(10, $substrate->getCanonical(30));
+        $this->assertSame(20, $substrate->getCanonical(20));
+
+        $group = $substrate->getCanonicalGroup(30);
+        $this->assertCount(2, $group);
+        $this->assertContains(10, $group);
+        $this->assertContains(30, $group);
+    }
+
     // ---- Helpers ----
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php
@@ -249,7 +249,175 @@ class GraphSubstrateTest extends BaseTestCase
         $this->assertEmpty($substrate->scc_profiles);
     }
 
+    /**
+     * Test that two nodes sharing the same address are unified for SCC detection.
+     *
+     * Simulates streaming mode: object A appears as node 100 (objects_store phase)
+     * and node 500 (call_frames phase). Similarly for object B.
+     * Edge 100 -> 200 (A->B in objects_store) and 600 -> 500 (B->A in call_frames).
+     * Without unification: no cycle. With unification: cycle A->B->A.
+     */
+    public function testSccDetectsCycleViaAddressUnification(): void
+    {
+        $db = $this->createDirectDb();
+
+        // Insert nodes: A has two nodes (100, 500), B has two nodes (200, 600)
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type, canonical_node_id) VALUES
+            (1, 100, 'ObjectContext', 100),
+            (1, 200, 'ObjectContext', 200),
+            (1, 500, 'ObjectContext', 100),
+            (1, 600, 'ObjectContext', 200)
+        ");
+
+        // Insert locations with shared addresses
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 100, 1000, 64, 'ZendObjectMemoryLocation', 'App\\NodeA'),
+            (1, 200, 2000, 64, 'ZendObjectMemoryLocation', 'App\\NodeB'),
+            (1, 500, 1000, 64, 'ZendObjectMemoryLocation', 'App\\NodeA'),
+            (1, 600, 2000, 64, 'ZendObjectMemoryLocation', 'App\\NodeB')
+        ");
+
+        // Insert edges: A->B (tree, strong) and B->A (non-tree, strong)
+        // In objects_store phase: 100 -> 200
+        // In call_frames phase: 600 -> 500
+        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 100, 'objects_store', 1, 'strong'),
+            (1, 100, 200, 'next', 1, 'strong'),
+            (1, NULL, 500, 'call_frames', 1, 'strong'),
+            (1, 600, 500, 'next', 0, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        // With address unification, a cycle should be detected: A(100,500) <-> B(200,600)
+        $this->assertNotEmpty($substrate->scc_profiles, 'SCC should detect cycle via address unification');
+        $scc = $substrate->scc_profiles[0];
+        // All 4 nodes should be in the SCC (expanded from canonical)
+        $this->assertCount(4, $scc['nodes']);
+        $this->assertEqualsCanonicalizing([100, 200, 500, 600], $scc['nodes']);
+    }
+
+    /**
+     * Test that nodes with different addresses are NOT unified.
+     */
+    public function testNoUnificationWhenAddressesDiffer(): void
+    {
+        $db = $this->createDirectDb();
+
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 1, 'ObjectContext'),
+            (1, 2, 'ObjectContext'),
+            (1, 3, 'ObjectContext')
+        ");
+
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type) VALUES
+            (1, 1, 1000, 64, 'ZendObjectMemoryLocation'),
+            (1, 2, 2000, 64, 'ZendObjectMemoryLocation'),
+            (1, 3, 3000, 64, 'ZendObjectMemoryLocation')
+        ");
+
+        // Linear chain: 1 -> 2 -> 3 (no cycle)
+        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 1, 'root', 1, 'strong'),
+            (1, 1, 2, 'a', 1, 'strong'),
+            (1, 2, 3, 'b', 1, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        $this->assertEmpty($substrate->scc_profiles, 'No SCC should exist without shared addresses');
+    }
+
+    /**
+     * Test SCC profile generation with expanded node sets after unification.
+     */
+    public function testSccProfileWithUnifiedNodes(): void
+    {
+        $db = $this->createDirectDb();
+
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type, canonical_node_id) VALUES
+            (1, 10, 'ObjectContext', 10),
+            (1, 20, 'ObjectContext', 20),
+            (1, 30, 'ObjectContext', 10),
+            (1, 40, 'ObjectContext', 20)
+        ");
+
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 10, 100, 100, 'ZendObjectMemoryLocation', 'App\\Foo'),
+            (1, 20, 200, 200, 'ZendObjectMemoryLocation', 'App\\Bar'),
+            (1, 30, 100, 100, 'ZendObjectMemoryLocation', 'App\\Foo'),
+            (1, 40, 200, 200, 'ZendObjectMemoryLocation', 'App\\Bar')
+        ");
+
+        // Cycle: 10 -> 20 (tree), 40 -> 30 (non-tree, creates cycle via unification)
+        $db->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 10, 'root', 1, 'strong'),
+            (1, 10, 20, 'link', 1, 'strong'),
+            (1, NULL, 30, 'root2', 1, 'strong'),
+            (1, 40, 30, 'back', 0, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+
+        $this->assertNotEmpty($substrate->scc_profiles);
+        $scc = $substrate->scc_profiles[0];
+        // total_size should include all 4 nodes
+        $this->assertSame(600, $scc['total_size']);
+        // class_counts should aggregate across unified nodes
+        $this->assertArrayHasKey('App\\Foo', $scc['class_counts']);
+        $this->assertArrayHasKey('App\\Bar', $scc['class_counts']);
+    }
+
     // ---- Helpers ----
+
+    /**
+     * Create a test DB with tables directly (without going through PdoMemoryOutput).
+     */
+    private function createDirectDb(): \PDO
+    {
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $db->exec('CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY, created_at TEXT NOT NULL)');
+        $db->exec("INSERT INTO runs (run_id, created_at) VALUES (1, '2024-01-01T00:00:00Z')");
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS context_edges (
+                run_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
+            )
+        ");
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                address BIGINT,
+                size BIGINT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                string_value TEXT,
+                refcount BIGINT,
+                type_info BIGINT,
+                region TEXT
+            )
+        ');
+
+        return $db;
+    }
 
     private function openDb(): \PDO
     {


### PR DESCRIPTION
## Summary

Streaming + defer mode produces a graph where the same PHP object appears as multiple graph nodes (one per collection phase). This breaks SCC (cycle) detection and causes report passes to double-count nodes.

This PR fixes both problems in two phases:

### Phase 1: Address-Based Node Unification for SCC

- **Union-Find in GraphSubstrate**: `findCanonical()`, `union()` with path compression to track which nodes represent the same memory address
- **`canonical_node_id` column**: Added to `context_nodes` table; computed in `computeCanonicalNodeIds()` by grouping nodes sharing the same address in `context_node_locations`
- **Unified SCC adjacency**: `buildSccAdjacency()` maps all strong edges through canonical IDs; Tarjan runs on the unified graph, then expands results back to all original nodes
- **FFI CSR variant**: `computeSccFfiUnified()` provides the same logic for large graphs (>2M edges)
- **DB copy support**: `copyFromPrePopulatedDb()` preserves `canonical_node_id`

### Phase 2: Canonical-Aware Report Passes

Added 3 public helpers to `GraphSubstrate`:
- `isCanonicalOrUnique(int $nodeId): bool`
- `getCanonical(int $nodeId): int`
- `getCanonicalGroup(int $nodeId): array`

Fixed 6 report passes to avoid double-counting duplicate nodes:

| Pass | Fix |
|------|-----|
| **DrillDownPass** | Skip already-visited canonicals when selecting heaviest child |
| **BlameAllocationPass** | Aggregate blame by canonical group |
| **PropertyScalingPass** | Skip non-canonical instances; deduplicate property children by canonical |
| **ChokePointPass** | Skip non-canonical duplicates in subtree iteration |
| **OwnershipPatternPass** | Filter class counts and ownership traversal to canonical-or-unique nodes |
| **StructuralDedupPass** | Skip non-canonical duplicates when grouping shapes |

Passes confirmed unaffected: RetainedSizeConfidencePass, CompanionDetectionPass, CycleClusterPass, NonTreeEdgePass, CallStackPass, OverviewPass, TopArraysPass, TopStringsPass, ClassRankingPass, DynamicPropertiesPass, GcPendingPass, TypeBreakdownPass.

## Test plan

- [x] 5 new unit tests for address unification and canonical helpers (GraphSubstrateTest)
- [x] 131 Output-related unit tests pass
- [x] Integration tests pass with PHP 8.4 Docker target
- [x] phpcs clean
- [x] Verify with a real circular-reference target in streaming mode

https://claude.ai/code/session_01KqVGFGq9PpY8CHEkcyh1fX