### PR TITLE
Refine resource leak detection to exclude strongly-rooted cycles

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -238,7 +238,13 @@ final class CycleClusterPass implements PassInterface
     }
 
     /**
-     * Detect PDO/PDOStatement/Mysqli downstream of SCCs.
+     * Detect PDO/PDOStatement/Mysqli downstream of SCCs that are GC candidates.
+     *
+     * Only reports when the SCC is reachable solely via objects_store (weak
+     * references). Cycles that are strongly rooted — such as those formed by
+     * DI containers in frameworks like Laravel — are excluded because the
+     * resource's lifetime is governed by the application, not the GC.
+     *
      * @return list<Finding>
      */
     private function detectResourceLeakRisks(): array
@@ -248,10 +254,21 @@ final class CycleClusterPass implements PassInterface
             'Mysqli', 'mysqli', 'mysqli_stmt', 'mysqli_result',
         ];
 
+        // Build root-ownership map (same approach as GcPendingPass)
+        $gc_only_scc_ids = $this->findGcOnlySccIds();
+        if ($gc_only_scc_ids === []) {
+            return [];
+        }
+
         $findings = [];
         $seen_risks = [];
 
         foreach ($this->substrate->getSccProfiles() as $profile) {
+            // Skip SCCs that are strongly rooted (not GC candidates)
+            if (!isset($gc_only_scc_ids[$profile['id']])) {
+                continue;
+            }
+
             $scc_set = array_flip($profile['nodes']);
 
             // Check ext_outgoing: strong children of SCC nodes that are outside SCC
@@ -272,6 +289,84 @@ final class CycleClusterPass implements PassInterface
         }
 
         return $findings;
+    }
+
+    /**
+     * Find SCC IDs where ALL member nodes are owned only by objects_store.
+     *
+     * @return array<int, true> scc_id => true
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function findGcOnlySccIds(): array
+    {
+        // BFS from roots via tree edges to determine root ownership
+        $root_link_names = $this->loadRootLinkNames();
+        $node_root_owner = [];
+
+        foreach ($this->substrate->getRoots() as $root) {
+            $queue = [$root];
+            $qi = 0;
+            $node_root_owner[$root] = $root;
+            while ($qi < count($queue)) {
+                $node = $queue[$qi++];
+                foreach ($this->substrate->getChildren($node) as $child) {
+                    if (!isset($node_root_owner[$child])) {
+                        $node_root_owner[$child] = $root;
+                        $queue[] = $child;
+                    }
+                }
+            }
+        }
+
+        // Find objects_store root
+        $objects_store_root = null;
+        foreach ($this->substrate->getRoots() as $root) {
+            if (($root_link_names[$root] ?? '') === 'objects_store') {
+                $objects_store_root = $root;
+                break;
+            }
+        }
+
+        if ($objects_store_root === null) {
+            return [];
+        }
+
+        // Collect SCCs where ALL members are owned by objects_store
+        $gc_only_scc_ids = [];
+        foreach ($this->substrate->getSccProfiles() as $profile) {
+            $all_gc = true;
+            foreach ($profile['nodes'] as $node) {
+                $owner = $node_root_owner[$node] ?? null;
+                if ($owner !== $objects_store_root) {
+                    $all_gc = false;
+                    break;
+                }
+            }
+            if ($all_gc) {
+                $gc_only_scc_ids[$profile['id']] = true;
+            }
+        }
+
+        return $gc_only_scc_ids;
+    }
+
+    /**
+     * @return array<int, string> root_node_id => link_name
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadRootLinkNames(): array
+    {
+        $rows = $this->db->query(
+            "SELECT child_node_id, link_name FROM context_edges"
+            . " WHERE parent_node_id IS NULL AND is_tree = 1"
+            . " AND run_id = {$this->run_id}"
+        )->fetchAll(\PDO::FETCH_NUM);
+
+        $map = [];
+        foreach ($rows as $r) {
+            $map[(int)$r[0]] = (string)$r[1];
+        }
+        return $map;
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPassTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+
+class CycleClusterPassTest extends BaseTestCase
+{
+    private string $db_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db_path = tempnam(sys_get_temp_dir(), 'reli_cycle_test_') . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    /**
+     * PDO downstream of a cycle that is only reachable from objects_store
+     * (GC candidate) should be reported as resource_leak_risk.
+     */
+    public function testResourceLeakReportedForGcCandidateCycle(): void
+    {
+        $db = $this->createDirectDb();
+
+        // Nodes: two cyclic objects (10, 20) and a PDO (30), all under objects_store
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 1, 'RootContext'),
+            (1, 10, 'ObjectContext'),
+            (1, 20, 'ObjectContext'),
+            (1, 30, 'ObjectContext')
+        ");
+        $db->exec("INSERT INTO context_node_locations
+            (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 10, 1000, 64, 'ZendObjectMemoryLocation', 'App\\Service'),
+            (1, 20, 2000, 64, 'ZendObjectMemoryLocation', 'App\\Repository'),
+            (1, 30, 3000, 64, 'ZendObjectMemoryLocation', 'PDO')
+        ");
+        // objects_store -> 10 -> 20 (tree), 20 -> 10 (non-tree, creates cycle)
+        // 10 -> 30 (tree, PDO downstream)
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 1, 'objects_store', 1, 'weak'),
+            (1, 1, 10, 'obj_0', 1, 'strong'),
+            (1, 1, 20, 'obj_1', 1, 'strong'),
+            (1, 10, 20, 'repo', 1, 'strong'),
+            (1, 20, 10, 'service', 0, 'strong'),
+            (1, 10, 30, 'pdo', 1, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $this->assertNotEmpty($substrate->getSccProfiles(), 'SCC should be detected');
+
+        $pass = new CycleClusterPass($substrate, $db, 1);
+        $findings = $pass->analyze();
+
+        $resource_risks = array_filter(
+            $findings,
+            fn(Finding $f) => $f->kind === 'resource_leak_risk'
+        );
+        $this->assertNotEmpty(
+            $resource_risks,
+            'PDO downstream of GC-only cycle should be reported'
+        );
+    }
+
+    /**
+     * PDO downstream of a cycle that is reachable from a strong root
+     * (e.g. DI container in Laravel) should NOT be reported.
+     */
+    public function testResourceLeakNotReportedForStronglyRootedCycle(): void
+    {
+        $db = $this->createDirectDb();
+
+        // Two roots: call_frames (strong) and objects_store (weak)
+        // The cycle nodes are reachable from call_frames → not GC candidates
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 1, 'RootContext'),
+            (1, 2, 'RootContext'),
+            (1, 10, 'ObjectContext'),
+            (1, 20, 'ObjectContext'),
+            (1, 30, 'ObjectContext')
+        ");
+        $db->exec("INSERT INTO context_node_locations
+            (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 10, 1000, 64, 'ZendObjectMemoryLocation', 'App\\Container'),
+            (1, 20, 2000, 64, 'ZendObjectMemoryLocation', 'App\\Service'),
+            (1, 30, 3000, 64, 'ZendObjectMemoryLocation', 'PDO')
+        ");
+        // call_frames (strong) -> 10 -> 20 (tree), 20 -> 10 (non-tree, cycle)
+        // objects_store (weak) -> 10, 20 (also reachable, but weak)
+        // 10 -> 30 (PDO downstream)
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 1, 'call_frames', 1, 'strong'),
+            (1, 1, 10, 'container', 1, 'strong'),
+            (1, 10, 20, 'service', 1, 'strong'),
+            (1, 20, 10, 'container', 0, 'strong'),
+            (1, 10, 30, 'pdo', 1, 'strong'),
+            (1, NULL, 2, 'objects_store', 1, 'weak'),
+            (1, 2, 10, 'obj_0', 0, 'weak'),
+            (1, 2, 20, 'obj_1', 0, 'weak'),
+            (1, 2, 30, 'obj_2', 0, 'weak')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $this->assertNotEmpty($substrate->getSccProfiles(), 'SCC should be detected');
+
+        $pass = new CycleClusterPass($substrate, $db, 1);
+        $findings = $pass->analyze();
+
+        $resource_risks = array_filter(
+            $findings,
+            fn(Finding $f) => $f->kind === 'resource_leak_risk'
+        );
+        $this->assertEmpty(
+            $resource_risks,
+            'PDO downstream of strongly-rooted cycle should NOT be reported'
+        );
+    }
+
+    /**
+     * When there is no objects_store root at all, no resource leak risks
+     * should be reported (conservative: cannot determine GC candidacy).
+     */
+    public function testResourceLeakNotReportedWithoutObjectsStore(): void
+    {
+        $db = $this->createDirectDb();
+
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 1, 'RootContext'),
+            (1, 10, 'ObjectContext'),
+            (1, 20, 'ObjectContext'),
+            (1, 30, 'ObjectContext')
+        ");
+        $db->exec("INSERT INTO context_node_locations
+            (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 10, 1000, 64, 'ZendObjectMemoryLocation', 'App\\A'),
+            (1, 20, 2000, 64, 'ZendObjectMemoryLocation', 'App\\B'),
+            (1, 30, 3000, 64, 'ZendObjectMemoryLocation', 'PDO')
+        ");
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 1, 'call_frames', 1, 'strong'),
+            (1, 1, 10, 'a', 1, 'strong'),
+            (1, 10, 20, 'b', 1, 'strong'),
+            (1, 20, 10, 'back', 0, 'strong'),
+            (1, 10, 30, 'pdo', 1, 'strong')
+        ");
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $pass = new CycleClusterPass($substrate, $db, 1);
+        $findings = $pass->analyze();
+
+        $resource_risks = array_filter(
+            $findings,
+            fn(Finding $f) => $f->kind === 'resource_leak_risk'
+        );
+        $this->assertEmpty(
+            $resource_risks,
+            'No resource_leak_risk without objects_store root'
+        );
+    }
+
+    private function createDirectDb(): \PDO
+    {
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $db->exec('CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY, created_at TEXT NOT NULL)');
+        $db->exec("INSERT INTO runs (run_id, created_at) VALUES (1, '2024-01-01T00:00:00Z')");
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS context_edges (
+                run_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
+            )
+        ");
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                address BIGINT,
+                size BIGINT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                string_value TEXT,
+                refcount BIGINT,
+                type_info BIGINT,
+                region TEXT
+            )
+        ');
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_attributes (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            )
+        ');
+
+        return $db;
+    }
+}


### PR DESCRIPTION
## Summary
Enhanced the `CycleClusterPass` resource leak detection to distinguish between garbage-collection-only cycles and strongly-rooted cycles (e.g., those formed by DI containers). Resources downstream of strongly-rooted cycles are now excluded from reporting since their lifetime is governed by the application, not PHP's garbage collector.

## Key Changes
- **Updated `detectResourceLeakRisks()` method**: Now filters SCCs to only report resource leak risks for cycles that are GC candidates (reachable solely via `objects_store`)
- **Added `findGcOnlySccIds()` method**: Implements BFS-based root ownership analysis to identify which SCC nodes are owned exclusively by the `objects_store` root
- **Added `loadRootLinkNames()` method**: Helper to retrieve root link names from the database for identifying the `objects_store` root
- **Improved documentation**: Enhanced docstring for `detectResourceLeakRisks()` to clarify the GC-candidacy requirement
- **Added comprehensive test coverage**: New `CycleClusterPassTest` class with three test cases:
  - `testResourceLeakReportedForGcCandidateCycle()`: Verifies PDO downstream of GC-only cycles is reported
  - `testResourceLeakNotReportedForStronglyRootedCycle()`: Confirms cycles reachable from strong roots are excluded
  - `testResourceLeakNotReportedWithoutObjectsStore()`: Ensures conservative behavior when `objects_store` is absent

## Implementation Details
- Uses BFS traversal from all roots via tree edges to determine which root owns each node
- Only reports resource leak risks when ALL members of an SCC are owned by `objects_store`
- Returns empty findings if `objects_store` root doesn't exist (conservative approach)
- Maintains backward compatibility with existing SCC detection logic

https://claude.ai/code/session_013MbcvizFRYZTxQfgFGh6yU