### PR TITLE
Add memory peak usage and limit tracking to memory analysis

### DIFF
--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -91,6 +91,8 @@ final class CoreDumpReader
                 + [
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                    'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
+                    'memory_limit' => $collected_memories->memory_limit,
                     'cached_chunks_size' => $collected_memories->cached_chunks_size,
                 ]
                 + [

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -72,13 +73,19 @@ final class MemoryDumpReader
                 $collected_memories->memory_locations,
             );
 
+            $rss_reader = new RssReader();
+            $rss_bytes = $rss_reader->read($this->pid);
+
             $summary = [
                 $analyzed_regions->summary->toArray()
                 + [
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                    'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
+                    'memory_limit' => $collected_memories->memory_limit,
                     'cached_chunks_size' => $collected_memories->cached_chunks_size,
                 ]
+                + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
                 + [
                     'heap_memory_analyzed_percentage' =>
                         (float)$analyzed_regions->summary->zend_mm_heap_usage

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
@@ -46,30 +46,90 @@ final class OverviewPass implements PassInterface
         $vm_stack = (int)($flat['vm_stack_total'] ?? 0);
         $compiler_arena = (int)($flat['compiler_arena_total'] ?? 0);
         $analyzed_pct = (float)($flat['heap_memory_analyzed_percentage'] ?? 0);
+        $memory_get_usage = (int)($flat['memory_get_usage'] ?? 0);
+        $memory_get_real_usage = (int)($flat['memory_get_real_usage'] ?? 0);
+        $memory_get_peak_usage = (int)($flat['memory_get_peak_usage'] ?? 0);
+        $memory_limit = (int)($flat['memory_limit'] ?? 0);
+        $rss = isset($flat['rss']) ? (int)$flat['rss'] : null;
+
+        $summary_parts = [
+            sprintf('memory_get_usage(): %s', SizeFormatter::format($memory_get_usage)),
+            sprintf('memory_get_usage(true): %s', SizeFormatter::format($memory_get_real_usage)),
+        ];
+        if ($memory_get_peak_usage > 0) {
+            $summary_parts[] = sprintf('peak: %s', SizeFormatter::format($memory_get_peak_usage));
+        }
+        if ($memory_limit > 0) {
+            $summary_parts[] = sprintf('memory_limit: %s', SizeFormatter::format($memory_limit));
+        }
+        if ($rss !== null) {
+            $summary_parts[] = sprintf('RSS: %s', SizeFormatter::format($rss));
+        }
+        $summary_parts[] = sprintf(
+            'Heap: %s (%.1f%% analyzed), VM stack: %s, Compiler arena: %s',
+            SizeFormatter::format($heap_usage),
+            $analyzed_pct,
+            SizeFormatter::format($vm_stack),
+            SizeFormatter::format($compiler_arena),
+        );
+
+        $facts = [
+            'memory_get_usage' => $memory_get_usage,
+            'memory_get_real_usage' => $memory_get_real_usage,
+            'memory_get_peak_usage' => $memory_get_peak_usage,
+            'memory_limit' => $memory_limit,
+            'heap_total' => $heap_total,
+            'heap_usage' => $heap_usage,
+            'vm_stack_total' => $vm_stack,
+            'compiler_arena_total' => $compiler_arena,
+            'analyzed_percentage' => $analyzed_pct,
+        ];
+        if ($rss !== null) {
+            $facts['rss'] = $rss;
+        }
 
         $findings[] = new Finding(
             kind: 'overview',
             severity: FindingSeverity::Info,
             confidence: FindingConfidence::High,
-            summary: sprintf(
-                'Heap: %s (%.1f%% analyzed), VM stack: %s, Compiler arena: %s',
-                SizeFormatter::format($heap_usage),
-                $analyzed_pct,
-                SizeFormatter::format($vm_stack),
-                SizeFormatter::format($compiler_arena),
-            ),
-            facts: [
-                'heap_total' => $heap_total,
-                'heap_usage' => $heap_usage,
-                'vm_stack_total' => $vm_stack,
-                'compiler_arena_total' => $compiler_arena,
-                'analyzed_percentage' => $analyzed_pct,
-            ],
+            summary: implode(' | ', $summary_parts),
+            facts: $facts,
             replay_query: "SELECT key, value FROM summary WHERE key IN"
                 . " ('zend_mm_heap_total', 'zend_mm_heap_usage',"
                 . " 'vm_stack_total', 'compiler_arena_total',"
-                . " 'heap_memory_analyzed_percentage')",
+                . " 'heap_memory_analyzed_percentage',"
+                . " 'memory_get_usage', 'memory_get_real_usage',"
+                . " 'memory_get_peak_usage', 'memory_limit', 'rss')",
         );
+
+        if ($memory_limit > 0 && $memory_get_peak_usage > 0) {
+            $usage_pct = (float)$memory_get_peak_usage / (float)$memory_limit * 100.0;
+            if ($usage_pct >= 80.0) {
+                $headroom = $memory_limit - $memory_get_peak_usage;
+                $findings[] = new Finding(
+                    kind: 'near_memory_limit',
+                    severity: $usage_pct >= 95.0 ? FindingSeverity::High : FindingSeverity::Warning,
+                    confidence: FindingConfidence::High,
+                    summary: sprintf(
+                        'Peak usage is %.1f%% of memory_limit — only %s headroom',
+                        $usage_pct,
+                        SizeFormatter::format($headroom),
+                    ),
+                    facts: [
+                        'peak' => $memory_get_peak_usage,
+                        'limit' => $memory_limit,
+                        'usage_percentage' => $usage_pct,
+                        'headroom' => $headroom,
+                    ],
+                    hypothesis: 'Process is at risk of hitting memory_limit and triggering a fatal error',
+                    next_checks: [
+                        'Review top memory consumers in this report',
+                        'Consider increasing memory_limit or reducing memory usage',
+                    ],
+                    impact_bytes: $memory_get_peak_usage,
+                );
+            }
+        }
 
         if ($analyzed_pct > 0 && $analyzed_pct < 95.0) {
             $gap_bytes = (int)($heap_usage * (100.0 - $analyzed_pct) / 100.0);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -28,6 +28,8 @@ final class CollectedMemories
         public ?TopReferenceContext $top_reference_context,
         public int $memory_get_usage_size,
         public int $memory_get_usage_real_size,
+        public int $memory_get_peak_usage,
+        public int $memory_limit,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -369,6 +369,8 @@ final class MemoryLocationsCollector
 
         $memory_get_usage_size = $zend_mm_main_chunk->heap_slot->size;
         $memory_get_usage_real_size = $zend_mm_main_chunk->heap_slot->real_size;
+        $memory_get_peak_usage = $zend_mm_main_chunk->heap_slot->peak;
+        $memory_limit = $zend_mm_main_chunk->heap_slot->limit;
         $cached_chunks_size = $zend_mm_main_chunk->heap_slot->cached_chunks_count * ZendMmChunk::SIZE;
 
         $eg_pointer = new Pointer(
@@ -671,6 +673,8 @@ final class MemoryLocationsCollector
                 null,
                 $memory_get_usage_size,
                 $memory_get_usage_real_size,
+                $memory_get_peak_usage,
+                $memory_limit,
             );
         }
 
@@ -806,6 +810,8 @@ final class MemoryLocationsCollector
             $top_reference_context,
             $memory_get_usage_size,
             $memory_get_usage_real_size,
+            $memory_get_peak_usage,
+            $memory_limit,
         );
     }
 

--- a/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
+++ b/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
@@ -149,6 +149,10 @@ class CoreDumpReaderIntegrationTest extends BaseTestCase
         $this->assertSame($php_version, $summary['php_version']);
         $this->assertGreaterThan(0, $summary['memory_get_usage']);
         $this->assertGreaterThan(0, $summary['memory_get_real_usage']);
+        $this->assertArrayHasKey('memory_get_peak_usage', $summary);
+        $this->assertGreaterThan(0, $summary['memory_get_peak_usage']);
+        $this->assertArrayHasKey('memory_limit', $summary);
+        $this->assertGreaterThan(0, $summary['memory_limit']);
     }
 
     private function takeCoreDump(int $pid): string

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -29,13 +29,90 @@ class SummaryPassesTest extends BaseTestCase
                 'vm_stack_total' => 65536,
                 'compiler_arena_total' => 32768,
                 'heap_memory_analyzed_percentage' => 99.0,
+                'memory_get_usage' => 8400000,
+                'memory_get_real_usage' => 10485760,
+                'memory_get_peak_usage' => 9000000,
+                'memory_limit' => 134217728,
+                'rss' => 20971520,
             ],
         ]);
         $findings = $pass->analyze();
 
         $overview = array_filter($findings, fn(Finding $f) => $f->kind === 'overview');
         $this->assertCount(1, $overview);
-        $this->assertStringContainsString('99.0%', array_values($overview)[0]->summary);
+        $f = array_values($overview)[0];
+        $this->assertStringContainsString('99.0%', $f->summary);
+        $this->assertStringContainsString('memory_get_usage()', $f->summary);
+        $this->assertStringContainsString('peak:', $f->summary);
+        $this->assertStringContainsString('memory_limit:', $f->summary);
+        $this->assertStringContainsString('RSS:', $f->summary);
+        $this->assertSame(8400000, $f->facts['memory_get_usage']);
+        $this->assertSame(10485760, $f->facts['memory_get_real_usage']);
+        $this->assertSame(9000000, $f->facts['memory_get_peak_usage']);
+        $this->assertSame(134217728, $f->facts['memory_limit']);
+        $this->assertSame(20971520, $f->facts['rss']);
+    }
+
+    public function testOverviewPassOmitsRssWhenUnavailable(): void
+    {
+        $pass = new OverviewPass([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'vm_stack_total' => 65536,
+                'compiler_arena_total' => 32768,
+                'heap_memory_analyzed_percentage' => 99.0,
+                'memory_get_usage' => 8400000,
+                'memory_get_real_usage' => 10485760,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $overview = array_filter($findings, fn(Finding $f) => $f->kind === 'overview');
+        $f = array_values($overview)[0];
+        $this->assertStringNotContainsString('RSS:', $f->summary);
+        $this->assertArrayNotHasKey('rss', $f->facts);
+    }
+
+    public function testOverviewPassDetectsNearMemoryLimit(): void
+    {
+        $pass = new OverviewPass([
+            [
+                'zend_mm_heap_total' => 134217728,
+                'zend_mm_heap_usage' => 130000000,
+                'heap_memory_analyzed_percentage' => 99.0,
+                'memory_get_usage' => 130000000,
+                'memory_get_real_usage' => 134217728,
+                'memory_get_peak_usage' => 130000000,  // ~96.9% of limit
+                'memory_limit' => 134217728,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $near_limit = array_filter($findings, fn(Finding $f) => $f->kind === 'near_memory_limit');
+        $this->assertCount(1, $near_limit);
+        $f = array_values($near_limit)[0];
+        $this->assertSame('high', $f->severity->value);
+        $this->assertStringContainsString('headroom', $f->summary);
+    }
+
+    public function testOverviewPassNoNearLimitWhenPlentyOfHeadroom(): void
+    {
+        $pass = new OverviewPass([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'heap_memory_analyzed_percentage' => 99.0,
+                'memory_get_usage' => 8400000,
+                'memory_get_real_usage' => 10485760,
+                'memory_get_peak_usage' => 9000000,  // ~6.7% of limit
+                'memory_limit' => 134217728,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $near_limit = array_filter($findings, fn(Finding $f) => $f->kind === 'near_memory_limit');
+        $this->assertCount(0, $near_limit);
     }
 
     public function testOverviewPassDetectsCoverageGap(): void


### PR DESCRIPTION
## Summary
Enhanced memory analysis reporting to include PHP's `memory_get_peak_usage()`, `memory_limit`, and RSS (Resident Set Size) metrics. Added detection for processes approaching their memory limit with actionable warnings.

## Key Changes

- **Extended memory metrics collection**: Capture `memory_get_peak_usage()`, `memory_limit`, and RSS from the target process
  - Modified `CollectedMemories` to include `memory_get_peak_usage` and `memory_limit` fields
  - Updated `MemoryLocationsCollector` to extract peak usage and limit from Zend MM heap slot
  - Added `RssReader` integration to capture RSS when available

- **Enhanced overview reporting**: Improved the overview finding summary to display all memory metrics
  - Summary now includes `memory_get_usage()`, `memory_get_usage(true)`, peak usage, memory limit, and RSS
  - Facts dictionary expanded to include all new metrics
  - RSS is conditionally included only when available

- **New near-memory-limit detection**: Added automatic detection and warnings when process approaches memory limit
  - Triggers when peak usage is ≥80% of memory_limit
  - Severity escalates to "High" when usage ≥95%
  - Provides headroom calculation and actionable next steps
  - Only emitted when both memory_limit and memory_get_peak_usage are available

- **Updated test coverage**: Added comprehensive tests for new functionality
  - Tests for overview finding with all metrics
  - Tests for RSS omission when unavailable
  - Tests for near-memory-limit detection at various thresholds

## Implementation Details

- RSS reading is gracefully handled as optional (null when unavailable)
- Memory limit warnings use percentage-based thresholds to avoid false positives
- All new metrics are included in the replay query for consistency
- Changes maintain backward compatibility with existing analysis logic

https://claude.ai/code/session_01F5V22E6Vqfdzp5KfuuU5Rm