### PR TITLE
Correct memory usage in streaming mode using DB region sums

### DIFF
--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -130,6 +130,13 @@ final class MemoryCommand extends Command
                 $sink,
             );
 
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
+
             $region_analyzer = new RegionAnalyzer(
                 $collected_memories->chunk_memory_locations,
                 $collected_memories->huge_memory_locations,
@@ -143,8 +150,11 @@ final class MemoryCommand extends Command
 
             // In streaming mode, memory_locations uses lightweight (address-only)
             // tracking, so RegionAnalyzer cannot compute usage from individual
-            // locations.  Correct the summary using region sums from the DB.
+            // locations.  Back-fill the region column (NULL during streaming
+            // because RegionBoundaries was not yet available) and correct the
+            // summary using region sums from the DB.
             $sink->flush();
+            $region_boundaries->backfillRegions($db, $run_id);
             $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
             $summary_base = $region_sums !== []
                 ? $analyzed_regions->summary->correctedToArray($region_sums)
@@ -169,13 +179,6 @@ final class MemoryCommand extends Command
                     'analyzer' => ReliProfiler::toolSignature(),
                 ]
             ];
-
-            $region_boundaries = new RegionBoundaries(
-                $collected_memories->chunk_memory_locations,
-                $collected_memories->huge_memory_locations,
-                $collected_memories->vm_stack_memory_locations,
-                $collected_memories->compiler_arena_memory_locations,
-            );
 
             unset($collected_memories, $analyzed_regions, $region_analyzer);
 

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -24,6 +24,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Reli\ReliProfiler;
@@ -140,8 +141,17 @@ final class MemoryCommand extends Command
                 $collected_memories->memory_locations,
             );
 
+            // In streaming mode, memory_locations uses lightweight (address-only)
+            // tracking, so RegionAnalyzer cannot compute usage from individual
+            // locations.  Correct the summary using region sums from the DB.
+            $sink->flush();
+            $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
+            $summary_base = $region_sums !== []
+                ? $analyzed_regions->summary->correctedToArray($region_sums)
+                : $analyzed_regions->summary->toArray();
+
             $summary = [
-                $analyzed_regions->summary->toArray()
+                $summary_base
                 + [
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
@@ -149,7 +159,7 @@ final class MemoryCommand extends Command
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>
-                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        (float)$summary_base['zend_mm_heap_usage']
                         /
                         (float)$collected_memories->memory_get_usage_size * 100.0
                     ,

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -76,6 +76,13 @@ final class CoreDumpReader
                 $sink,
             );
 
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
+
             $region_analyzer = new RegionAnalyzer(
                 $collected_memories->chunk_memory_locations,
                 $collected_memories->huge_memory_locations,
@@ -88,6 +95,7 @@ final class CoreDumpReader
             );
 
             $sink->flush();
+            $region_boundaries->backfillRegions($db, $run_id);
             $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
             $summary_base = $region_sums !== []
                 ? $analyzed_regions->summary->correctedToArray($region_sums)
@@ -114,13 +122,6 @@ final class CoreDumpReader
                     'analyzer' => ReliProfiler::toolSignature(),
                 ]
             ];
-
-            $region_boundaries = new RegionBoundaries(
-                $collected_memories->chunk_memory_locations,
-                $collected_memories->huge_memory_locations,
-                $collected_memories->vm_stack_memory_locations,
-                $collected_memories->compiler_arena_memory_locations,
-            );
 
             unset($collected_memories, $analyzed_regions, $region_analyzer);
 

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -21,6 +21,7 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\ReliProfiler;
@@ -86,8 +87,14 @@ final class CoreDumpReader
                 $collected_memories->memory_locations,
             );
 
+            $sink->flush();
+            $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
+            $summary_base = $region_sums !== []
+                ? $analyzed_regions->summary->correctedToArray($region_sums)
+                : $analyzed_regions->summary->toArray();
+
             $summary = [
-                $analyzed_regions->summary->toArray()
+                $summary_base
                 + [
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
@@ -97,7 +104,7 @@ final class CoreDumpReader
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>
-                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        (float)$summary_base['zend_mm_heap_usage']
                         /
                         (float)$collected_memories->memory_get_usage_size * 100.0
                     ,

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -22,6 +22,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\ReliProfiler;
 
@@ -76,8 +77,14 @@ final class MemoryDumpReader
             $rss_reader = new RssReader();
             $rss_bytes = $rss_reader->read($this->pid);
 
+            $sink->flush();
+            $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
+            $summary_base = $region_sums !== []
+                ? $analyzed_regions->summary->correctedToArray($region_sums)
+                : $analyzed_regions->summary->toArray();
+
             $summary = [
-                $analyzed_regions->summary->toArray()
+                $summary_base
                 + [
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
@@ -88,7 +95,7 @@ final class MemoryDumpReader
                 + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
                 + [
                     'heap_memory_analyzed_percentage' =>
-                        (float)$analyzed_regions->summary->zend_mm_heap_usage
+                        (float)$summary_base['zend_mm_heap_usage']
                         /
                         (float)$collected_memories->memory_get_usage_size * 100.0
                     ,

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -63,6 +63,13 @@ final class MemoryDumpReader
                 $sink,
             );
 
+            $region_boundaries = new RegionBoundaries(
+                $collected_memories->chunk_memory_locations,
+                $collected_memories->huge_memory_locations,
+                $collected_memories->vm_stack_memory_locations,
+                $collected_memories->compiler_arena_memory_locations,
+            );
+
             $region_analyzer = new RegionAnalyzer(
                 $collected_memories->chunk_memory_locations,
                 $collected_memories->huge_memory_locations,
@@ -78,6 +85,7 @@ final class MemoryDumpReader
             $rss_bytes = $rss_reader->read($this->pid);
 
             $sink->flush();
+            $region_boundaries->backfillRegions($db, $run_id);
             $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
             $summary_base = $region_sums !== []
                 ? $analyzed_regions->summary->correctedToArray($region_sums)
@@ -105,13 +113,6 @@ final class MemoryDumpReader
                     'analyzer' => ReliProfiler::toolSignature(),
                 ]
             ];
-
-            $region_boundaries = new RegionBoundaries(
-                $collected_memories->chunk_memory_locations,
-                $collected_memories->huge_memory_locations,
-                $collected_memories->vm_stack_memory_locations,
-                $collected_memories->compiler_arena_memory_locations,
-            );
 
             unset($collected_memories, $analyzed_regions, $region_analyzer);
 

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -252,6 +252,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             'CREATE INDEX IF NOT EXISTS idx_context_nodes_canonical'
             . ' ON context_nodes(run_id, canonical_node_id)'
         );
+        $db->exec(
+            'CREATE INDEX IF NOT EXISTS idx_context_node_locations_region_addr_size'
+            . ' ON context_node_locations(run_id, region, address, size)'
+        );
     }
 
     private function createViews(\PDO $db): void

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundaries.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundaries.php
@@ -42,4 +42,30 @@ final class RegionBoundaries
         }
         return 'outside';
     }
+
+    /**
+     * Back-fill the region column for rows that were inserted with NULL
+     * (because RegionBoundaries was not yet available during streaming).
+     */
+    public function backfillRegions(\PDO $db, int $run_id): void
+    {
+        $select = $db->prepare(
+            'SELECT id, address, size FROM context_node_locations'
+            . ' WHERE run_id = ? AND region IS NULL'
+        );
+        $select->execute([$run_id]);
+
+        $update = $db->prepare(
+            'UPDATE context_node_locations SET region = ? WHERE id = ?'
+        );
+
+        /** @psalm-suppress MixedAssignment */
+        while ($row = $select->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
+            $location = new MemoryLocation((int)$row['address'], (int)$row['size']);
+            $region = $this->classifyRegion($location);
+            /** @psalm-suppress MixedArrayAccess */
+            $update->execute([$region, $row['id']]);
+        }
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
@@ -97,10 +97,12 @@ final class RegionsSummary
     public static function queryRegionSums(\PDO $db, int $run_id): array
     {
         $stmt = $db->prepare(
-            'SELECT region, COALESCE(SUM(size), 0) AS total_size'
-            . ' FROM context_node_locations'
-            . ' WHERE run_id = ? AND region IS NOT NULL'
-            . ' GROUP BY region'
+            'SELECT region, COALESCE(SUM(size), 0) AS total_size FROM ('
+            . '  SELECT address, region, MAX(size) AS size'
+            . '  FROM context_node_locations'
+            . '  WHERE run_id = ? AND region IS NOT NULL'
+            . '  GROUP BY address, region'
+            . ') GROUP BY region'
         );
         $stmt->execute([$run_id]);
         $sums = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
@@ -51,4 +51,62 @@ final class RegionsSummary
             'possible_array_overhead_total' => $this->possible_array_overhead_total,
         ];
     }
+
+    /**
+     * Build a corrected summary array using region sums from the DB.
+     *
+     * In streaming mode the main memory_locations collection uses lightweight
+     * (address-only) tracking, so RegionAnalyzer cannot compute usage from
+     * individual locations.  This method reconstructs the usage values from
+     * SUM(size) grouped by region in the context_node_locations table.
+     *
+     * @param array<string, int> $region_sums  region name => SUM(size) from DB
+     * @return array<string, int>
+     */
+    public function correctedToArray(array $region_sums): array
+    {
+        $db_chunk_usage = $region_sums['zend_mm_heap'] ?? 0;
+        $db_huge_usage = $region_sums['zend_mm_huge'] ?? 0;
+
+        $corrected_chunk_usage = $db_chunk_usage
+            + $this->possible_allocation_overhead_total
+            + $this->vm_stack_total
+            + $this->compiler_arena_total;
+
+        return [
+            'zend_mm_heap_total' => $this->zend_mm_heap_total,
+            'zend_mm_heap_usage' => $corrected_chunk_usage + $db_huge_usage,
+            'zend_mm_chunk_total' => $this->zend_mm_chunk_total,
+            'zend_mm_chunk_usage' => $corrected_chunk_usage,
+            'zend_mm_huge_total' => $this->zend_mm_huge_total,
+            'zend_mm_huge_usage' => $db_huge_usage,
+            'vm_stack_total' => $this->vm_stack_total,
+            'vm_stack_usage' => $region_sums['vm_stack'] ?? 0,
+            'compiler_arena_total' => $this->compiler_arena_total,
+            'compiler_arena_usage' => $region_sums['compiler_arena'] ?? 0,
+            'possible_allocation_overhead_total' => $this->possible_allocation_overhead_total,
+            'possible_array_overhead_total' => $this->possible_array_overhead_total,
+        ];
+    }
+
+    /**
+     * Query context_node_locations for SUM(size) grouped by region.
+     *
+     * @return array<string, int> region name => total size
+     */
+    public static function queryRegionSums(\PDO $db, int $run_id): array
+    {
+        $stmt = $db->prepare(
+            'SELECT region, COALESCE(SUM(size), 0) AS total_size'
+            . ' FROM context_node_locations'
+            . ' WHERE run_id = ? AND region IS NOT NULL'
+            . ' GROUP BY region'
+        );
+        $stmt->execute([$run_id]);
+        $sums = [];
+        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            $sums[(string)$row['region']] = (int)$row['total_size'];
+        }
+        return $sums;
+    }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
@@ -104,7 +104,9 @@ final class RegionsSummary
         );
         $stmt->execute([$run_id]);
         $sums = [];
+        /** @psalm-suppress MixedAssignment */
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            /** @psalm-suppress MixedArrayAccess */
             $sums[(string)$row['region']] = (int)$row['total_size'];
         }
         return $sums;

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -41,6 +41,11 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ObjectClassAnalyzer\ObjectClassAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\PdoContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
@@ -366,6 +371,208 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ['included_files']
                 ['#count']
         );
+    }
+
+    /**
+     * End-to-end streaming test: collectAll with PdoContextTreeSink,
+     * backfill regions, and verify the percentage is reasonable.
+     *
+     * This ensures that vm_stack / compiler_arena (which live inside
+     * zend_mm_heap chunks) are classified correctly, and the corrected
+     * summary produces a non-zero analysed percentage.
+     */
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testStreamingPercentageIsReasonable(string $php_version, string $docker_image_name): void
+    {
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            $arr = range(1, 1000);
+            $obj = new stdClass;
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+
+        // ---- set up streaming sink (in-memory SQLite) ----
+        $tmp_path = tempnam(sys_get_temp_dir(), 'reli_test_stream_') . '.sqlite3';
+        $driver = new SqliteDriver($tmp_path);
+        $pdo_output = new PdoMemoryOutput($driver);
+        [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
+
+        // ---- collect with streaming ----
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+
+        // ---- build RegionBoundaries and backfill ----
+        $region_boundaries = new RegionBoundaries(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+
+        $region_analyzer = new RegionAnalyzer(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+        $analyzed_regions = $region_analyzer->analyze(
+            $collected_memories->memory_locations,
+        );
+
+        $sink->flush();
+        $region_boundaries->backfillRegions($db, $run_id);
+
+        // ---- verify region data in DB ----
+        $region_sums = RegionsSummary::queryRegionSums($db, $run_id);
+
+        // There must be at least zend_mm_heap data (normal heap allocations)
+        $this->assertArrayHasKey('zend_mm_heap', $region_sums);
+        $this->assertGreaterThan(0, $region_sums['zend_mm_heap']);
+
+        // vm_stack should exist inside a chunk
+        $this->assertGreaterThan(
+            0,
+            $collected_memories->vm_stack_memory_locations->memory_locations !== []
+                ? count($collected_memories->vm_stack_memory_locations->memory_locations)
+                : 0,
+            'vm_stack regions should be collected'
+        );
+
+        // If there are vm_stack locations in the DB they must be classified
+        if (isset($region_sums['vm_stack'])) {
+            $this->assertGreaterThan(0, $region_sums['vm_stack']);
+        }
+
+        // ---- compute corrected summary and percentage ----
+        $summary_base = $analyzed_regions->summary->correctedToArray($region_sums);
+
+        $pct = (float)$summary_base['zend_mm_heap_usage']
+            / (float)$collected_memories->memory_get_usage_size * 100.0;
+
+        // The percentage must NOT be near-zero (the bug we're fixing).
+        // A real analysis of a simple script typically yields 60-100%.
+        $this->assertGreaterThan(
+            30.0,
+            $pct,
+            sprintf(
+                'heap_memory_analyzed_percentage too low: %.2f%% '
+                . '(heap_usage=%d, memory_get_usage=%d, region_sums=%s)',
+                $pct,
+                $summary_base['zend_mm_heap_usage'],
+                $collected_memories->memory_get_usage_size,
+                json_encode($region_sums),
+            )
+        );
+
+        // Also verify it doesn't exceed a sane upper bound (the DB SUM may
+        // slightly over-count due to overlapping locations that weren't
+        // filtered, plus the region totals for vm_stack/compiler_arena).
+        $this->assertLessThan(
+            200.0,
+            $pct,
+            'percentage should not wildly exceed 100%'
+        );
+
+        // ---- cleanup ----
+        $db = null;
+        @unlink($tmp_path);
     }
 
     #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundariesTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundariesTest.php
@@ -15,6 +15,7 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer;
 
 use Reli\BaseTestCase;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
 use Reli\Lib\Process\MemoryLocation;
 
 class RegionBoundariesTest extends BaseTestCase
@@ -115,5 +116,134 @@ class RegionBoundariesTest extends BaseTestCase
             'SELECT region FROM context_node_locations WHERE id = 1'
         )->fetch(\PDO::FETCH_ASSOC);
         $this->assertSame('zend_mm_heap', $row['region']);
+    }
+
+    /**
+     * End-to-end test simulating the streaming mode percentage calculation.
+     *
+     * Models a realistic ZendMM layout where vm_stack and compiler_arena
+     * are allocated WITHIN a chunk.  All rows start with region=NULL (as
+     * in real streaming collection), then backfill → queryRegionSums →
+     * correctedToArray → percentage.
+     */
+    public function testEndToEndPercentageWithVmStackInsideChunk(): void
+    {
+        $db = $this->createDb();
+
+        // ---- region layout (mirrors real ZendMM) ----
+        // chunk:          0x7F00_0000 .. +2 MB
+        // vm_stack:       0x7F00_1000 .. +64 KB  (inside chunk)
+        // compiler_arena: 0x7F10_0000 .. +32 KB  (inside chunk)
+        // huge:           0x7E00_0000 .. +4 MB    (separate mmap)
+        $chunk_addr  = 0x7F000000;
+        $chunk_size  = 2 * 1024 * 1024;  // 2 MB
+        $vm_addr     = 0x7F001000;
+        $vm_size     = 65536;            // 64 KB
+        $ca_addr     = 0x7F100000;
+        $ca_size     = 32768;            // 32 KB
+        $huge_addr   = 0x7E000000;
+        $huge_size   = 4 * 1024 * 1024;  // 4 MB
+
+        $chunk = new MemoryLocations([new MemoryLocation($chunk_addr, $chunk_size)]);
+        $huge  = new MemoryLocations([new MemoryLocation($huge_addr, $huge_size)]);
+        $vm    = new MemoryLocations([new MemoryLocation($vm_addr, $vm_size)]);
+        $ca    = new MemoryLocations([new MemoryLocation($ca_addr, $ca_size)]);
+
+        $boundaries = new RegionBoundaries($chunk, $huge, $vm, $ca);
+
+        // ---- insert location rows with NULL region ----
+        $ins = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, region)'
+            . ' VALUES (?, ?, ?, ?, ?, NULL)'
+        );
+
+        // heap allocations (in chunk, outside vm_stack & compiler_arena)
+        $ins->execute([1, 1, 0x7F050000, 40000, 'ZendObjectMemoryLocation']);
+        $ins->execute([1, 2, 0x7F060000, 30000, 'ZendStringMemoryLocation']);
+        $ins->execute([1, 3, 0x7F070000, 20000, 'ZendArrayMemoryLocation']);
+        // vm_stack content (inside vm_stack range, thus inside chunk)
+        $ins->execute([1, 4, 0x7F001100, 4096,  'ZendStringMemoryLocation']);
+        $ins->execute([1, 5, 0x7F002000, 2048,  'ZendStringMemoryLocation']);
+        // compiler_arena content (inside compiler_arena range)
+        $ins->execute([1, 6, 0x7F100100, 1024,  'ZendOpArrayHeaderMemoryLocation']);
+        // huge allocation
+        $ins->execute([1, 7, 0x7E000100, 500000, 'ZendArrayMemoryLocation']);
+
+        // ---- backfill ----
+        $boundaries->backfillRegions($db, 1);
+
+        // ---- verify region classification ----
+        /** @var array<int, string> */
+        $regions = [];
+        $rows = $db->query(
+            'SELECT node_id, region FROM context_node_locations WHERE run_id = 1 ORDER BY node_id'
+        )->fetchAll(\PDO::FETCH_ASSOC);
+        foreach ($rows as $r) {
+            $regions[(int)$r['node_id']] = $r['region'];
+        }
+
+        // heap objects in chunk but outside vm_stack/compiler_arena → zend_mm_heap
+        $this->assertSame('zend_mm_heap', $regions[1]);
+        $this->assertSame('zend_mm_heap', $regions[2]);
+        $this->assertSame('zend_mm_heap', $regions[3]);
+        // vm_stack content → vm_stack (even though it is INSIDE the chunk)
+        $this->assertSame('vm_stack', $regions[4]);
+        $this->assertSame('vm_stack', $regions[5]);
+        // compiler_arena content → compiler_arena
+        $this->assertSame('compiler_arena', $regions[6]);
+        // huge allocation → zend_mm_huge
+        $this->assertSame('zend_mm_huge', $regions[7]);
+
+        // ---- queryRegionSums ----
+        $sums = RegionsSummary::queryRegionSums($db, 1);
+
+        $this->assertSame(90000, $sums['zend_mm_heap']);  // 40000+30000+20000
+        $this->assertSame(6144, $sums['vm_stack']);    // 4096+2048
+        $this->assertSame(1024, $sums['compiler_arena']);
+        $this->assertSame(500000, $sums['zend_mm_huge']);
+
+        // ---- correctedToArray ----
+        // In streaming mode the RegionAnalyzer produces a summary with
+        // overhead=0 (no ZendMmChunkMemoryLocation), usage from individual
+        // locations = 0 (lightweight), but totals are correct.
+        $base_summary = new RegionsSummary(
+            zend_mm_heap_total:  $chunk_size + $huge_size,  // chunk + huge
+            zend_mm_heap_usage:  $vm_size + $ca_size,       // streaming: only totals
+            zend_mm_chunk_total: $chunk_size,
+            zend_mm_chunk_usage: $vm_size + $ca_size,
+            zend_mm_huge_total:  $huge_size,
+            zend_mm_huge_usage:  0,
+            vm_stack_total:      $vm_size,
+            vm_stack_usage:      0,
+            compiler_arena_total: $ca_size,
+            compiler_arena_usage: 0,
+            possible_allocation_overhead_total: 0,
+            possible_array_overhead_total: 0,
+        );
+
+        $corrected = $base_summary->correctedToArray($sums);
+
+        // chunk_usage = db_heap(90000) + overhead(0) + vm_total(65536) + ca_total(32768)
+        $expected_chunk_usage = 90000 + 0 + $vm_size + $ca_size;
+        $this->assertSame($expected_chunk_usage, $corrected['zend_mm_chunk_usage']);
+        $this->assertSame(500000, $corrected['zend_mm_huge_usage']);
+        $this->assertSame(
+            $expected_chunk_usage + 500000,
+            $corrected['zend_mm_heap_usage']
+        );
+        $this->assertSame(6144, $corrected['vm_stack_usage']);
+        $this->assertSame(1024, $corrected['compiler_arena_usage']);
+
+        // ---- percentage ----
+        // memory_get_usage typically ≈ heap_usage.  Use a plausible value.
+        $memory_get_usage = 700000;
+        $pct = (float)$corrected['zend_mm_heap_usage']
+            / (float)$memory_get_usage * 100.0;
+
+        // Should be well above 0 (the bug gave near-zero).
+        $this->assertGreaterThan(50.0, $pct, 'percentage must not be near-zero');
+        // Exact expected: (188304 + 500000) / 700000 * 100 ≈ 98.3%
+        $this->assertEqualsWithDelta(98.3, $pct, 0.5);
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundariesTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionBoundariesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
+use Reli\Lib\Process\MemoryLocation;
+
+class RegionBoundariesTest extends BaseTestCase
+{
+    private function createDb(): \PDO
+    {
+        $db = new \PDO('sqlite::memory:');
+        $db->exec('CREATE TABLE context_node_locations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL,
+            node_id INTEGER NOT NULL,
+            address BIGINT,
+            size BIGINT,
+            location_type TEXT NOT NULL,
+            class_name TEXT,
+            string_value TEXT,
+            refcount BIGINT,
+            type_info BIGINT,
+            region TEXT
+        )');
+        return $db;
+    }
+
+    public function testBackfillRegionsClassifiesNullRows(): void
+    {
+        $db = $this->createDb();
+
+        // Chunk at 0x100000, size 2MB (0x100000..0x300000)
+        $chunk = new MemoryLocations([new MemoryLocation(0x100000, 2 * 1024 * 1024)]);
+        // Huge at 0x400000, size 4MB
+        $huge = new MemoryLocations([new MemoryLocation(0x400000, 4 * 1024 * 1024)]);
+        // VM stack inside chunk at 0x100000, size 64KB (0x100000..0x110000)
+        $vm_stack = new MemoryLocations([new MemoryLocation(0x100000, 65536)]);
+        // Compiler arena inside chunk at 0x180000, size 32KB (0x180000..0x188000)
+        $compiler_arena = new MemoryLocations([new MemoryLocation(0x180000, 32768)]);
+
+        $boundaries = new RegionBoundaries($chunk, $huge, $vm_stack, $compiler_arena);
+
+        $stmt = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, region)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        // In chunk, not vm_stack or compiler_arena → zend_mm_heap
+        $stmt->execute([1, 1, 0x150000, 100, 'ZendStringMemoryLocation', null]);
+        // In vm_stack → vm_stack
+        $stmt->execute([1, 2, 0x100100, 50, 'ZendStringMemoryLocation', null]);
+        // In compiler_arena → compiler_arena
+        $stmt->execute([1, 3, 0x180100, 30, 'ZendStringMemoryLocation', null]);
+        // In huge → zend_mm_huge
+        $stmt->execute([1, 4, 0x400100, 200, 'ZendArrayMemoryLocation', null]);
+        // Outside all regions → outside
+        $stmt->execute([1, 5, 0xF00000, 10, 'ZendStringMemoryLocation', null]);
+        // Already has region → should NOT be updated
+        $stmt->execute([1, 6, 0x150100, 80, 'ZendStringMemoryLocation', 'zend_mm_heap']);
+        // Different run_id → should NOT be updated
+        $stmt->execute([2, 7, 0x150200, 60, 'ZendStringMemoryLocation', null]);
+
+        $boundaries->backfillRegions($db, 1);
+
+        // Verify results
+        $rows = $db->query(
+            'SELECT id, region FROM context_node_locations ORDER BY id'
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        $this->assertSame('zend_mm_heap', $rows[0]['region']);     // id=1
+        $this->assertSame('vm_stack', $rows[1]['region']);          // id=2
+        $this->assertSame('compiler_arena', $rows[2]['region']);    // id=3
+        $this->assertSame('zend_mm_huge', $rows[3]['region']);      // id=4
+        $this->assertSame('outside', $rows[4]['region']);           // id=5
+        $this->assertSame('zend_mm_heap', $rows[5]['region']);      // id=6 (unchanged)
+        $this->assertNull($rows[6]['region']);                      // id=7 (different run)
+    }
+
+    public function testBackfillRegionsWithNoNullRows(): void
+    {
+        $db = $this->createDb();
+
+        $chunk = new MemoryLocations([new MemoryLocation(0x1000, 2 * 1024 * 1024)]);
+        $boundaries = new RegionBoundaries(
+            $chunk,
+            new MemoryLocations(),
+            new MemoryLocations(),
+            new MemoryLocations(),
+        );
+
+        $stmt = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, region)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([1, 1, 0x10000, 100, 'ZendStringMemoryLocation', 'zend_mm_heap']);
+
+        // Should not error
+        $boundaries->backfillRegions($db, 1);
+
+        $row = $db->query(
+            'SELECT region FROM context_node_locations WHERE id = 1'
+        )->fetch(\PDO::FETCH_ASSOC);
+        $this->assertSame('zend_mm_heap', $row['region']);
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionsSummaryTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionsSummaryTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
+
+class RegionsSummaryTest extends BaseTestCase
+{
+    private function makeSummary(
+        int $heap_total = 4194304,
+        int $heap_usage = 100,
+        int $chunk_total = 2097152,
+        int $chunk_usage = 100,
+        int $huge_total = 2097152,
+        int $huge_usage = 0,
+        int $vm_stack_total = 65536,
+        int $vm_stack_usage = 0,
+        int $compiler_arena_total = 32768,
+        int $compiler_arena_usage = 0,
+        int $overhead = 500,
+        int $array_overhead = 0,
+    ): RegionsSummary {
+        return new RegionsSummary(
+            $heap_total,
+            $heap_usage,
+            $chunk_total,
+            $chunk_usage,
+            $huge_total,
+            $huge_usage,
+            $vm_stack_total,
+            $vm_stack_usage,
+            $compiler_arena_total,
+            $compiler_arena_usage,
+            $overhead,
+            $array_overhead,
+        );
+    }
+
+    public function testCorrectedToArrayUsesDbSums(): void
+    {
+        // Simulate streaming mode: RegionAnalyzer saw no individual locations,
+        // so usage fields are near-zero (only overhead + region totals).
+        $summary = $this->makeSummary(
+            heap_usage: 65536 + 32768 + 500, // vm_stack_total + compiler_arena_total + overhead
+            chunk_usage: 65536 + 32768 + 500,
+            huge_usage: 0,
+        );
+
+        $region_sums = [
+            'zend_mm_heap' => 800000,
+            'zend_mm_huge' => 200000,
+            'vm_stack' => 4096,
+            'compiler_arena' => 2048,
+        ];
+
+        $corrected = $summary->correctedToArray($region_sums);
+
+        // chunk_usage = db_chunk(800000) + overhead(500) + vm_stack_total(65536) + compiler_arena_total(32768)
+        $expected_chunk = 800000 + 500 + 65536 + 32768;
+        $this->assertSame($expected_chunk, $corrected['zend_mm_chunk_usage']);
+        $this->assertSame(200000, $corrected['zend_mm_huge_usage']);
+        $this->assertSame($expected_chunk + 200000, $corrected['zend_mm_heap_usage']);
+        $this->assertSame(4096, $corrected['vm_stack_usage']);
+        $this->assertSame(2048, $corrected['compiler_arena_usage']);
+
+        // Totals should be unchanged
+        $this->assertSame(4194304, $corrected['zend_mm_heap_total']);
+        $this->assertSame(2097152, $corrected['zend_mm_chunk_total']);
+        $this->assertSame(2097152, $corrected['zend_mm_huge_total']);
+        $this->assertSame(65536, $corrected['vm_stack_total']);
+        $this->assertSame(32768, $corrected['compiler_arena_total']);
+    }
+
+    public function testCorrectedToArrayWithEmptyRegionSums(): void
+    {
+        $summary = $this->makeSummary();
+
+        // Empty region sums (no data in DB)
+        $corrected = $summary->correctedToArray([]);
+
+        // Should still include overhead + region totals
+        $expected_chunk = 0 + 500 + 65536 + 32768;
+        $this->assertSame($expected_chunk, $corrected['zend_mm_chunk_usage']);
+        $this->assertSame(0, $corrected['zend_mm_huge_usage']);
+    }
+
+    public function testQueryRegionSums(): void
+    {
+        $db = new \PDO('sqlite::memory:');
+        $db->exec('CREATE TABLE context_node_locations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL,
+            node_id INTEGER NOT NULL,
+            address BIGINT,
+            size BIGINT,
+            location_type TEXT NOT NULL,
+            class_name TEXT,
+            string_value TEXT,
+            refcount BIGINT,
+            type_info BIGINT,
+            region TEXT
+        )');
+
+        $stmt = $db->prepare(
+            'INSERT INTO context_node_locations (run_id, node_id, address, size, location_type, region)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([1, 1, 0x1000, 100, 'ZendStringMemoryLocation', 'zend_mm_heap']);
+        $stmt->execute([1, 2, 0x2000, 200, 'ZendObjectMemoryLocation', 'zend_mm_heap']);
+        $stmt->execute([1, 3, 0x3000, 500, 'ZendArrayMemoryLocation', 'zend_mm_huge']);
+        $stmt->execute([1, 4, 0x4000, 50, 'ZendStringMemoryLocation', 'vm_stack']);
+        $stmt->execute([1, 5, 0x5000, 25, 'ZendStringMemoryLocation', 'compiler_arena']);
+        // Different run_id — should be excluded
+        $stmt->execute([2, 6, 0x6000, 999, 'ZendStringMemoryLocation', 'zend_mm_heap']);
+        // NULL region — should be excluded
+        $stmt->execute([1, 7, 0x7000, 888, 'ZendStringMemoryLocation', null]);
+
+        $sums = RegionsSummary::queryRegionSums($db, 1);
+
+        $this->assertSame(300, $sums['zend_mm_heap']);
+        $this->assertSame(500, $sums['zend_mm_huge']);
+        $this->assertSame(50, $sums['vm_stack']);
+        $this->assertSame(25, $sums['compiler_arena']);
+        $this->assertArrayNotHasKey('', $sums);
+    }
+
+    public function testToArrayIsUnchanged(): void
+    {
+        $summary = $this->makeSummary();
+        $arr = $summary->toArray();
+
+        $this->assertSame(4194304, $arr['zend_mm_heap_total']);
+        $this->assertSame(100, $arr['zend_mm_heap_usage']);
+        $this->assertSame(2097152, $arr['zend_mm_chunk_total']);
+        $this->assertSame(100, $arr['zend_mm_chunk_usage']);
+        $this->assertSame(2097152, $arr['zend_mm_huge_total']);
+        $this->assertSame(0, $arr['zend_mm_huge_usage']);
+        $this->assertSame(65536, $arr['vm_stack_total']);
+        $this->assertSame(0, $arr['vm_stack_usage']);
+        $this->assertSame(32768, $arr['compiler_arena_total']);
+        $this->assertSame(0, $arr['compiler_arena_usage']);
+        $this->assertSame(500, $arr['possible_allocation_overhead_total']);
+        $this->assertSame(0, $arr['possible_array_overhead_total']);
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionsSummaryTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/RegionsSummaryTest.php
@@ -122,6 +122,9 @@ class RegionsSummaryTest extends BaseTestCase
         $stmt->execute([1, 3, 0x3000, 500, 'ZendArrayMemoryLocation', 'zend_mm_huge']);
         $stmt->execute([1, 4, 0x4000, 50, 'ZendStringMemoryLocation', 'vm_stack']);
         $stmt->execute([1, 5, 0x5000, 25, 'ZendStringMemoryLocation', 'compiler_arena']);
+        // Same address reached via different context path — must be deduped
+        $stmt->execute([1, 8, 0x1000, 100, 'ZendStringMemoryLocation', 'zend_mm_heap']);
+        $stmt->execute([1, 9, 0x2000, 200, 'ZendObjectMemoryLocation', 'zend_mm_heap']);
         // Different run_id — should be excluded
         $stmt->execute([2, 6, 0x6000, 999, 'ZendStringMemoryLocation', 'zend_mm_heap']);
         // NULL region — should be excluded
@@ -129,6 +132,7 @@ class RegionsSummaryTest extends BaseTestCase
 
         $sums = RegionsSummary::queryRegionSums($db, 1);
 
+        // 0x1000 and 0x2000 appear twice but must be counted once each
         $this->assertSame(300, $sums['zend_mm_heap']);
         $this->assertSame(500, $sums['zend_mm_huge']);
         $this->assertSame(50, $sums['vm_stack']);


### PR DESCRIPTION
## Summary
This PR adds support for correcting memory usage statistics in streaming mode by querying region sums from the database. In streaming mode, the memory locations collector uses lightweight address-only tracking, which prevents the RegionAnalyzer from computing accurate usage values from individual locations. This change reconstructs those values from aggregated data in the database.

## Key Changes
- **Added `RegionsSummary.correctedToArray()` method**: Reconstructs memory usage values using region sums from the database, combining DB data with overhead and region totals
- **Added `RegionsSummary.queryRegionSums()` static method**: Queries the `context_node_locations` table to compute SUM(size) grouped by region for a given run_id
- **Updated memory analysis commands**: Modified `MemoryCommand`, `CoreDumpReader`, and `MemoryDumpReader` to:
  - Query region sums from the database after flushing the sink
  - Use corrected summary values when region data is available
  - Fall back to original summary when no region data exists
- **Added comprehensive test coverage**: New `RegionsSummaryTest` class with tests for:
  - Corrected array generation with region sums
  - Handling empty region sums
  - Database querying with filtering (by run_id and non-null regions)
  - Unchanged behavior of the original `toArray()` method

## Implementation Details
- The correction formula adds database chunk usage + overhead + vm_stack_total + compiler_arena_total to compute corrected chunk usage
- Region sums are filtered to exclude NULL regions and only include the specified run_id
- The implementation gracefully handles missing region data by falling back to the original summary
- All three memory analysis entry points (MemoryCommand, CoreDumpReader, MemoryDumpReader) follow the same pattern for consistency

https://claude.ai/code/session_01RALoMnXxGtdJqgLDpU9icD