### PR TITLE
Track mysqlnd result buffers and PDO internal emalloc allocations

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -413,9 +413,61 @@ jobs:
           flag-name: unit-arm64
           parallel: true
 
+  build-test-mysql-images-arm64:
+    name: Build PHP ${{ matrix.php_version }}+pdo_mysql (ARM64)
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ["7.4", "8.2", "8.4"]
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}/test-php-mysql
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute Dockerfile hash
+        id: hash
+        run: echo "tag=php${{ matrix.php_version }}-sha-$(sha256sum Dockerfile-test-php-mysql | cut -c1-16)-arm64" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image already exists
+        id: check
+        run: |
+          if docker manifest inspect "${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile-test-php-mysql
+          push: true
+          build-args: PHP_VERSION=${{ matrix.php_version }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
+            ${{ env.IMAGE }}:php${{ matrix.php_version }}-arm64
+          cache-from: type=gha,scope=test-php-mysql-${{ matrix.php_version }}-arm64
+          cache-to: type=gha,mode=max,scope=test-php-mysql-${{ matrix.php_version }}-arm64
+
   phpunit-target-version-arm64:
     name: phpunit (${{ matrix.name }}, ARM64)
-    needs: build-dev-image-arm64
+    needs: [build-dev-image-arm64, build-test-mysql-images-arm64]
     runs-on: ubuntu-24.04-arm
     permissions:
       packages: read
@@ -425,12 +477,16 @@ jobs:
         include:
           - name: "PHP 7.4"
             targets: "v74"
+            php_minor: "7.4"
           - name: "PHP 8.2"
             targets: "v82"
+            php_minor: "8.2"
           - name: "PHP 8.4"
             targets: "v84"
+            php_minor: "8.4"
           - name: "PHP 8.4 ZTS"
             targets: "v84_zts"
+            php_minor: "8.4"
     steps:
       - uses: actions/checkout@v6
 
@@ -446,6 +502,13 @@ jobs:
           docker pull ${{ needs.build-dev-image-arm64.outputs.image }}
           docker tag ${{ needs.build-dev-image-arm64.outputs.image }} reli-dev
 
+      - name: Pull PHP+pdo_mysql test image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/test-php-mysql
+        run: |
+          docker pull "$IMAGE:php${{ matrix.php_minor }}-arm64" || true
+          docker tag "$IMAGE:php${{ matrix.php_minor }}-arm64" "reli-test-php-mysql:${{ matrix.php_minor }}" 2>/dev/null || true
+
       - name: Restore target Docker image cache
         id: target-cache
         uses: actions/cache@v5
@@ -459,6 +522,9 @@ jobs:
 
       - name: Install dependencies
         run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Pull MySQL image for pdo_mysql tests
+        run: docker pull mysql:8.0
 
       - name: Run target version tests
         env:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -108,9 +108,61 @@ jobs:
     outputs:
       image: ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
 
+  build-test-mysql-images:
+    name: Build PHP ${{ matrix.php_version }}+pdo_mysql
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}/test-php-mysql
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute Dockerfile hash
+        id: hash
+        run: echo "tag=php${{ matrix.php_version }}-sha-$(sha256sum Dockerfile-test-php-mysql | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image already exists
+        id: check
+        run: |
+          if docker manifest inspect "${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile-test-php-mysql
+          push: true
+          build-args: PHP_VERSION=${{ matrix.php_version }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
+            ${{ env.IMAGE }}:php${{ matrix.php_version }}
+          cache-from: type=gha,scope=test-php-mysql-${{ matrix.php_version }}
+          cache-to: type=gha,mode=max,scope=test-php-mysql-${{ matrix.php_version }}
+
   phpunit-target-version:
     name: phpunit (${{ matrix.name }})
-    needs: build-dev-image
+    needs: [build-dev-image, build-test-mysql-images]
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -120,42 +172,61 @@ jobs:
         include:
           - name: "PHP 7.0"
             targets: "v70"
+            php_minor: "7.0"
           - name: "PHP 7.1"
             targets: "v71"
+            php_minor: "7.1"
           - name: "PHP 7.2"
             targets: "v72"
+            php_minor: "7.2"
           - name: "PHP 7.3"
             targets: "v73"
+            php_minor: "7.3"
           - name: "PHP 7.4"
             targets: "v74"
+            php_minor: "7.4"
           - name: "PHP 8.0"
             targets: "v80"
+            php_minor: "8.0"
           - name: "PHP 8.1"
             targets: "v81"
+            php_minor: "8.1"
           - name: "PHP 8.2"
             targets: "v82"
+            php_minor: "8.2"
           - name: "PHP 8.3"
             targets: "v83"
+            php_minor: "8.3"
           - name: "PHP 8.4"
             targets: "v84"
+            php_minor: "8.4"
           - name: "PHP 8.5"
             targets: "v85"
+            php_minor: "8.5"
           - name: "PHP 7.3 ZTS"
             targets: "v73_zts"
+            php_minor: "7.3"
           - name: "PHP 7.4 ZTS"
             targets: "v74_zts"
+            php_minor: "7.4"
           - name: "PHP 8.0 ZTS"
             targets: "v80_zts"
+            php_minor: "8.0"
           - name: "PHP 8.1 ZTS"
             targets: "v81_zts"
+            php_minor: "8.1"
           - name: "PHP 8.2 ZTS"
             targets: "v82_zts"
+            php_minor: "8.2"
           - name: "PHP 8.3 ZTS"
             targets: "v83_zts"
+            php_minor: "8.3"
           - name: "PHP 8.4 ZTS"
             targets: "v84_zts"
+            php_minor: "8.4"
           - name: "PHP 8.5 ZTS"
             targets: "v85_zts"
+            php_minor: "8.5"
     steps:
       - uses: actions/checkout@v6
 
@@ -171,6 +242,13 @@ jobs:
           docker pull ${{ needs.build-dev-image.outputs.image }}
           docker tag ${{ needs.build-dev-image.outputs.image }} reli-dev
 
+      - name: Pull PHP+pdo_mysql test image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/test-php-mysql
+        run: |
+          docker pull "$IMAGE:php${{ matrix.php_minor }}" || true
+          docker tag "$IMAGE:php${{ matrix.php_minor }}" "reli-test-php-mysql:${{ matrix.php_minor }}" 2>/dev/null || true
+
       - name: Restore target Docker image cache
         id: target-cache
         uses: actions/cache@v5
@@ -184,6 +262,9 @@ jobs:
 
       - name: Install dependencies
         run: docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Pull MySQL image for pdo_mysql tests
+        run: docker pull mysql:8.0
 
       - name: Run target version tests
         env:

--- a/Dockerfile-test-php-mysql
+++ b/Dockerfile-test-php-mysql
@@ -1,0 +1,3 @@
+ARG PHP_VERSION=8.4
+FROM php:${PHP_VERSION}-cli
+RUN docker-php-ext-install pdo_mysql > /dev/null 2>&1

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1403,7 +1403,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1430,13 +1429,13 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[24]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1448,13 +1447,12 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	unsigned char ps; /* zend_bool */
+	unsigned char ps;
 	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
-	int buffered_type; /* enum mysqlnd_buffered_type */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
-	/* _zval fields (largest variant) */
-	uintptr_t data; /* zval * */
-	uintptr_t data_cursor; /* zval * */
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1403,3 +1403,58 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *last;
+	void *checkpoint;
+	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	uint64_t initialized_rows;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	unsigned char ps; /* zend_bool */
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type; /* enum mysqlnd_buffered_type */
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+	/* _zval fields (largest variant) */
+	uintptr_t data; /* zval * */
+	uintptr_t data_cursor; /* zval * */
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1430,3 +1430,58 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *last;
+	void *checkpoint;
+	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	uint64_t initialized_rows;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	unsigned char ps; /* zend_bool */
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type; /* enum mysqlnd_buffered_type */
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+	/* _zval fields (largest variant) */
+	uintptr_t data; /* zval * */
+	uintptr_t data_cursor; /* zval * */
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1430,7 +1430,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1457,13 +1456,13 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[24]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1475,13 +1474,12 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	unsigned char ps; /* zend_bool */
+	unsigned char ps;
 	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
-	int buffered_type; /* enum mysqlnd_buffered_type */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
-	/* _zval fields (largest variant) */
-	uintptr_t data; /* zval * */
-	uintptr_t data_cursor; /* zval * */
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1424,3 +1424,58 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *last;
+	void *checkpoint;
+	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	uint64_t initialized_rows;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	unsigned char ps; /* zend_bool */
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type; /* enum mysqlnd_buffered_type */
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+	/* _zval fields (largest variant) */
+	uintptr_t data; /* zval * */
+	uintptr_t data_cursor; /* zval * */
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1424,7 +1424,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1451,13 +1450,13 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[24]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1469,13 +1468,12 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	unsigned char ps; /* zend_bool */
+	unsigned char ps;
 	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
-	int buffered_type; /* enum mysqlnd_buffered_type */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
-	/* _zval fields (largest variant) */
-	uintptr_t data; /* zval * */
-	uintptr_t data_cursor; /* zval * */
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1417,7 +1417,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1444,13 +1443,13 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[24]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1462,13 +1461,12 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	unsigned char ps; /* zend_bool */
+	unsigned char ps;
 	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
-	int buffered_type; /* enum mysqlnd_buffered_type */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
-	/* _zval fields (largest variant) */
-	uintptr_t data; /* zval * */
-	uintptr_t data_cursor; /* zval * */
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1417,3 +1417,58 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *last;
+	void *checkpoint;
+	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	uint64_t initialized_rows;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	unsigned char ps; /* zend_bool */
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type; /* enum mysqlnd_buffered_type */
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+	/* _zval fields (largest variant) */
+	uintptr_t data; /* zval * */
+	uintptr_t data_cursor; /* zval * */
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1457,7 +1457,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1484,13 +1483,13 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[26]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1502,13 +1501,12 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	unsigned char ps; /* zend_bool */
+	unsigned char ps;
 	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
-	int buffered_type; /* enum mysqlnd_buffered_type */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
-	/* _zval fields (largest variant) */
-	uintptr_t data; /* zval * */
-	uintptr_t data_cursor; /* zval * */
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1457,3 +1457,58 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *last;
+	void *checkpoint;
+	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[24]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	uint64_t initialized_rows;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	unsigned char ps; /* zend_bool */
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type; /* enum mysqlnd_buffered_type */
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+	/* _zval fields (largest variant) */
+	uintptr_t data; /* zval * */
+	uintptr_t data_cursor; /* zval * */
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1484,3 +1484,52 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	unsigned char persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1484,7 +1484,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1502,34 +1501,39 @@ typedef struct st_mysqlnd_error_info {
 
 typedef struct st_mysqlnd_memory_pool {
 	zend_arena *arena;
+	void *last;
 	void *checkpoint;
 	uintptr_t get_chunk;
+	uintptr_t resize_chunk;
+	uintptr_t free_chunk;
 } MYSQLND_MEMORY_POOL;
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[26]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
-	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
 	MYSQLND_ROW_BUFFER *row_buffers;
 	uint64_t row_count;
+	uint64_t initialized_rows;
 	size_t *lengths;
 	MYSQLND_MEMORY_POOL *result_set_memory_pool;
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
-	uint64_t current_row;
+	unsigned char ps;
+	uintptr_t m[7]; /* mysqlnd_result_buffered method table */
+	int buffered_type;
 	uintptr_t unused1;
 	uintptr_t unused2;
 	uintptr_t unused3;
+	uintptr_t data;
+	uintptr_t data_cursor;
 } MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1640,7 +1640,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1664,15 +1663,15 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
+	uintptr_t row_data;
 	bool free_row_data;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[26]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1684,7 +1683,7 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uintptr_t stmt;
 	uint64_t current_row;
 	uintptr_t unused1;
 	uintptr_t unused2;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1640,3 +1640,53 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	bool persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	bool free_row_data;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1684,3 +1684,53 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	bool persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	bool free_row_data;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1684,7 +1684,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1708,15 +1707,15 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
+	uintptr_t row_data;
 	bool free_row_data;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[25]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1728,7 +1727,7 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uintptr_t stmt;
 	uint64_t current_row;
 	uintptr_t unused1;
 	uintptr_t unused2;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1726,3 +1726,53 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	bool persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	bool free_row_data;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1726,7 +1726,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1750,15 +1749,15 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
+	uintptr_t row_data;
 	bool free_row_data;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[26]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1770,7 +1769,7 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uintptr_t stmt;
 	uint64_t current_row;
 	uintptr_t unused1;
 	uintptr_t unused2;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1814,7 +1814,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1838,15 +1837,15 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
+	uintptr_t row_data;
 	bool free_row_data;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[25]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1858,7 +1857,7 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uintptr_t stmt;
 	uint64_t current_row;
 	uintptr_t unused1;
 	uintptr_t unused2;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1814,3 +1814,53 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	bool persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	bool free_row_data;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1833,7 +1833,6 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
-
 // ext/mysqlnd/mysqlnd_structs.h
 typedef struct st_mysqlnd_row_buffer {
 	void *ptr;
@@ -1857,15 +1856,15 @@ typedef struct st_mysqlnd_memory_pool {
 
 typedef struct {
 	uintptr_t conn;
-	int type; /* enum_mysqlnd_res_type */
+	int type;
 	unsigned int field_count;
-	uintptr_t row_data; /* zval * */
+	uintptr_t row_data;
 	bool free_row_data;
-	uintptr_t meta; /* MYSQLND_RES_METADATA * */
-	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
-	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	uintptr_t meta;
+	uintptr_t stored_data;
+	uintptr_t unbuf;
 	MYSQLND_MEMORY_POOL *memory_pool;
-	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+	uintptr_t m[25]; /* mysqlnd_res method table */
 } MYSQLND_RES;
 
 typedef struct {
@@ -1877,7 +1876,7 @@ typedef struct {
 	unsigned int references;
 	MYSQLND_ERROR_INFO error_info;
 	unsigned int field_count;
-	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uintptr_t stmt;
 	uint64_t current_row;
 	uintptr_t unused1;
 	uintptr_t unused2;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1833,3 +1833,53 @@ typedef struct {
 	uintptr_t current_row; /* zval * */
 	uint32_t pdo_mysql_stmt_flags; /* max_length:1, done:1 */
 } pdo_mysql_stmt;
+
+// ext/mysqlnd/mysqlnd_structs.h
+typedef struct st_mysqlnd_row_buffer {
+	void *ptr;
+	size_t size;
+} MYSQLND_ROW_BUFFER;
+
+typedef struct st_mysqlnd_error_info {
+	char error[513]; /* MYSQLND_ERRMSG_SIZE + 1 */
+	char sqlstate[6]; /* MYSQLND_SQLSTATE_LENGTH + 1 */
+	unsigned int error_no;
+	zend_llist error_list;
+	bool persistent;
+	uintptr_t m; /* method table pointer */
+} MYSQLND_ERROR_INFO;
+
+typedef struct st_mysqlnd_memory_pool {
+	zend_arena *arena;
+	void *checkpoint;
+	uintptr_t get_chunk;
+} MYSQLND_MEMORY_POOL;
+
+typedef struct {
+	uintptr_t conn;
+	int type; /* enum_mysqlnd_res_type */
+	unsigned int field_count;
+	uintptr_t row_data; /* zval * */
+	bool free_row_data;
+	uintptr_t meta; /* MYSQLND_RES_METADATA * */
+	uintptr_t stored_data; /* MYSQLND_RES_BUFFERED * */
+	uintptr_t unbuf; /* MYSQLND_RES_UNBUFFERED * */
+	MYSQLND_MEMORY_POOL *memory_pool;
+	uintptr_t m[22]; /* mysqlnd_res method table (inlined) */
+} MYSQLND_RES;
+
+typedef struct {
+	uintptr_t m[6]; /* mysqlnd_result_buffered method table */
+	MYSQLND_ROW_BUFFER *row_buffers;
+	uint64_t row_count;
+	size_t *lengths;
+	MYSQLND_MEMORY_POOL *result_set_memory_pool;
+	unsigned int references;
+	MYSQLND_ERROR_INFO error_info;
+	unsigned int field_count;
+	uintptr_t stmt; /* MYSQLND_STMT_DATA * */
+	uint64_t current_row;
+	uintptr_t unused1;
+	uintptr_t unused2;
+	uintptr_t unused3;
+} MYSQLND_RES_BUFFERED;

--- a/src/Lib/PhpInternals/Types/Php/MysqlndRes.php
+++ b/src/Lib/PhpInternals/Types/Php/MysqlndRes.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\MYSQLND_RES;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+
+final class MysqlndRes implements CDataDereferencable
+{
+    /**
+     * @param CastedCData<MYSQLND_RES> $casted_cdata
+     * @param Pointer<MysqlndRes> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'MYSQLND_RES';
+    }
+
+    #[\Override]
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /**
+         * @var CastedCData<MYSQLND_RES> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpInternals/Types/Php/MysqlndResBuffered.php
+++ b/src/Lib/PhpInternals/Types/Php/MysqlndResBuffered.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\MYSQLND_RES_BUFFERED;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+
+final class MysqlndResBuffered implements CDataDereferencable
+{
+    /**
+     * @param CastedCData<MYSQLND_RES_BUFFERED> $casted_cdata
+     * @param Pointer<MysqlndResBuffered> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'MYSQLND_RES_BUFFERED';
+    }
+
+    #[\Override]
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /**
+         * @var CastedCData<MYSQLND_RES_BUFFERED> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MysqlndMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MysqlndMemoryLocation.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+final class MysqlndMemoryLocation extends MemoryLocation
+{
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1188,6 +1188,56 @@ final class MemoryLocationsCollector
                 $memory_locations,
             );
         }
+
+        // Track data_source, username, password strings (pestrdup allocations)
+        $this->collectPdoDbhStrings(
+            $inner_address,
+            $dereferencer,
+            $zend_type_reader,
+            $memory_locations,
+        );
+    }
+
+    private function collectPdoDbhStrings(
+        int $dbh_address,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+    ): void {
+        // data_source: read address and length
+        try {
+            [$ds_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_dbh_t', 'data_source');
+            $ds_ptr = new Pointer(RawInt64::class, $dbh_address + $ds_offset, 8);
+            $ds_address = $dereferencer->deref($ds_ptr)->value;
+
+            [$dsl_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_dbh_t', 'data_source_len');
+            $dsl_ptr = new Pointer(RawInt64::class, $dbh_address + $dsl_offset, 8);
+            $ds_len = $dereferencer->deref($dsl_ptr)->value;
+
+            if ($ds_address !== 0 && $ds_len > 0 && $ds_len < 65536) {
+                $memory_locations->add(new PdoDbhMemoryLocation($ds_address, $ds_len + 1));
+            }
+        } catch (\Throwable) {
+        }
+
+        // username and password: read address, measure with RawString
+        foreach (['username', 'password'] as $field) {
+            try {
+                [$f_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_dbh_t', $field);
+                $f_ptr = new Pointer(RawInt64::class, $dbh_address + $f_offset, 8);
+                $f_address = $dereferencer->deref($f_ptr)->value;
+                if ($f_address !== 0 && !$memory_locations->has($f_address)) {
+                    // Read up to 256 bytes to find string length
+                    $raw_ptr = new Pointer(RawString::class, $f_address, 256);
+                    $str = (string)$dereferencer->deref($raw_ptr);
+                    $len = strlen($str);
+                    if ($len > 0) {
+                        $memory_locations->add(new PdoDbhMemoryLocation($f_address, $len + 1));
+                    }
+                }
+            } catch (\Throwable) {
+            }
+        }
     }
 
     private function collectPdoStmt(
@@ -1203,24 +1253,57 @@ final class MemoryLocationsCollector
         [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_stmt_t', 'std');
         $stmt_address = $object->getPointer()->address - $std_offset;
 
-        // Read query_string pointer (v81+: zend_string *)
+        // Read query_string and active_query_string (v81+: zend_string *)
         if (!$zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V81)) {
-            [$qs_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_stmt_t', 'query_string');
-            $qs_ptr = new Pointer(RawInt64::class, $stmt_address + $qs_offset, 8);
-            $query_string_address = $dereferencer->deref($qs_ptr)->value;
-            if ($query_string_address !== 0) {
-                $string_pointer = new Pointer(
-                    ZendString::class,
-                    $query_string_address,
-                    $zend_type_reader->sizeOf('zend_string'),
-                );
-                $string_context = $this->collectZendStringPointer(
-                    $string_pointer,
-                    $memory_locations,
-                    $dereferencer,
-                    $context_pools,
-                );
-                $object_context->add('pdo_query_string', $string_context);
+            foreach (['query_string', 'active_query_string'] as $idx => $field) {
+                try {
+                    [$qs_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_stmt_t', $field);
+                    $qs_ptr = new Pointer(RawInt64::class, $stmt_address + $qs_offset, 8);
+                    $qs_address = $dereferencer->deref($qs_ptr)->value;
+                    if ($qs_address !== 0) {
+                        $string_pointer = new Pointer(
+                            ZendString::class,
+                            $qs_address,
+                            $zend_type_reader->sizeOf('zend_string'),
+                        );
+                        $string_context = $this->collectZendStringPointer(
+                            $string_pointer,
+                            $memory_locations,
+                            $dereferencer,
+                            $context_pools,
+                        );
+                        if ($idx === 0) {
+                            $object_context->add('pdo_query_string', $string_context);
+                        }
+                    }
+                } catch (\Throwable) {
+                }
+            }
+        }
+
+        // Track bound_params, bound_param_map, bound_columns HashTables
+        foreach (['bound_params', 'bound_param_map', 'bound_columns'] as $ht_field) {
+            try {
+                [$ht_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_stmt_t', $ht_field);
+                $ht_ptr = new Pointer(RawInt64::class, $stmt_address + $ht_offset, 8);
+                $ht_address = $dereferencer->deref($ht_ptr)->value;
+                if ($ht_address !== 0 && !$memory_locations->has($ht_address)) {
+                    $ht_pointer = new Pointer(
+                        ZendArray::class,
+                        $ht_address,
+                        $zend_type_reader->sizeOf('zend_array'),
+                    );
+                    $this->collectZendArray(
+                        $dereferencer->deref($ht_pointer),
+                        0,
+                        $dereferencer,
+                        $zend_type_reader,
+                        $memory_locations,
+                        $context_pools,
+                        null,
+                    );
+                }
+            } catch (\Throwable) {
             }
         }
 
@@ -1268,6 +1351,14 @@ final class MemoryLocationsCollector
 
         if ($columns_address !== 0 && $column_count > 0 && $column_count < 10000) {
             $column_data_size = $zend_type_reader->sizeOf('pdo_column_data');
+
+            // Track the columns array allocation: ecalloc(column_count, sizeof(pdo_column_data))
+            if (!$memory_locations->has($columns_address)) {
+                $memory_locations->add(
+                    new PdoDriverDataMemoryLocation($columns_address, (int)$column_count * $column_data_size)
+                );
+            }
+
             for ($i = 0; $i < $column_count; $i++) {
                 $col_pointer = new Pointer(
                     PdoColumnData::class,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -45,6 +45,8 @@ use Reli\Lib\PhpInternals\Types\Php\PdoPgsqlDbHandle;
 use Reli\Lib\PhpInternals\Types\Php\PdoPgsqlStmt;
 use Reli\Lib\PhpInternals\Types\Php\PdoSqliteDbHandle;
 use Reli\Lib\PhpInternals\Types\Php\PdoSqliteStmt;
+use Reli\Lib\PhpInternals\Types\Php\MysqlndRes;
+use Reli\Lib\PhpInternals\Types\Php\MysqlndResBuffered;
 use Reli\Lib\PhpInternals\Types\Php\PhpStream;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamMemoryData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamOps;
@@ -82,6 +84,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendOpArrayBodyMemo
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendOpArrayHeaderMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendPropertyInfoMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendReferenceMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MysqlndMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\PdoDbhMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\PdoDriverDataMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendResourceMemoryLocation;
@@ -1369,6 +1372,177 @@ final class MemoryLocationsCollector
             $dereferencer->deref(new Pointer($class, $driver_data_address, $size));
             $memory_locations->add(new PdoDriverDataMemoryLocation($driver_data_address, $size));
         } catch (\Throwable) {
+            return;
+        }
+
+        // For MySQL (mysqlnd), follow the result pointer to track buffered result data
+        if ($driver_name === 'mysql') {
+            $this->collectMysqlndResultFromPdoMysqlStmt(
+                $driver_data_address,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+            );
+        }
+    }
+
+    private function collectMysqlndResultFromPdoMysqlStmt(
+        int $pdo_mysql_stmt_address,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+    ): void {
+        try {
+            // pdo_mysql_stmt.result is the 2nd pointer field (after H)
+            $result_ptr = new Pointer(
+                RawInt64::class,
+                $pdo_mysql_stmt_address + 8, // offset of result (after H pointer)
+                8,
+            );
+            $result_address = $dereferencer->deref($result_ptr)->value;
+            if ($result_address === 0) {
+                return;
+            }
+
+            $this->collectMysqlndResult(
+                $result_address,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+            );
+        } catch (\Throwable) {
+        }
+    }
+
+    private function collectMysqlndResult(
+        int $res_address,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+    ): void {
+        if ($memory_locations->has($res_address)) {
+            return;
+        }
+
+        $res_size = $zend_type_reader->sizeOf('MYSQLND_RES');
+        try {
+            $dereferencer->deref(new Pointer(MysqlndRes::class, $res_address, $res_size));
+        } catch (\Throwable) {
+            return;
+        }
+        $memory_locations->add(new MysqlndMemoryLocation($res_address, $res_size));
+
+        // Read stored_data pointer (MYSQLND_RES_BUFFERED *)
+        [$sd_offset] = $zend_type_reader->getOffsetAndSizeOfMember('MYSQLND_RES', 'stored_data');
+        $sd_ptr = new Pointer(RawInt64::class, $res_address + $sd_offset, 8);
+        $stored_data_address = $dereferencer->deref($sd_ptr)->value;
+
+        if ($stored_data_address !== 0) {
+            $this->collectMysqlndResBuffered(
+                $stored_data_address,
+                $dereferencer,
+                $zend_type_reader,
+                $memory_locations,
+            );
+        }
+
+        // Read memory_pool pointer
+        [$mp_offset] = $zend_type_reader->getOffsetAndSizeOfMember('MYSQLND_RES', 'memory_pool');
+        $mp_ptr = new Pointer(RawInt64::class, $res_address + $mp_offset, 8);
+        $mempool_address = $dereferencer->deref($mp_ptr)->value;
+
+        if ($mempool_address !== 0 && !$memory_locations->has($mempool_address)) {
+            $mp_size = $zend_type_reader->sizeOf('MYSQLND_MEMORY_POOL');
+            try {
+                $memory_locations->add(new MysqlndMemoryLocation($mempool_address, $mp_size));
+            } catch (\Throwable) {
+            }
+        }
+    }
+
+    private function collectMysqlndResBuffered(
+        int $buf_address,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        MemoryLocations $memory_locations,
+    ): void {
+        if ($memory_locations->has($buf_address)) {
+            return;
+        }
+
+        $buf_size = $zend_type_reader->sizeOf('MYSQLND_RES_BUFFERED');
+        try {
+            $dereferencer->deref(new Pointer(MysqlndResBuffered::class, $buf_address, $buf_size));
+        } catch (\Throwable) {
+            return;
+        }
+        $memory_locations->add(new MysqlndMemoryLocation($buf_address, $buf_size));
+
+        // Read row_buffers array pointer and row_count
+        [$rb_offset] = $zend_type_reader->getOffsetAndSizeOfMember('MYSQLND_RES_BUFFERED', 'row_buffers');
+        $rb_ptr = new Pointer(RawInt64::class, $buf_address + $rb_offset, 8);
+        $row_buffers_address = $dereferencer->deref($rb_ptr)->value;
+
+        [$rc_offset] = $zend_type_reader->getOffsetAndSizeOfMember('MYSQLND_RES_BUFFERED', 'row_count');
+        $rc_ptr = new Pointer(RawInt64::class, $buf_address + $rc_offset, 8);
+        $row_count = $dereferencer->deref($rc_ptr)->value;
+
+        // Track the row_buffers array (MYSQLND_ROW_BUFFER[row_count])
+        if ($row_buffers_address !== 0 && $row_count > 0 && $row_count < 1000000) {
+            $rb_element_size = $zend_type_reader->sizeOf('MYSQLND_ROW_BUFFER');
+            $total_size = (int)($row_count * $rb_element_size);
+            if (!$memory_locations->has($row_buffers_address)) {
+                $memory_locations->add(new MysqlndMemoryLocation($row_buffers_address, $total_size));
+            }
+        }
+
+        // Read result_set_memory_pool
+        [$rmp_offset] = $zend_type_reader->getOffsetAndSizeOfMember('MYSQLND_RES_BUFFERED', 'result_set_memory_pool');
+        $rmp_ptr = new Pointer(RawInt64::class, $buf_address + $rmp_offset, 8);
+        $rmp_address = $dereferencer->deref($rmp_ptr)->value;
+
+        if ($rmp_address !== 0 && !$memory_locations->has($rmp_address)) {
+            $mp_size = $zend_type_reader->sizeOf('MYSQLND_MEMORY_POOL');
+            $memory_locations->add(new MysqlndMemoryLocation($rmp_address, $mp_size));
+
+            // Follow arena pointer to track arena chunks
+            $arena_ptr = new Pointer(RawInt64::class, $rmp_address, 8);
+            $arena_address = $dereferencer->deref($arena_ptr)->value;
+            $this->collectZendArenaChain($arena_address, $memory_locations, $dereferencer);
+        }
+    }
+
+    private function collectZendArenaChain(
+        int $arena_address,
+        MemoryLocations $memory_locations,
+        Dereferencer $dereferencer,
+    ): void {
+        // zend_arena: { char *ptr; char *end; zend_arena *prev; }
+        // Walk the linked list of arena chunks
+        $visited = 0;
+        while ($arena_address !== 0 && $visited < 1000) {
+            if ($memory_locations->has($arena_address)) {
+                break;
+            }
+            try {
+                // Read end pointer to determine arena size: end - arena_address = total chunk size
+                $end_ptr = new Pointer(RawInt64::class, $arena_address + 8, 8);
+                $end_address = $dereferencer->deref($end_ptr)->value;
+
+                if ($end_address > $arena_address) {
+                    $chunk_size = $end_address - $arena_address;
+                    if ($chunk_size < 64 * 1024 * 1024) { // sanity: max 64MB per chunk
+                        $memory_locations->add(new MysqlndMemoryLocation($arena_address, (int)$chunk_size));
+                    }
+                }
+
+                // Read prev pointer
+                $prev_ptr = new Pointer(RawInt64::class, $arena_address + 16, 8);
+                $arena_address = $dereferencer->deref($prev_ptr)->value;
+                $visited++;
+            } catch (\Throwable) {
+                break;
+            }
         }
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -1390,23 +1390,22 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
     ): string {
         try {
-            [$ds_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_dbh_t', 'data_source');
-            $ds_ptr = new Pointer(RawInt64::class, $dbh_address + $ds_offset, 8);
-            $ds_address = $dereferencer->deref($ds_ptr)->value;
-            if ($ds_address === 0) {
+            // Read pdo_dbh_t.driver -> pdo_driver_t, then read driver_name
+            // pdo_driver_t: { const char *driver_name; size_t driver_name_len; ... }
+            [$drv_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_dbh_t', 'driver');
+            $drv_ptr = new Pointer(RawInt64::class, $dbh_address + $drv_offset, 8);
+            $driver_struct_address = $dereferencer->deref($drv_ptr)->value;
+            if ($driver_struct_address === 0) {
                 return '';
             }
-            // Read first 16 bytes of data_source to detect driver prefix
-            $label_pointer = new Pointer(RawString::class, $ds_address, 16);
-            $dsn = (string)$dereferencer->deref($label_pointer);
-            if (str_starts_with($dsn, ':memory:') || str_starts_with($dsn, '/')) {
-                return 'sqlite';
+            // driver_name is the first field of pdo_driver_t (a char* pointer)
+            $name_ptr_ptr = new Pointer(RawInt64::class, $driver_struct_address, 8);
+            $name_address = $dereferencer->deref($name_ptr_ptr)->value;
+            if ($name_address === 0) {
+                return '';
             }
-            $colon_pos = strpos($dsn, ':');
-            if ($colon_pos !== false) {
-                return substr($dsn, 0, $colon_pos);
-            }
-            return $dsn;
+            $name_pointer = new Pointer(RawString::class, $name_address, 16);
+            return (string)$dereferencer->deref($name_pointer);
         } catch (\Throwable) {
             return '';
         }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -235,11 +235,39 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
             'pdo_dbh_t internal handle should be tracked',
         );
 
-        // Verify PdoDriverDataMemoryLocation is tracked (sqlite driver data)
+        // Verify PdoDriverDataMemoryLocation is tracked (sqlite driver data + columns array)
         $this->assertArrayHasKey(
             'PdoDriverDataMemoryLocation',
             $location_type_result->per_type_usage,
             'PDO driver data should be tracked',
+        );
+        // pdo_sqlite_db_handle + pdo_sqlite_stmt + columns array = at least 3
+        $this->assertGreaterThanOrEqual(
+            3,
+            $location_type_result->per_type_usage['PdoDriverDataMemoryLocation']['count'],
+            'Driver data should include sqlite handles and columns array',
+        );
+
+        // pdo_dbh_t.data_source string is also tracked as PdoDbhMemoryLocation
+        // (pdo_dbh_t itself + data_source string = at least 2)
+        $this->assertGreaterThanOrEqual(
+            2,
+            $location_type_result->per_type_usage['PdoDbhMemoryLocation']['count'],
+            'PdoDbhMemoryLocation should include pdo_dbh_t and DSN string',
+        );
+
+        // Verify ZendArrayMemoryLocation count increased due to bound_params tracking
+        $this->assertArrayHasKey(
+            'ZendArrayMemoryLocation',
+            $location_type_result->per_type_usage,
+        );
+        $array_count = $location_type_result->per_type_usage['ZendArrayMemoryLocation']['count'];
+        // The script creates bound_params via bindValue, so there should be
+        // at least the global symbol table + bound_params HashTable
+        $this->assertGreaterThanOrEqual(
+            2,
+            $array_count,
+            'Should track HashTables including PDO bound_params',
         );
 
         // Verify memory coverage is reasonable

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -38,7 +39,9 @@ use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\Process\ProcessSpecifier;
+use Reli\TargetPhpVmProvider;
 
 #[Group('target-version')]
 #[Group('pdo_mysql')]
@@ -83,23 +86,44 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
         }
     }
 
-    public function testCollectPdoMysqlMysqlndBuffers(): void
-    {
-        $php_version = 'v84';
-        $docker_image_name = 'reli-test-php-mysql:8.4';
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testCollectPdoMysqlMysqlndBuffers(
+        string $php_version,
+        string $base_docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
 
-        // Build PHP image with pdo_mysql (cached after first run)
-        exec(
-            "docker build -q -t $docker_image_name -f- /tmp <<'DEOF'\n"
-            . "FROM php:8.4-cli\nRUN docker-php-ext-install pdo_mysql > /dev/null 2>&1\n"
-            . "DEOF\n2>/dev/null",
-            $build_output,
-            $build_exit,
-        );
-        if ($build_exit !== 0) {
-            $this->markTestSkipped(
-                'Cannot build PHP image with pdo_mysql (docker pull may be needed)'
+        // ZTS images don't have a pre-built pdo_mysql variant; skip for now
+        if (str_contains($base_docker_image_name, '-zts')) {
+            $this->markTestSkipped('pdo_mysql test not supported on ZTS images');
+        }
+
+        // Derive pdo_mysql image name: reli-test-php-mysql:7.4, reli-test-php-mysql:8.4, etc.
+        // The version tag is extracted from the base image (e.g. "php:8.4-cli" -> "8.4")
+        preg_match('/php:(\d+\.\d+)/', $base_docker_image_name, $m);
+        $php_minor = $m[1] ?? '';
+        if ($php_minor === '') {
+            $this->markTestSkipped("Cannot determine PHP minor version from $base_docker_image_name");
+        }
+        $docker_image_name = "reli-test-php-mysql:$php_minor";
+
+        // Check if the pre-built image exists; if not, build it on-the-fly
+        exec("docker image inspect $docker_image_name 2>/dev/null", $inspect_output, $inspect_exit);
+        if ($inspect_exit !== 0) {
+            exec(
+                "docker build -q -t $docker_image_name"
+                . " --build-arg PHP_VERSION=$php_minor"
+                . " -f Dockerfile-test-php-mysql . 2>/dev/null",
+                $build_output,
+                $build_exit,
             );
+            if ($build_exit !== 0) {
+                $this->markTestSkipped(
+                    "Cannot build PHP $php_minor image with pdo_mysql"
+                );
+            }
         }
 
         // Create Docker network

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -58,10 +58,10 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
         $this->memory_limit_backup = ini_get('memory_limit');
         ini_set('memory_limit', '1G');
 
-        // Check if MySQL image is available
-        exec('docker image inspect mysql:8.0 2>/dev/null', $output, $exit_code);
+        // Skip unless Docker is available
+        exec('docker ps 2>/dev/null', $output, $exit_code);
         if ($exit_code !== 0) {
-            $this->markTestSkipped('mysql:8.0 Docker image not available');
+            $this->markTestSkipped('Docker is not available');
         }
     }
 
@@ -86,25 +86,20 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
     public function testCollectPdoMysqlMysqlndBuffers(): void
     {
         $php_version = 'v84';
-        $docker_image_name = 'php:8.4-cli';
+        $docker_image_name = 'reli-test-php-mysql:8.4';
 
-        // Check PHP image has pdo_mysql; if not, build one with it
-        exec("docker run --rm $docker_image_name php -m 2>/dev/null", $modules);
-        if (!in_array('pdo_mysql', $modules, true)) {
-            // Build a derived image with pdo_mysql
-            $docker_image_name = 'reli-test-php-mysql:8.4';
-            exec(
-                "docker build -q -t $docker_image_name -f- /tmp <<'DEOF'\n"
-                . "FROM php:8.4-cli\nRUN docker-php-ext-install pdo_mysql > /dev/null 2>&1\n"
-                . "DEOF\n2>/dev/null",
-                $build_output,
-                $build_exit,
+        // Build PHP image with pdo_mysql (cached after first run)
+        exec(
+            "docker build -q -t $docker_image_name -f- /tmp <<'DEOF'\n"
+            . "FROM php:8.4-cli\nRUN docker-php-ext-install pdo_mysql > /dev/null 2>&1\n"
+            . "DEOF\n2>/dev/null",
+            $build_output,
+            $build_exit,
+        );
+        if ($build_exit !== 0) {
+            $this->markTestSkipped(
+                'Cannot build PHP image with pdo_mysql (docker pull may be needed)'
             );
-            if ($build_exit !== 0) {
-                $this->markTestSkipped(
-                    'Cannot build PHP image with pdo_mysql: ' . implode("\n", $build_output)
-                );
-            }
         }
 
         // Create Docker network
@@ -128,8 +123,10 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
             escapeshellarg($mysql_password),
         );
         $this->mysql_container_id = trim(shell_exec($cmd) ?? '');
-        if (empty($this->mysql_container_id)) {
-            $this->markTestSkipped('Cannot start MySQL container');
+        if (empty($this->mysql_container_id) || strlen($this->mysql_container_id) < 12) {
+            $this->markTestSkipped(
+                'Cannot start MySQL container (mysql:8.0 image may not be available)'
+            );
         }
 
         // Wait for MySQL to be ready (first start can take ~30s)

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -258,40 +258,63 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
         $memory_reader_for_finder = new MemoryReader();
         $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
         $tsrm_globals_resolver = new TsrmGlobalsResolver(
-            $php_symbol_reader_creator, $integer_reader, $memory_reader_for_finder,
-            $binary_analysis_cache, $process_memory_map_creator, $binary_fingerprint_creator,
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
         $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
-            $php_symbol_reader_creator, $tsrm_globals_resolver, $memory_reader_for_finder,
-            $integer_reader, new Elf64Parser($integer_reader), new CatFileReader(),
-            ProcessMemoryMapCreator::create(), new ContainerAwarePathResolver(),
-            new ZendTypeReaderCreator(), $binary_analysis_cache, $binary_fingerprint_creator,
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
         );
         $php_globals_finder = new PhpGlobalsFinder(
-            $php_symbol_reader_creator, $integer_reader, $memory_reader_for_finder,
-            $tsrm_ls_cache_finder, $tsrm_globals_resolver,
-            $binary_analysis_cache, $process_memory_map_creator, $binary_fingerprint_creator,
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
         );
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(php_version: $php_version);
 
         $executor_globals_address = $php_globals_finder->findExecutorGlobals(
-            $process_specifier, $target_php_settings,
+            $process_specifier,
+            $target_php_settings,
         );
         $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
-            $process_specifier, $target_php_settings,
+            $process_specifier,
+            $target_php_settings,
         );
 
         $memory_locations_collector = new MemoryLocationsCollector(
-            $memory_reader, $type_reader_creator,
+            $memory_reader,
+            $type_reader_creator,
             new PhpZendMemoryManagerChunkFinder(
-                ProcessMemoryMapCreator::create(), $type_reader_creator, $php_globals_finder,
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder,
             ),
         );
         $collected_memories = $memory_locations_collector->collectAll(
-            $process_specifier, $target_php_settings,
-            $executor_globals_address, $compiler_globals_address,
+            $process_specifier,
+            $target_php_settings,
+            $executor_globals_address,
+            $compiler_globals_address,
         );
 
         $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -1,0 +1,346 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
+use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\File\CatFileReader;
+use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\LocationTypeAnalyzer\LocationTypeAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
+use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\Process\ProcessSpecifier;
+
+#[Group('target-version')]
+#[Group('pdo_mysql')]
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
+{
+    /** @var resource|null */
+    private $child = null;
+    private ?string $mysql_container_id = null;
+    private ?string $docker_network = null;
+    private string $memory_limit_backup;
+
+    public function setUp(): void
+    {
+        $this->child = null;
+        $this->memory_limit_backup = ini_get('memory_limit');
+        ini_set('memory_limit', '1G');
+
+        // Check if MySQL image is available
+        exec('docker image inspect mysql:8.0 2>/dev/null', $output, $exit_code);
+        if ($exit_code !== 0) {
+            $this->markTestSkipped('mysql:8.0 Docker image not available');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('memory_limit', $this->memory_limit_backup);
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status) && $child_status['running']) {
+                posix_kill($child_status['pid'], SIGKILL);
+            }
+            $this->child = null;
+        }
+        if ($this->mysql_container_id !== null) {
+            exec("docker rm -f {$this->mysql_container_id} 2>/dev/null");
+        }
+        if ($this->docker_network !== null) {
+            exec("docker network rm {$this->docker_network} 2>/dev/null");
+        }
+    }
+
+    public function testCollectPdoMysqlMysqlndBuffers(): void
+    {
+        $php_version = 'v84';
+        $docker_image_name = 'php:8.4-cli';
+
+        // Check PHP image has pdo_mysql; if not, build one with it
+        exec("docker run --rm $docker_image_name php -m 2>/dev/null", $modules);
+        if (!in_array('pdo_mysql', $modules, true)) {
+            // Build a derived image with pdo_mysql
+            $docker_image_name = 'reli-test-php-mysql:8.4';
+            exec(
+                "docker build -q -t $docker_image_name -f- /tmp <<'DEOF'\n"
+                . "FROM php:8.4-cli\nRUN docker-php-ext-install pdo_mysql > /dev/null 2>&1\n"
+                . "DEOF\n2>/dev/null",
+                $build_output,
+                $build_exit,
+            );
+            if ($build_exit !== 0) {
+                $this->markTestSkipped(
+                    'Cannot build PHP image with pdo_mysql: ' . implode("\n", $build_output)
+                );
+            }
+        }
+
+        // Create Docker network
+        $this->docker_network = 'reli-test-mysql-' . uniqid();
+        exec("docker network create {$this->docker_network} 2>&1", $output, $exit_code);
+        if ($exit_code !== 0) {
+            $this->markTestSkipped('Cannot create Docker network');
+        }
+
+        // Start MySQL container
+        $mysql_password = 'reli_test_pass';
+        $mysql_name = 'reli-mysql-' . uniqid();
+        $cmd = sprintf(
+            'docker run -d --network %s --name %s '
+            . '-e MYSQL_ROOT_PASSWORD=%s '
+            . '-e MYSQL_DATABASE=reli_test '
+            . 'mysql:8.0 '
+            . '--default-authentication-plugin=mysql_native_password 2>&1',
+            escapeshellarg($this->docker_network),
+            escapeshellarg($mysql_name),
+            escapeshellarg($mysql_password),
+        );
+        $this->mysql_container_id = trim(shell_exec($cmd) ?? '');
+        if (empty($this->mysql_container_id)) {
+            $this->markTestSkipped('Cannot start MySQL container');
+        }
+
+        // Wait for MySQL to be ready (first start can take ~30s)
+        $mysql_ready = false;
+        for ($i = 0; $i < 60; $i++) {
+            $ping_output = [];
+            exec(
+                "docker exec {$this->mysql_container_id} mysqladmin ping -uroot -p{$mysql_password} 2>&1",
+                $ping_output,
+            );
+            if (str_contains(implode('', $ping_output), 'alive')) {
+                $mysql_ready = true;
+                break;
+            }
+            sleep(2);
+        }
+        if (!$mysql_ready) {
+            $this->markTestSkipped('MySQL did not become ready in time');
+        }
+
+        // Get MySQL container IP
+        $mysql_ip = trim(shell_exec(
+            "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "
+            . "{$this->mysql_container_id} 2>/dev/null"
+        ) ?? '');
+        if (empty($mysql_ip)) {
+            $this->markTestSkipped('Cannot get MySQL container IP');
+        }
+
+        $target_script = <<<CODE
+            <?php
+            \$db = new PDO(
+                'mysql:host={$mysql_ip};dbname=reli_test',
+                'root',
+                '{$mysql_password}',
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+            \$db->exec('CREATE TABLE test_data (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(100), value TEXT)');
+            for (\$i = 0; \$i < 100; \$i++) {
+                \$db->exec("INSERT INTO test_data (name, value) VALUES ('item_\$i', '" . str_repeat('x', 200) . "')");
+            }
+            \$stmt = \$db->prepare('SELECT * FROM test_data');
+            \$stmt->execute();
+            \$rows = \$stmt->fetchAll(PDO::FETCH_ASSOC);
+            fputs(STDOUT, "ready\\n");
+            fgets(STDIN);
+            CODE;
+
+        // Run PHP in the same Docker network
+        $tmp_file = tempnam('/tmp/reli-test', 'reli-mysql-test');
+        $pid_writer = tempnam('/tmp/reli-test', 'reli-mysql-test-pw');
+        $pid_file = tempnam('/tmp/reli-test', 'reli-mysql-test-pid');
+        chmod($tmp_file, 0777);
+        chmod($pid_writer, 0777);
+        chmod($pid_file, 0777);
+
+        file_put_contents($pid_writer, <<<'CODE'
+            <?php
+            file_put_contents('/target-pid', getmypid());
+            fputs(STDOUT, "pid written\n");
+            CODE);
+        file_put_contents($tmp_file, $target_script);
+
+        $uid = posix_getuid();
+        $gid = posix_getgid();
+
+        $docker_command = [
+            'docker', 'run', '--rm',
+            '--pid', 'host',
+            '--network', $this->docker_network,
+            '-i',
+            "-v$tmp_file:/source:rw",
+            "-v$pid_writer:/pid-writer:rw",
+            "-v$pid_file:/target-pid:rw",
+            "-v/tmp/reli-test:/tmp/reli-test:rw",
+            $docker_image_name,
+            'php', '-dauto_prepend_file=/pid-writer', '/source',
+        ];
+
+        $pipes = [];
+        $this->child = proc_open(
+            $docker_command,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+        );
+
+        $pid_written = fgets($pipes[1]);
+        $this->assertSame("pid written\n", $pid_written);
+        $pid = (int)file_get_contents($pid_file);
+
+        $s = fgets($pipes[1]);
+        if ($s !== "ready\n") {
+            $stderr = stream_get_contents($pipes[2]);
+            // Kill child and clean up before failing
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status) && $child_status['running']) {
+                posix_kill($child_status['pid'], SIGKILL);
+            }
+            $this->child = null;
+            $this->fail(
+                "PHP script did not output 'ready'. Got: " . var_export($s, true)
+                . "\nStderr: " . $stderr
+            );
+        }
+
+        // Set up memory analysis infrastructure
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+        $integer_reader = new LittleEndianReader();
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(new CatFileReader(), new Elf64Parser($integer_reader)),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                $integer_reader,
+                new LinkMapLoader($memory_reader, $integer_reader),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator, $integer_reader, $memory_reader_for_finder,
+            $binary_analysis_cache, $process_memory_map_creator, $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator, $tsrm_globals_resolver, $memory_reader_for_finder,
+            $integer_reader, new Elf64Parser($integer_reader), new CatFileReader(),
+            ProcessMemoryMapCreator::create(), new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(), $binary_analysis_cache, $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator, $integer_reader, $memory_reader_for_finder,
+            $tsrm_ls_cache_finder, $tsrm_globals_resolver,
+            $binary_analysis_cache, $process_memory_map_creator, $binary_fingerprint_creator,
+        );
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(php_version: $php_version);
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier, $target_php_settings,
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier, $target_php_settings,
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader, $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(), $type_reader_creator, $php_globals_finder,
+            ),
+        );
+        $collected_memories = $memory_locations_collector->collectAll(
+            $process_specifier, $target_php_settings,
+            $executor_globals_address, $compiler_globals_address,
+        );
+
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $region_analyzer = new RegionAnalyzer(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+        $region_analyzed = $region_analyzer->analyze($collected_memories->memory_locations);
+
+        $location_type_analyzer = new LocationTypeAnalyzer();
+        $location_type_result = $location_type_analyzer->analyze(
+            $region_analyzed->regional_memory_locations->locations_in_zend_mm_heap,
+        );
+
+        // Verify PDO structures are tracked
+        $this->assertArrayHasKey(
+            'PdoDbhMemoryLocation',
+            $location_type_result->per_type_usage,
+            'pdo_dbh_t should be tracked for MySQL',
+        );
+        $this->assertArrayHasKey(
+            'PdoDriverDataMemoryLocation',
+            $location_type_result->per_type_usage,
+            'pdo_mysql_db_handle should be tracked',
+        );
+
+        // Verify mysqlnd result buffers are tracked
+        $this->assertArrayHasKey(
+            'MysqlndMemoryLocation',
+            $location_type_result->per_type_usage,
+            'mysqlnd result buffers should be tracked (MYSQLND_RES, MYSQLND_RES_BUFFERED, row_buffers, arena)',
+        );
+        // With 100 rows fetched, we expect: MYSQLND_RES + MYSQLND_RES_BUFFERED
+        // + row_buffers array + memory_pool(s) + arena chunk(s) = at least 3 locations
+        $mysqlnd_count = $location_type_result->per_type_usage['MysqlndMemoryLocation']['count'];
+        $this->assertGreaterThanOrEqual(
+            3,
+            $mysqlnd_count,
+            "Expected at least 3 MysqlndMemoryLocation entries, got $mysqlnd_count",
+        );
+        // The total tracked mysqlnd memory should be significant (100 rows * ~200 bytes)
+        $mysqlnd_bytes = $location_type_result->per_type_usage['MysqlndMemoryLocation']['memory_usage'];
+        $this->assertGreaterThan(
+            1000,
+            $mysqlnd_bytes,
+            "mysqlnd buffer tracking should capture significant memory ($mysqlnd_bytes bytes)",
+        );
+    }
+}

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -406,6 +406,14 @@ class pdo_mysql_db_handle extends CData
 class pdo_mysql_stmt extends CData
 {
 }
+
+class MYSQLND_RES extends CData
+{
+}
+
+class MYSQLND_RES_BUFFERED extends CData
+{
+}
 class zend_type extends CData
 {
     public int $ptr;


### PR DESCRIPTION
## Summary

- Track mysqlnd result set buffers (`MYSQLND_RES` → `MYSQLND_RES_BUFFERED` → `row_buffers` → `zend_arena` chain) for MySQL PDO memory coverage
- Track PDO internal `emalloc` allocations: `columns` array, `data_source`/`username`/`password` strings, `active_query_string`, `bound_params`/`bound_param_map`/`bound_columns` HashTables

Follows up on #581 which added basic PDO/PDOStatement struct tracking and PostgreSQL/MySQL driver support.

### mysqlnd result buffer tracking

MySQL (mysqlnd) allocates result set data via `emalloc`/`zend_arena`, so these buffers are in PHP's heap but were previously untracked. This follows the pointer chain:

```
pdo_mysql_stmt.result → MYSQLND_RES → stored_data → MYSQLND_RES_BUFFERED
                                                      ├── row_buffers[] array
                                                      └── result_set_memory_pool
                                                           └── zend_arena chain
```

### PDO internal emalloc tracking

Additional PHP-heap allocations within PDO that improve `heap_memory_analyzed_percentage`:

| Allocation | Allocator | Notes |
|---|---|---|
| `pdo_dbh_t.data_source` | `pestrdup` | DSN string |
| `pdo_dbh_t.username/password` | `pestrdup` | Auth strings |
| `pdo_stmt_t.columns[]` | `ecalloc` | `column_count * sizeof(pdo_column_data)` |
| `pdo_stmt_t.active_query_string` | `zend_string` (v81+) | Expanded query with bound params |
| `pdo_stmt_t.bound_params` | `HashTable` | Bound parameters |
| `pdo_stmt_t.bound_param_map` | `HashTable` | Named→positional mapping |
| `pdo_stmt_t.bound_columns` | `HashTable` | Bound columns |

## Test plan

- [x] Existing PDO integration test passes (PHP 8.0, 8.3, 8.4)
- [x] psalm: no errors
- [x] phpcs: no errors
- [x] Verify coverage improvement with a real MySQL PDO workload

https://claude.ai/code/session_011KtZGg1t5EZovRw1EV7Jre