### PR TITLE
[codex] Deduplicate streaming edges with node placeholders

### DIFF
--- a/docs/internals/memory-analysis-optimization.md
+++ b/docs/internals/memory-analysis-optimization.md
@@ -20,7 +20,7 @@ in streaming mode:
 2. Within branches, inner loops (array elements, object properties, local
    variables) also emit per-iteration via `emitChildIfStreaming()`
 3. After each emission, `flushPoolsIfStreaming()` converts pool entries to
-   lightweight sentinels and clears the pools
+   lightweight node_id placeholders and clears the pools
 
 **Collection order** (streaming mode only):
 ```
@@ -29,7 +29,7 @@ class_table → global_variables → global_constants → global_callbacks →
 modules → call_frames
 ```
 
-objects_store is collected first so that subsequent phases hit sentinels
+objects_store is collected first so that subsequent phases hit cached node IDs
 for most objects/arrays/strings instead of recursively expanding.
 
 Non-streaming mode preserves the original 0.12.x collection order.
@@ -47,24 +47,25 @@ $this->deferred_object_edges[] = [parent_node_id, child_address, link_name, poin
 ```
 
 After all phases complete, deferred edges are resolved:
-1. If the child address has a sentinel → emit reference edge
+1. If the child address already has a node_id → emit reference edge
 2. Otherwise → collect the target with defer off and emit normally
 
 Dynamic properties, closures, generators, fibers, and weak references/maps
 are also skipped during defer mode to prevent bypassing the defer guard.
 
-### Sentinel-based deduplication
+### Node-id based deduplication
 
 **Status: Implemented**
 
-`ContextPools` maintains a sentinel map (`array<int, int>` address → node_id).
+`ContextPools` maintains a node-id map (`array<int, int>` address → node_id).
 After each branch emission, `convertToSentinels()` extracts node_ids from the
-analyzer's WeakMap and stores them. `getSentinel()` returns a shared
-`SentinelContext` (single instance, node_id updated per call) to avoid
-per-sentinel object overhead.
+analyzer's WeakMap and stores them. Later cache hits reuse the integer node_id
+directly, and parent contexts keep only encoded ints for already-emitted
+children rather than full child objects.
 
-`ContextAnalyzer` recognizes `SentinelContext` and emits a reference edge
-without traversing.
+`ContextAnalyzer` recognizes these encoded node IDs and either emits a
+reference edge or skips edge emission when the parent-child edge was already
+materialized earlier.
 
 ### Lightweight MemoryLocations
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -85,29 +85,42 @@ final class ContextAnalyzer
         ContextTreeSink $sink,
         ?int $parent_node_id = null,
         ?WeakMap $memo = null,
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
         if ($memo === null) {
             /** @var WeakMap<ReferenceContext, int> $memo */
             $memo = new WeakMap();
         }
-        $this->analyzeContext($context, $link_name, $parent_node_id, $sink, $memo);
+        $this->analyzeContext($context, $link_name, $parent_node_id, $sink, $memo, $edge_strength);
     }
 
     /**
      * @param WeakMap<ReferenceContext, int> $memo
      */
     private function analyzeContext(
-        ReferenceContext $linked_context,
+        ReferenceContext|int $linked_context,
         string $link_name,
         ?int $parent_node_id,
         ContextTreeSink $sink,
         WeakMap $memo,
         EdgeStrength $edge_strength = EdgeStrength::Strong,
     ): void {
-        // SentinelContext: already emitted to DB in a previous branch,
-        // just record the reference edge.
+        if (is_int($linked_context)) {
+            // Encoded node_id placeholder:
+            //   >= 0 ... node already emitted elsewhere, emit a reference edge
+            //   < 0  ... node and incoming edge already emitted, skip
+            if ($linked_context >= 0) {
+                $sink->emitReference($linked_context, $parent_node_id, $link_name, $edge_strength);
+            }
+            return;
+        }
+
+        // SentinelContext is retained for compatibility in tests and
+        // non-hot paths. Streaming collection uses encoded int placeholders.
         if ($linked_context instanceof SentinelContext) {
-            $sink->emitReference($linked_context->node_id, $parent_node_id, $link_name, $edge_strength);
+            if ($linked_context->emit_reference_edge) {
+                $sink->emitReference($linked_context->node_id, $parent_node_id, $link_name, $edge_strength);
+            }
             return;
         }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextPools.php
@@ -19,7 +19,6 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectContextPool
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\PhpReferenceContextPool;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContextPool;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContextPool;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContextPool;
 
@@ -27,8 +26,6 @@ final class ContextPools
 {
     /** @var array<int, int> address → node_id for cross-branch dedup */
     private array $sentinels = [];
-
-    private SentinelContext $shared_sentinel;
 
     public function __construct(
         public StringContextPool $string_context_pool,
@@ -39,22 +36,14 @@ final class ContextPools
         public UserFunctionDefinitionContextPool $user_function_definition_context_pool,
         public ClosureContextPool $closure_context_pool = new ClosureContextPool(),
     ) {
-        $this->shared_sentinel = new SentinelContext(0);
     }
 
     /**
      * Check if the given address was already emitted to DB in a previous branch.
-     * Returns a shared SentinelContext with the node_id set, or null.
-     * The returned object is reused across calls — do not store it.
      */
-    public function getSentinel(int $address): ?SentinelContext
+    public function getSentinel(int $address): ?int
     {
-        $node_id = $this->sentinels[$address] ?? null;
-        if ($node_id === null) {
-            return null;
-        }
-        $this->shared_sentinel->node_id = $node_id;
-        return $this->shared_sentinel;
+        return $this->sentinels[$address] ?? null;
     }
 
     public static function createDefault(): self
@@ -81,10 +70,10 @@ final class ContextPools
     }
 
     /**
-     * Convert emitted pooled contexts to lightweight sentinels.
+     * Convert emitted pooled contexts to lightweight node_id placeholders.
      * Only drains entries that have been emitted (have a node_id in memo).
      * Entries not yet emitted are kept in the pool so they can be emitted
-     * later and their sentinels stored correctly.
+     * later and their node_ids stored correctly.
      *
      * @param \WeakMap<ReferenceContext, int> $memo
      */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -135,7 +135,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\RuntimeCacheContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ScalarValueContext;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SentinelContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\TopReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContext;
@@ -261,7 +261,7 @@ final class MemoryLocationsCollector
         }
         $existing = $this->streaming_memo[$parent] ?? null;
         if ($existing !== null) {
-            return $existing;
+            return $existing < 0 ? -$existing - 1 : $existing;
         }
         $node_id = $this->streaming_analyzer->assignNodeId($parent, $this->streaming_memo);
         return $node_id;
@@ -269,14 +269,17 @@ final class MemoryLocationsCollector
 
     /**
      * In streaming mode, emit a child context that was just collected,
-     * and return a SentinelContext so the parent holds only node_id.
+     * and return an encoded node_id so the parent holds only an int.
+     * Non-negative values mean "emit a reference edge later".
+     * Negative values mean "the edge was already emitted".
      * In non-streaming mode, return the child as-is for normal tree building.
      */
     private function emitChildIfStreaming(
         string $link_name,
-        ReferenceContext $child,
+        ReferenceContext|int $child,
         int $parent_node_id,
-    ): ReferenceContext {
+        EdgeStrength $edge_strength = EdgeStrength::Strong,
+    ): ReferenceContext|int {
         if (
             $this->streaming_sink === null
             || $this->streaming_analyzer === null
@@ -284,8 +287,8 @@ final class MemoryLocationsCollector
         ) {
             return $child;
         }
-        // Already a sentinel — no need to emit again
-        if ($child instanceof SentinelContext) {
+        // Already emitted elsewhere — keep only the node_id placeholder.
+        if (is_int($child)) {
             return $child;
         }
         // Emit the child subtree to DB
@@ -295,11 +298,12 @@ final class MemoryLocationsCollector
             $this->streaming_sink,
             $parent_node_id,
             $this->streaming_memo,
+            $edge_strength,
         );
         // Look up the node_id that was assigned
         $node_id = $this->streaming_memo[$child] ?? null;
         if ($node_id !== null) {
-            return new SentinelContext($node_id);
+            return -$node_id - 1;
         }
         return $child;
     }
@@ -519,7 +523,14 @@ final class MemoryLocationsCollector
                 $context_pools,
                 $memory_limit_error_details,
             );
-            $analyzer->analyzeSingleLink('objects_store', $objects_store_context, $sink, null, $memo);
+            $analyzer->analyzeSingleLink(
+                'objects_store',
+                $objects_store_context,
+                $sink,
+                null,
+                $memo,
+                EdgeStrength::Weak,
+            );
             unset($objects_store_context);
             $context_pools->convertToSentinels($memo);
 
@@ -646,9 +657,9 @@ final class MemoryLocationsCollector
             $this->defer_unseen_objects = false;
             $remaining_deferred = [];
             foreach ($this->deferred_object_edges as [$parent_node_id, $child_address, $link_name, $pointer_type]) {
-                $child_sentinel = $context_pools->getSentinel($child_address);
-                if ($child_sentinel !== null) {
-                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
+                $child_node_id = $context_pools->getSentinel($child_address);
+                if ($child_node_id !== null) {
+                    $sink->emitReference($child_node_id, $parent_node_id, $link_name);
                     continue;
                 }
                 // Not resolved — collect it now
@@ -661,9 +672,9 @@ final class MemoryLocationsCollector
             // will be fully expanded. Each is emitted as a child of the
             // original parent.
             foreach ($remaining_deferred as [$parent_node_id, $child_address, $link_name, $pointer_type]) {
-                $child_sentinel = $context_pools->getSentinel($child_address);
-                if ($child_sentinel !== null) {
-                    $sink->emitReference($child_sentinel->node_id, $parent_node_id, $link_name);
+                $child_node_id = $context_pools->getSentinel($child_address);
+                if ($child_node_id !== null) {
+                    $sink->emitReference($child_node_id, $parent_node_id, $link_name);
                     continue;
                 }
                 $child_context = match ($pointer_type) {
@@ -684,9 +695,11 @@ final class MemoryLocationsCollector
                     ),
                     default => null,
                 };
-                if ($child_context !== null) {
+                if ($child_context instanceof ReferenceContext) {
                     $analyzer->analyzeSingleLink($link_name, $child_context, $sink, $parent_node_id, $memo);
                     $context_pools->convertToSentinels($memo);
+                } elseif (is_int($child_context)) {
+                    $sink->emitReference($child_context, $parent_node_id, $link_name);
                 }
             }
 
@@ -694,11 +707,10 @@ final class MemoryLocationsCollector
             // defer, collectClosure() was skipped. Now collect this_ptr/func
             // and emit as children of the Closure's ObjectContext node.
             foreach ($this->deferred_closure_addresses as $closure_address) {
-                $sentinel = $context_pools->getSentinel($closure_address);
-                if ($sentinel === null) {
+                $closure_node_id = $context_pools->getSentinel($closure_address);
+                if ($closure_node_id === null) {
                     continue;
                 }
-                $closure_node_id = $sentinel->node_id;
                 $closure_pointer = ZendClosure::getPointerFromZendObjectPointer(
                     new Pointer(
                         ZendObject::class,
@@ -734,11 +746,10 @@ final class MemoryLocationsCollector
 
             // Resolve deferred Generator objects
             foreach ($this->deferred_generator_addresses as $gen_address) {
-                $sentinel = $context_pools->getSentinel($gen_address);
-                if ($sentinel === null) {
+                $gen_node_id = $context_pools->getSentinel($gen_address);
+                if ($gen_node_id === null) {
                     continue;
                 }
-                $gen_node_id = $sentinel->node_id;
                 try {
                     $gen_pointer = ZendGenerator::getPointerFromZendObjectPointer(
                         new Pointer(
@@ -772,11 +783,10 @@ final class MemoryLocationsCollector
 
             // Resolve deferred Fiber objects
             foreach ($this->deferred_fiber_addresses as $fiber_address) {
-                $sentinel = $context_pools->getSentinel($fiber_address);
-                if ($sentinel === null) {
+                $fiber_node_id = $context_pools->getSentinel($fiber_address);
+                if ($fiber_node_id === null) {
                     continue;
                 }
-                $fiber_node_id = $sentinel->node_id;
                 try {
                     $fiber_pointer = ZendFiber::getPointerFromZendObjectPointer(
                         new Pointer(
@@ -976,7 +986,7 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ?ReferenceContext {
+    ): ReferenceContext|int|null {
         if ($zval->isArray()) {
             assert(!is_null($zval->value->arr));
             return $this->collectZendArrayPointer(
@@ -1066,11 +1076,11 @@ final class MemoryLocationsCollector
         Dereferencer $dereferencer,
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools
-    ): ResourceContext|SentinelContext {
+    ): ResourceContext|int {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->resource_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -1786,11 +1796,11 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): PhpReferenceContext|SentinelContext|null {
+    ): PhpReferenceContext|int|null {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->php_reference_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -1849,11 +1859,11 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ArrayHeaderContext|SentinelContext|null {
+    ): ArrayHeaderContext|int|null {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->array_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -1904,11 +1914,11 @@ final class MemoryLocationsCollector
         ZendTypeReader $zend_type_reader,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ObjectContext|SentinelContext|null {
+    ): ObjectContext|int|null {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->object_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -1957,11 +1967,11 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         Dereferencer $dereferencer,
         ContextPools $context_pools
-    ): StringContext|SentinelContext {
+    ): StringContext|int {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->string_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -3091,11 +3101,11 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): FunctionDefinitionContext|SentinelContext {
+    ): FunctionDefinitionContext|int {
         if ($memory_locations->has($pointer->address)) {
-            $sentinel = $context_pools->getSentinel($pointer->address);
-            if ($sentinel !== null) {
-                return $sentinel;
+            $node_id = $context_pools->getSentinel($pointer->address);
+            if ($node_id !== null) {
+                return $node_id;
             }
             $cached = $context_pools->user_function_definition_context_pool->getContextByAddress($pointer->address);
             if ($cached !== null) {
@@ -3790,6 +3800,7 @@ final class MemoryLocationsCollector
                     (string)$key,
                     $objects_store_bucket_context,
                     $parent_node_id,
+                    EdgeStrength::Weak,
                 );
                 $this->flushPoolsIfStreaming();
             }
@@ -3978,7 +3989,7 @@ final class MemoryLocationsCollector
         MemoryLocations $memory_locations,
         ContextPools $context_pools,
         ?MemoryLimitErrorDetails $memory_limit_error_details,
-    ): ?ReferenceContext {
+    ): ReferenceContext|int|null {
         if ($zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V81)) {
             // v70-v80: function_name is an inline zval
             $callable_zval = $entry->getFunctionNameDirect();

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayElementsContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayElementsContext.php
@@ -29,7 +29,7 @@ final class ArrayElementsContext implements ReferenceContext
         return count($this->referencing_contexts);
     }
 
-    public function getElementByKey(int|string $key): ?ReferenceContext
+    public function getElementByKey(int|string $key): ReferenceContext|int|null
     {
         return $this->referencing_contexts[(string)$key] ?? null;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayHeaderContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ArrayHeaderContext.php
@@ -30,7 +30,7 @@ final class ArrayHeaderContext implements ReferenceContext
         return $this->referencing_contexts['array_elements'] ?? null;
     }
 
-    public function getElement(int|string $key): ?ReferenceContext
+    public function getElement(int|string $key): ReferenceContext|int|null
     {
         return $this->getElements()?->getElementByKey($key) ?? null;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
@@ -29,7 +29,7 @@ final class CallFrameContext implements ReferenceContext
         return $this->referencing_contexts['local_variables'] ?? null;
     }
 
-    public function getLocalVariable(string $variable_name): ?ReferenceContext
+    public function getLocalVariable(string $variable_name): ReferenceContext|int|null
     {
         return $this->getLocalVariables()?->getVariable($variable_name) ?? null;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameVariableTableContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameVariableTableContext.php
@@ -17,7 +17,7 @@ final class CallFrameVariableTableContext implements ReferenceContext
 {
     use ReferenceContextDefault;
 
-    public function getVariable(string $variable_name): ?ReferenceContext
+    public function getVariable(string $variable_name): ReferenceContext|int|null
     {
         return $this->referencing_contexts[$variable_name] ?? null;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContext.php
@@ -19,9 +19,9 @@ interface ReferenceContext
 {
     public function getName(): string;
 
-    public function add(string $link_name, self $reference_context): void;
+    public function add(string $link_name, self|int $reference_context): void;
 
-    /** @return iterable<string, self> */
+    /** @return iterable<string, self|int> */
     public function getLinks(): iterable;
 
     /** @return iterable<array-key, MemoryLocation> */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ReferenceContextDefault.php
@@ -18,7 +18,7 @@ use Reli\Lib\Process\MemoryLocation;
 /** @psalm-require-implements ReferenceContext */
 trait ReferenceContextDefault
 {
-    /** @var array<string, ReferenceContext> */
+    /** @var array<string, ReferenceContext|int> */
     private array $referencing_contexts = [];
 
     public function getName(): string
@@ -26,12 +26,12 @@ trait ReferenceContextDefault
         return (new \ReflectionClass(static::class))->getShortName();
     }
 
-    public function add(string $link_name, ReferenceContext $reference_context): void
+    public function add(string $link_name, ReferenceContext|int $reference_context): void
     {
         $this->referencing_contexts[$link_name] = $reference_context;
     }
 
-    /** @return array<string, ReferenceContext> */
+    /** @return array<string, ReferenceContext|int> */
     public function getLinks(): iterable
     {
         return $this->referencing_contexts;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContext.php
@@ -17,13 +17,14 @@ use Reli\Lib\Process\MemoryLocation;
 
 /**
  * Lightweight placeholder for a context that was already emitted to DB.
- * Holds only the node_id so the analyzer can emit a reference edge
- * without keeping the full context object in memory.
+ * Holds only the node_id and whether the incoming edge still needs to be
+ * materialized by the analyzer.
  */
 final class SentinelContext implements ReferenceContext
 {
     public function __construct(
-        public int $node_id,
+        public readonly int $node_id,
+        public readonly bool $emit_reference_edge = true,
     ) {
     }
 
@@ -34,12 +35,12 @@ final class SentinelContext implements ReferenceContext
     }
 
     #[\Override]
-    public function add(string $link_name, ReferenceContext $reference_context): void
+    public function add(string $link_name, ReferenceContext|int $reference_context): void
     {
         throw new \LogicException('SentinelContext cannot have children');
     }
 
-    /** @return array<string, ReferenceContext> */
+    /** @return array<string, ReferenceContext|int> */
     #[\Override]
     public function getLinks(): iterable
     {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/StringContext.php
@@ -30,7 +30,7 @@ final class StringContext implements ReferenceContext
     }
 
     #[\Override]
-    public function add(string $link_name, ReferenceContext $reference_context): void
+    public function add(string $link_name, ReferenceContext|int $reference_context): void
     {
         throw new \LogicException("StringContext cannot have reference to another context");
     }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzerTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
+use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ObjectsStoreMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ObjectsStoreContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\StringContext;
+
+class ContextAnalyzerTest extends BaseTestCase
+{
+    private string $db_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db_path = tempnam(sys_get_temp_dir(), 'reli_ctx_') . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    public function testSentinelWithPreEmittedEdgeDoesNotDuplicateReference(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        [$sink, $run_id, $db] = $output->createStreamingSink();
+
+        $analyzer = new ContextAnalyzer();
+        $memo = new \WeakMap();
+
+        $objects_store = new ObjectsStoreContext(
+            new ObjectsStoreMemoryLocation(0x3000, 64),
+        );
+        $store_node_id = $analyzer->assignNodeId($objects_store, $memo);
+
+        $child = new StringContext(
+            new ZendStringMemoryLocation(0x1000, 16, 1, 0, 'hello'),
+        );
+        $analyzer->analyzeSingleLink(
+            '1',
+            $child,
+            $sink,
+            $store_node_id,
+            $memo,
+            EdgeStrength::Weak,
+        );
+
+        $child_node_id = $memo[$child] ?? null;
+        $this->assertIsInt($child_node_id);
+
+        $objects_store->add('1', -$child_node_id - 1);
+        $analyzer->analyzeSingleLink(
+            'objects_store',
+            $objects_store,
+            $sink,
+            null,
+            $memo,
+            EdgeStrength::Weak,
+        );
+        $sink->flush();
+
+        $edge_count_stmt = $db->prepare(
+            'SELECT COUNT(*) FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ? AND link_name = ?'
+        );
+        $edge_count_stmt->execute([$run_id, $store_node_id, $child_node_id, '1']);
+        $this->assertSame(1, (int)$edge_count_stmt->fetchColumn());
+
+        $total_count_stmt = $db->prepare(
+            'SELECT COUNT(*) FROM context_edges WHERE run_id = ?'
+        );
+        $total_count_stmt->execute([$run_id]);
+        $this->assertSame(2, (int)$total_count_stmt->fetchColumn());
+
+        $strength_stmt = $db->prepare(
+            'SELECT strength FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ? AND link_name = ?'
+        );
+        $strength_stmt->execute([$run_id, $store_node_id, $child_node_id, '1']);
+        $this->assertSame('weak', $strength_stmt->fetchColumn());
+
+        $root_strength_stmt = $db->prepare(
+            'SELECT strength FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id IS NULL AND child_node_id = ? AND link_name = ?'
+        );
+        $root_strength_stmt->execute([$run_id, $store_node_id, 'objects_store']);
+        $this->assertSame('weak', $root_strength_stmt->fetchColumn());
+
+        if ($db->inTransaction()) {
+            $db->rollBack();
+        }
+    }
+
+    public function testPositiveNodeIdPlaceholderEmitsReferenceEdge(): void
+    {
+        $output = new PdoMemoryOutput(new SqliteDriver($this->db_path));
+        [$sink, $run_id, $db] = $output->createStreamingSink();
+
+        $analyzer = new ContextAnalyzer();
+        $memo = new \WeakMap();
+
+        $child = new StringContext(
+            new ZendStringMemoryLocation(0x1000, 16, 1, 0, 'hello'),
+        );
+        $analyzer->analyzeSingleLink(
+            'pre_emitted',
+            $child,
+            $sink,
+            null,
+            $memo,
+            EdgeStrength::Weak,
+        );
+
+        $child_node_id = $memo[$child] ?? null;
+        $this->assertIsInt($child_node_id);
+
+        $objects_store = new ObjectsStoreContext(
+            new ObjectsStoreMemoryLocation(0x3000, 64),
+        );
+        $objects_store->add('1', $child_node_id);
+        $analyzer->analyzeSingleLink(
+            'objects_store',
+            $objects_store,
+            $sink,
+            null,
+            $memo,
+            EdgeStrength::Weak,
+        );
+        $sink->flush();
+
+        $store_node_id_stmt = $db->prepare(
+            'SELECT child_node_id FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id IS NULL AND link_name = ?'
+        );
+        $store_node_id_stmt->execute([$run_id, 'objects_store']);
+        $store_node_id = $store_node_id_stmt->fetchColumn();
+        $this->assertIsNumeric($store_node_id);
+
+        $edge_count_stmt = $db->prepare(
+            'SELECT COUNT(*) FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ? AND link_name = ?'
+        );
+        $edge_count_stmt->execute([$run_id, (int)$store_node_id, $child_node_id, '1']);
+        $this->assertSame(1, (int)$edge_count_stmt->fetchColumn());
+
+        $strength_stmt = $db->prepare(
+            'SELECT strength FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ? AND link_name = ?'
+        );
+        $strength_stmt->execute([$run_id, (int)$store_node_id, $child_node_id, '1']);
+        $this->assertSame('weak', $strength_stmt->fetchColumn());
+
+        if ($db->inTransaction()) {
+            $db->rollBack();
+        }
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextPoolsTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ContextPoolsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
+
+class ContextPoolsTest extends BaseTestCase
+{
+    public function testGetSentinelKeepsNodeIdsStableAcrossAddresses(): void
+    {
+        $pools = ContextPools::createDefault();
+
+        $context_a = $pools->string_context_pool->getContextForLocation(
+            new ZendStringMemoryLocation(0x1000, 16, 1, 0, 'a'),
+        );
+        $context_b = $pools->string_context_pool->getContextForLocation(
+            new ZendStringMemoryLocation(0x2000, 16, 1, 0, 'b'),
+        );
+
+        $memo = new \WeakMap();
+        $memo[$context_a] = 10;
+        $memo[$context_b] = 20;
+
+        $pools->convertToSentinels($memo);
+
+        $sentinel_a = $pools->getSentinel(0x1000);
+        $sentinel_b = $pools->getSentinel(0x2000);
+
+        $this->assertSame(10, $sentinel_a);
+        $this->assertSame(20, $sentinel_b);
+        $this->assertSame(10, $pools->getSentinel(0x1000));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2660,6 +2660,86 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     }
 
     /**
+     * Bug 3 regression test: In streaming mode, eager child emission must not
+     * be followed by a duplicate reference edge when the parent context is
+     * later analyzed from its encoded placeholder links.
+     */
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testStreamingObjectsStoreEdgeIsNotDuplicated(string $php_version, string $docker_image_name): void
+    {
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            class EdgeDupProbe {
+                public $label = '';
+            }
+            $tracked = new EdgeDupProbe;
+            $tracked->label = 'streaming-edge-dedup';
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        [$db, $run_id, $tmp_path] = $this->collectStreamingDb(
+            $pid,
+            $php_version,
+            $memory_reader,
+            $type_reader_creator,
+        );
+
+        $objects_store_node_stmt = $db->prepare(
+            'SELECT child_node_id FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id IS NULL AND link_name = ?'
+        );
+        $objects_store_node_stmt->execute([$run_id, 'objects_store']);
+        $objects_store_node_id = $objects_store_node_stmt->fetchColumn();
+        $this->assertIsNumeric($objects_store_node_id);
+
+        $object_node_stmt = $db->prepare(
+            "SELECT cn.node_id FROM context_nodes cn"
+            . " JOIN context_node_locations loc"
+            . "   ON loc.run_id = cn.run_id AND loc.node_id = cn.node_id"
+            . " WHERE cn.run_id = ? AND cn.type = 'ObjectContext' AND loc.class_name = ?"
+            . " LIMIT 1"
+        );
+        $object_node_stmt->execute([$run_id, 'EdgeDupProbe']);
+        $object_node_id = $object_node_stmt->fetchColumn();
+        $this->assertIsNumeric($object_node_id);
+
+        $edge_count_stmt = $db->prepare(
+            'SELECT COUNT(*) FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ?'
+        );
+        $edge_count_stmt->execute([$run_id, (int)$objects_store_node_id, (int)$object_node_id]);
+        $this->assertSame(1, (int)$edge_count_stmt->fetchColumn());
+
+        $edge_strength_stmt = $db->prepare(
+            'SELECT strength, is_tree FROM context_edges'
+            . ' WHERE run_id = ? AND parent_node_id = ? AND child_node_id = ?'
+            . ' LIMIT 1'
+        );
+        $edge_strength_stmt->execute([$run_id, (int)$objects_store_node_id, (int)$object_node_id]);
+        $edge_row = $edge_strength_stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertIsArray($edge_row);
+        $this->assertSame('weak', $edge_row['strength']);
+        $this->assertContains((int)$edge_row['is_tree'], [0, 1]);
+
+        $db = null;
+        @unlink($tmp_path);
+    }
+
+    /**
      * Bug 2 + report regression test: Streaming mode must produce findings
      * from graph-based analysis passes (CycleCluster, DrillDown, etc.)
      * when the graph has cycles.

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContextTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SentinelContextTest.php
@@ -29,11 +29,16 @@ class SentinelContextTest extends BaseTestCase
         $this->assertSame(99, $sentinel->node_id);
     }
 
-    public function testNodeIdIsMutable(): void
+    public function testEmitReferenceEdgeDefaultsToTrue(): void
     {
         $sentinel = new SentinelContext(1);
-        $sentinel->node_id = 2;
-        $this->assertSame(2, $sentinel->node_id);
+        $this->assertTrue($sentinel->emit_reference_edge);
+    }
+
+    public function testReferenceEmissionCanBeSuppressed(): void
+    {
+        $sentinel = new SentinelContext(1, false);
+        $this->assertFalse($sentinel->emit_reference_edge);
     }
 
     public function testAddThrowsLogicException(): void


### PR DESCRIPTION
## Summary

This changes the streaming memory analysis path to replace mutable sentinel objects with encoded node-id placeholders and to prevent duplicate edge emission when a child has already been emitted earlier in the stream.

## What changed

- changed `ReferenceContext` links to allow `int` placeholders in addition to context objects
- switched `ContextPools` to cache emitted node IDs directly instead of reusing a mutable shared sentinel object
- taught `ContextAnalyzer` to interpret both placeholder modes correctly
  - non-negative node IDs emit a reference edge
  - negative encoded node IDs skip a duplicate incoming edge because it was already materialized
- updated streaming collection in `MemoryLocationsCollector` to preserve weak edge semantics for `objects_store` and its bucket children
- added regression coverage for placeholder handling and streaming edge deduplication

## Root cause

Streaming collection was eagerly emitting some child subtrees and then later re-analyzing parent links that still referred to those children. Without a lightweight encoding that distinguished "emit a reference edge" from "edge already emitted", the collector/analyzer path could duplicate edges or rely on mutable sentinel state.

## Impact

- reduces per-node placeholder overhead in streaming mode
- makes duplicate-edge prevention explicit in the data flow
- keeps streaming graph output stable for report generation and downstream graph passes

## Validation

- `docker compose run --rm reli-test-for-ci vendor/bin/psalm.phar --no-cache --show-info=false`
- `vendor/bin/phpcs --standard=./phpcs.xml ./src ./tests`
- `vendor/bin/phpunit tests/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzerTest.php`
- `env RELI_TEST_PHP_TARGETS=v70,v83,v83_zts vendor/bin/phpunit --filter testStreamingObjectsStoreEdgeIsNotDuplicated tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php`
- `env RELI_TEST_PHP_TARGETS=v70,v83,v83_zts vendor/bin/phpunit tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php`
