### PR TITLE
[codex] Cache canonical neighbors in computeSccFfi

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -622,6 +622,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // csrIdx → canonical csrIdx. This avoids repeated node_id lookups.
         /** @var array<int, int> $canonIdx  csrIdx → canonical csrIdx */
         $canonIdx = [];
+        /** @var array<int, list<int>> $canonical_original_indices canonical csrIdx => original csrIdx list */
+        $canonical_original_indices = [];
         if ($has_canonical) {
             for ($v = 0; $v < $this->nodeCount; $v++) {
                 $nid = (int)$this->indexToNodeFfi[$v];
@@ -632,8 +634,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 if ($canon !== $nid) {
                     $canonIdx[$v] = $this->nodeIdToIndex($canon);
                 }
+                $canonical_original_indices[$canonIdx[$v] ?? $v][] = $v;
             }
         }
+        /** @var array<int, list<int>> $canonical_neighbors canonical csrIdx => canonical neighbor csrIdx list */
+        $canonical_neighbors = [];
 
         $index_counter = 0;
         $stack = [];
@@ -660,38 +665,38 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             while ($call_stack) {
                 [$node, $ci] = array_pop($call_stack);
 
-                // Collect neighbors from all CSR indices that map to this
-                // canonical index. For non-canonical graphs, just the node itself.
-                // For canonical, iterate all originals.
-                /** @var list<int> $originals CSR indices sharing this canonical */
-                $originals = [];
                 if ($has_canonical) {
-                    $canonNid = (int)$this->indexToNodeFfi[$node];
-                    foreach ($this->canonicalToOriginals[$canonNid] ?? [$canonNid] as $origNid) {
-                        $oi = $this->nodeIdToIndex($origNid);
-                        if ($oi >= 0) {
-                            $originals[] = $oi;
+                    if (!isset($canonical_neighbors[$node])) {
+                        $neighbors = [];
+                        $seen = [];
+                        foreach ($canonical_original_indices[$node] ?? [$node] as $oi) {
+                            $start = (int)$this->strongAllOffsets[$oi];
+                            $end = (int)$this->strongAllOffsets[$oi + 1];
+                            for ($j = $start; $j < $end; $j++) {
+                                $w = (int)$this->strongAllEdges[$j];
+                                $cw = $canonIdx[$w] ?? $w;
+                                if ($cw !== $node && !isset($seen[$cw])) {
+                                    $seen[$cw] = true;
+                                    $neighbors[] = $cw;
+                                }
+                            }
                         }
+                        $canonical_neighbors[$node] = $neighbors;
                     }
+                    $neighbors = $canonical_neighbors[$node];
                 } else {
-                    $originals[] = $node;
-                }
-
-                // Flatten all neighbors from all original indices
-                $neighbors = [];
-                foreach ($originals as $oi) {
-                    $start = (int)$this->strongAllOffsets[$oi];
-                    $end = (int)$this->strongAllOffsets[$oi + 1];
+                    $neighbors = [];
+                    $seen = [];
+                    $start = (int)$this->strongAllOffsets[$node];
+                    $end = (int)$this->strongAllOffsets[$node + 1];
                     for ($j = $start; $j < $end; $j++) {
                         $w = (int)$this->strongAllEdges[$j];
-                        $cw = $canonIdx[$w] ?? $w;
-                        if ($cw !== $node) {
-                            $neighbors[] = $cw;
+                        if ($w !== $node && !isset($seen[$w])) {
+                            $seen[$w] = true;
+                            $neighbors[] = $w;
                         }
                     }
                 }
-                // Deduplicate (cheap for small neighbor lists)
-                $neighbors = array_values(array_unique($neighbors));
                 $count = count($neighbors);
 
                 $found_unvisited = false;
@@ -740,16 +745,12 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($has_canonical) {
             foreach ($sccs as &$scc) {
                 $expanded = [];
-                foreach ($scc as $canonicalIdx) {
-                    $canonNid = (int)$this->indexToNodeFfi[$canonicalIdx];
-                    foreach ($this->canonicalToOriginals[$canonNid] ?? [$canonNid] as $origNid) {
-                        $oi = $this->nodeIdToIndex($origNid);
-                        if ($oi >= 0) {
-                            $expanded[] = $oi;
-                        }
+                foreach ($scc as $canonical_idx) {
+                    foreach ($canonical_original_indices[$canonical_idx] ?? [$canonical_idx] as $original_idx) {
+                        $expanded[] = $original_idx;
                     }
                 }
-                $scc = array_values(array_unique($expanded));
+                $scc = $expanded;
             }
             unset($scc);
         }

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
@@ -262,6 +262,48 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
         );
     }
 
+    public function testConsistencyWithPhpArrayVersionForUnifiedScc(): void
+    {
+        $db = $this->createDirectDb();
+
+        $db->exec("INSERT INTO context_nodes (run_id, node_id, type, canonical_node_id) VALUES
+            (1, 100, 'ObjectContext', 100),
+            (1, 200, 'ObjectContext', 200),
+            (1, 500, 'ObjectContext', 100),
+            (1, 600, 'ObjectContext', 200)
+        ");
+
+        $db->exec("INSERT INTO context_node_locations (run_id, node_id, address, size, location_type, class_name) VALUES
+            (1, 100, 1000, 64, 'ZendObjectMemoryLocation', 'App\\NodeA'),
+            (1, 200, 2000, 64, 'ZendObjectMemoryLocation', 'App\\NodeB'),
+            (1, 500, 1000, 64, 'ZendObjectMemoryLocation', 'App\\NodeA'),
+            (1, 600, 2000, 64, 'ZendObjectMemoryLocation', 'App\\NodeB')
+        ");
+
+        $db->exec("INSERT INTO context_edges
+            (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
+            (1, NULL, 100, 'objects_store', 1, 'strong'),
+            (1, 100, 200, 'next', 1, 'strong'),
+            (1, NULL, 500, 'call_frames', 1, 'strong'),
+            (1, 600, 500, 'next', 0, 'strong')
+        ");
+
+        $php = GraphSubstrate::loadFromDb($db, 1);
+        $ffi = FfiCsrGraphSubstrate::loadFromDb($db, 1);
+
+        $this->assertSame(count($php->getSccProfiles()), count($ffi->getSccProfiles()));
+        $this->assertNotEmpty($ffi->getSccProfiles());
+
+        $php_scc = $php->getSccProfiles()[0];
+        $ffi_scc = $ffi->getSccProfiles()[0];
+
+        $this->assertEqualsCanonicalizing($php_scc['nodes'], $ffi_scc['nodes']);
+        $this->assertSame($php_scc['node_count'], $ffi_scc['node_count']);
+        $this->assertSame($php_scc['total_size'], $ffi_scc['total_size']);
+        $this->assertSame($php_scc['ext_in'], $ffi_scc['ext_in']);
+        $this->assertSame($php_scc['ext_out'], $ffi_scc['ext_out']);
+    }
+
     public function testCreateFromDbSelectsCorrectImplementation(): void
     {
         $child = $this->createMockContext('child', [], [
@@ -284,6 +326,51 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
     {
         $db = new \PDO('sqlite:' . $this->db_path);
         $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        return $db;
+    }
+
+    private function createDirectDb(): \PDO
+    {
+        $db = $this->openDb();
+
+        $db->exec('CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY, created_at TEXT NOT NULL)');
+        $db->exec("INSERT INTO runs (run_id, created_at) VALUES (1, '2024-01-01T00:00:00Z')");
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS context_edges (
+                run_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
+            )
+        ");
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                address BIGINT,
+                size BIGINT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                string_value TEXT,
+                refcount BIGINT,
+                type_info BIGINT,
+                region TEXT
+            )
+        ');
+
         return $db;
     }
 


### PR DESCRIPTION
## Summary

This optimizes `FfiCsrGraphSubstrate::computeSccFfi()` by caching canonical neighbor lists during Tarjan SCC traversal instead of rebuilding them repeatedly from CSR slices.

## What changed

- build a `canonical_original_indices` map once up front for canonical CSR indices
- lazily cache canonical neighbor lists per canonical CSR index during SCC traversal
- reuse the original-index map when expanding canonical SCCs back to original node indices
- add FFI substrate regression coverage that compares SCC results against the PHP-array substrate for a canonical-unification case

## Why

The canonical path in `computeSccFfi()` was repeatedly:

- looking up all original nodes for a canonical node
- flattening strong-all neighbors across those originals
- mapping each neighbor back through canonical resolution
- deduplicating the resulting list

That work was repeated every time the canonical node was revisited by the iterative Tarjan walk, which makes SCC computation unnecessarily expensive on large unified graphs.

## Impact

- reduces repeated neighbor materialization work inside `computeSccFfi()`
- keeps SCC results aligned with the PHP-array implementation
- preserves snake_case local variable naming in the new code

## Validation

- `vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php`
- `vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrateTest.php`
- `vendor/bin/phpcs --standard=./phpcs.xml src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php`
- `docker compose run --rm reli-test-for-ci vendor/bin/psalm.phar --no-cache --show-info=false`
