### PR TITLE
[codex] Optimize NonTreeEdgePass full-analysis path

### DIFF
--- a/docs/internals/memory-report-performance-hotspots.md
+++ b/docs/internals/memory-report-performance-hotspots.md
@@ -1,0 +1,199 @@
+# Memory Report Performance Hotspots
+
+Notes for future optimization work on `inspector:memory:report`.
+
+As of 2026-04-07, `FfiCsrGraphSubstrate::computeSccFfi()` already caches
+canonical neighbor lists. The next bottlenecks are mostly in Phase 3 report
+passes that repeatedly materialize adjacency lists from the FFI CSR substrate.
+
+## Main Observation
+
+The likely remaining hotspot is not a single pass, but the access pattern
+shared by many passes:
+
+- `FfiCsrGraphSubstrate::getChildren()`
+- `FfiCsrGraphSubstrate::getStrongChildren()`
+- `FfiCsrGraphSubstrate::getAllChildren()`
+- `FfiCsrGraphSubstrate::getAllParents()`
+
+Each of those currently calls `csrSlice()`, which allocates a fresh PHP array
+for every lookup. Several passes call these methods inside nested loops over
+large parts of the graph.
+
+Files:
+
+- `src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php`
+- `src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php`
+
+## Priority Candidates
+
+### 1. Substrate-level no-allocation traversal
+
+Highest leverage change.
+
+Why it looks expensive:
+
+- FFI CSR stores edges compactly, but pass code still pays to convert each
+  touched adjacency range into a PHP array.
+- Optimizing a single pass helps locally; reducing adjacency materialization
+  helps almost every graph-based pass.
+
+Likely direction:
+
+- Add APIs that return scalar facts without building arrays:
+  - child count
+  - parent count
+  - "does this node have any child in set X"
+  - "scan children until predicate matches"
+- Prefer APIs that do the scan inside the substrate implementation rather than
+  by yielding a generator or invoking a PHP callback per edge.
+- Keep PHP-array `GraphSubstrate` compatibility, but optimize the FFI
+  implementation first.
+
+Candidate API sketch:
+
+```php
+public function getChildrenCount(int $node_id): int;
+public function getStrongChildrenCount(int $node_id): int;
+public function hasAnyChildInSet(int $node_id, array $node_set): bool;
+public function hasAnyParentOutsideSet(int $node_id, array $node_set): bool;
+```
+
+The exact API can differ; the point is to avoid `list<int>` materialization
+when the caller only needs counts or membership tests.
+
+### 2. `TopArraysPass`
+
+Probably the simplest next win.
+
+File:
+
+- `src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php`
+
+Why it looks expensive:
+
+- Iterates all nodes with `iterateNodeSizes()`
+- For each node, scans `getChildren($node)`
+- On array nodes, calls `count($this->substrate->getChildren($child))`
+  just to count elements
+
+The element count path is especially wasteful in FFI mode because it
+materializes the whole child list only to call `count()`.
+
+Likely direction:
+
+- Add `getChildrenCount()` to substrate and switch
+  `count($this->substrate->getChildren($child))` to it
+- If useful, add a cheap "first matching child" helper to avoid scanning and
+  materializing more than needed
+
+### 3. `CycleClusterPass`
+
+Likely one of the heaviest remaining passes.
+
+File:
+
+- `src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php`
+
+Why it looks expensive:
+
+- Per top SCC group, it runs multiple graph walks:
+  - `findBackReference()`
+  - `computeRetained()`
+  - `findEntryPath()`
+- Resource leak detection later in the file walks strong children again
+- `findBackReference()` currently does:
+  - `getAllChildren($node)`
+  - `getChildren($node)`
+  - `in_array()` tree-edge membership check
+
+Likely direction:
+
+- Avoid repeated tree-child materialization inside `findBackReference()`
+- Precompute a cheap tree-child membership structure for nodes touched by the
+  top SCC groups
+- Replace "load children array and test membership in userland" with a
+  substrate-level membership helper if possible
+
+### 4. `BlameAllocationPass`
+
+Likely expensive on graphs with many shared nodes.
+
+File:
+
+- `src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php`
+
+Why it looks expensive:
+
+- BFS from every root via `getChildren()`
+- Then full node-size iteration
+- For shared nodes, calls `getAllParents($node)` and distributes blame
+
+Likely direction:
+
+- Use substrate helpers for parent counts and parent scanning
+- Consider building ownership data in one pass rather than repeated per-node
+  parent materialization
+
+### 5. Property / ownership passes
+
+Second-tier candidates after the above.
+
+Files:
+
+- `src/Inspector/Output/MemoryOutput/Report/Pass/OwnershipPatternPass.php`
+- `src/Inspector/Output/MemoryOutput/Report/Pass/PerPropertyMemoryPass.php`
+- `src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php`
+
+Why they look expensive:
+
+- Repeated `getChildren()` calls nested 2 to 3 levels deep
+- Common pattern:
+  - object
+  - `object_properties`
+  - property node
+  - maybe one more child level
+
+Likely direction:
+
+- Consider precomputing or caching the `object_properties` child for object
+  nodes touched by these passes
+- Reuse any substrate-level count / scan helpers added above
+
+## Probably Not First Priority
+
+### `TopStringsPass`
+
+File:
+
+- `src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php`
+
+Reason:
+
+- Main SQL query is already `ORDER BY size DESC LIMIT 10`
+- Path reconstruction does extra DB work, but only for a tiny result set
+
+### `ReportGenerator`
+
+File:
+
+- `src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php`
+
+Reason:
+
+- Mostly orchestration
+- The heavy cost appears to sit inside graph-based passes and substrate access
+
+## Suggested Next Session Plan
+
+1. Add one or two cheap substrate APIs that avoid PHP array materialization.
+2. Convert `TopArraysPass` first and measure again.
+3. If report runtime is still dominated by graph work, convert
+   `CycleClusterPass` next.
+4. Then revisit `BlameAllocationPass`.
+
+## Measurement Guidance
+
+When validating improvements, prefer a snapshot large enough to use
+`FfiCsrGraphSubstrate` automatically. Small snapshots can hide the real cost
+because the PHP-array substrate has a different performance profile.

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -21,6 +21,8 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class NonTreeEdgePass implements PassInterface
 {
+    private ?\PDOStatement $node_location_stmt = null;
+
     public function __construct(
         private \PDO $db,
         private int $run_id,
@@ -36,6 +38,23 @@ final class NonTreeEdgePass implements PassInterface
      */
     #[\Override]
     public function analyze(): array
+    {
+        if ($this->substrate !== null) {
+            return $this->analyzeWithSubstrate();
+        }
+
+        return $this->analyzeWithSql();
+    }
+
+    /**
+     * SQL-only path for report generation without GraphSubstrate.
+     *
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
+     * @psalm-suppress MixedArgumentTypeCoercion
+     */
+    private function analyzeWithSql(): array
     {
         // Classify shared references by link_name with class context
         $stmt = $this->db->query("
@@ -332,6 +351,389 @@ final class NonTreeEdgePass implements PassInterface
     }
 
     /**
+     * Full-analysis path: keep the expensive aggregation in SQL, but resolve
+     * class/owner metadata only for top candidates.
+     *
+     * @return list<Finding>
+     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
+     * @psalm-suppress MixedArgumentTypeCoercion
+     */
+    private function analyzeWithSubstrate(): array
+    {
+        assert($this->substrate !== null);
+
+        [$tree_parents, $tree_links] = $this->loadTreeParentsAndLinks();
+
+        $findings = [];
+        $shared_rows = $this->db->query("
+            SELECT
+                e.link_name,
+                count(*) as ref_count,
+                count(DISTINCT e.child_node_id) as target_count,
+                min(e.parent_node_id) as sample_parent_node_id,
+                min(e.child_node_id) as sample_child_node_id
+            FROM context_edges e
+            WHERE e.run_id = {$this->run_id}
+                AND e.is_tree = 0
+                AND e.strength = 'strong'
+            GROUP BY e.link_name
+            HAVING count(*) > 10
+            ORDER BY count(*) DESC
+            LIMIT 20
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        foreach ($shared_rows as $row) {
+            $link_name = (string)$row['link_name'];
+            if (ctype_digit($link_name)) {
+                continue;
+            }
+
+            $ref_count = (int)$row['ref_count'];
+            $target_count = (int)$row['target_count'];
+            $avg_refs = round($ref_count / max(1, $target_count), 1);
+            $source_class = $this->resolveDirectSourceClass(
+                (int)$row['sample_parent_node_id'],
+                $tree_parents,
+                $tree_links,
+            );
+            $target_class = $this->substrate->getNodeClass(
+                (int)$row['sample_child_node_id']
+            );
+            $qualified = $source_class
+                ? "{$source_class}::\${$link_name}"
+                : $link_name;
+            $target_label = $target_class ? " ({$target_class})" : '';
+
+            if ($target_count === 1 && $ref_count > 50) {
+                $findings[] = new Finding(
+                    kind: 'shared_singleton',
+                    severity: FindingSeverity::Info,
+                    confidence: FindingConfidence::High,
+                    summary: sprintf(
+                        '%s%s: %s refs -> 1 target [singleton]',
+                        $qualified,
+                        $target_label,
+                        number_format($ref_count),
+                    ),
+                    facts: [
+                        'link_name' => $link_name,
+                        'source_class' => $source_class,
+                        'target_class' => $target_class,
+                        'ref_count' => $ref_count,
+                        'target_count' => $target_count,
+                    ],
+                );
+            } elseif ($target_count > 1 && $avg_refs > 2.0) {
+                $findings[] = new Finding(
+                    kind: 'shared_fanin',
+                    severity: FindingSeverity::Info,
+                    confidence: FindingConfidence::Medium,
+                    summary: sprintf(
+                        '%s -> %s (%s refs -> %s targets, %.1f each)',
+                        $qualified,
+                        $target_class ?? '?',
+                        number_format($ref_count),
+                        number_format($target_count),
+                        $avg_refs,
+                    ),
+                    facts: [
+                        'link_name' => $link_name,
+                        'ref_count' => $ref_count,
+                        'target_count' => $target_count,
+                        'avg_refs_per_target' => $avg_refs,
+                    ],
+                    hypothesis: 'Multiple references to shared objects — may indicate cycle back-references',
+                    next_checks: [
+                        'Check if these are intentional shared references or cycle artifacts',
+                    ],
+                );
+            }
+        }
+
+        $dedup_rows = $this->db->query("
+            SELECT
+                e.link_name,
+                cnl.size,
+                count(*) as cnt,
+                count(*) * cnl.size as total_waste,
+                min(e.parent_node_id) as sample_parent_node_id,
+                min(e.child_node_id) as sample_child_node_id
+            FROM context_edges e
+            JOIN context_node_locations cnl
+                ON cnl.node_id = e.child_node_id
+                AND cnl.run_id = {$this->run_id}
+            WHERE e.run_id = {$this->run_id}
+                AND e.is_tree = 0
+                AND e.strength = 'strong'
+            GROUP BY e.link_name, cnl.size
+            HAVING count(*) > 50 AND count(*) * cnl.size > 10240
+            ORDER BY count(*) * cnl.size DESC
+            LIMIT 10
+        ")->fetchAll(\PDO::FETCH_ASSOC);
+
+        $use_retained = $this->substrate->hasSubtreeSizes();
+        foreach ($dedup_rows as $row) {
+            $link_name = (string)$row['link_name'];
+            $cnt = (int)$row['cnt'];
+            $shallow_size = (int)$row['size'];
+            $total = (int)$row['total_waste'];
+            $sample_parent_node_id = (int)$row['sample_parent_node_id'];
+            $sample_child_node_id = (int)$row['sample_child_node_id'];
+
+            $target_info = $this->loadNodeLocationInfo($sample_child_node_id);
+            if (($target_info['location_type'] ?? null) === 'ZendArrayMemoryLocation') {
+                continue;
+            }
+
+            $size = $shallow_size;
+            if ($use_retained) {
+                $retained = $this->getRetainedForDedup(
+                    $link_name,
+                    $shallow_size,
+                );
+                if ($retained > $shallow_size) {
+                    $size = $retained;
+                    $total = $cnt * $retained;
+                }
+            }
+
+            [
+                'source_class' => $dedup_src,
+                'owner_prop' => $owner_prop,
+            ] = $this->resolveDedupOwnerInfo(
+                $sample_parent_node_id,
+                $tree_parents,
+                $tree_links,
+            );
+            $dedup_tgt = $this->substrate->getNodeClass($sample_child_node_id);
+
+            if ($dedup_src && $owner_prop) {
+                $dedup_label = "{$dedup_src}::\${$owner_prop}[{$link_name}]";
+            } elseif ($dedup_src) {
+                $dedup_label = "{$dedup_src}::\${$link_name}";
+            } else {
+                $dedup_label = $link_name;
+            }
+            if ($dedup_tgt) {
+                $dedup_label .= " ({$dedup_tgt})";
+            }
+
+            $examples = $this->getDedupExamples($link_name, $shallow_size);
+
+            $hypothesis = 'Multiple copies of same-size objects'
+                . ' via shared references; may be shareable';
+            $confidence = FindingConfidence::Low;
+
+            if ($examples['type'] === 'string') {
+                if ($examples['identical_count'] > 0) {
+                    $pct = $cnt > 0
+                        ? $examples['identical_count'] / $cnt * 100.0
+                        : 0;
+                    $hypothesis = sprintf(
+                        '%d/%d copies have identical content (%.0f%%).'
+                        . ' Example: "%s"',
+                        $examples['identical_count'],
+                        $cnt,
+                        $pct,
+                        $examples['sample_value'],
+                    );
+                    $confidence = $pct > 50.0
+                        ? FindingConfidence::High
+                        : FindingConfidence::Medium;
+                } else {
+                    $hypothesis = sprintf(
+                        'Same size but different content.'
+                        . ' Examples: "%s", "%s"',
+                        $examples['samples'][0] ?? '?',
+                        $examples['samples'][1] ?? '?',
+                    );
+                }
+            } elseif ($examples['type'] === 'object') {
+                $hypothesis .= sprintf(
+                    '. Examples: %s',
+                    implode(', ', array_slice($examples['samples'], 0, 3)),
+                );
+            }
+
+            $findings[] = new Finding(
+                kind: 'dedup_candidate',
+                severity: $total > 102400
+                    ? FindingSeverity::Low
+                    : FindingSeverity::Info,
+                confidence: $confidence,
+                summary: sprintf(
+                    '%s: %s copies x %s%s = %s',
+                    $dedup_label,
+                    number_format($cnt),
+                    SizeFormatter::format($size),
+                    $size > $shallow_size ? ' retained' : '',
+                    SizeFormatter::format($total),
+                ),
+                facts: [
+                    'link_name' => $link_name,
+                    'source_class' => $dedup_src,
+                    'target_class' => $dedup_tgt,
+                    'count' => $cnt,
+                    'each_size' => $size,
+                    'total_waste' => $total,
+                    'examples' => $examples,
+                ],
+                hypothesis: $hypothesis,
+                impact_bytes: $total,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return array{array<int, int>, array<int, string>}
+     * @psalm-suppress MixedAssignment
+     */
+    private function loadTreeParentsAndLinks(): array
+    {
+        $tree_parents = [];
+        $tree_links = [];
+
+        $stmt = $this->db->query(
+            "SELECT parent_node_id, child_node_id, link_name"
+            . " FROM context_edges"
+            . " WHERE run_id = {$this->run_id}"
+            . " AND is_tree = 1"
+            . " AND parent_node_id IS NOT NULL"
+        );
+
+        while (true) {
+            /** @var array{0: int|string, 1: int|string, 2: string}|false $row */
+            $row = $stmt->fetch(\PDO::FETCH_NUM);
+            if ($row === false) {
+                break;
+            }
+            $tree_parents[(int)$row[1]] = (int)$row[0];
+            $tree_links[(int)$row[1]] = $row[2];
+        }
+
+        return [$tree_parents, $tree_links];
+    }
+
+    /**
+     * @param array<int, int> $tree_parents
+     * @param array<int, string> $tree_links
+     */
+    private function resolveDirectSourceClass(
+        int $parent_node_id,
+        array $tree_parents,
+        array $tree_links,
+    ): ?string {
+        if (($tree_links[$parent_node_id] ?? null) !== 'object_properties') {
+            return null;
+        }
+
+        $owner_node_id = $tree_parents[$parent_node_id] ?? null;
+        if ($owner_node_id === null) {
+            return null;
+        }
+
+        assert($this->substrate !== null);
+        return $this->substrate->getNodeClass($owner_node_id);
+    }
+
+    /**
+     * @param array<int, int> $tree_parents
+     * @param array<int, string> $tree_links
+     * @return array{source_class: ?string, owner_prop: ?string}
+     */
+    private function resolveDedupOwnerInfo(
+        int $parent_node_id,
+        array $tree_parents,
+        array $tree_links,
+    ): array {
+        $source_class = $this->resolveDirectSourceClass(
+            $parent_node_id,
+            $tree_parents,
+            $tree_links,
+        );
+        if ($source_class !== null) {
+            return [
+                'source_class' => $source_class,
+                'owner_prop' => null,
+            ];
+        }
+
+        $array_elements_node_id = $tree_parents[$parent_node_id] ?? null;
+        if ($array_elements_node_id === null) {
+            return [
+                'source_class' => null,
+                'owner_prop' => null,
+            ];
+        }
+
+        if (($tree_links[$array_elements_node_id] ?? null) !== 'array_elements') {
+            return [
+                'source_class' => null,
+                'owner_prop' => null,
+            ];
+        }
+
+        $array_header_node_id = $tree_parents[$array_elements_node_id] ?? null;
+        if ($array_header_node_id === null) {
+            return [
+                'source_class' => null,
+                'owner_prop' => null,
+            ];
+        }
+
+        $owner_prop = $tree_links[$array_header_node_id] ?? null;
+        $object_properties_node_id = $tree_parents[$array_header_node_id] ?? null;
+        if (
+            $object_properties_node_id === null
+            || ($tree_links[$object_properties_node_id] ?? null) !== 'object_properties'
+        ) {
+            return [
+                'source_class' => null,
+                'owner_prop' => null,
+            ];
+        }
+
+        $owner_node_id = $tree_parents[$object_properties_node_id] ?? null;
+        if ($owner_node_id === null) {
+            return [
+                'source_class' => null,
+                'owner_prop' => null,
+            ];
+        }
+
+        assert($this->substrate !== null);
+        return [
+            'source_class' => $this->substrate->getNodeClass($owner_node_id),
+            'owner_prop' => $owner_prop,
+        ];
+    }
+
+    /**
+     * @return array{location_type: ?string}
+     * @psalm-suppress MixedAssignment
+     */
+    private function loadNodeLocationInfo(int $node_id): array
+    {
+        if ($this->node_location_stmt === null) {
+            $this->node_location_stmt = $this->db->prepare(
+                "SELECT location_type FROM context_node_locations"
+                . " WHERE run_id = ? AND node_id = ? LIMIT 1"
+            );
+        }
+
+        $this->node_location_stmt->execute([$this->run_id, $node_id]);
+        /** @var array{location_type?: string}|false $row */
+        $row = $this->node_location_stmt->fetch(\PDO::FETCH_ASSOC);
+
+        return [
+            'location_type' => $row['location_type'] ?? null,
+        ];
+    }
+
+    /**
      * Get average retained size for a dedup candidate group.
      * @psalm-suppress MixedArrayAccess, MixedAssignment
      */
@@ -351,6 +753,7 @@ final class NonTreeEdgePass implements PassInterface
                 AND cnl.size = {$shallow_size}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
+                AND e.strength = 'strong'
                 AND e.link_name = " . $this->db->quote($link_name) . "
             LIMIT 20
         ");
@@ -391,6 +794,7 @@ final class NonTreeEdgePass implements PassInterface
                 AND cnl.run_id = {$this->run_id}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
+                AND e.strength = 'strong'
                 AND e.link_name = " . $this->db->quote($link_name) . "
                 AND cnl.size = {$size}
                 AND cnl.string_value IS NOT NULL
@@ -436,6 +840,7 @@ final class NonTreeEdgePass implements PassInterface
                 AND cnl.run_id = {$this->run_id}
             WHERE e.run_id = {$this->run_id}
                 AND e.is_tree = 0
+                AND e.strength = 'strong'
                 AND e.link_name = " . $this->db->quote($link_name) . "
                 AND cnl.size = {$size}
             LIMIT 3

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
+
+class NonTreeEdgePassTest extends BaseTestCase
+{
+    private string $db_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db_path = tempnam(sys_get_temp_dir(), 'reli_non_tree_edge_test_') . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    public function testAnalyzeWithSubstrateMatchesSqlPathForRepresentativeFindings(): void
+    {
+        $db = $this->createDirectDb();
+        $this->seedRepresentativeScenario($db);
+
+        $sql_findings = (new NonTreeEdgePass($db, 1))->analyze();
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $graph_findings = (new NonTreeEdgePass($db, 1, $substrate))->analyze();
+
+        $shared_sql = $this->findFinding(
+            $sql_findings,
+            'shared_singleton',
+            'App\\Owner::$service',
+        );
+        $shared_graph = $this->findFinding(
+            $graph_findings,
+            'shared_singleton',
+            'App\\Owner::$service',
+        );
+        $this->assertNotNull($shared_sql);
+        $this->assertNotNull($shared_graph);
+        $this->assertSame($shared_sql->summary, $shared_graph->summary);
+        $this->assertSame($shared_sql->facts, $shared_graph->facts);
+
+        $dedup_sql = $this->findFinding(
+            $sql_findings,
+            'dedup_candidate',
+            'App\\Owner::$names[value]',
+        );
+        $dedup_graph = $this->findFinding(
+            $graph_findings,
+            'dedup_candidate',
+            'App\\Owner::$names[value]',
+        );
+        $this->assertNotNull($dedup_sql);
+        $this->assertNotNull($dedup_graph);
+        $this->assertSame($dedup_sql->summary, $dedup_graph->summary);
+        $this->assertSame(
+            $dedup_sql->facts['count'],
+            $dedup_graph->facts['count'],
+        );
+        $this->assertSame(
+            $dedup_sql->facts['examples']['sample_value'],
+            $dedup_graph->facts['examples']['sample_value'],
+        );
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function findFinding(
+        array $findings,
+        string $kind,
+        string $summary_part,
+    ): ?Finding {
+        foreach ($findings as $finding) {
+            if (
+                $finding->kind === $kind
+                && str_contains($finding->summary, $summary_part)
+            ) {
+                return $finding;
+            }
+        }
+
+        return null;
+    }
+
+    private function seedRepresentativeScenario(\PDO $db): void
+    {
+        $edge_stmt = $db->prepare(
+            'INSERT INTO context_edges'
+            . ' (run_id, parent_node_id, child_node_id, link_name, is_tree, strength)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $node_stmt = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, class_name, string_value)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+
+        $edge_stmt->execute([1, null, 1, 'call_frames', 1, 'strong']);
+        $node_stmt->execute([
+            1,
+            900,
+            9000,
+            64,
+            'ZendObjectMemoryLocation',
+            'App\\Service',
+            null,
+        ]);
+
+        for ($i = 0; $i < 60; $i++) {
+            $owner_node_id = 1000 + $i * 10;
+            $properties_node_id = $owner_node_id + 1;
+            $array_header_node_id = $owner_node_id + 2;
+            $array_elements_node_id = $owner_node_id + 3;
+            $array_element_node_id = $owner_node_id + 4;
+            $string_node_id = 100000 + $i;
+
+            $node_stmt->execute([
+                1,
+                $owner_node_id,
+                1000000 + $i,
+                64,
+                'ZendObjectMemoryLocation',
+                'App\\Owner',
+                null,
+            ]);
+            $node_stmt->execute([
+                1,
+                $array_header_node_id,
+                2000000 + $i,
+                56,
+                'ZendArrayMemoryLocation',
+                null,
+                null,
+            ]);
+            $node_stmt->execute([
+                1,
+                $string_node_id,
+                3000000 + $i,
+                256,
+                'ZendStringMemoryLocation',
+                null,
+                'same-shared-string',
+            ]);
+
+            $edge_stmt->execute([1, 1, $owner_node_id, "owner_{$i}", 1, 'strong']);
+            $edge_stmt->execute([
+                1,
+                $owner_node_id,
+                $properties_node_id,
+                'object_properties',
+                1,
+                'strong',
+            ]);
+            $edge_stmt->execute([
+                1,
+                $properties_node_id,
+                900,
+                'service',
+                0,
+                'strong',
+            ]);
+            $edge_stmt->execute([
+                1,
+                $properties_node_id,
+                $array_header_node_id,
+                'names',
+                1,
+                'strong',
+            ]);
+            $edge_stmt->execute([
+                1,
+                $array_header_node_id,
+                $array_elements_node_id,
+                'array_elements',
+                1,
+                'strong',
+            ]);
+            $edge_stmt->execute([
+                1,
+                $array_elements_node_id,
+                $array_element_node_id,
+                '0',
+                1,
+                'strong',
+            ]);
+            $edge_stmt->execute([
+                1,
+                $array_element_node_id,
+                $string_node_id,
+                'value',
+                0,
+                'strong',
+            ]);
+        }
+    }
+
+    private function createDirectDb(): \PDO
+    {
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $db->exec('CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY, created_at TEXT NOT NULL)');
+        $db->exec("INSERT INTO runs (run_id, created_at) VALUES (1, '2024-01-01T00:00:00Z')");
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS context_edges (
+                run_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
+            )
+        ");
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                address BIGINT,
+                size BIGINT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                string_value TEXT,
+                refcount BIGINT,
+                type_info BIGINT,
+                region TEXT
+            )
+        ');
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_attributes (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            )
+        ');
+
+        return $db;
+    }
+}


### PR DESCRIPTION
## Summary
- add a full-analysis fast path for `NonTreeEdgePass` when `GraphSubstrate` is available
- remove correlated metadata lookups from the main non-tree edge aggregations and resolve source/target labels only for top candidates
- add a regression test covering parity between the SQL path and the substrate-backed path
- document remaining report performance hotspots for follow-up work

## Why
`NonTreeEdgePass::analyze()` was dominated by large grouped queries with correlated subqueries on `context_edges` and `context_node_locations`. In full-analysis mode we already have a substrate loaded, so the expensive metadata lookups do not need to run inside the main aggregate query.

## Validation
- `vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php`
- `vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php`
- `vendor/bin/phpcs --standard=./phpcs.xml src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php`
- `docker compose run --rm reli-test-for-ci vendor/bin/psalm.phar --no-cache --show-info=false`
