### PR TITLE
Fix overlapping location sums and reduce dedup false positives

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -246,6 +246,11 @@ final class NonTreeEdgePass implements PassInterface
             if (($row['location_type'] ?? '') === 'ZendArrayMemoryLocation') {
                 continue;
             }
+            // Skip ArrayElementContext key links — the value side is
+            // the actionable finding, key side is just noise
+            if ($row['link_name'] === 'key') {
+                continue;
+            }
 
             // Use retained size when substrate available
             $size = $shallow_size;

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -83,12 +83,15 @@ final class StructuralDedupPass implements PassInterface
                     evidence_node_ids: [$g['example_id']],
                 );
             } else {
+                // Same class + same property names = same shape, but values may differ.
+                // This is expected for any class with many instances — only actionable
+                // if instances are actually interchangeable (flyweight pattern).
                 $findings[] = new Finding(
                     kind: 'structural_duplicate',
                     severity: $waste > 102400
-                        ? FindingSeverity::Medium
-                        : FindingSeverity::Low,
-                    confidence: FindingConfidence::Medium,
+                        ? FindingSeverity::Low
+                        : FindingSeverity::Info,
+                    confidence: FindingConfidence::Low,
                     summary: sprintf(
                         '%s: %s identical shapes x %s = %s'
                         . ' (saving: %s)',
@@ -106,8 +109,8 @@ final class StructuralDedupPass implements PassInterface
                         'theoretical_saving' => $waste,
                         'properties' => $g['props'],
                     ],
-                    hypothesis: 'Identical object shapes'
-                        . ' — candidates for flyweight/sharing',
+                    hypothesis: 'Same class and property names (shape match).'
+                        . ' Values may differ — check if instances are interchangeable.',
                     impact_bytes: $waste,
                     evidence_node_ids: [$g['example_id']],
                 );
@@ -145,17 +148,24 @@ final class StructuralDedupPass implements PassInterface
 
             // Find object_properties child, collect property names
             $props = [];
+            $has_dynamic_props = false;
             foreach ($this->substrate->getChildren($node_id) as $child) {
-                if (($this->lookupLinkName($link_stmt, $child)) !== 'object_properties') {
-                    continue;
-                }
-                foreach ($this->substrate->getChildren($child) as $prop_child) {
-                    $prop_name = $this->lookupLinkName($link_stmt, $prop_child);
-                    if ($prop_name !== null) {
-                        $props[] = $prop_name;
+                $child_link = $this->lookupLinkName($link_stmt, $child);
+                if ($child_link === 'object_properties') {
+                    foreach ($this->substrate->getChildren($child) as $prop_child) {
+                        $prop_name = $this->lookupLinkName($link_stmt, $prop_child);
+                        if ($prop_name !== null) {
+                            $props[] = $prop_name;
+                        }
+                    }
+                } elseif ($child_link === 'dynamic_properties') {
+                    // stdClass and __set() classes store props here
+                    $dyn_count = count($this->substrate->getChildren($child));
+                    if ($dyn_count > 0) {
+                        $has_dynamic_props = true;
+                        $props[] = "[dynamic:{$dyn_count}]";
                     }
                 }
-                break;
             }
 
             sort($props);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionAnalyzer/Result/RegionsSummary.php
@@ -91,25 +91,41 @@ final class RegionsSummary
 
     /**
      * Query context_node_locations for SUM(size) grouped by region.
+     * Deduplicates by address and filters overlapping locations (where one
+     * allocation is contained within another, e.g. Closure op_array inside
+     * ZendObject).
      *
      * @return array<string, int> region name => total size
+     * @psalm-suppress MixedAssignment, MixedArrayAccess
      */
     public static function queryRegionSums(\PDO $db, int $run_id): array
     {
+        // Get deduplicated locations sorted by address for overlap filtering
         $stmt = $db->prepare(
-            'SELECT region, COALESCE(SUM(size), 0) AS total_size FROM ('
-            . '  SELECT address, region, MAX(size) AS size'
-            . '  FROM context_node_locations'
-            . '  WHERE run_id = ? AND region IS NOT NULL'
-            . '  GROUP BY address, region'
-            . ') GROUP BY region'
+            'SELECT address, MAX(size) AS size, region'
+            . ' FROM context_node_locations'
+            . ' WHERE run_id = ? AND region IS NOT NULL'
+            . ' GROUP BY address, region'
+            . ' ORDER BY address ASC, size DESC'
         );
         $stmt->execute([$run_id]);
+
+        // Walk through sorted by address, skip locations contained within
+        // the previous one (same logic as RegionAnalyzer::filterOverlappingLocations)
         $sums = [];
-        /** @psalm-suppress MixedAssignment */
+        $prev_end = -1;
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-            /** @psalm-suppress MixedArrayAccess */
-            $sums[(string)$row['region']] = (int)$row['total_size'];
+            $address = (int)$row['address'];
+            $size = (int)$row['size'];
+            $region = (string)$row['region'];
+
+            $end = $address + $size;
+            if ($address < $prev_end && $end <= $prev_end) {
+                // Contained within previous location — skip
+                continue;
+            }
+            $prev_end = $end;
+            $sums[$region] = ($sums[$region] ?? 0) + $size;
         }
         return $sums;
     }


### PR DESCRIPTION
## Summary

- Fix heap percentage exceeding 100% due to overlapping memory locations
- Reduce false positive findings in structural dedup and non-tree edge passes

## Bug Fixes

### Bug 8: Heap percentage exceeds 100% (Case 14: 123.3%)
Closure objects embed their op_array (`zend_function`) inside the `zend_closure` struct. The `ZendOpArrayHeaderMemoryLocation` address falls within the `ZendObjectMemoryLocation` range, causing double-counting in `queryRegionSums`.

**Fix:** Apply overlap filtering (same algorithm as `RegionAnalyzer::filterOverlappingLocations`) when computing region sums from the DB — sort by address, skip locations contained within the previous one.

### Bug 9: dedup_candidate key/value noise
ArrayElementContext stores `key` and `value` as separate children, producing duplicate findings for the same array elements (`$hoge[key]` N copies + `$hoge[value]` N copies).

**Fix:** Skip `link_name='key'` findings — the value side is the actionable one.

### Bug 10: structural_duplicate same-class false positive
All instances of a PHP class have the same size by definition. Reporting "2,000 copies x 88 B" for Widget is not actionable unless values are actually identical.

**Fix:** Downgrade severity to Low/Info, confidence to Low. Updated hypothesis to note values may differ.

### Bug 11: empty_object false positive for stdClass
`StructuralDedupPass` only checked `object_properties` children, missing `dynamic_properties` where stdClass stores all properties.

**Fix:** Also check `dynamic_properties` child. Include dynamic property count in prop_sig as `[dynamic:N]`.

## Test plan
- [x] Psalm: no errors
- [x] phpcs PSR12: no violations
- [x] Unit tests pass (ReportGeneratorTest, RegionsSummaryTest)
- [x] Integration test: testStreamingPercentageIsReasonable passes

https://claude.ai/code/session_01SvcMG3HFDhjgBb5mcUZL5b