### PR TITLE
Improve PDO memory tracking for columns and bound parameters

### DIFF
--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1272,6 +1272,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1299,6 +1299,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1293,6 +1293,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1286,6 +1286,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1324,6 +1324,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1351,6 +1351,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1510,6 +1510,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1554,6 +1554,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1596,6 +1596,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1684,6 +1684,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1709,6 +1709,14 @@ struct _pdo_dbh_object_t {
 	zend_object std;
 };
 
+typedef struct {
+	zend_long paramno;
+	zend_string *name;
+	zend_long max_value_len;
+	zval parameter;
+	zend_long param_type;
+} pdo_bound_param_data;
+
 struct pdo_column_data {
 	zend_string *name;
 	size_t maxlen;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/PdoHelper.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/PdoHelper.php
@@ -32,6 +32,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MysqlndMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\PdoDbhMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\PdoDriverDataMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\PdoStatementColumnsMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableOverheadMemoryLocation;
@@ -192,21 +193,28 @@ final class PdoHelper
             $column_data_size = $ctx->zend_type_reader->sizeOf('pdo_column_data');
             if (!$ctx->memory_locations->has($columns_address)) {
                 $col_size = (int)$column_count * $column_data_size;
-                $columns_location = new PdoDriverDataMemoryLocation($columns_address, $col_size);
+                $columns_location = new PdoStatementColumnsMemoryLocation($columns_address, $col_size);
                 $ctx->memory_locations->add($columns_location);
                 $object_context->addLocation($columns_location);
             }
+            $zend_string_size = $ctx->zend_type_reader->sizeOf('zend_string');
             for ($i = 0; $i < $column_count; $i++) {
-                $col = $ctx->dereferencer->deref(new Pointer(
-                    PdoColumnData::class,
-                    $columns_address + $i * $column_data_size,
-                    $column_data_size,
-                ));
-                if ($col->name !== 0) {
-                    CollectorHelpers::collectZendStringPointer(
-                        new Pointer(ZendString::class, $col->name, $ctx->zend_type_reader->sizeOf('zend_string')),
-                        $ctx,
-                    );
+                try {
+                    $col = $ctx->dereferencer->deref(new Pointer(
+                        PdoColumnData::class,
+                        $columns_address + $i * $column_data_size,
+                        $column_data_size,
+                    ));
+                    if ($col->name !== 0) {
+                        $name_pointer = new Pointer(ZendString::class, $col->name, $zend_string_size);
+                        $name_str = $ctx->dereferencer->deref($name_pointer);
+                        $name_location = ZendStringMemoryLocation::fromZendString($name_str, $ctx->dereferencer);
+                        if (!$ctx->memory_locations->has($name_location->address)) {
+                            $ctx->memory_locations->add($name_location);
+                            $object_context->addLocation($name_location);
+                        }
+                    }
+                } catch (\Throwable) {
                 }
             }
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/PdoHelper.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/PdoHelper.php
@@ -150,6 +150,11 @@ final class PdoHelper
                         $object_context->addLocation($array_table_location);
                         $ctx->memory_locations->add($array_table_overhead_location);
                         $object_context->addLocation($array_table_overhead_location);
+
+                        // Track IS_PTR entries (pdo_bound_param_data) in bound_columns/bound_params
+                        if ($ht_field !== 'bound_param_map') {
+                            self::collectBoundParamDataEntries($array, $ctx, $object_context);
+                        }
                     }
                 }
             } catch (\Throwable) {
@@ -432,6 +437,27 @@ final class PdoHelper
             } catch (\Throwable) {
                 break;
             }
+        }
+    }
+
+    private static function collectBoundParamDataEntries(
+        ZendArray $array,
+        CollectorContext $ctx,
+        ObjectContext $object_context,
+    ): void {
+        $bound_param_size = $ctx->zend_type_reader->sizeOf('pdo_bound_param_data');
+        try {
+            foreach ($array->getBucketIterator($ctx->dereferencer) as $bucket) {
+                if ($bucket->val->getType() === 'IS_PTR') {
+                    $ptr_address = $bucket->val->value->lval;
+                    if ($ptr_address !== 0 && !$ctx->memory_locations->has($ptr_address)) {
+                        $location = new PdoDriverDataMemoryLocation($ptr_address, $bound_param_size);
+                        $ctx->memory_locations->add($location);
+                        $object_context->addLocation($location);
+                    }
+                }
+            }
+        } catch (\Throwable) {
         }
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/PdoStatementColumnsMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/PdoStatementColumnsMemoryLocation.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+final class PdoStatementColumnsMemoryLocation extends MemoryLocation
+{
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -244,6 +244,35 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
         )->fetchColumn();
         $this->assertGreaterThan(0, (int)$pdo_dbh_count, 'pdo_dbh_t should be tracked');
 
+        // Verify pdo_column_data[] is tracked as PdoStatementColumnsMemoryLocation
+        /** @psalm-suppress MixedAssignment */
+        $columns_count = $db->query(
+            "SELECT COUNT(*) FROM context_node_locations"
+            . " WHERE run_id = {$run_id} AND location_type = 'PdoStatementColumnsMemoryLocation'"
+        )->fetchColumn();
+        $this->assertGreaterThan(
+            0,
+            (int)$columns_count,
+            'pdo_stmt_t->columns (pdo_column_data[]) should be tracked'
+        );
+
+        // Verify column name strings are tracked under PDOStatement context
+        /** @psalm-suppress MixedAssignment */
+        $stmt_string_count = $db->query(
+            "SELECT COUNT(*) FROM context_node_locations"
+            . " WHERE run_id = {$run_id}"
+            . " AND location_type = 'ZendStringMemoryLocation'"
+            . " AND node_id IN ("
+            . "   SELECT node_id FROM context_node_locations"
+            . "   WHERE run_id = {$run_id} AND class_name = 'PDOStatement'"
+            . " )"
+        )->fetchColumn();
+        $this->assertGreaterThan(
+            0,
+            (int)$stmt_string_count,
+            'Column name zend_strings should be tracked under PDOStatement context'
+        );
+
         $db = null;
         @unlink($tmp_path);
     }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -273,6 +273,23 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
             'Column name zend_strings should be tracked under PDOStatement context'
         );
 
+        // Verify pdo_bound_param_data entries from bound_columns are tracked
+        /** @psalm-suppress MixedAssignment */
+        $bound_param_count = $db->query(
+            "SELECT COUNT(*) FROM context_node_locations"
+            . " WHERE run_id = {$run_id}"
+            . " AND location_type = 'PdoDriverDataMemoryLocation'"
+            . " AND node_id IN ("
+            . "   SELECT node_id FROM context_node_locations"
+            . "   WHERE run_id = {$run_id} AND class_name = 'PDOStatement'"
+            . " )"
+        )->fetchColumn();
+        $this->assertGreaterThan(
+            0,
+            (int)$bound_param_count,
+            'pdo_bound_param_data entries from bound_columns should be tracked'
+        );
+
         $db = null;
         @unlink($tmp_path);
     }


### PR DESCRIPTION
## Summary
Enhanced PDO memory collection to properly track column metadata and bound parameter data structures in PDOStatement objects. This improves memory profiling accuracy for PDO-based database operations.

## Key Changes

- **New Memory Location Type**: Added `PdoStatementColumnsMemoryLocation` class to specifically track PDO statement column arrays, replacing the generic `PdoDriverDataMemoryLocation` for this purpose
- **Column Name String Tracking**: Enhanced column data collection to properly track and deduplicate zend_string objects for column names, with error handling for malformed data
- **Bound Parameter Data Collection**: Implemented `collectBoundParamDataEntries()` method to track `pdo_bound_param_data` structures referenced in `bound_columns` and `bound_params` arrays
- **PHP Header Updates**: Added `pdo_bound_param_data` struct definition across all supported PHP versions (7.0-8.5) to enable proper memory size calculations
- **Improved Error Handling**: Wrapped column iteration in try-catch blocks to gracefully handle corrupted or inaccessible memory regions

## Implementation Details

- Column name strings are now collected as `ZendStringMemoryLocation` objects and deduplicated to avoid tracking the same string multiple times
- Bound parameter data entries are identified by checking for `IS_PTR` type values in the bound columns/params arrays
- The collection skips `bound_param_map` to avoid duplicate tracking of the same data
- All operations include error handling to prevent profiling failures when encountering inaccessible memory

## Testing
Added comprehensive integration tests to verify:
- `PdoStatementColumnsMemoryLocation` entries are properly tracked
- Column name strings are tracked under PDOStatement context
- Bound parameter data entries from bound_columns are tracked

https://claude.ai/code/session_014TAfT8hLC6PrKj2cZ5TARY