### PR TITLE
Add sidecar daemon for remote memory dump requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Reli is a sampling profiler (or a VM state inspector) written in PHP. It can rea
 - [Automatic memory analysis report](docs/memory-report.md): generate prioritized findings from a memory snapshot — dominant classes, cycles, choke points, blame allocation, and more
 - [Condition-based monitoring](docs/watch-command.md): automatically trigger memory dumps, trace captures, or alerts when memory thresholds, function calls, or variable conditions are met
 - [Variable inspection](docs/peek-var-command.md): read PHP variable values from a running process without modifying it
+- [Sidecar daemon](docs/sidecar.md): run a daemon that accepts on-demand memory dump requests from PHP processes via Unix socket — no FFI needed in the application, ideal for memory_limit crash analysis and CI regression detection
 
 ## How it works
 It's implemented by using following techniques:

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -1,0 +1,427 @@
+# inspector:sidecar — On-Demand Memory Dump Daemon
+
+`inspector:sidecar` runs a daemon that listens on a Unix domain socket for memory dump requests from PHP processes. When a process needs a memory snapshot — for example, when hitting `memory_limit` — it sends a lightweight request over the socket, and the sidecar takes the dump from outside using `process_vm_readv`.
+
+Unlike `inspector:watch` (polling-based monitoring), the sidecar responds to **explicit requests from the application itself**, so it captures snapshots at the exact moment the application needs them.
+
+## Quick Start
+
+**Start the sidecar:**
+
+```bash
+reli inspector:sidecar \
+  --socket=/tmp/reli-sidecar.sock \
+  --output-dir=/tmp/reli-dumps
+```
+
+**In your PHP application (one line in bootstrap):**
+
+```php
+\Reli\Sidecar\Client\MemoryLimitHandler::register();
+```
+
+When your application hits `memory_limit`, the handler automatically requests a dump from the sidecar. The dump file and a `.meta.json` with the call trace and memory stats are written to `--output-dir`.
+
+## Requirements
+
+- Same as other `inspector:*` commands (FFI, PCNTL, PHP 8.1+ for execution, PHP 7.0+ for targets)
+- `CAP_SYS_PTRACE` capability (usually root)
+- The sidecar process must share the PID namespace with target processes (important for Docker setups)
+
+## Why Use a Sidecar?
+
+When a PHP process hits `memory_limit`, the shutdown handler has very limited capabilities:
+
+| Approach | FFI needed in app? | Call trace? | Memory dump? | Timing |
+|----------|-------------------|-------------|-------------|--------|
+| `error_get_last()` in shutdown handler | No | **No** (PHP ≤ 8.4) | No | At crash |
+| exec reli from shutdown handler | **Yes** | Yes | Yes | At crash |
+| `inspector:watch --memory-usage` | No | Yes | Yes | Polling (may miss) |
+| **`inspector:sidecar`** | **No** | **Yes** | **Yes** | **At crash (exact)** |
+
+The sidecar approach:
+- **No FFI in the application** — the client library uses only `stream_socket_client` + `fwrite`
+- **Exact timing** — the dump happens when the process reports it's dying, not on a poll interval
+- **Call trace from outside** — reli reads `EG(current_execute_data)` via `process_vm_readv`, so it gets the full call stack even though `debug_backtrace()` fails in a `memory_limit` shutdown handler on PHP ≤ 8.4
+
+## Client Library
+
+The client library requires **no FFI** and has **no heavy dependencies**. It's designed to work in shutdown handlers with minimal memory overhead.
+
+### Automatic memory_limit Handler
+
+```php
+// In your application bootstrap (e.g., index.php, bin/console)
+\Reli\Sidecar\Client\MemoryLimitHandler::register();
+```
+
+With custom callbacks:
+
+```php
+use Reli\Sidecar\Client\SidecarClientResponse;
+
+\Reli\Sidecar\Client\MemoryLimitHandler::register(
+    socket_path: '/tmp/reli-sidecar.sock',
+    on_response: function (SidecarClientResponse $r) {
+        error_log("reli dump: {$r->path} ({$r->bytes} bytes)");
+        foreach ($r->trace as $frame) {
+            error_log("  {$frame}");
+        }
+    },
+);
+```
+
+### Manual Dump Requests
+
+```php
+use Reli\Sidecar\Client\SidecarClient;
+
+$client = new SidecarClient('/tmp/reli-sidecar.sock');
+$response = $client->requestDump(
+    pid: getmypid(),
+    error_file: __FILE__,
+    error_line: __LINE__,
+);
+
+if ($response !== null && $response->isOk()) {
+    echo "Dump saved to: {$response->path}\n";
+}
+```
+
+### CI / Benchmark Snapshots
+
+```php
+$client = new SidecarClient();
+
+$client->snapshot('baseline');
+
+loadFixtures();
+$client->snapshot('after-fixtures');
+
+runHeavyProcess();
+$client->snapshot('after-processing');
+```
+
+### Socket Path Resolution
+
+The socket path is resolved in this order:
+
+1. Constructor argument (`$socket_path`)
+2. `RELI_SIDECAR_SOCKET` environment variable
+3. Default: `/var/run/reli-sidecar.sock`
+
+```bash
+export RELI_SIDECAR_SOCKET=/tmp/reli-sidecar.sock
+```
+
+### Default Metadata
+
+Pass `default_metadata` to the constructor to include key-value pairs in every request:
+
+```php
+$client = new SidecarClient(
+    default_metadata: ['branch' => 'main', 'runner' => 'ci-1'],
+);
+$client->snapshot('baseline'); // metadata is automatically included
+```
+
+## Server Options
+
+```
+Usage:
+  inspector:sidecar [options]
+
+Options:
+  -s, --socket=SOCKET              Unix domain socket path
+                                   [default: /var/run/reli-sidecar.sock]
+  -o, --output-dir=OUTPUT-DIR      Directory for dump output files [default: .]
+      --disk-usage-limit=LIMIT     Max total disk usage for dumps (e.g., 1G, 512M)
+                                   [default: 1G]
+      --include-binary             Include read-only binary segments in dumps
+  -t, --tag=TAG                    Session-level tag applied to every snapshot
+                                   (key=value, repeatable)
+      --memory-limit=LIMIT         Set PHP memory_limit for the sidecar process
+      --no-cache                   Disable the binary analysis cache
+```
+
+## Session Tags
+
+Tags set at server startup are automatically included in every snapshot's `.meta.json`. Use them to identify what software and version is being profiled:
+
+```bash
+reli inspector:sidecar \
+  --tag product=my-app \
+  --tag version=2.4.0 \
+  --tag commit=$(git rev-parse --short HEAD) \
+  --socket=/tmp/reli.sock \
+  --output-dir=/tmp/dumps
+```
+
+Tags from three sources are merged (later wins on key conflict):
+
+1. Server `--tag` options (session-level)
+2. Client `default_metadata` (client-level)
+3. Per-call `metadata` in `snapshot()` / `requestDump()` (call-level)
+
+## Output Files
+
+Each dump request produces two files:
+
+### Dump File (`sidecar-<pid>-<datetime>[-<label>].dump`)
+
+Binary memory dump in the same format as `inspector:memory:dump`. Can be analyzed with:
+
+```bash
+reli inspector:memory:analyze /tmp/dumps/sidecar-1234-20260403-120000-after-fixtures.dump \
+  --output-format sqlite3 --output result.db
+```
+
+### Metadata File (`.meta.json`)
+
+```json
+{
+    "pid": 1234,
+    "timestamp": "2026-04-03T12:00:00+09:00",
+    "trigger": "sidecar_request",
+    "php_version": "v84",
+    "memory_stats": {
+        "memory_usage": 52428800,
+        "memory_real_usage": 67108864,
+        "memory_peak_usage": 67108864,
+        "memory_limit": 134217728,
+        "rss": 89128960
+    },
+    "call_trace": [
+        "App\\Service\\HeavyProcessor::process /app/src/Service/HeavyProcessor.php:142",
+        "App\\Controller\\ApiController::handle /app/src/Controller/ApiController.php:58"
+    ],
+    "label": "after-fixtures",
+    "metadata": {
+        "product": "my-app",
+        "version": "2.4.0",
+        "commit": "abc123"
+    }
+}
+```
+
+When triggered by a `memory_limit` error, the file and line are also included:
+
+```json
+{
+    "memory_limit_error_file": "/app/src/Service/HeavyProcessor.php",
+    "memory_limit_error_line": 142
+}
+```
+
+This information can be passed to `inspector:memory:analyze` with `--memory-limit-error-file` and `--memory-limit-error-line` for targeted analysis.
+
+## Docker / Kubernetes Setup
+
+> [!CAUTION]
+> The sidecar must share the PID namespace with the target processes. Without this, `process_vm_readv` cannot read the target's memory.
+
+### docker compose
+
+```yaml
+services:
+  app:
+    image: my-php-app
+    volumes:
+      - reli-sock:/var/run/reli
+      - reli-dumps:/tmp/reli-dumps
+
+  reli-sidecar:
+    image: reliforp/reli-prof
+    command: >
+      inspector:sidecar
+        --socket=/var/run/reli/sidecar.sock
+        --output-dir=/tmp/reli-dumps
+        --tag product=my-app
+    pid: "service:app"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - reli-sock:/var/run/reli
+      - reli-dumps:/tmp/reli-dumps
+
+volumes:
+  reli-sock:
+  reli-dumps:
+```
+
+Set the socket path in the application container:
+
+```yaml
+services:
+  app:
+    environment:
+      RELI_SIDECAR_SOCKET: /var/run/reli/sidecar.sock
+```
+
+### Kubernetes (sidecar container)
+
+```yaml
+spec:
+  shareProcessNamespace: true
+  containers:
+    - name: app
+      image: my-php-app
+      env:
+        - name: RELI_SIDECAR_SOCKET
+          value: /var/run/reli/sidecar.sock
+      volumeMounts:
+        - name: reli-sock
+          mountPath: /var/run/reli
+    - name: reli-sidecar
+      image: reliforp/reli-prof
+      args:
+        - inspector:sidecar
+        - --socket=/var/run/reli/sidecar.sock
+        - --output-dir=/tmp/reli-dumps
+      securityContext:
+        capabilities:
+          add: ["SYS_PTRACE"]
+      volumeMounts:
+        - name: reli-sock
+          mountPath: /var/run/reli
+        - name: reli-dumps
+          mountPath: /tmp/reli-dumps
+  volumes:
+    - name: reli-sock
+      emptyDir: {}
+    - name: reli-dumps
+      emptyDir: {}
+```
+
+## CI Workflow: Cross-Release Memory Comparison
+
+The sidecar enables CI workflows that capture memory snapshots at specific points in a benchmark, then compare across releases to detect regressions.
+
+### Pipeline Overview
+
+```
+v2.3.0 release                         v2.4.0 PR
+┌─────────────────────┐                ┌─────────────────────┐
+│ sidecar + benchmark  │                │ sidecar + benchmark  │
+│ → snapshot(baseline) │                │ → snapshot(baseline) │
+│ → snapshot(loaded)   │                │ → snapshot(loaded)   │
+│ → analyze → v2.3.db  │                │ → analyze → v2.4.db  │
+│ → upload artifact    │                │ → download v2.3.db   │
+└─────────────────────┘                │ → compare → pass/fail│
+                                        └─────────────────────┘
+```
+
+### GitHub Actions Example
+
+```yaml
+name: Memory Regression Check
+on: [pull_request]
+
+jobs:
+  memory-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download baseline from the previous release
+      - uses: actions/download-artifact@v4
+        with:
+          name: memory-baseline
+          path: baseline/
+        continue-on-error: true
+
+      # Start sidecar
+      - name: Start sidecar
+        run: |
+          reli inspector:sidecar \
+            --socket=/tmp/reli.sock \
+            --output-dir=/tmp/dumps \
+            --tag version=${{ github.head_ref }} \
+            --tag commit=${{ github.sha }} &
+
+      # Run benchmark
+      - name: Run benchmark
+        env:
+          RELI_SIDECAR_SOCKET: /tmp/reli.sock
+        run: php bench/memory_trend.php
+
+      # Analyze dumps
+      - name: Analyze snapshots
+        run: |
+          for f in /tmp/dumps/sidecar-*.dump; do
+            reli inspector:memory:analyze "$f" \
+              --output-format sqlite3 \
+              --output "/tmp/analyzed/$(basename "$f" .dump).db"
+          done
+
+      # Compare with baseline (if available)
+      - name: Compare with baseline
+        if: hashFiles('baseline/*.db') != ''
+        run: |
+          reli inspector:memory:compare \
+            baseline/*.db /tmp/analyzed/*.db \
+            --threshold 5%
+
+      # Save current results as new baseline
+      - uses: actions/upload-artifact@v4
+        with:
+          name: memory-baseline
+          path: /tmp/analyzed/
+```
+
+### Benchmark Script
+
+```php
+<?php
+// bench/memory_trend.php
+use Reli\Sidecar\Client\SidecarClient;
+
+$client = new SidecarClient();
+
+// Initial state
+$client->snapshot('baseline');
+
+// Simulate workload
+loadFixtures();
+$client->snapshot('after-fixtures');
+
+processOrders();
+$client->snapshot('after-orders');
+
+generateReport();
+$client->snapshot('after-report');
+```
+
+## IPC Protocol
+
+The sidecar uses a simple newline-delimited JSON protocol over the Unix domain socket.
+
+**Request:**
+
+```json
+{"command": "dump", "pid": 1234, "file": "/app/Foo.php", "line": 42, "label": "my-label", "metadata": {"key": "value"}}
+```
+
+Only `command` and `pid` are required. All other fields are optional.
+
+**Response:**
+
+```json
+{"status": "ok", "path": "/tmp/dumps/sidecar-1234-20260403-120000.dump", "bytes": 52428800, "trace": ["..."], "memory_stats": {"memory_usage": 52428800, "rss": 89128960}}
+```
+
+```json
+{"status": "error", "message": "process 1234 not found"}
+```
+
+## Relationship with Other Commands
+
+| Command | Use Case | Trigger |
+|---------|----------|---------|
+| `inspector:memory:dump` | One-shot dump of a known process | Manual (CLI) |
+| `inspector:watch` | Passive monitoring with threshold triggers | Polling (automatic) |
+| **`inspector:sidecar`** | **Application-initiated dump on error/at specific points** | **On-demand (IPC)** |
+| `inspector:memory:analyze` | Offline analysis of dump files | Post-hoc (CLI) |
+| `inspector:memory:compare` | Diff two analysis databases | Post-hoc (CLI) |

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -421,12 +421,21 @@ Only `command` and `pid` are required. All other fields are optional.
 **Response:**
 
 ```json
-{"status": "ok", "path": "/tmp/dumps/sidecar-1234-20260403-120000.dump", "bytes": 52428800, "trace": ["..."], "memory_stats": {"memory_usage": 52428800, "rss": 89128960}}
+{"protocol_version": 1, "status": "ok", "path": "/tmp/dumps/sidecar-1234-20260403-120000.dump", "bytes": 52428800, "trace": ["..."], "memory_stats": {"memory_usage": 52428800, "rss": 89128960}}
 ```
 
 ```json
-{"status": "error", "message": "process 1234 not found"}
+{"protocol_version": 1, "status": "error", "message": "process 1234 not found"}
 ```
+
+### Protocol Versioning
+
+Every response includes `protocol_version` (integer). The compatibility contract:
+
+- **Additive changes** (new optional fields) do **not** bump the version. Both sides ignore unknown JSON keys.
+- **Breaking changes** (removed/renamed fields, semantic changes) **must** bump the version.
+
+Clients can check `$response->isCompatible()` to detect whether the server's version exceeds what the client understands. A response without `protocol_version` (from a pre-versioning server) is treated as compatible.
 
 ## Relationship with Other Commands
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -48,6 +48,18 @@ The sidecar approach:
 
 The client library requires **no FFI** and has **no heavy dependencies**. It's designed to work in shutdown handlers with minimal memory overhead.
 
+### Emergency Memory Reserve
+
+When PHP hits `memory_limit`, the shutdown handler runs with almost no free memory — even `stream_socket_client()` can fail because it needs to allocate internal buffers. To handle this, `MemoryLimitHandler` pre-allocates a block of memory (default 256 KB) at `register()` time and releases it at the very start of the shutdown handler, freeing enough headroom for socket operations.
+
+```php
+// Default: 256 KB reserve
+\Reli\Sidecar\Client\MemoryLimitHandler::register();
+
+// Custom reserve size (e.g., 512 KB for applications with heavy shutdown hooks)
+\Reli\Sidecar\Client\MemoryLimitHandler::register(reserve_bytes: 512 * 1024);
+```
+
 ### Automatic memory_limit Handler
 
 ```php

--- a/src/Command/Inspector/SidecarCommand.php
+++ b/src/Command/Inspector/SidecarCommand.php
@@ -19,6 +19,8 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Sidecar\SidecarDumpHandler;
 use Reli\Inspector\Sidecar\SidecarServer;
 use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\Inspector\Watch\HeapStatsReader;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\Directory\AppDirectory;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
@@ -37,6 +39,8 @@ final class SidecarCommand extends Command
         private PhpVersionDetector $php_version_detector,
         private MemoryDumper $memory_dumper,
         private CallTraceReader $call_trace_reader,
+        private HeapStatsReader $heap_stats_reader,
+        private RssReader $rss_reader,
         private ProcessStopper $process_stopper,
         private BinaryAnalysisCache $binary_analysis_cache,
         private SidecarSettingsFromConsoleInput $sidecar_settings_from_console_input,
@@ -90,6 +94,8 @@ final class SidecarCommand extends Command
             php_version_detector: $this->php_version_detector,
             memory_dumper: $this->memory_dumper,
             call_trace_reader: $this->call_trace_reader,
+            heap_stats_reader: $this->heap_stats_reader,
+            rss_reader: $this->rss_reader,
             process_stopper: $this->process_stopper,
             disk_tracker: $disk_tracker,
             output_dir: $settings->output_dir,

--- a/src/Command/Inspector/SidecarCommand.php
+++ b/src/Command/Inspector/SidecarCommand.php
@@ -100,6 +100,7 @@ final class SidecarCommand extends Command
             disk_tracker: $disk_tracker,
             output_dir: $settings->output_dir,
             include_binary: $settings->include_binary,
+            session_tags: $settings->tags,
         );
 
         $server = new SidecarServer($dump_handler);

--- a/src/Command/Inspector/SidecarCommand.php
+++ b/src/Command/Inspector/SidecarCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Reli\Inspector\MemoryDump\MemoryDumper;
+use Reli\Inspector\Settings\SidecarSettings\SidecarSettingsFromConsoleInput;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
+use Reli\Inspector\Sidecar\SidecarDumpHandler;
+use Reli\Inspector\Sidecar\SidecarServer;
+use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\Lib\Directory\AppDirectory;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpVersionDetector;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SidecarCommand extends Command
+{
+    public function __construct(
+        private PhpGlobalsFinder $php_globals_finder,
+        private PhpVersionDetector $php_version_detector,
+        private MemoryDumper $memory_dumper,
+        private CallTraceReader $call_trace_reader,
+        private ProcessStopper $process_stopper,
+        private BinaryAnalysisCache $binary_analysis_cache,
+        private SidecarSettingsFromConsoleInput $sidecar_settings_from_console_input,
+        private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('inspector:sidecar')
+            ->setDescription(
+                'run a sidecar daemon that listens on a Unix domain socket'
+                    . ' for memory dump requests from PHP processes'
+            )
+        ;
+        $this->sidecar_settings_from_console_input->setOptions($this);
+        $this->target_php_settings_from_console_input->setOptions($this);
+        $this->addOption(
+            'no-cache',
+            null,
+            InputOption::VALUE_NONE,
+            'disable the binary analysis cache',
+        );
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getOption('no-cache')) {
+            $this->binary_analysis_cache->disable();
+        }
+
+        $settings = $this->sidecar_settings_from_console_input->createSettings($input);
+
+        if ($settings->memory_limit !== null) {
+            ini_set('memory_limit', $settings->memory_limit);
+        }
+
+        AppDirectory::ensureDirectoryExists($settings->output_dir);
+        AppDirectory::ensureDirectoryExists(dirname($settings->socket_path));
+
+        $disk_tracker = new DiskUsageTracker(
+            $settings->disk_usage_limit_bytes,
+            $settings->output_dir,
+        );
+
+        $dump_handler = new SidecarDumpHandler(
+            php_globals_finder: $this->php_globals_finder,
+            php_version_detector: $this->php_version_detector,
+            memory_dumper: $this->memory_dumper,
+            call_trace_reader: $this->call_trace_reader,
+            process_stopper: $this->process_stopper,
+            disk_tracker: $disk_tracker,
+            output_dir: $settings->output_dir,
+            include_binary: $settings->include_binary,
+        );
+
+        $server = new SidecarServer($dump_handler);
+        $server->run($settings->socket_path, $output);
+
+        return 0;
+    }
+}

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
@@ -18,12 +18,16 @@ final class SidecarSettings
 {
     public const DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock';
 
+    /**
+     * @param array<string, string> $tags session-level tags applied to every snapshot
+     */
     public function __construct(
         public string $socket_path = self::DEFAULT_SOCKET_PATH,
         public string $output_dir = '.',
         public int $disk_usage_limit_bytes = 1073741824, // 1GB
         public bool $include_binary = false,
         public ?string $memory_limit = null,
+        public array $tags = [],
     ) {
     }
 }

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\SidecarSettings;
+
+/** @psalm-immutable */
+final class SidecarSettings
+{
+    public const DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock';
+
+    public function __construct(
+        public string $socket_path = self::DEFAULT_SOCKET_PATH,
+        public string $output_dir = '.',
+        public int $disk_usage_limit_bytes = 1073741824, // 1GB
+        public bool $include_binary = false,
+        public ?string $memory_limit = null,
+    ) {
+    }
+}

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\SidecarSettings;
+
+use PhpCast\NullableCast;
+use Reli\Inspector\Watch\HeapStats;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+final class SidecarSettingsFromConsoleInput
+{
+    /** @codeCoverageIgnore */
+    public function setOptions(Command $command): void
+    {
+        $command
+            ->addOption(
+                'socket',
+                's',
+                InputOption::VALUE_REQUIRED,
+                'Unix domain socket path',
+                SidecarSettings::DEFAULT_SOCKET_PATH,
+            )
+            ->addOption(
+                'output-dir',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'directory for dump output files',
+                '.',
+            )
+            ->addOption(
+                'disk-usage-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'max total disk usage for dumps (e.g., 1G, 512M)',
+                '1G',
+            )
+            ->addOption(
+                'include-binary',
+                null,
+                InputOption::VALUE_NONE,
+                'include read-only binary segments in dumps',
+            )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for the sidecar process (e.g., 2G)',
+            )
+        ;
+    }
+
+    public function createSettings(InputInterface $input): SidecarSettings
+    {
+        $disk_limit_str = NullableCast::toString($input->getOption('disk-usage-limit'));
+        $disk_limit = $disk_limit_str !== null
+            ? HeapStats::parseSize($disk_limit_str)
+            : 1073741824;
+
+        return new SidecarSettings(
+            socket_path: (string)$input->getOption('socket'),
+            output_dir: (string)$input->getOption('output-dir'),
+            disk_usage_limit_bytes: $disk_limit,
+            include_binary: (bool)$input->getOption('include-binary'),
+            memory_limit: NullableCast::toString($input->getOption('memory-limit')),
+        );
+    }
+}

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
@@ -58,6 +58,12 @@ final class SidecarSettingsFromConsoleInput
                 InputOption::VALUE_REQUIRED,
                 'set PHP memory_limit for the sidecar process (e.g., 2G)',
             )
+            ->addOption(
+                'tag',
+                't',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'session-level tag applied to every snapshot (key=value)',
+            )
         ;
     }
 
@@ -68,12 +74,23 @@ final class SidecarSettingsFromConsoleInput
             ? HeapStats::parseSize($disk_limit_str)
             : 1073741824;
 
+        /** @var list<string> $tag_options */
+        $tag_options = $input->getOption('tag');
+        $tags = [];
+        foreach ($tag_options as $tag) {
+            $pos = strpos($tag, '=');
+            if ($pos !== false) {
+                $tags[substr($tag, 0, $pos)] = substr($tag, $pos + 1);
+            }
+        }
+
         return new SidecarSettings(
             socket_path: (string)$input->getOption('socket'),
             output_dir: (string)$input->getOption('output-dir'),
             disk_usage_limit_bytes: $disk_limit,
             include_binary: (bool)$input->getOption('include-binary'),
             memory_limit: NullableCast::toString($input->getOption('memory-limit')),
+            tags: $tags,
         );
     }
 }

--- a/src/Inspector/Sidecar/Protocol/SidecarRequest.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarRequest.php
@@ -45,6 +45,7 @@ final class SidecarRequest
 
         $metadata = [];
         if (isset($data['metadata']) && is_array($data['metadata'])) {
+            /** @var mixed $v */
             foreach ($data['metadata'] as $k => $v) {
                 if (is_string($k) && is_string($v)) {
                     $metadata[$k] = $v;

--- a/src/Inspector/Sidecar/Protocol/SidecarRequest.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarRequest.php
@@ -15,11 +15,16 @@ namespace Reli\Inspector\Sidecar\Protocol;
 
 final class SidecarRequest
 {
+    /**
+     * @param array<string, string> $metadata arbitrary key-value pairs (e.g. commit SHA, PHP version, env)
+     */
     public function __construct(
         public readonly string $command,
         public readonly int $pid,
         public readonly ?string $error_file = null,
         public readonly ?int $error_line = null,
+        public readonly ?string $label = null,
+        public readonly array $metadata = [],
     ) {
     }
 
@@ -37,11 +42,23 @@ final class SidecarRequest
         if (!is_string($command) || !is_int($pid)) {
             return null;
         }
+
+        $metadata = [];
+        if (isset($data['metadata']) && is_array($data['metadata'])) {
+            foreach ($data['metadata'] as $k => $v) {
+                if (is_string($k) && is_string($v)) {
+                    $metadata[$k] = $v;
+                }
+            }
+        }
+
         return new self(
             command: $command,
             pid: $pid,
             error_file: isset($data['file']) && is_string($data['file']) ? $data['file'] : null,
             error_line: isset($data['line']) && is_int($data['line']) ? $data['line'] : null,
+            label: isset($data['label']) && is_string($data['label']) ? $data['label'] : null,
+            metadata: $metadata,
         );
     }
 }

--- a/src/Inspector/Sidecar/Protocol/SidecarRequest.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar\Protocol;
+
+final class SidecarRequest
+{
+    public function __construct(
+        public readonly string $command,
+        public readonly int $pid,
+        public readonly ?string $error_file = null,
+        public readonly ?int $error_line = null,
+    ) {
+    }
+
+    /**
+     * @return self|null null on invalid JSON
+     */
+    public static function fromJson(string $json): ?self
+    {
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return null;
+        }
+        $command = $data['command'] ?? null;
+        $pid = $data['pid'] ?? null;
+        if (!is_string($command) || !is_int($pid)) {
+            return null;
+        }
+        return new self(
+            command: $command,
+            pid: $pid,
+            error_file: isset($data['file']) && is_string($data['file']) ? $data['file'] : null,
+            error_line: isset($data['line']) && is_int($data['line']) ? $data['line'] : null,
+        );
+    }
+}

--- a/src/Inspector/Sidecar/Protocol/SidecarResponse.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarResponse.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar\Protocol;
+
+final class SidecarResponse
+{
+    /**
+     * @param list<string> $trace
+     * @param array<string, mixed>|null $error_context
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly ?string $path = null,
+        public readonly ?int $bytes = null,
+        public readonly array $trace = [],
+        public readonly ?array $error_context = null,
+        public readonly ?string $message = null,
+    ) {
+    }
+
+    public static function ok(
+        string $path,
+        int $bytes,
+        array $trace = [],
+        ?array $error_context = null,
+    ): self {
+        return new self(
+            status: 'ok',
+            path: $path,
+            bytes: $bytes,
+            trace: $trace,
+            error_context: $error_context,
+        );
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(
+            status: 'error',
+            message: $message,
+        );
+    }
+
+    public function toJson(): string
+    {
+        $data = ['status' => $this->status];
+        if ($this->path !== null) {
+            $data['path'] = $this->path;
+        }
+        if ($this->bytes !== null) {
+            $data['bytes'] = $this->bytes;
+        }
+        if (count($this->trace) > 0) {
+            $data['trace'] = $this->trace;
+        }
+        if ($this->error_context !== null) {
+            $data['error_context'] = $this->error_context;
+        }
+        if ($this->message !== null) {
+            $data['message'] = $this->message;
+        }
+        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/src/Inspector/Sidecar/Protocol/SidecarResponse.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarResponse.php
@@ -18,6 +18,7 @@ final class SidecarResponse
     /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
+     * @param array<string, int>|null $memory_stats
      */
     public function __construct(
         public readonly string $status,
@@ -25,15 +26,22 @@ final class SidecarResponse
         public readonly ?int $bytes = null,
         public readonly array $trace = [],
         public readonly ?array $error_context = null,
+        public readonly ?array $memory_stats = null,
         public readonly ?string $message = null,
     ) {
     }
 
+    /**
+     * @param list<string> $trace
+     * @param array<string, mixed>|null $error_context
+     * @param array<string, int>|null $memory_stats
+     */
     public static function ok(
         string $path,
         int $bytes,
         array $trace = [],
         ?array $error_context = null,
+        ?array $memory_stats = null,
     ): self {
         return new self(
             status: 'ok',
@@ -41,6 +49,7 @@ final class SidecarResponse
             bytes: $bytes,
             trace: $trace,
             error_context: $error_context,
+            memory_stats: $memory_stats,
         );
     }
 
@@ -66,6 +75,9 @@ final class SidecarResponse
         }
         if ($this->error_context !== null) {
             $data['error_context'] = $this->error_context;
+        }
+        if ($this->memory_stats !== null) {
+            $data['memory_stats'] = $this->memory_stats;
         }
         if ($this->message !== null) {
             $data['message'] = $this->message;

--- a/src/Inspector/Sidecar/Protocol/SidecarResponse.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarResponse.php
@@ -16,6 +16,17 @@ namespace Reli\Inspector\Sidecar\Protocol;
 final class SidecarResponse
 {
     /**
+     * Protocol version. Bump on breaking changes.
+     *
+     * Compatibility contract:
+     *  - Additive changes (new optional fields) do NOT bump the version.
+     *    Both sides ignore unknown keys via fromJson/isset.
+     *  - Breaking changes (removed/renamed fields, semantic changes)
+     *    MUST bump the version so clients can detect incompatibility.
+     */
+    public const PROTOCOL_VERSION = 1;
+
+    /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
      * @param array<string, int|null> $memory_stats
@@ -63,7 +74,10 @@ final class SidecarResponse
 
     public function toJson(): string
     {
-        $data = ['status' => $this->status];
+        $data = [
+            'protocol_version' => self::PROTOCOL_VERSION,
+            'status' => $this->status,
+        ];
         if ($this->path !== null) {
             $data['path'] = $this->path;
         }

--- a/src/Inspector/Sidecar/Protocol/SidecarResponse.php
+++ b/src/Inspector/Sidecar/Protocol/SidecarResponse.php
@@ -18,7 +18,7 @@ final class SidecarResponse
     /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
-     * @param array<string, int>|null $memory_stats
+     * @param array<string, int|null> $memory_stats
      */
     public function __construct(
         public readonly string $status,
@@ -34,7 +34,7 @@ final class SidecarResponse
     /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
-     * @param array<string, int>|null $memory_stats
+     * @param array<string, int|null>|null $memory_stats
      */
     public static function ok(
         string $path,
@@ -82,6 +82,6 @@ final class SidecarResponse
         if ($this->message !== null) {
             $data['message'] = $this->message;
         }
-        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        return (string)json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 }

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -18,6 +18,8 @@ use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Inspector\Sidecar\Protocol\SidecarRequest;
 use Reli\Inspector\Sidecar\Protocol\SidecarResponse;
 use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\Inspector\Watch\HeapStatsReader;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
@@ -34,6 +36,8 @@ final class SidecarDumpHandler
         private PhpVersionDetector $php_version_detector,
         private MemoryDumper $memory_dumper,
         private CallTraceReader $call_trace_reader,
+        private HeapStatsReader $heap_stats_reader,
+        private RssReader $rss_reader,
         private ProcessStopper $process_stopper,
         private DiskUsageTracker $disk_tracker,
         private string $output_dir,
@@ -89,6 +93,14 @@ final class SidecarDumpHandler
             $target_php_settings,
         );
 
+        // Collect lightweight heap stats and RSS before stopping
+        $heap_stats = $this->heap_stats_reader->read(
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+        );
+        $rss_bytes = $this->rss_reader->read($pid);
+
         $stopped = $this->process_stopper->stop($pid);
         try {
             $trace_strings = $this->readTrace(
@@ -120,7 +132,21 @@ final class SidecarDumpHandler
 
             $this->disk_tracker->recordFile($output_path);
 
-            $this->writeMetadata($request, $output_path, $trace_strings, $php_version);
+            $memory_stats = [
+                'memory_usage' => $heap_stats->size,
+                'memory_real_usage' => $heap_stats->real_size,
+                'memory_peak_usage' => $heap_stats->peak,
+                'memory_limit' => $heap_stats->limit,
+                'rss' => $rss_bytes,
+            ];
+
+            $this->writeMetadata(
+                $request,
+                $output_path,
+                $trace_strings,
+                $php_version,
+                $memory_stats,
+            );
 
             Log::info('sidecar dump saved', [
                 'path' => $result->output_path,
@@ -142,6 +168,7 @@ final class SidecarDumpHandler
                 bytes: $result->total_bytes,
                 trace: $trace_strings,
                 error_context: $error_context,
+                memory_stats: $memory_stats,
             );
         } finally {
             if ($stopped) {
@@ -187,12 +214,14 @@ final class SidecarDumpHandler
 
     /**
      * @param list<string> $trace
+     * @param array<string, int> $memory_stats
      */
     private function writeMetadata(
         SidecarRequest $request,
         string $dump_path,
         array $trace,
         string $php_version,
+        array $memory_stats,
     ): void {
         $meta_path = $dump_path . '.meta.json';
         $meta = [
@@ -200,6 +229,7 @@ final class SidecarDumpHandler
             'timestamp' => date('c'),
             'trigger' => 'sidecar_request',
             'php_version' => $php_version,
+            'memory_stats' => $memory_stats,
             'call_trace' => $trace,
         ];
         if ($request->label !== null) {

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -98,11 +98,15 @@ final class SidecarDumpHandler
                 $sg_address,
             );
 
+            $label_slug = $request->label !== null
+                ? '-' . preg_replace('/[^a-zA-Z0-9_-]/', '_', $request->label)
+                : '';
             $output_path = sprintf(
-                '%s/sidecar-%d-%s.dump',
+                '%s/sidecar-%d-%s%s.dump',
                 rtrim($this->output_dir, '/'),
                 $pid,
                 date('Ymd-His'),
+                $label_slug,
             );
 
             $result = $this->memory_dumper->dump(
@@ -198,6 +202,12 @@ final class SidecarDumpHandler
             'php_version' => $php_version,
             'call_trace' => $trace,
         ];
+        if ($request->label !== null) {
+            $meta['label'] = $request->label;
+        }
+        if (count($request->metadata) > 0) {
+            $meta['metadata'] = $request->metadata;
+        }
         if ($request->error_file !== null) {
             $meta['memory_limit_error_file'] = $request->error_file;
         }

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar;
+
+use Reli\Inspector\MemoryDump\MemoryDumper;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Inspector\Sidecar\Protocol\SidecarRequest;
+use Reli\Inspector\Sidecar\Protocol\SidecarResponse;
+use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\Lib\Log\Log;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
+use Reli\Lib\PhpProcessReader\CallTraceReader\TraceCache;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpVersionDetector;
+use Reli\Lib\Process\ProcessSpecifier;
+use Reli\Lib\Process\ProcessStopper\ProcessStopper;
+
+final class SidecarDumpHandler
+{
+    public function __construct(
+        private PhpGlobalsFinder $php_globals_finder,
+        private PhpVersionDetector $php_version_detector,
+        private MemoryDumper $memory_dumper,
+        private CallTraceReader $call_trace_reader,
+        private ProcessStopper $process_stopper,
+        private DiskUsageTracker $disk_tracker,
+        private string $output_dir,
+        private bool $include_binary,
+    ) {
+    }
+
+    public function handle(SidecarRequest $request): SidecarResponse
+    {
+        $pid = $request->pid;
+
+        if (!file_exists("/proc/{$pid}/status")) {
+            return SidecarResponse::error("process {$pid} not found");
+        }
+
+        if (!$this->disk_tracker->canWrite()) {
+            return SidecarResponse::error('disk usage limit reached');
+        }
+
+        try {
+            return $this->doDump($request);
+        } catch (\Throwable $e) {
+            Log::debug('sidecar dump failed', [
+                'pid' => $pid,
+                'error' => $e->getMessage(),
+            ]);
+            return SidecarResponse::error($e->getMessage());
+        }
+    }
+
+    private function doDump(SidecarRequest $request): SidecarResponse
+    {
+        $pid = $request->pid;
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings();
+
+        $target_php_settings = $this->php_version_detector->decidePhpVersion(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $php_version = $target_php_settings->php_version;
+
+        $eg_address = $this->php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $cg_address = $this->php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $sg_address = $this->php_globals_finder->findSAPIGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $stopped = $this->process_stopper->stop($pid);
+        try {
+            $trace_strings = $this->readTrace(
+                $pid,
+                $php_version,
+                $eg_address,
+                $sg_address,
+            );
+
+            $output_path = sprintf(
+                '%s/sidecar-%d-%s.dump',
+                rtrim($this->output_dir, '/'),
+                $pid,
+                date('Ymd-His'),
+            );
+
+            $result = $this->memory_dumper->dump(
+                $process_specifier,
+                $target_php_settings,
+                $eg_address,
+                $cg_address,
+                $output_path,
+                $this->include_binary,
+            );
+
+            $this->disk_tracker->recordFile($output_path);
+
+            $this->writeMetadata($request, $output_path, $trace_strings, $php_version);
+
+            Log::info('sidecar dump saved', [
+                'path' => $result->output_path,
+                'regions' => $result->region_count,
+                'bytes' => $result->total_bytes,
+                'pid' => $pid,
+            ]);
+
+            $error_context = null;
+            if ($request->error_file !== null && $request->error_line !== null) {
+                $error_context = [
+                    'file' => $request->error_file,
+                    'line' => $request->error_line,
+                ];
+            }
+
+            return SidecarResponse::ok(
+                path: $result->output_path,
+                bytes: $result->total_bytes,
+                trace: $trace_strings,
+                error_context: $error_context,
+            );
+        } finally {
+            if ($stopped) {
+                $this->process_stopper->resume($pid);
+            }
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readTrace(
+        int $pid,
+        string $php_version,
+        int $eg_address,
+        int $sg_address,
+    ): array {
+        try {
+            $call_trace = $this->call_trace_reader->readCallTrace(
+                $pid,
+                $php_version,
+                $eg_address,
+                $sg_address,
+                PHP_INT_MAX,
+                new TraceCache(),
+            );
+            if ($call_trace === null) {
+                return [];
+            }
+            return array_map(
+                fn (CallFrame $frame): string => sprintf(
+                    '%s %s:%d',
+                    $frame->getFullyQualifiedFunctionName(),
+                    $frame->file_name,
+                    $frame->getLineno(),
+                ),
+                $call_trace->call_frames,
+            );
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param list<string> $trace
+     */
+    private function writeMetadata(
+        SidecarRequest $request,
+        string $dump_path,
+        array $trace,
+        string $php_version,
+    ): void {
+        $meta_path = $dump_path . '.meta.json';
+        $meta = [
+            'pid' => $request->pid,
+            'timestamp' => date('c'),
+            'trigger' => 'sidecar_request',
+            'php_version' => $php_version,
+            'call_trace' => $trace,
+        ];
+        if ($request->error_file !== null) {
+            $meta['memory_limit_error_file'] = $request->error_file;
+        }
+        if ($request->error_line !== null) {
+            $meta['memory_limit_error_line'] = $request->error_line;
+        }
+        file_put_contents(
+            $meta_path,
+            json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n",
+        );
+    }
+}

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -133,52 +133,55 @@ final class SidecarDumpHandler
                 $output_path,
                 $this->include_binary,
             );
-
-            $this->disk_tracker->recordFile($output_path);
-
-            $memory_stats = [
-                'memory_usage' => $heap_stats->size,
-                'memory_real_usage' => $heap_stats->real_size,
-                'memory_peak_usage' => $heap_stats->peak,
-                'memory_limit' => $heap_stats->limit,
-                'rss' => $rss_bytes,
-            ];
-
-            $this->writeMetadata(
-                $request,
-                $output_path,
-                $trace_strings,
-                $php_version,
-                $memory_stats,
-            );
-
-            Log::info('sidecar dump saved', [
-                'path' => $result->output_path,
-                'regions' => $result->region_count,
-                'bytes' => $result->total_bytes,
-                'pid' => $pid,
-            ]);
-
-            $error_context = null;
-            if ($request->error_file !== null && $request->error_line !== null) {
-                $error_context = [
-                    'file' => $request->error_file,
-                    'line' => $request->error_line,
-                ];
-            }
-
-            return SidecarResponse::ok(
-                path: $result->output_path,
-                bytes: $result->total_bytes,
-                trace: $trace_strings,
-                error_context: $error_context,
-                memory_stats: $memory_stats,
-            );
         } finally {
+            // Resume the target as soon as dump is captured.
+            // Everything below (metadata write, response build) doesn't
+            // need the process stopped — minimize the stop window.
             if ($stopped) {
                 $this->process_stopper->resume($pid);
             }
         }
+
+        $this->disk_tracker->recordFile($output_path);
+
+        $memory_stats = [
+            'memory_usage' => $heap_stats->size,
+            'memory_real_usage' => $heap_stats->real_size,
+            'memory_peak_usage' => $heap_stats->peak,
+            'memory_limit' => $heap_stats->limit,
+            'rss' => $rss_bytes,
+        ];
+
+        $this->writeMetadata(
+            $request,
+            $output_path,
+            $trace_strings,
+            $php_version,
+            $memory_stats,
+        );
+
+        Log::info('sidecar dump saved', [
+            'path' => $result->output_path,
+            'regions' => $result->region_count,
+            'bytes' => $result->total_bytes,
+            'pid' => $pid,
+        ]);
+
+        $error_context = null;
+        if ($request->error_file !== null && $request->error_line !== null) {
+            $error_context = [
+                'file' => $request->error_file,
+                'line' => $request->error_line,
+            ];
+        }
+
+        return SidecarResponse::ok(
+            path: $result->output_path,
+            bytes: $result->total_bytes,
+            trace: $trace_strings,
+            error_context: $error_context,
+            memory_stats: $memory_stats,
+        );
     }
 
     /**

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -31,6 +31,9 @@ use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 final class SidecarDumpHandler
 {
+    /**
+     * @param array<string, string> $session_tags tags applied to every snapshot
+     */
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,
@@ -42,6 +45,7 @@ final class SidecarDumpHandler
         private DiskUsageTracker $disk_tracker,
         private string $output_dir,
         private bool $include_binary,
+        private array $session_tags = [],
     ) {
     }
 
@@ -235,8 +239,10 @@ final class SidecarDumpHandler
         if ($request->label !== null) {
             $meta['label'] = $request->label;
         }
-        if (count($request->metadata) > 0) {
-            $meta['metadata'] = $request->metadata;
+        // Merge session tags with per-request metadata (request wins on conflict)
+        $merged_metadata = array_merge($this->session_tags, $request->metadata);
+        if (count($merged_metadata) > 0) {
+            $meta['metadata'] = $merged_metadata;
         }
         if ($request->error_file !== null) {
             $meta['memory_limit_error_file'] = $request->error_file;

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -115,7 +115,7 @@ final class SidecarDumpHandler
             );
 
             $label_slug = $request->label !== null
-                ? '-' . preg_replace('/[^a-zA-Z0-9_-]/', '_', $request->label)
+                ? '-' . (string)preg_replace('/[^a-zA-Z0-9_-]/', '_', $request->label)
                 : '';
             $output_path = sprintf(
                 '%s/sidecar-%d-%s%s.dump',
@@ -182,6 +182,7 @@ final class SidecarDumpHandler
     }
 
     /**
+     * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      * @return list<string>
      */
     private function readTrace(
@@ -202,7 +203,7 @@ final class SidecarDumpHandler
             if ($call_trace === null) {
                 return [];
             }
-            return array_map(
+            return array_values(array_map(
                 fn (CallFrame $frame): string => sprintf(
                     '%s %s:%d',
                     $frame->getFullyQualifiedFunctionName(),
@@ -210,7 +211,7 @@ final class SidecarDumpHandler
                     $frame->getLineno(),
                 ),
                 $call_trace->call_frames,
-            );
+            ));
         } catch (\Throwable) {
             return [];
         }
@@ -218,7 +219,7 @@ final class SidecarDumpHandler
 
     /**
      * @param list<string> $trace
-     * @param array<string, int> $memory_stats
+     * @param array<string, int|null> $memory_stats
      */
     private function writeMetadata(
         SidecarRequest $request,
@@ -252,7 +253,7 @@ final class SidecarDumpHandler
         }
         file_put_contents(
             $meta_path,
-            json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n",
+            (string)json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n",
         );
     }
 }

--- a/src/Inspector/Sidecar/SidecarServer.php
+++ b/src/Inspector/Sidecar/SidecarServer.php
@@ -114,12 +114,17 @@ final class SidecarServer
                 return;
             }
 
+            $context_parts = [];
+            if ($request->label !== null) {
+                $context_parts[] = sprintf('label=%s', $request->label);
+            }
+            if ($request->error_file !== null) {
+                $context_parts[] = sprintf('file=%s line=%d', $request->error_file, $request->error_line ?? 0);
+            }
             $output->writeln(sprintf(
                 '<info>[sidecar] Dump request: PID=%d%s</info>',
                 $request->pid,
-                $request->error_file !== null
-                    ? sprintf(' file=%s line=%d', $request->error_file, $request->error_line ?? 0)
-                    : '',
+                count($context_parts) > 0 ? ' ' . implode(' ', $context_parts) : '',
             ));
 
             $response = $this->dump_handler->handle($request);

--- a/src/Inspector/Sidecar/SidecarServer.php
+++ b/src/Inspector/Sidecar/SidecarServer.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar;
+
+use Reli\Inspector\Sidecar\Protocol\SidecarRequest;
+use Reli\Inspector\Sidecar\Protocol\SidecarResponse;
+use Reli\Lib\Log\Log;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SidecarServer
+{
+    private bool $running = false;
+
+    public function __construct(
+        private SidecarDumpHandler $dump_handler,
+    ) {
+    }
+
+    public function run(string $socket_path, OutputInterface $output): void
+    {
+        $this->cleanup($socket_path);
+        $this->running = true;
+
+        $server = stream_socket_server(
+            "unix://{$socket_path}",
+            $errno,
+            $errstr,
+        );
+        if ($server === false) {
+            throw new \RuntimeException(
+                "Failed to create socket at {$socket_path}: [{$errno}] {$errstr}"
+            );
+        }
+
+        // Allow group read/write so app processes in the same group can connect
+        chmod($socket_path, 0660);
+
+        // Clean up socket file on shutdown
+        $cleanup = function () use ($socket_path, $server): void {
+            $this->running = false;
+            fclose($server);
+            $this->cleanup($socket_path);
+        };
+
+        pcntl_signal(SIGTERM, $cleanup);
+        pcntl_signal(SIGINT, $cleanup);
+
+        $output->writeln(sprintf(
+            '<info>[sidecar] Listening on %s</info>',
+            $socket_path,
+        ));
+
+        while ($this->running) {
+            // Use stream_select to allow signal handling between polls
+            $read = [$server];
+            $write = null;
+            $except = null;
+            $changed = @stream_select($read, $write, $except, 1);
+
+            pcntl_signal_dispatch();
+
+            if (!$this->running) {
+                break;
+            }
+
+            if ($changed === false || $changed === 0) {
+                continue;
+            }
+
+            $client = @stream_socket_accept($server, 5);
+            if ($client === false) {
+                continue;
+            }
+
+            $this->handleConnection($client, $output);
+        }
+
+        $output->writeln('<info>[sidecar] Stopped.</info>');
+    }
+
+    /**
+     * @param resource $client
+     */
+    private function handleConnection($client, OutputInterface $output): void
+    {
+        try {
+            stream_set_timeout($client, 5);
+            $line = fgets($client, 8192);
+            if ($line === false || $line === '') {
+                return;
+            }
+
+            $request = SidecarRequest::fromJson(trim($line));
+            if ($request === null) {
+                $response = SidecarResponse::error('invalid request');
+                fwrite($client, $response->toJson() . "\n");
+                return;
+            }
+
+            if ($request->command !== 'dump') {
+                $response = SidecarResponse::error("unknown command: {$request->command}");
+                fwrite($client, $response->toJson() . "\n");
+                return;
+            }
+
+            $output->writeln(sprintf(
+                '<info>[sidecar] Dump request: PID=%d%s</info>',
+                $request->pid,
+                $request->error_file !== null
+                    ? sprintf(' file=%s line=%d', $request->error_file, $request->error_line ?? 0)
+                    : '',
+            ));
+
+            $response = $this->dump_handler->handle($request);
+
+            fwrite($client, $response->toJson() . "\n");
+
+            if ($response->status === 'ok') {
+                $output->writeln(sprintf(
+                    '<info>[sidecar] Dump complete: %s (%.1f MB)</info>',
+                    $response->path,
+                    ($response->bytes ?? 0) / 1024.0 / 1024.0,
+                ));
+            } else {
+                $output->writeln(sprintf(
+                    '<comment>[sidecar] Dump failed: %s</comment>',
+                    $response->message ?? 'unknown error',
+                ));
+            }
+        } catch (\Throwable $e) {
+            Log::debug('sidecar connection error', [
+                'error' => $e->getMessage(),
+            ]);
+            $response = SidecarResponse::error($e->getMessage());
+            @fwrite($client, $response->toJson() . "\n");
+        } finally {
+            fclose($client);
+        }
+    }
+
+    private function cleanup(string $socket_path): void
+    {
+        if (file_exists($socket_path)) {
+            unlink($socket_path);
+        }
+    }
+}

--- a/src/Inspector/Sidecar/SidecarServer.php
+++ b/src/Inspector/Sidecar/SidecarServer.php
@@ -61,6 +61,7 @@ final class SidecarServer
             $socket_path,
         ));
 
+        /** @psalm-suppress RedundantCondition -- $this->running is set to false by signal handler */
         while ($this->running) {
             // Use stream_select to allow signal handling between polls
             $read = [$server];
@@ -70,6 +71,7 @@ final class SidecarServer
 
             pcntl_signal_dispatch();
 
+            /** @psalm-suppress TypeDoesNotContainType -- signal handler sets $this->running = false */
             if (!$this->running) {
                 break;
             }
@@ -134,8 +136,8 @@ final class SidecarServer
             if ($response->status === 'ok') {
                 $output->writeln(sprintf(
                     '<info>[sidecar] Dump complete: %s (%.1f MB)</info>',
-                    $response->path,
-                    ($response->bytes ?? 0) / 1024.0 / 1024.0,
+                    $response->path ?? '',
+                    (float)($response->bytes ?? 0) / 1024.0 / 1024.0,
                 ));
             } else {
                 $output->writeln(sprintf(

--- a/src/Inspector/Watch/DiskUsageTracker.php
+++ b/src/Inspector/Watch/DiskUsageTracker.php
@@ -28,15 +28,17 @@ final class DiskUsageTracker
 
     private function scanExistingFiles(string $dir): void
     {
-        $pattern = rtrim($dir, '/') . '/watch-*.dump';
-        $files = glob($pattern);
-        if ($files === false) {
-            return;
-        }
-        foreach ($files as $file) {
-            $size = filesize($file);
-            if ($size !== false) {
-                $this->total_bytes += $size;
+        $dir = rtrim($dir, '/');
+        foreach (['watch-*.dump', 'sidecar-*.dump'] as $glob) {
+            $files = glob($dir . '/' . $glob);
+            if ($files === false) {
+                continue;
+            }
+            foreach ($files as $file) {
+                $size = filesize($file);
+                if ($size !== false) {
+                    $this->total_bytes += $size;
+                }
             }
         }
     }

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Sidecar\Client;
+
+/**
+ * Registers a shutdown handler that requests a memory dump
+ * from the reli sidecar daemon when a memory_limit error occurs.
+ *
+ * Usage:
+ *   MemoryLimitHandler::register();
+ *
+ * Or with options:
+ *   MemoryLimitHandler::register(
+ *       socket_path: '/custom/path.sock',
+ *       on_response: function (SidecarClientResponse $r) {
+ *           error_log('reli dump: ' . $r->path);
+ *       },
+ *   );
+ *
+ * Socket path is resolved via:
+ *   1. $socket_path argument
+ *   2. RELI_SIDECAR_SOCKET environment variable
+ *   3. Default: /var/run/reli-sidecar.sock
+ */
+final class MemoryLimitHandler
+{
+    /**
+     * @param string|null $socket_path UDS path (null = auto-detect)
+     * @param (callable(SidecarClientResponse): void)|null $on_response
+     * @param (callable(string): void)|null $on_error called with error message on failure
+     */
+    public static function register(
+        ?string $socket_path = null,
+        ?callable $on_response = null,
+        ?callable $on_error = null,
+    ): void {
+        register_shutdown_function(
+            self::createHandler($socket_path, $on_response, $on_error),
+        );
+    }
+
+    /**
+     * @param string|null $socket_path
+     * @param (callable(SidecarClientResponse): void)|null $on_response
+     * @param (callable(string): void)|null $on_error
+     * @return callable(): void
+     */
+    private static function createHandler(
+        ?string $socket_path,
+        ?callable $on_response,
+        ?callable $on_error,
+    ): \Closure {
+        return static function () use ($socket_path, $on_response, $on_error): void {
+            $error = error_get_last();
+            if ($error === null) {
+                return;
+            }
+
+            if (!self::isMemoryLimitError($error['message'])) {
+                return;
+            }
+
+            $pid = getmypid();
+            if ($pid === false) {
+                return;
+            }
+
+            $client = new SidecarClient($socket_path);
+            $response = $client->requestDump(
+                pid: $pid,
+                error_file: $error['file'] ?? null,
+                error_line: $error['line'] ?? null,
+            );
+
+            if ($response === null) {
+                if ($on_error !== null) {
+                    $on_error('failed to connect to reli sidecar');
+                }
+                return;
+            }
+
+            if ($on_response !== null) {
+                $on_response($response);
+            } elseif ($response->isOk()) {
+                error_log(sprintf(
+                    'reli-sidecar: memory dump saved to %s (%.1f MB)',
+                    $response->path,
+                    ($response->bytes ?? 0) / 1024.0 / 1024.0,
+                ));
+            } else {
+                error_log(sprintf(
+                    'reli-sidecar: dump failed: %s',
+                    $response->message ?? 'unknown error',
+                ));
+            }
+        };
+    }
+
+    private static function isMemoryLimitError(string $message): bool
+    {
+        return str_contains($message, 'Allowed memory size');
+    }
+}

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -54,7 +54,7 @@ final class MemoryLimitHandler
      * @param string|null $socket_path
      * @param (callable(SidecarClientResponse): void)|null $on_response
      * @param (callable(string): void)|null $on_error
-     * @return callable(): void
+     * @return \Closure
      */
     private static function createHandler(
         ?string $socket_path,
@@ -95,8 +95,8 @@ final class MemoryLimitHandler
             } elseif ($response->isOk()) {
                 error_log(sprintf(
                     'reli-sidecar: memory dump saved to %s (%.1f MB)',
-                    $response->path,
-                    ($response->bytes ?? 0) / 1024.0 / 1024.0,
+                    $response->path ?? '',
+                    (float)($response->bytes ?? 0) / 1024.0 / 1024.0,
                 ));
             } else {
                 error_log(sprintf(

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -32,19 +32,38 @@ namespace Reli\Sidecar\Client;
  *   1. $socket_path argument
  *   2. RELI_SIDECAR_SOCKET environment variable
  *   3. Default: /var/run/reli-sidecar.sock
+ *
+ * ## Emergency Memory Reserve
+ *
+ * When PHP hits memory_limit, the shutdown handler runs with almost no
+ * free memory. Even `stream_socket_client()` needs to allocate buffers.
+ * To ensure the handler can function, this class pre-allocates a block
+ * of memory (default 256 KB) at `register()` time and releases it at
+ * the very start of the shutdown handler, freeing enough headroom for
+ * the socket operations.
+ *
+ * Adjust the reserve size via the $reserve_bytes parameter if needed.
  */
 final class MemoryLimitHandler
 {
+    private const DEFAULT_RESERVE_BYTES = 256 * 1024;
+
+    /** @var string|null Pre-allocated memory block, released on shutdown */
+    private static ?string $reserve = null;
+
     /**
      * @param string|null $socket_path UDS path (null = auto-detect)
      * @param (callable(SidecarClientResponse): void)|null $on_response
      * @param (callable(string): void)|null $on_error called with error message on failure
+     * @param int $reserve_bytes emergency memory reserve size (default: 256 KB)
      */
     public static function register(
         ?string $socket_path = null,
         ?callable $on_response = null,
         ?callable $on_error = null,
+        int $reserve_bytes = self::DEFAULT_RESERVE_BYTES,
     ): void {
+        self::$reserve = str_repeat("\0", $reserve_bytes);
         register_shutdown_function(
             self::createHandler($socket_path, $on_response, $on_error),
         );
@@ -62,6 +81,9 @@ final class MemoryLimitHandler
         ?callable $on_error,
     ): \Closure {
         return static function () use ($socket_path, $on_response, $on_error): void {
+            // Release emergency reserve to free memory for socket operations
+            self::$reserve = null;
+
             $error = error_get_last();
             if ($error === null) {
                 return;

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -63,6 +63,12 @@ final class MemoryLimitHandler
         ?callable $on_error = null,
         int $reserve_bytes = self::DEFAULT_RESERVE_BYTES,
     ): void {
+        // Pre-load classes so autoload doesn't run inside the shutdown handler.
+        // Autoloading involves file I/O + parsing which can easily exceed
+        // the emergency reserve when memory_limit is already exhausted.
+        class_exists(SidecarClient::class);
+        class_exists(SidecarClientResponse::class);
+
         self::$reserve = str_repeat("\0", $reserve_bytes);
         register_shutdown_function(
             self::createHandler($socket_path, $on_response, $on_error),

--- a/src/Sidecar/Client/SidecarClient.php
+++ b/src/Sidecar/Client/SidecarClient.php
@@ -32,9 +32,13 @@ final class SidecarClient
 
     private string $socket_path;
 
+    /**
+     * @param array<string, string> $default_metadata merged into every request (per-call metadata wins)
+     */
     public function __construct(
         ?string $socket_path = null,
         private int $timeout_seconds = 30,
+        private array $default_metadata = [],
     ) {
         $this->socket_path = $socket_path
             ?? ($_SERVER[self::ENV_SOCKET_PATH] ?? null)
@@ -69,8 +73,9 @@ final class SidecarClient
         if ($label !== null) {
             $payload['label'] = $label;
         }
-        if (count($metadata) > 0) {
-            $payload['metadata'] = $metadata;
+        $merged = array_merge($this->default_metadata, $metadata);
+        if (count($merged) > 0) {
+            $payload['metadata'] = $merged;
         }
 
         return $this->send($payload);

--- a/src/Sidecar/Client/SidecarClient.php
+++ b/src/Sidecar/Client/SidecarClient.php
@@ -40,10 +40,14 @@ final class SidecarClient
         private int $timeout_seconds = 30,
         private array $default_metadata = [],
     ) {
-        $this->socket_path = $socket_path
-            ?? ($_SERVER[self::ENV_SOCKET_PATH] ?? null)
-            ?? (getenv(self::ENV_SOCKET_PATH) ?: null)
-            ?? self::DEFAULT_SOCKET_PATH;
+        if ($socket_path !== null) {
+            $this->socket_path = $socket_path;
+        } else {
+            $env = getenv(self::ENV_SOCKET_PATH);
+            $this->socket_path = (is_string($env) && $env !== '')
+                ? $env
+                : self::DEFAULT_SOCKET_PATH;
+        }
     }
 
     /**
@@ -125,7 +129,7 @@ final class SidecarClient
         try {
             stream_set_timeout($sock, $this->timeout_seconds);
 
-            $written = fwrite($sock, json_encode($payload) . "\n");
+            $written = fwrite($sock, (string)json_encode($payload) . "\n");
             if ($written === false) {
                 return null;
             }

--- a/src/Sidecar/Client/SidecarClient.php
+++ b/src/Sidecar/Client/SidecarClient.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Sidecar\Client;
+
+/**
+ * Lightweight client for communicating with the reli sidecar daemon.
+ *
+ * This class requires no FFI and no heavy dependencies.
+ * It is designed to be usable from within a PHP application's
+ * shutdown handler with minimal memory overhead.
+ *
+ * Socket path resolution order:
+ *   1. Constructor argument ($socket_path)
+ *   2. RELI_SIDECAR_SOCKET environment variable
+ *   3. Default: /var/run/reli-sidecar.sock
+ */
+final class SidecarClient
+{
+    public const DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock';
+    public const ENV_SOCKET_PATH = 'RELI_SIDECAR_SOCKET';
+
+    private string $socket_path;
+
+    public function __construct(
+        ?string $socket_path = null,
+        private int $timeout_seconds = 30,
+    ) {
+        $this->socket_path = $socket_path
+            ?? ($_SERVER[self::ENV_SOCKET_PATH] ?? null)
+            ?? (getenv(self::ENV_SOCKET_PATH) ?: null)
+            ?? self::DEFAULT_SOCKET_PATH;
+    }
+
+    /**
+     * Request a memory dump of the given process.
+     *
+     * @param int $pid target process ID
+     * @param string|null $error_file file where the error occurred
+     * @param int|null $error_line line where the error occurred
+     * @return SidecarClientResponse|null null on connection failure
+     */
+    public function requestDump(
+        int $pid,
+        ?string $error_file = null,
+        ?int $error_line = null,
+    ): ?SidecarClientResponse {
+        $sock = @stream_socket_client(
+            "unix://{$this->socket_path}",
+            $errno,
+            $errstr,
+            $this->timeout_seconds,
+        );
+        if ($sock === false) {
+            return null;
+        }
+
+        try {
+            stream_set_timeout($sock, $this->timeout_seconds);
+
+            $payload = ['command' => 'dump', 'pid' => $pid];
+            if ($error_file !== null) {
+                $payload['file'] = $error_file;
+            }
+            if ($error_line !== null) {
+                $payload['line'] = $error_line;
+            }
+
+            $written = fwrite($sock, json_encode($payload) . "\n");
+            if ($written === false) {
+                return null;
+            }
+
+            $response = fgets($sock, 65536);
+            if ($response === false || $response === '') {
+                return null;
+            }
+
+            return SidecarClientResponse::fromJson(trim($response));
+        } finally {
+            fclose($sock);
+        }
+    }
+}

--- a/src/Sidecar/Client/SidecarClient.php
+++ b/src/Sidecar/Client/SidecarClient.php
@@ -48,13 +48,65 @@ final class SidecarClient
      * @param int $pid target process ID
      * @param string|null $error_file file where the error occurred
      * @param int|null $error_line line where the error occurred
+     * @param string|null $label human-readable label for the snapshot
+     * @param array<string, string> $metadata arbitrary key-value pairs
      * @return SidecarClientResponse|null null on connection failure
      */
     public function requestDump(
         int $pid,
         ?string $error_file = null,
         ?int $error_line = null,
+        ?string $label = null,
+        array $metadata = [],
     ): ?SidecarClientResponse {
+        $payload = ['command' => 'dump', 'pid' => $pid];
+        if ($error_file !== null) {
+            $payload['file'] = $error_file;
+        }
+        if ($error_line !== null) {
+            $payload['line'] = $error_line;
+        }
+        if ($label !== null) {
+            $payload['label'] = $label;
+        }
+        if (count($metadata) > 0) {
+            $payload['metadata'] = $metadata;
+        }
+
+        return $this->send($payload);
+    }
+
+    /**
+     * Take a named snapshot of the current process.
+     *
+     * Convenience wrapper for CI / benchmarking scripts:
+     *   $client->snapshot('after-fixtures');
+     *   $client->snapshot('post-processing', ['commit' => 'abc123']);
+     *
+     * @param string $label human-readable label
+     * @param array<string, string> $metadata arbitrary key-value pairs (commit SHA, PHP version, etc.)
+     * @return SidecarClientResponse|null null on connection failure
+     */
+    public function snapshot(
+        string $label,
+        array $metadata = [],
+    ): ?SidecarClientResponse {
+        $pid = getmypid();
+        if ($pid === false) {
+            return null;
+        }
+        return $this->requestDump(
+            pid: $pid,
+            label: $label,
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function send(array $payload): ?SidecarClientResponse
+    {
         $sock = @stream_socket_client(
             "unix://{$this->socket_path}",
             $errno,
@@ -67,14 +119,6 @@ final class SidecarClient
 
         try {
             stream_set_timeout($sock, $this->timeout_seconds);
-
-            $payload = ['command' => 'dump', 'pid' => $pid];
-            if ($error_file !== null) {
-                $payload['file'] = $error_file;
-            }
-            if ($error_line !== null) {
-                $payload['line'] = $error_line;
-            }
 
             $written = fwrite($sock, json_encode($payload) . "\n");
             if ($written === false) {

--- a/src/Sidecar/Client/SidecarClientResponse.php
+++ b/src/Sidecar/Client/SidecarClientResponse.php
@@ -42,13 +42,26 @@ final class SidecarClientResponse
         if (!is_array($data) || !isset($data['status']) || !is_string($data['status'])) {
             return null;
         }
+        /** @var list<string> $trace */
+        $trace = isset($data['trace']) && is_array($data['trace'])
+            ? array_values(array_filter($data['trace'], 'is_string'))
+            : [];
+        /** @var array<string, mixed>|null $error_context */
+        $error_context = isset($data['error_context']) && is_array($data['error_context'])
+            ? $data['error_context']
+            : null;
+        /** @var array<string, int>|null $memory_stats */
+        $memory_stats = isset($data['memory_stats']) && is_array($data['memory_stats'])
+            ? $data['memory_stats']
+            : null;
+
         return new self(
             status: $data['status'],
             path: isset($data['path']) && is_string($data['path']) ? $data['path'] : null,
             bytes: isset($data['bytes']) && is_int($data['bytes']) ? $data['bytes'] : null,
-            trace: isset($data['trace']) && is_array($data['trace']) ? array_values($data['trace']) : [],
-            error_context: isset($data['error_context']) && is_array($data['error_context']) ? $data['error_context'] : null,
-            memory_stats: isset($data['memory_stats']) && is_array($data['memory_stats']) ? $data['memory_stats'] : null,
+            trace: $trace,
+            error_context: $error_context,
+            memory_stats: $memory_stats,
             message: isset($data['message']) && is_string($data['message']) ? $data['message'] : null,
         );
     }

--- a/src/Sidecar/Client/SidecarClientResponse.php
+++ b/src/Sidecar/Client/SidecarClientResponse.php
@@ -18,6 +18,7 @@ final class SidecarClientResponse
     /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
+     * @param array<string, int>|null $memory_stats heap stats and RSS at snapshot time
      */
     public function __construct(
         public readonly string $status,
@@ -25,6 +26,7 @@ final class SidecarClientResponse
         public readonly ?int $bytes = null,
         public readonly array $trace = [],
         public readonly ?array $error_context = null,
+        public readonly ?array $memory_stats = null,
         public readonly ?string $message = null,
     ) {
     }
@@ -46,6 +48,7 @@ final class SidecarClientResponse
             bytes: isset($data['bytes']) && is_int($data['bytes']) ? $data['bytes'] : null,
             trace: isset($data['trace']) && is_array($data['trace']) ? array_values($data['trace']) : [],
             error_context: isset($data['error_context']) && is_array($data['error_context']) ? $data['error_context'] : null,
+            memory_stats: isset($data['memory_stats']) && is_array($data['memory_stats']) ? $data['memory_stats'] : null,
             message: isset($data['message']) && is_string($data['message']) ? $data['message'] : null,
         );
     }

--- a/src/Sidecar/Client/SidecarClientResponse.php
+++ b/src/Sidecar/Client/SidecarClientResponse.php
@@ -16,12 +16,20 @@ namespace Reli\Sidecar\Client;
 final class SidecarClientResponse
 {
     /**
+     * Maximum protocol version this client understands.
+     * When the server's protocol_version exceeds this, the response
+     * may be missing fields or have incompatible semantics.
+     */
+    public const MAX_SUPPORTED_PROTOCOL_VERSION = 1;
+
+    /**
      * @param list<string> $trace
      * @param array<string, mixed>|null $error_context
      * @param array<string, int>|null $memory_stats heap stats and RSS at snapshot time
      */
     public function __construct(
         public readonly string $status,
+        public readonly ?int $protocol_version = null,
         public readonly ?string $path = null,
         public readonly ?int $bytes = null,
         public readonly array $trace = [],
@@ -34,6 +42,20 @@ final class SidecarClientResponse
     public function isOk(): bool
     {
         return $this->status === 'ok';
+    }
+
+    /**
+     * Whether this response came from a server with a compatible protocol version.
+     *
+     * Returns true if the server's version is within the range this client
+     * understands, or if the server didn't send a version (pre-versioning server).
+     */
+    public function isCompatible(): bool
+    {
+        if ($this->protocol_version === null) {
+            return true;
+        }
+        return $this->protocol_version <= self::MAX_SUPPORTED_PROTOCOL_VERSION;
     }
 
     public static function fromJson(string $json): ?self
@@ -57,6 +79,9 @@ final class SidecarClientResponse
 
         return new self(
             status: $data['status'],
+            protocol_version: isset($data['protocol_version']) && is_int($data['protocol_version'])
+                ? $data['protocol_version']
+                : null,
             path: isset($data['path']) && is_string($data['path']) ? $data['path'] : null,
             bytes: isset($data['bytes']) && is_int($data['bytes']) ? $data['bytes'] : null,
             trace: $trace,

--- a/src/Sidecar/Client/SidecarClientResponse.php
+++ b/src/Sidecar/Client/SidecarClientResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Sidecar\Client;
+
+final class SidecarClientResponse
+{
+    /**
+     * @param list<string> $trace
+     * @param array<string, mixed>|null $error_context
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly ?string $path = null,
+        public readonly ?int $bytes = null,
+        public readonly array $trace = [],
+        public readonly ?array $error_context = null,
+        public readonly ?string $message = null,
+    ) {
+    }
+
+    public function isOk(): bool
+    {
+        return $this->status === 'ok';
+    }
+
+    public static function fromJson(string $json): ?self
+    {
+        $data = json_decode($json, true);
+        if (!is_array($data) || !isset($data['status']) || !is_string($data['status'])) {
+            return null;
+        }
+        return new self(
+            status: $data['status'],
+            path: isset($data['path']) && is_string($data['path']) ? $data['path'] : null,
+            bytes: isset($data['bytes']) && is_int($data['bytes']) ? $data['bytes'] : null,
+            trace: isset($data['trace']) && is_array($data['trace']) ? array_values($data['trace']) : [],
+            error_context: isset($data['error_context']) && is_array($data['error_context']) ? $data['error_context'] : null,
+            message: isset($data['message']) && is_string($data['message']) ? $data['message'] : null,
+        );
+    }
+}

--- a/tests/Command/Inspector/SidecarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/SidecarCommandIntegrationTest.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use DI\ContainerBuilder;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Reli\BaseTestCase;
+use Reli\Inspector\Sidecar\Protocol\SidecarRequest;
+use Reli\Inspector\Sidecar\SidecarDumpHandler;
+use Reli\Inspector\Sidecar\SidecarServer;
+use Reli\Inspector\Watch\DiskUsageTracker;
+use Reli\TargetPhpVmProvider;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[Group('target-version')]
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class SidecarCommandIntegrationTest extends BaseTestCase
+{
+    /** @var resource|null */
+    private $child = null;
+
+    /** @var list<string> */
+    private array $tmp_files = [];
+
+    private string $memory_limit_backup;
+
+    protected function setUp(): void
+    {
+        $this->child = null;
+        $this->memory_limit_backup = ini_get('memory_limit');
+        ini_set('memory_limit', '1G');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('memory_limit', $this->memory_limit_backup);
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status) && $child_status['running']) {
+                posix_kill($child_status['pid'], SIGKILL);
+            }
+            $this->child = null;
+        }
+        foreach ($this->tmp_files as $file) {
+            if (file_exists($file)) {
+                @unlink($file);
+            }
+            // Also clean up .meta.json
+            if (file_exists($file . '.meta.json')) {
+                @unlink($file . '.meta.json');
+            }
+        }
+        parent::tearDown();
+    }
+
+    private function createContainer(): \DI\Container
+    {
+        return (new ContainerBuilder())
+            ->addDefinitions(__DIR__ . '/../../../config/di.php')
+            ->build();
+    }
+
+    /**
+     * @return array{resource, int, array<int, resource>}
+     */
+    private function startTargetProcess(string $docker_image_name): array
+    {
+        $target_script = <<<'PHP'
+        <?php
+        $data = [];
+        for ($i = 0; $i < 100; $i++) {
+            $data[] = str_repeat('x', 1024);
+        }
+        fputs(STDOUT, "ready\n");
+        fgets(STDIN);
+        PHP;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $ready = fgets($pipes[1]);
+        $this->assertSame("ready\n", $ready);
+
+        return [$this->child, $pid, $pipes];
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testDumpHandlerCreatesDumpAndMetadata(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no target version');
+        }
+
+        $output_dir = sys_get_temp_dir() . '/reli_sidecar_test_' . uniqid();
+        mkdir($output_dir, 0777, true);
+        $this->tmp_files[] = $output_dir;
+
+        $container = $this->createContainer();
+        [, $pid, ] = $this->startTargetProcess($docker_image_name);
+
+        /** @var SidecarDumpHandler $handler */
+        $handler = new SidecarDumpHandler(
+            php_globals_finder: $container->get(\Reli\Lib\PhpProcessReader\PhpGlobalsFinder::class),
+            php_version_detector: $container->get(\Reli\Lib\PhpProcessReader\PhpVersionDetector::class),
+            memory_dumper: $container->get(\Reli\Inspector\MemoryDump\MemoryDumper::class),
+            call_trace_reader: $container->get(\Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
+            heap_stats_reader: $container->get(\Reli\Inspector\Watch\HeapStatsReader::class),
+            rss_reader: $container->get(\Reli\Inspector\Watch\RssReader::class),
+            process_stopper: $container->get(\Reli\Lib\Process\ProcessStopper\ProcessStopper::class),
+            disk_tracker: new DiskUsageTracker(0),
+            output_dir: $output_dir,
+            include_binary: false,
+            session_tags: ['product' => 'test-app', 'version' => '1.0'],
+        );
+
+        $request = new SidecarRequest(
+            command: 'dump',
+            pid: $pid,
+            label: 'integration-test',
+            metadata: ['step' => 'after-setup'],
+        );
+
+        $response = $handler->handle($request);
+
+        $this->assertSame('ok', $response->status);
+        $this->assertNotNull($response->path);
+        $this->assertGreaterThan(0, $response->bytes);
+
+        // Verify dump file
+        $this->assertFileExists($response->path);
+        $magic = file_get_contents($response->path, false, null, 0, 8);
+        $this->assertSame("RELIMEM\0", $magic);
+        $this->tmp_files[] = $response->path;
+
+        // Verify .meta.json
+        $meta_path = $response->path . '.meta.json';
+        $this->assertFileExists($meta_path);
+        $meta = json_decode(file_get_contents($meta_path), true);
+        $this->assertSame($pid, $meta['pid']);
+        $this->assertSame('sidecar_request', $meta['trigger']);
+        $this->assertSame('integration-test', $meta['label']);
+        // Session tags merged with per-request metadata
+        $this->assertSame('test-app', $meta['metadata']['product']);
+        $this->assertSame('1.0', $meta['metadata']['version']);
+        $this->assertSame('after-setup', $meta['metadata']['step']);
+
+        // Verify memory_stats
+        $this->assertArrayHasKey('memory_stats', $meta);
+        $this->assertGreaterThan(0, $meta['memory_stats']['memory_usage']);
+        $this->assertGreaterThan(0, $meta['memory_stats']['memory_real_usage']);
+
+        // Verify call trace is captured
+        $this->assertArrayHasKey('call_trace', $meta);
+
+        // Verify response also has memory_stats
+        $this->assertNotNull($response->memory_stats);
+        $this->assertGreaterThan(0, $response->memory_stats['memory_usage']);
+
+        // Filename contains label slug
+        $this->assertStringContainsString('integration-test', basename($response->path));
+
+        // Cleanup directory
+        array_map('unlink', glob($output_dir . '/*'));
+        rmdir($output_dir);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testDumpHandlerReturnsErrorForNonExistentPid(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no target version');
+        }
+
+        $container = $this->createContainer();
+
+        // Start a process just so DI setup works (some deps need FFI init)
+        $this->startTargetProcess($docker_image_name);
+
+        $handler = new SidecarDumpHandler(
+            php_globals_finder: $container->get(\Reli\Lib\PhpProcessReader\PhpGlobalsFinder::class),
+            php_version_detector: $container->get(\Reli\Lib\PhpProcessReader\PhpVersionDetector::class),
+            memory_dumper: $container->get(\Reli\Inspector\MemoryDump\MemoryDumper::class),
+            call_trace_reader: $container->get(\Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
+            heap_stats_reader: $container->get(\Reli\Inspector\Watch\HeapStatsReader::class),
+            rss_reader: $container->get(\Reli\Inspector\Watch\RssReader::class),
+            process_stopper: $container->get(\Reli\Lib\Process\ProcessStopper\ProcessStopper::class),
+            disk_tracker: new DiskUsageTracker(0),
+            output_dir: sys_get_temp_dir(),
+            include_binary: false,
+        );
+
+        $request = new SidecarRequest(
+            command: 'dump',
+            pid: 999999999,
+        );
+
+        $response = $handler->handle($request);
+
+        $this->assertSame('error', $response->status);
+        $this->assertStringContainsString('not found', $response->message);
+    }
+
+    public function testSidecarServerRejectsUnknownCommand(): void
+    {
+        $socket_path = tempnam(sys_get_temp_dir(), 'reli_sock_');
+        unlink($socket_path);
+        $this->tmp_files[] = $socket_path;
+
+        $container = $this->createContainer();
+        $handler = new SidecarDumpHandler(
+            php_globals_finder: $container->get(\Reli\Lib\PhpProcessReader\PhpGlobalsFinder::class),
+            php_version_detector: $container->get(\Reli\Lib\PhpProcessReader\PhpVersionDetector::class),
+            memory_dumper: $container->get(\Reli\Inspector\MemoryDump\MemoryDumper::class),
+            call_trace_reader: $container->get(\Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
+            heap_stats_reader: $container->get(\Reli\Inspector\Watch\HeapStatsReader::class),
+            rss_reader: $container->get(\Reli\Inspector\Watch\RssReader::class),
+            process_stopper: $container->get(\Reli\Lib\Process\ProcessStopper\ProcessStopper::class),
+            disk_tracker: new DiskUsageTracker(0),
+            output_dir: sys_get_temp_dir(),
+            include_binary: false,
+        );
+        $server = new SidecarServer($handler);
+
+        // Start server in child process
+        $child = pcntl_fork();
+        if ($child === 0) {
+            $output = new BufferedOutput();
+            $server->run($socket_path, $output);
+            exit(0);
+        }
+
+        // Wait for socket to appear
+        $timeout = 5;
+        $start = time();
+        while (!file_exists($socket_path) && time() - $start < $timeout) {
+            usleep(50000);
+        }
+        $this->assertFileExists($socket_path);
+
+        // Send unknown command
+        $sock = stream_socket_client("unix://{$socket_path}", $errno, $errstr, 5);
+        $this->assertNotFalse($sock);
+        fwrite($sock, json_encode(['command' => 'unknown', 'pid' => 1]) . "\n");
+        $response_line = fgets($sock, 8192);
+        fclose($sock);
+
+        $response = json_decode(trim($response_line), true);
+        $this->assertSame('error', $response['status']);
+        $this->assertStringContainsString('unknown command', $response['message']);
+
+        // Clean up server
+        posix_kill($child, SIGTERM);
+        pcntl_waitpid($child, $status);
+    }
+
+    public function testSidecarServerRejectsInvalidJson(): void
+    {
+        $socket_path = tempnam(sys_get_temp_dir(), 'reli_sock_');
+        unlink($socket_path);
+        $this->tmp_files[] = $socket_path;
+
+        $container = $this->createContainer();
+        $handler = new SidecarDumpHandler(
+            php_globals_finder: $container->get(\Reli\Lib\PhpProcessReader\PhpGlobalsFinder::class),
+            php_version_detector: $container->get(\Reli\Lib\PhpProcessReader\PhpVersionDetector::class),
+            memory_dumper: $container->get(\Reli\Inspector\MemoryDump\MemoryDumper::class),
+            call_trace_reader: $container->get(\Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
+            heap_stats_reader: $container->get(\Reli\Inspector\Watch\HeapStatsReader::class),
+            rss_reader: $container->get(\Reli\Inspector\Watch\RssReader::class),
+            process_stopper: $container->get(\Reli\Lib\Process\ProcessStopper\ProcessStopper::class),
+            disk_tracker: new DiskUsageTracker(0),
+            output_dir: sys_get_temp_dir(),
+            include_binary: false,
+        );
+        $server = new SidecarServer($handler);
+
+        $child = pcntl_fork();
+        if ($child === 0) {
+            $server->run($socket_path, new BufferedOutput());
+            exit(0);
+        }
+
+        $timeout = 5;
+        $start = time();
+        while (!file_exists($socket_path) && time() - $start < $timeout) {
+            usleep(50000);
+        }
+
+        $sock = stream_socket_client("unix://{$socket_path}", $errno, $errstr, 5);
+        $this->assertNotFalse($sock);
+        fwrite($sock, "not valid json\n");
+        $response_line = fgets($sock, 8192);
+        fclose($sock);
+
+        $response = json_decode(trim($response_line), true);
+        $this->assertSame('error', $response['status']);
+        $this->assertStringContainsString('invalid request', $response['message']);
+
+        posix_kill($child, SIGTERM);
+        pcntl_waitpid($child, $status);
+    }
+}

--- a/tests/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInputTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Settings\SidecarSettings;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+class SidecarSettingsFromConsoleInputTest extends BaseTestCase
+{
+    public function testCreateSettingsDefaults(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('socket')->andReturns(SidecarSettings::DEFAULT_SOCKET_PATH);
+        $input->expects()->getOption('output-dir')->andReturns('.');
+        $input->expects()->getOption('disk-usage-limit')->andReturns('1G');
+        $input->expects()->getOption('include-binary')->andReturns(false);
+        $input->expects()->getOption('memory-limit')->andReturns(null);
+        $input->expects()->getOption('tag')->andReturns([]);
+
+        $settings = (new SidecarSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame(SidecarSettings::DEFAULT_SOCKET_PATH, $settings->socket_path);
+        $this->assertSame('.', $settings->output_dir);
+        $this->assertSame(1073741824, $settings->disk_usage_limit_bytes);
+        $this->assertFalse($settings->include_binary);
+        $this->assertNull($settings->memory_limit);
+        $this->assertSame([], $settings->tags);
+    }
+
+    public function testCreateSettingsCustomValues(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('socket')->andReturns('/tmp/custom.sock');
+        $input->expects()->getOption('output-dir')->andReturns('/tmp/dumps');
+        $input->expects()->getOption('disk-usage-limit')->andReturns('512M');
+        $input->expects()->getOption('include-binary')->andReturns(true);
+        $input->expects()->getOption('memory-limit')->andReturns('2G');
+        $input->expects()->getOption('tag')->andReturns(['product=my-app', 'version=2.4.0']);
+
+        $settings = (new SidecarSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame('/tmp/custom.sock', $settings->socket_path);
+        $this->assertSame('/tmp/dumps', $settings->output_dir);
+        $this->assertSame(512 * 1024 * 1024, $settings->disk_usage_limit_bytes);
+        $this->assertTrue($settings->include_binary);
+        $this->assertSame('2G', $settings->memory_limit);
+        $this->assertSame(['product' => 'my-app', 'version' => '2.4.0'], $settings->tags);
+    }
+
+    public function testTagParsingIgnoresInvalidFormat(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('socket')->andReturns('/s');
+        $input->expects()->getOption('output-dir')->andReturns('.');
+        $input->expects()->getOption('disk-usage-limit')->andReturns('1G');
+        $input->expects()->getOption('include-binary')->andReturns(false);
+        $input->expects()->getOption('memory-limit')->andReturns(null);
+        $input->expects()->getOption('tag')->andReturns(['good=value', 'no-equals-sign']);
+
+        $settings = (new SidecarSettingsFromConsoleInput())->createSettings($input);
+
+        // Only valid key=value pairs are included
+        $this->assertSame(['good' => 'value'], $settings->tags);
+    }
+}

--- a/tests/Inspector/Sidecar/Protocol/SidecarRequestTest.php
+++ b/tests/Inspector/Sidecar/Protocol/SidecarRequestTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar\Protocol;
+
+use Reli\BaseTestCase;
+
+class SidecarRequestTest extends BaseTestCase
+{
+    public function testFromJsonValidDump(): void
+    {
+        $json = json_encode(['command' => 'dump', 'pid' => 1234]);
+        $request = SidecarRequest::fromJson($json);
+
+        $this->assertNotNull($request);
+        $this->assertSame('dump', $request->command);
+        $this->assertSame(1234, $request->pid);
+        $this->assertNull($request->error_file);
+        $this->assertNull($request->error_line);
+        $this->assertNull($request->label);
+        $this->assertSame([], $request->metadata);
+    }
+
+    public function testFromJsonWithAllFields(): void
+    {
+        $json = json_encode([
+            'command' => 'dump',
+            'pid' => 5678,
+            'file' => '/app/src/Foo.php',
+            'line' => 42,
+            'label' => 'after-fixtures',
+            'metadata' => ['version' => '2.4.0', 'commit' => 'abc123'],
+        ]);
+        $request = SidecarRequest::fromJson($json);
+
+        $this->assertNotNull($request);
+        $this->assertSame(5678, $request->pid);
+        $this->assertSame('/app/src/Foo.php', $request->error_file);
+        $this->assertSame(42, $request->error_line);
+        $this->assertSame('after-fixtures', $request->label);
+        $this->assertSame(['version' => '2.4.0', 'commit' => 'abc123'], $request->metadata);
+    }
+
+    public function testFromJsonInvalidJson(): void
+    {
+        $this->assertNull(SidecarRequest::fromJson('not json'));
+    }
+
+    public function testFromJsonMissingCommand(): void
+    {
+        $this->assertNull(SidecarRequest::fromJson(json_encode(['pid' => 1])));
+    }
+
+    public function testFromJsonMissingPid(): void
+    {
+        $this->assertNull(SidecarRequest::fromJson(json_encode(['command' => 'dump'])));
+    }
+
+    public function testFromJsonWrongTypes(): void
+    {
+        $this->assertNull(SidecarRequest::fromJson(json_encode(['command' => 123, 'pid' => 'abc'])));
+    }
+
+    public function testFromJsonIgnoresNonStringMetadata(): void
+    {
+        $json = json_encode([
+            'command' => 'dump',
+            'pid' => 1,
+            'metadata' => ['good' => 'value', 'bad' => 123, 'also_bad' => true],
+        ]);
+        $request = SidecarRequest::fromJson($json);
+        $this->assertNotNull($request);
+        $this->assertSame(['good' => 'value'], $request->metadata);
+    }
+}

--- a/tests/Inspector/Sidecar/Protocol/SidecarResponseTest.php
+++ b/tests/Inspector/Sidecar/Protocol/SidecarResponseTest.php
@@ -41,6 +41,7 @@ class SidecarResponseTest extends BaseTestCase
         $response = SidecarResponse::ok('/tmp/d.bin', 512);
         $decoded = json_decode($response->toJson(), true);
 
+        $this->assertSame(SidecarResponse::PROTOCOL_VERSION, $decoded['protocol_version']);
         $this->assertSame('ok', $decoded['status']);
         $this->assertSame('/tmp/d.bin', $decoded['path']);
         $this->assertSame(512, $decoded['bytes']);
@@ -53,6 +54,7 @@ class SidecarResponseTest extends BaseTestCase
         $response = SidecarResponse::error('boom');
         $decoded = json_decode($response->toJson(), true);
 
+        $this->assertSame(SidecarResponse::PROTOCOL_VERSION, $decoded['protocol_version']);
         $this->assertSame('error', $decoded['status']);
         $this->assertSame('boom', $decoded['message']);
         $this->assertArrayNotHasKey('path', $decoded);

--- a/tests/Inspector/Sidecar/Protocol/SidecarResponseTest.php
+++ b/tests/Inspector/Sidecar/Protocol/SidecarResponseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar\Protocol;
+
+use Reli\BaseTestCase;
+
+class SidecarResponseTest extends BaseTestCase
+{
+    public function testOkResponse(): void
+    {
+        $response = SidecarResponse::ok(
+            path: '/tmp/dump.bin',
+            bytes: 1024,
+            trace: ['func1 file.php:10'],
+            error_context: ['file' => 'a.php', 'line' => 5],
+            memory_stats: ['memory_usage' => 1000, 'rss' => 2000],
+        );
+
+        $this->assertSame('ok', $response->status);
+        $this->assertSame('/tmp/dump.bin', $response->path);
+        $this->assertSame(1024, $response->bytes);
+        $this->assertSame(['func1 file.php:10'], $response->trace);
+        $this->assertSame(['file' => 'a.php', 'line' => 5], $response->error_context);
+        $this->assertSame(['memory_usage' => 1000, 'rss' => 2000], $response->memory_stats);
+        $this->assertNull($response->message);
+    }
+
+    public function testErrorResponse(): void
+    {
+        $response = SidecarResponse::error('process not found');
+
+        $this->assertSame('error', $response->status);
+        $this->assertSame('process not found', $response->message);
+        $this->assertNull($response->path);
+    }
+
+    public function testToJsonOk(): void
+    {
+        $response = SidecarResponse::ok('/tmp/d.bin', 512);
+        $decoded = json_decode($response->toJson(), true);
+
+        $this->assertSame('ok', $decoded['status']);
+        $this->assertSame('/tmp/d.bin', $decoded['path']);
+        $this->assertSame(512, $decoded['bytes']);
+        $this->assertArrayNotHasKey('message', $decoded);
+        $this->assertArrayNotHasKey('trace', $decoded);
+    }
+
+    public function testToJsonError(): void
+    {
+        $response = SidecarResponse::error('boom');
+        $decoded = json_decode($response->toJson(), true);
+
+        $this->assertSame('error', $decoded['status']);
+        $this->assertSame('boom', $decoded['message']);
+        $this->assertArrayNotHasKey('path', $decoded);
+    }
+
+    public function testToJsonIncludesAllFieldsWhenSet(): void
+    {
+        $response = SidecarResponse::ok(
+            '/p',
+            1,
+            ['trace line'],
+            ['file' => 'x'],
+            ['memory_usage' => 100],
+        );
+        $decoded = json_decode($response->toJson(), true);
+
+        $this->assertArrayHasKey('trace', $decoded);
+        $this->assertArrayHasKey('error_context', $decoded);
+        $this->assertArrayHasKey('memory_stats', $decoded);
+    }
+}

--- a/tests/Sidecar/Client/SidecarClientResponseTest.php
+++ b/tests/Sidecar/Client/SidecarClientResponseTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reli\Sidecar\Client;
+
+use Reli\BaseTestCase;
+
+class SidecarClientResponseTest extends BaseTestCase
+{
+    public function testFromJsonOk(): void
+    {
+        $json = json_encode([
+            'status' => 'ok',
+            'path' => '/tmp/dump.bin',
+            'bytes' => 2048,
+            'trace' => ['A::b c.php:1'],
+            'error_context' => ['file' => 'x.php', 'line' => 10],
+            'memory_stats' => ['memory_usage' => 5000],
+        ]);
+
+        $response = SidecarClientResponse::fromJson($json);
+        $this->assertNotNull($response);
+        $this->assertTrue($response->isOk());
+        $this->assertSame('/tmp/dump.bin', $response->path);
+        $this->assertSame(2048, $response->bytes);
+        $this->assertSame(['A::b c.php:1'], $response->trace);
+        $this->assertSame(['file' => 'x.php', 'line' => 10], $response->error_context);
+        $this->assertSame(['memory_usage' => 5000], $response->memory_stats);
+    }
+
+    public function testFromJsonError(): void
+    {
+        $json = json_encode(['status' => 'error', 'message' => 'fail']);
+        $response = SidecarClientResponse::fromJson($json);
+
+        $this->assertNotNull($response);
+        $this->assertFalse($response->isOk());
+        $this->assertSame('fail', $response->message);
+    }
+
+    public function testFromJsonInvalid(): void
+    {
+        $this->assertNull(SidecarClientResponse::fromJson('not json'));
+    }
+
+    public function testFromJsonMissingStatus(): void
+    {
+        $this->assertNull(SidecarClientResponse::fromJson(json_encode(['path' => '/tmp'])));
+    }
+
+    public function testFromJsonMinimal(): void
+    {
+        $response = SidecarClientResponse::fromJson(json_encode(['status' => 'ok']));
+        $this->assertNotNull($response);
+        $this->assertTrue($response->isOk());
+        $this->assertNull($response->path);
+        $this->assertNull($response->bytes);
+        $this->assertSame([], $response->trace);
+        $this->assertNull($response->memory_stats);
+    }
+}

--- a/tests/Sidecar/Client/SidecarClientResponseTest.php
+++ b/tests/Sidecar/Client/SidecarClientResponseTest.php
@@ -59,4 +59,31 @@ class SidecarClientResponseTest extends BaseTestCase
         $this->assertSame([], $response->trace);
         $this->assertNull($response->memory_stats);
     }
+
+    public function testProtocolVersionParsed(): void
+    {
+        $response = SidecarClientResponse::fromJson(
+            json_encode(['status' => 'ok', 'protocol_version' => 1]),
+        );
+        $this->assertNotNull($response);
+        $this->assertSame(1, $response->protocol_version);
+        $this->assertTrue($response->isCompatible());
+    }
+
+    public function testIsCompatibleWithoutVersion(): void
+    {
+        $response = SidecarClientResponse::fromJson(json_encode(['status' => 'ok']));
+        $this->assertNotNull($response);
+        $this->assertNull($response->protocol_version);
+        $this->assertTrue($response->isCompatible());
+    }
+
+    public function testIsCompatibleWithFutureVersion(): void
+    {
+        $response = SidecarClientResponse::fromJson(
+            json_encode(['status' => 'ok', 'protocol_version' => 999]),
+        );
+        $this->assertNotNull($response);
+        $this->assertFalse($response->isCompatible());
+    }
 }

--- a/tests/Sidecar/Client/SidecarClientTest.php
+++ b/tests/Sidecar/Client/SidecarClientTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reli\Sidecar\Client;
+
+use Reli\BaseTestCase;
+
+class SidecarClientTest extends BaseTestCase
+{
+    private ?string $socket_path = null;
+    /** @var resource|null */
+    private $server = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->server !== null) {
+            fclose($this->server);
+            $this->server = null;
+        }
+        if ($this->socket_path !== null && file_exists($this->socket_path)) {
+            unlink($this->socket_path);
+            $this->socket_path = null;
+        }
+        parent::tearDown();
+    }
+
+    private function createMockServer(): string
+    {
+        $this->socket_path = tempnam(sys_get_temp_dir(), 'reli_test_sock_');
+        unlink($this->socket_path);
+        $this->server = stream_socket_server("unix://{$this->socket_path}");
+        $this->assertNotFalse($this->server);
+        return $this->socket_path;
+    }
+
+    public function testRequestDumpSendsCorrectPayload(): void
+    {
+        $path = $this->createMockServer();
+
+        // Run client in a separate process to avoid blocking
+        $client = new SidecarClient($path, timeout_seconds: 5);
+
+        // Accept in a fiber-like fashion: spawn client request in background
+        $pid_to_send = getmypid();
+
+        // We need to handle both sides. Use non-blocking approach:
+        // 1. Start client request in a forked process
+        $child_pid = pcntl_fork();
+        if ($child_pid === 0) {
+            // Child: act as client
+            $response = $client->requestDump(
+                pid: 12345,
+                error_file: '/app/Foo.php',
+                error_line: 99,
+                label: 'test-label',
+                metadata: ['key' => 'val'],
+            );
+            // Write result to a temp file
+            file_put_contents(
+                $path . '.result',
+                $response !== null ? $response->status : 'null',
+            );
+            exit(0);
+        }
+
+        // Parent: act as server
+        $conn = stream_socket_accept($this->server, 5);
+        $this->assertNotFalse($conn);
+
+        $line = fgets($conn, 8192);
+        $this->assertNotFalse($line);
+
+        $request = json_decode(trim($line), true);
+        $this->assertSame('dump', $request['command']);
+        $this->assertSame(12345, $request['pid']);
+        $this->assertSame('/app/Foo.php', $request['file']);
+        $this->assertSame(99, $request['line']);
+        $this->assertSame('test-label', $request['label']);
+        $this->assertSame(['key' => 'val'], $request['metadata']);
+
+        // Send response
+        fwrite($conn, json_encode(['status' => 'ok', 'path' => '/tmp/d', 'bytes' => 100]) . "\n");
+        fclose($conn);
+
+        pcntl_waitpid($child_pid, $status);
+        $this->assertTrue(pcntl_wifexited($status));
+
+        $result = file_get_contents($path . '.result');
+        $this->assertSame('ok', $result);
+        @unlink($path . '.result');
+    }
+
+    public function testSnapshotUsesCurrentPid(): void
+    {
+        $path = $this->createMockServer();
+        $client = new SidecarClient($path, timeout_seconds: 5);
+
+        $child_pid = pcntl_fork();
+        if ($child_pid === 0) {
+            $client->snapshot('my-label', ['ver' => '1.0']);
+            exit(0);
+        }
+
+        $conn = stream_socket_accept($this->server, 5);
+        $this->assertNotFalse($conn);
+
+        $line = fgets($conn, 8192);
+        $request = json_decode(trim($line), true);
+        $this->assertSame('dump', $request['command']);
+        $this->assertSame('my-label', $request['label']);
+        $this->assertSame(['ver' => '1.0'], $request['metadata']);
+        // PID should be the child's PID (some positive int)
+        $this->assertGreaterThan(0, $request['pid']);
+
+        fwrite($conn, json_encode(['status' => 'ok']) . "\n");
+        fclose($conn);
+
+        pcntl_waitpid($child_pid, $status);
+    }
+
+    public function testDefaultMetadataMerge(): void
+    {
+        $path = $this->createMockServer();
+        $client = new SidecarClient($path, timeout_seconds: 5, default_metadata: ['product' => 'app']);
+
+        $child_pid = pcntl_fork();
+        if ($child_pid === 0) {
+            $client->requestDump(pid: 1, metadata: ['step' => '1']);
+            exit(0);
+        }
+
+        $conn = stream_socket_accept($this->server, 5);
+        $this->assertNotFalse($conn);
+
+        $line = fgets($conn, 8192);
+        $request = json_decode(trim($line), true);
+        // default_metadata + per-call metadata
+        $this->assertSame('app', $request['metadata']['product']);
+        $this->assertSame('1', $request['metadata']['step']);
+
+        fwrite($conn, json_encode(['status' => 'ok']) . "\n");
+        fclose($conn);
+        pcntl_waitpid($child_pid, $status);
+    }
+
+    public function testConnectionFailureReturnsNull(): void
+    {
+        $client = new SidecarClient('/nonexistent/path.sock', timeout_seconds: 1);
+        $this->assertNull($client->requestDump(pid: 1));
+    }
+
+    public function testEnvSocketPath(): void
+    {
+        $original = getenv(SidecarClient::ENV_SOCKET_PATH);
+        putenv(SidecarClient::ENV_SOCKET_PATH . '=/custom/env/path.sock');
+
+        try {
+            $client = new SidecarClient();
+            // Can't easily inspect the private field, but we can test
+            // that connecting to the env path fails as expected
+            $this->assertNull($client->requestDump(pid: 1));
+        } finally {
+            if ($original === false) {
+                putenv(SidecarClient::ENV_SOCKET_PATH);
+            } else {
+                putenv(SidecarClient::ENV_SOCKET_PATH . '=' . $original);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a sidecar daemon architecture that allows PHP applications to request memory dumps from a background service via Unix domain sockets. This enables non-intrusive profiling and memory analysis without requiring direct access to profiling tools from within the application code.

## Key Changes

- **Sidecar Server** (`SidecarServer`): A Unix domain socket server that listens for dump requests and coordinates with the dump handler
- **Dump Handler** (`SidecarDumpHandler`): Processes incoming dump requests, captures memory state, call traces, and heap statistics, then writes dumps and metadata to disk
- **Client Library** (`SidecarClient`): A lightweight, dependency-free client for PHP applications to request dumps via `requestDump()` or `snapshot()` methods
- **Memory Limit Handler** (`MemoryLimitHandler`): Automatic shutdown handler that triggers a dump when PHP hits memory_limit errors
- **Protocol** (`SidecarRequest`/`SidecarResponse`): JSON-based request/response protocol for socket communication
- **Settings** (`SidecarSettings`): Configuration for socket path, output directory, disk usage limits, and session-level tags
- **Console Command** (`SidecarCommand`): CLI entry point to start the sidecar daemon with configurable options
- **Disk Usage Tracking**: Enhanced `DiskUsageTracker` to monitor both watch-mode and sidecar dump files

## Notable Implementation Details

- Socket path resolution order: constructor argument → `RELI_SIDECAR_SOCKET` env var → default `/var/run/reli-sidecar.sock`
- Metadata merging: session-level tags combined with per-request metadata
- Dump filenames include optional label slug for easy identification
- Metadata files (`.meta.json`) capture PID, trigger type, label, merged metadata, memory stats, and call traces
- Process suspension during dump to ensure consistent memory state
- Comprehensive integration tests with Docker-based target PHP processes
- Signal handling (SIGTERM/SIGINT) for graceful daemon shutdown

https://claude.ai/code/session_01HmzKDZtuvHxyCsDC8p36MK