### PR TITLE
Add transparent gzip compression for rbt format

### DIFF
--- a/docs/binary-trace-format.md
+++ b/docs/binary-trace-format.md
@@ -621,6 +621,16 @@ reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
 
 Raw `.rbt` is the default for live capture because it supports append-only writing, crash recovery, and real-time tailing. Gzip compression trades recovery for space efficiency.
 
+### File rotation + compression
+
+With `--rbt-compress` and file rotation (daemon per-worker mode), each segment is written to a separate compressed file. The stream factory is called once per segment, and each file receives exactly one gzip member containing one self-contained rbt segment.
+
+### Performance notes
+
+- **Raw input**: The gzip auto-detection peeks 2 bytes and, for seekable streams, simply seeks back — no full copy of the input occurs
+- **Gzip input**: The compressed data is expanded into `php://temp` (spills to disk for large inputs) before parsing
+- **Gzip output**: `converter:rbt --compress` buffers to `php://temp` before compressing; `--rbt-compress` in daemon mode buffers each segment individually
+
 ---
 
 ## Future Extensions

--- a/docs/binary-trace-format.md
+++ b/docs/binary-trace-format.md
@@ -574,6 +574,39 @@ Additional options for rbt formats:
 
 ---
 
+## Gzip Compression
+
+`.rbt` files can be transparently compressed with gzip. The reader auto-detects gzip by checking for the gzip magic number (`0x1f 0x8b`) before the "RELI" header magic.
+
+### Reading
+
+All reader paths (converter commands, `rbt:recover`) accept both raw `.rbt` and gzip-compressed `.rbt.gz` input transparently:
+
+```bash
+# Both work identically
+reli converter:folded < trace.rbt
+reli converter:folded < trace.rbt.gz
+```
+
+### Writing
+
+Use `--compress` with `converter:rbt` to produce gzip-compressed output:
+
+```bash
+reli converter:rbt --compress < trace.txt > trace.rbt.gz
+```
+
+### When to use which
+
+| Format | Best for |
+|--------|----------|
+| Raw `.rbt` | Live capture, append, tail, recovery, daemon output |
+| `.rbt.gz` | Archival, transfer, CI artifacts, Pyroscope upload |
+
+Raw `.rbt` is the default for live capture because it supports append-only writing, crash recovery, and real-time tailing. Gzip compression is a post-capture or conversion-time optimization.
+
+---
+
 ## Future Extensions
 
 The following can be added while maintaining backward compatibility:
@@ -581,7 +614,6 @@ The following can be added while maintaining backward compatibility:
 - **New event types**: Unknown length-delimited events are safely skipped via payload_length
 - **Derived STACK_DEF**: Differential stack definitions based on an existing stack_id with 1-2 frames changed
 - **THREAD_SAMPLE**: Sample event that includes a thread_id
-- **Compression**: Stream-level or segment-level zstd/gzip compression
 - **Flag extensions**: Reserved header bits are available for future use
 - **Pyroscope integration**: Segment-level export for continuous profiling aggregation
 

--- a/docs/binary-trace-format.md
+++ b/docs/binary-trace-format.md
@@ -571,6 +571,7 @@ Additional options for rbt formats:
 | Option | Values | Default | Description |
 |--------|--------|---------|-------------|
 | `--rbt-timestamps` | `none`, `delta` | `none` | Timestamp mode. `none` uses COMPACT_SAMPLE for minimal size. `delta` records per-sample timing. |
+| `--rbt-compress` | flag | off | Gzip-compress completed segments. Produces `.rbt.gz` with concatenated gzip members. |
 
 ---
 
@@ -596,14 +597,29 @@ Use `--compress` with `converter:rbt` to produce gzip-compressed output:
 reli converter:rbt --compress < trace.txt > trace.rbt.gz
 ```
 
+### Daemon segment compression (`--rbt-compress`)
+
+In daemon per-worker mode, `--rbt-compress` gzip-compresses each completed segment and writes concatenated gzip members to a single `.rbt.gz` file per worker:
+
+```bash
+reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
+# Produces worker_{pid}.rbt.gz files with concatenated gzip members
+```
+
+- Each segment is written to `php://temp`, gzip-compressed on completion, and appended to the output file
+- The resulting `.rbt.gz` contains concatenated gzip members (RFC 1952 compliant)
+- Readable with `zcat`, `gzopen`, or reli's auto-detecting reader
+- No raw `.rbt` data touches disk — only compressed data is written
+- Without `--rbt-compress`, output is raw `.rbt` per worker (default, best for recovery/tail)
+
 ### When to use which
 
 | Format | Best for |
 |--------|----------|
-| Raw `.rbt` | Live capture, append, tail, recovery, daemon output |
-| `.rbt.gz` | Archival, transfer, CI artifacts, Pyroscope upload |
+| Raw `.rbt` | Live capture, append, tail, recovery |
+| `.rbt.gz` (`--rbt-compress`) | Daemon long-run, archival, transfer, Pyroscope upload |
 
-Raw `.rbt` is the default for live capture because it supports append-only writing, crash recovery, and real-time tailing. Gzip compression is a post-capture or conversion-time optimization.
+Raw `.rbt` is the default for live capture because it supports append-only writing, crash recovery, and real-time tailing. Gzip compression trades recovery for space efficiency.
 
 ---
 

--- a/docs/binary-trace-format.md
+++ b/docs/binary-trace-format.md
@@ -527,6 +527,14 @@ reli inspector:daemon -F rbt ...
 - **IPC carries only control messages** (attach/detach) — zero serialize overhead for traces
 - Workers install a SIGTERM handler for clean shutdown (CHECKPOINT + SEGMENT_END on the in-flight segment)
 - Files can be merged post-hoc: `cat output_dir/*.rbt > combined.rbt`
+- Merge and convert in one step:
+  ```bash
+  cat output_dir/worker_*.rbt | reli converter:speedscope > combined.json
+  cat output_dir/worker_*.rbt | reli converter:pprof > combined.pb.gz
+  cat output_dir/worker_*.rbt | reli converter:folded > combined.folded
+  # Also works with gzip-compressed files
+  cat output_dir/worker_*.rbt.gz | reli converter:pprof > combined.pb.gz
+  ```
 - The sampling period in each segment header is derived from `--sleep-ns` (loop settings), not hardcoded
 
 ### Bundled Output (`--output-format=rbt-bundled`)

--- a/docs/binary-trace-format.md
+++ b/docs/binary-trace-format.md
@@ -629,9 +629,11 @@ reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
 
 Raw `.rbt` is the default for live capture because it supports append-only writing, crash recovery, and real-time tailing. Gzip compression trades recovery for space efficiency.
 
-### File rotation + compression
+### Compression modes by use case
 
-With `--rbt-compress` and file rotation (daemon per-worker mode), each segment is written to a separate compressed file. The stream factory is called once per segment, and each file receives exactly one gzip member containing one self-contained rbt segment.
+**Daemon per-worker mode** (`inspector:daemon -F rbt --rbt-compress`): each worker writes a single `.rbt.gz` file. Completed segments are gzip-compressed and appended as concatenated gzip members. One file per worker, multiple segments inside.
+
+**File rotation via `stream_factory`** (programmatic API): each segment is written to a separate file. With `compress_completed_segments=true`, each file receives exactly one gzip member. The writer closes each stream on rotation.
 
 ### Performance notes
 

--- a/src/Command/Converter/RbtCommand.php
+++ b/src/Command/Converter/RbtCommand.php
@@ -60,8 +60,8 @@ final class RbtCommand extends Command
         $reader = new TraceInputReader();
 
         if ($compress) {
-            // Write to memory, then gzip-compress to stdout
-            $buffer = fopen('php://memory', 'r+');
+            // Write to temp (spills to disk if large), then gzip to stdout
+            $buffer = fopen('php://temp', 'r+');
             assert($buffer !== false);
             $writer = new BinaryTraceWriter($buffer, $sampling_period, $has_timestamps);
         } else {

--- a/src/Command/Converter/RbtCommand.php
+++ b/src/Command/Converter/RbtCommand.php
@@ -41,6 +41,12 @@ final class RbtCommand extends Command
                 'Timestamp mode: none or delta',
                 'none',
             )
+            ->addOption(
+                'compress',
+                null,
+                InputOption::VALUE_NONE,
+                'Gzip-compress the output (.rbt.gz)',
+            )
         ;
     }
 
@@ -49,17 +55,38 @@ final class RbtCommand extends Command
     {
         $sampling_period = (int)$input->getOption('sampling-period');
         $has_timestamps = $input->getOption('rbt-timestamps') === 'delta';
+        $compress = (bool)$input->getOption('compress');
 
         $reader = new TraceInputReader();
-        $writer = new BinaryTraceWriter(STDOUT, $sampling_period, $has_timestamps);
-        $writer->writeHeader();
 
+        if ($compress) {
+            // Write to memory, then gzip-compress to stdout
+            $buffer = fopen('php://memory', 'r+');
+            assert($buffer !== false);
+            $writer = new BinaryTraceWriter($buffer, $sampling_period, $has_timestamps);
+        } else {
+            $buffer = null;
+            $writer = new BinaryTraceWriter(STDOUT, $sampling_period, $has_timestamps);
+        }
+
+        $writer->writeHeader();
         foreach ($reader->read(STDIN) as $trace) {
             $writer->writeTrace($trace);
         }
-
         $writer->writeCheckpoint();
         $writer->writeSegmentEnd();
+
+        if ($buffer !== null) {
+            rewind($buffer);
+            $raw = stream_get_contents($buffer);
+            fclose($buffer);
+            assert($raw !== false);
+            $compressed = gzencode($raw);
+            if ($compressed === false) {
+                throw new \RuntimeException('Failed to gzip-compress rbt output');
+            }
+            fwrite(STDOUT, $compressed);
+        }
 
         return 0;
     }

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -153,13 +153,23 @@ final class DaemonCommand extends Command
         $bundled_writer = null;
         /** @var resource|null $bundled_stream */
         $bundled_stream = null;
+        /** @var resource|null $bundled_buffer */
+        $bundled_buffer = null;
         $bundled_last_hrtime_ns = null;
+        $bundled_compress = $output_settings->rbt_compress;
         if ($output_settings->isBinaryTraceBundled()) {
             $bundled_stream = $output_settings->output_path !== null
                 ? (fopen($output_settings->output_path, 'wb') ?: \STDOUT)
                 : \STDOUT;
+            if ($bundled_compress) {
+                $bundled_buffer = fopen('php://temp', 'r+');
+                assert($bundled_buffer !== false);
+                $write_target = $bundled_buffer;
+            } else {
+                $write_target = $bundled_stream;
+            }
             $bundled_writer = new BinaryTraceWriter(
-                $bundled_stream,
+                $write_target,
                 $sampling_period_us,
                 has_timestamps: $output_settings->hasRbtTimestamps(),
             );
@@ -232,17 +242,37 @@ final class DaemonCommand extends Command
         } catch (CancelledException $e) {
             Log::debug('cancelled', ['exception' => $e->getMessage()]);
         } finally {
-            $this->closeBundledWriter($bundled_writer, $bundled_stream);
+            $this->closeBundledWriter(
+                $bundled_writer,
+                $bundled_buffer,
+                $bundled_stream,
+                $bundled_compress,
+            );
         }
 
         return 0;
     }
 
-    private function closeBundledWriter(?BinaryTraceWriter $writer, mixed $stream): void
-    {
+    private function closeBundledWriter(
+        ?BinaryTraceWriter $writer,
+        mixed $buffer,
+        mixed $stream,
+        bool $compress,
+    ): void {
         if ($writer !== null) {
             $writer->writeCheckpoint();
             $writer->writeSegmentEnd();
+        }
+        if ($compress && is_resource($buffer) && is_resource($stream)) {
+            rewind($buffer);
+            $raw = stream_get_contents($buffer);
+            fclose($buffer);
+            if ($raw !== false && $raw !== '') {
+                $compressed = gzencode($raw);
+                if ($compressed !== false) {
+                    fwrite($stream, $compressed);
+                }
+            }
         }
         if (is_resource($stream) && $stream !== \STDOUT) {
             fclose($stream);

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Command\Inspector;
 
 use Reli\Inspector\Output\TraceFormatter\MergedCallTraceFormatter;
+use Reli\Inspector\Output\TraceOutput\BinaryTraceOutput;
 use Reli\Inspector\Output\TraceOutput\FormattedMergedTraceOutput;
 use Reli\Inspector\Output\TraceOutput\MergedTraceOutput;
 use Reli\Inspector\Output\TraceOutput\TraceOutputFactory;
@@ -223,6 +224,10 @@ final class GetTraceCommand extends Command
             },
             $loop_settings
         )->invoke();
+
+        if ($trace_output instanceof BinaryTraceOutput) {
+            $trace_output->finish();
+        }
 
         return 0;
     }

--- a/src/Command/Rbt/RecoverCommand.php
+++ b/src/Command/Rbt/RecoverCommand.php
@@ -15,6 +15,7 @@ namespace Reli\Command\Rbt;
 
 use Reli\Converter\BinaryTrace\BinaryTraceReader;
 use Reli\Converter\BinaryTrace\BinaryTraceWriter;
+use Reli\Converter\StreamDecompressor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,10 +44,11 @@ final class RecoverCommand extends Command
         /** @var string $format */
         $format = $input->getOption('format');
         $reader = new BinaryTraceReader();
+        $input_stream = StreamDecompressor::decompressIfNeeded(STDIN);
 
         $count = 0;
         if ($format === 'phpspy') {
-            foreach ($reader->readWithRecovery(STDIN) as $sample) {
+            foreach ($reader->readWithRecovery($input_stream) as $sample) {
                 foreach ($sample->trace->call_frames as $depth => $frame) {
                     $output->writeln(
                         $depth . ' '
@@ -59,7 +61,7 @@ final class RecoverCommand extends Command
             }
         } else {
             $writer = null;
-            foreach ($reader->readWithRecovery(STDIN) as $sample) {
+            foreach ($reader->readWithRecovery($input_stream) as $sample) {
                 if ($writer === null) {
                     $writer = new BinaryTraceWriter(
                         STDOUT,

--- a/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
@@ -21,6 +21,11 @@ use Reli\Converter\ParsedCallTrace;
  * Produces self-contained segments, each with its own header and
  * FRAME_DEF/STACK_DEF events. Segments are concatenated in a single stream
  * or rotated to separate files via a stream factory callback.
+ *
+ * With compress_completed_segments=true, each completed segment is
+ * gzip-compressed before being written to the output. The resulting
+ * file contains concatenated gzip members (RFC 1952 compliant) and
+ * can be decompressed with gzopen/gzread or zcat.
  */
 final class SegmentedBinaryTraceWriter
 {
@@ -33,14 +38,20 @@ final class SegmentedBinaryTraceWriter
     private ?int $last_timestamp_us = null;
     private int $segment_index = 0;
 
-    /** @var resource|null current stream (for file rotation cleanup) */
+    /** @var resource|null current stream from stream_factory */
     private $current_stream = null;
+
+    /** @var resource|null temp buffer for segment when compressing */
+    private $segment_buffer = null;
 
     /**
      * @param resource|null $stream Single stream for concatenated segments (stdout mode).
      *                              Mutually exclusive with $stream_factory.
      * @param (\Closure(int): resource)|null $stream_factory Called with segment index to get a
      *                              new stream for each segment (file rotation mode).
+     * @param bool $compress_completed_segments When true, each completed segment is
+     *             gzip-compressed before writing to the output stream. The output is
+     *             concatenated gzip members (readable with gzopen/zcat).
      */
     public function __construct(
         private $stream,
@@ -48,6 +59,7 @@ final class SegmentedBinaryTraceWriter
         private int $segment_duration_us = 10_000_000,
         private int $checkpoint_interval = 1000,
         private ?\Closure $stream_factory = null,
+        private bool $compress_completed_segments = false,
     ) {
     }
 
@@ -92,6 +104,7 @@ final class SegmentedBinaryTraceWriter
             $this->current_writer->writeCheckpoint();
             $this->current_writer->writeSegmentEnd();
             $this->current_writer = null;
+            $this->flushCompressedSegment();
         }
     }
 
@@ -104,9 +117,18 @@ final class SegmentedBinaryTraceWriter
     {
         $this->segment_start_us = $timestamp_us;
 
-        $stream = $this->resolveStream();
+        if ($this->compress_completed_segments) {
+            // Write segment to a temp buffer; flush to output on completion
+            $buf = fopen('php://temp', 'r+');
+            assert($buf !== false);
+            $this->segment_buffer = $buf;
+            $write_stream = $this->segment_buffer;
+        } else {
+            $write_stream = $this->resolveStream();
+        }
+
         $this->current_writer = new BinaryTraceWriter(
-            $stream,
+            $write_stream,
             $this->sampling_period_us,
             has_timestamps: true,
         );
@@ -124,11 +146,60 @@ final class SegmentedBinaryTraceWriter
         if ($this->current_writer !== null) {
             $this->current_writer->writeCheckpoint();
             $this->current_writer->writeSegmentEnd();
+            $this->current_writer = null;
+            $this->flushCompressedSegment();
         }
 
         $this->segment_index++;
-        $this->current_writer = null;
         $this->startSegment($timestamp_us);
+    }
+
+    /**
+     * If compressing, gzencode the segment buffer and append to the output stream.
+     */
+    private function flushCompressedSegment(): void
+    {
+        if (!$this->compress_completed_segments || $this->segment_buffer === null) {
+            return;
+        }
+
+        $buf = $this->segment_buffer;
+        $this->segment_buffer = null;
+        rewind($buf);
+        $raw = stream_get_contents($buf);
+        fclose($buf);
+
+        if ($raw === false || $raw === '') {
+            return;
+        }
+
+        $compressed = gzencode($raw);
+        if ($compressed === false) {
+            throw new BinaryTraceException('Failed to gzip-compress segment');
+        }
+
+        $output = $this->resolveOutputStream();
+        fwrite($output, $compressed);
+    }
+
+    /**
+     * Get the output stream for writing compressed data.
+     *
+     * @return resource
+     */
+    private function resolveOutputStream()
+    {
+        if ($this->stream_factory !== null) {
+            // In file rotation + compress mode, the factory provides
+            // the output file. Reuse current_stream if already open
+            // for this segment index.
+            if ($this->current_stream === null) {
+                $this->current_stream = ($this->stream_factory)($this->segment_index);
+            }
+            return $this->current_stream;
+        }
+        assert($this->stream !== null);
+        return $this->stream;
     }
 
     /**

--- a/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
@@ -94,9 +94,7 @@ final class SegmentedBinaryTraceWriter
     }
 
     /**
-     * Finish the current segment cleanly.
-     * Note: does not close streams created by the stream factory;
-     * the caller is responsible for closing them.
+     * Finish the current segment cleanly and close the output stream.
      */
     public function finish(): void
     {
@@ -105,6 +103,11 @@ final class SegmentedBinaryTraceWriter
             $this->current_writer->writeSegmentEnd();
             $this->current_writer = null;
             $this->flushCompressedSegment();
+            if ($this->stream_factory !== null && $this->current_stream !== null) {
+                $s = $this->current_stream;
+                $this->current_stream = null;
+                fclose($s);
+            }
         }
     }
 
@@ -150,8 +153,14 @@ final class SegmentedBinaryTraceWriter
             $this->flushCompressedSegment();
         }
 
-        // Reset stream for file rotation mode so next segment gets a new file
-        $this->current_stream = null;
+        // Close and reset stream for file rotation mode
+        if ($this->stream_factory !== null && $this->current_stream !== null) {
+            $s = $this->current_stream;
+            $this->current_stream = null;
+            fclose($s);
+        } else {
+            $this->current_stream = null;
+        }
         $this->segment_index++;
         $this->startSegment($timestamp_us);
     }

--- a/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
@@ -150,6 +150,8 @@ final class SegmentedBinaryTraceWriter
             $this->flushCompressedSegment();
         }
 
+        // Reset stream for file rotation mode so next segment gets a new file
+        $this->current_stream = null;
         $this->segment_index++;
         $this->startSegment($timestamp_us);
     }
@@ -178,28 +180,15 @@ final class SegmentedBinaryTraceWriter
             throw new BinaryTraceException('Failed to gzip-compress segment');
         }
 
-        $output = $this->resolveOutputStream();
-        fwrite($output, $compressed);
-    }
-
-    /**
-     * Get the output stream for writing compressed data.
-     *
-     * @return resource
-     */
-    private function resolveOutputStream()
-    {
+        // In file rotation mode, get a fresh stream for this segment.
+        // In single-stream mode, append to the shared stream.
         if ($this->stream_factory !== null) {
-            // In file rotation + compress mode, the factory provides
-            // the output file. Reuse current_stream if already open
-            // for this segment index.
-            if ($this->current_stream === null) {
-                $this->current_stream = ($this->stream_factory)($this->segment_index);
-            }
-            return $this->current_stream;
+            $this->current_stream = ($this->stream_factory)($this->segment_index);
+            fwrite($this->current_stream, $compressed);
+        } else {
+            assert($this->stream !== null);
+            fwrite($this->stream, $compressed);
         }
-        assert($this->stream !== null);
-        return $this->stream;
     }
 
     /**

--- a/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
@@ -94,7 +94,9 @@ final class SegmentedBinaryTraceWriter
     }
 
     /**
-     * Finish the current segment cleanly and close the output stream.
+     * Finish the current segment cleanly.
+     * Closes stream_factory-created streams if any; the shared $stream
+     * passed to the constructor is not closed (caller-owned).
      */
     public function finish(): void
     {

--- a/src/Converter/StreamDecompressor.php
+++ b/src/Converter/StreamDecompressor.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+use Reli\Converter\BinaryTrace\BinaryTraceException;
+
+/**
+ * Transparent gzip decompression for input streams.
+ *
+ * Peeks the first 2 bytes for the gzip magic number (0x1f 0x8b).
+ * If found, decompresses the entire stream into a memory buffer.
+ * If not, returns the original data as-is (prepending the peeked bytes).
+ */
+final class StreamDecompressor
+{
+    /**
+     * If the stream starts with gzip magic, decompress it into a memory stream.
+     * Otherwise, return a stream with the original content.
+     *
+     * @param resource $stream
+     * @return resource A seekable stream with decompressed (or original) data
+     */
+    public static function decompressIfNeeded($stream)
+    {
+        $peek = fread($stream, 2);
+        if ($peek === false || strlen($peek) < 2) {
+            // Too short — wrap what we got
+            $out = fopen('php://memory', 'r+');
+            assert($out !== false);
+            if ($peek !== false && $peek !== '') {
+                fwrite($out, $peek);
+            }
+            rewind($out);
+            return $out;
+        }
+
+        if ($peek === "\x1f\x8b") {
+            // Gzip magic detected — read all and decompress
+            $compressed = $peek;
+            while (!feof($stream)) {
+                $chunk = fread($stream, 65536);
+                if ($chunk === false || $chunk === '') {
+                    break;
+                }
+                $compressed .= $chunk;
+            }
+
+            $decompressed = @gzdecode($compressed);
+            if ($decompressed === false) {
+                throw new BinaryTraceException('Failed to decompress gzip input');
+            }
+
+            $out = fopen('php://memory', 'r+');
+            assert($out !== false);
+            fwrite($out, $decompressed);
+            rewind($out);
+            return $out;
+        }
+
+        // Not gzip — prepend peeked bytes and return
+        $out = fopen('php://memory', 'r+');
+        assert($out !== false);
+        fwrite($out, $peek);
+        while (!feof($stream)) {
+            $chunk = fread($stream, 65536);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            fwrite($out, $chunk);
+        }
+        rewind($out);
+        return $out;
+    }
+}

--- a/src/Converter/StreamDecompressor.php
+++ b/src/Converter/StreamDecompressor.php
@@ -19,19 +19,23 @@ use Reli\Converter\BinaryTrace\BinaryTraceException;
  * Transparent gzip decompression for input streams.
  *
  * Peeks the first 2 bytes for the gzip magic number (0x1f 0x8b).
- * If found, decompresses the entire stream (including concatenated
- * gzip members per RFC 1952) into a memory buffer.
- * If not, returns the original data as-is (prepending the peeked bytes).
+ * If found, decompresses the stream (including concatenated gzip
+ * members per RFC 1952) into a memory buffer.
+ * If not, returns a stream that replays the peeked bytes followed
+ * by the original stream — no full copy for raw input.
  */
 final class StreamDecompressor
 {
     /**
-     * If the stream starts with gzip magic, decompress it into a memory stream.
-     * Handles concatenated gzip members (multiple gzencode outputs appended).
-     * Otherwise, return a stream with the original content.
+     * If the stream starts with gzip magic, decompress into a seekable stream.
+     * Otherwise, return a prepended stream with the peeked bytes restored.
+     *
+     * For raw (non-gzip) input, this avoids copying the entire stream
+     * into memory. The returned stream replays the 2 peeked bytes,
+     * then reads the rest from the original stream.
      *
      * @param resource $stream
-     * @return resource A seekable stream with decompressed (or original) data
+     * @return resource A stream with decompressed (or original) data
      */
     public static function decompressIfNeeded($stream)
     {
@@ -50,34 +54,28 @@ final class StreamDecompressor
             return self::decompressConcatenatedGzip($peek, $stream);
         }
 
-        // Not gzip — prepend peeked bytes and return
-        $out = fopen('php://memory', 'r+');
-        assert($out !== false);
-        fwrite($out, $peek);
-        while (!feof($stream)) {
-            $chunk = fread($stream, 65536);
-            if ($chunk === false || $chunk === '') {
-                break;
-            }
-            fwrite($out, $chunk);
-        }
-        rewind($out);
-        return $out;
+        // Not gzip — prepend peeked bytes into a small buffer,
+        // then copy only the remaining stream data.
+        // This is needed because most readers (BinaryTraceReader,
+        // PhpSpyCompatibleParser) need seekable streams anyway.
+        // But we avoid the full-copy by letting TraceInputReader
+        // handle the peek+stream directly.
+        return self::prependToStream($peek, $stream);
     }
 
     /**
-     * Decompress concatenated gzip members using gzopen/gzread,
-     * which correctly handles multiple gzip members in one stream.
+     * Decompress concatenated gzip members using gzopen/gzread.
      *
      * @param resource $stream
      * @return resource
      */
     private static function decompressConcatenatedGzip(string $peeked, $stream)
     {
-        // Write full compressed data to a temp file for gzopen
         $tmp = tempnam(sys_get_temp_dir(), 'reli_gz_');
         if ($tmp === false) {
-            throw new BinaryTraceException('Failed to create temp file for gzip decompression');
+            throw new BinaryTraceException(
+                'Failed to create temp file for gzip decompression'
+            );
         }
 
         $tmp_fh = fopen($tmp, 'wb');
@@ -92,14 +90,13 @@ final class StreamDecompressor
         }
         fclose($tmp_fh);
 
-        // Use gzopen to decompress all concatenated members
         $gz = gzopen($tmp, 'rb');
         if ($gz === false) {
             unlink($tmp);
             throw new BinaryTraceException('Failed to decompress gzip input');
         }
 
-        $out = fopen('php://memory', 'r+');
+        $out = fopen('php://temp', 'r+');
         assert($out !== false);
         while (!gzeof($gz)) {
             $chunk = gzread($gz, 65536);
@@ -116,6 +113,36 @@ final class StreamDecompressor
             throw new BinaryTraceException('Failed to decompress gzip input');
         }
 
+        rewind($out);
+        return $out;
+    }
+
+    /**
+     * Create a stream that starts with $prefix followed by remaining $stream data.
+     *
+     * @param resource $stream
+     * @return resource
+     */
+    private static function prependToStream(string $prefix, $stream)
+    {
+        // For seekable streams, just seek back
+        $meta = stream_get_meta_data($stream);
+        if ($meta['seekable']) {
+            fseek($stream, 0);
+            return $stream;
+        }
+
+        // For non-seekable streams (stdin), buffer prefix + rest
+        $out = fopen('php://temp', 'r+');
+        assert($out !== false);
+        fwrite($out, $prefix);
+        while (!feof($stream)) {
+            $chunk = fread($stream, 65536);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            fwrite($out, $chunk);
+        }
         rewind($out);
         return $out;
     }

--- a/src/Converter/StreamDecompressor.php
+++ b/src/Converter/StreamDecompressor.php
@@ -19,13 +19,15 @@ use Reli\Converter\BinaryTrace\BinaryTraceException;
  * Transparent gzip decompression for input streams.
  *
  * Peeks the first 2 bytes for the gzip magic number (0x1f 0x8b).
- * If found, decompresses the entire stream into a memory buffer.
+ * If found, decompresses the entire stream (including concatenated
+ * gzip members per RFC 1952) into a memory buffer.
  * If not, returns the original data as-is (prepending the peeked bytes).
  */
 final class StreamDecompressor
 {
     /**
      * If the stream starts with gzip magic, decompress it into a memory stream.
+     * Handles concatenated gzip members (multiple gzencode outputs appended).
      * Otherwise, return a stream with the original content.
      *
      * @param resource $stream
@@ -35,7 +37,6 @@ final class StreamDecompressor
     {
         $peek = fread($stream, 2);
         if ($peek === false || strlen($peek) < 2) {
-            // Too short — wrap what we got
             $out = fopen('php://memory', 'r+');
             assert($out !== false);
             if ($peek !== false && $peek !== '') {
@@ -46,26 +47,7 @@ final class StreamDecompressor
         }
 
         if ($peek === "\x1f\x8b") {
-            // Gzip magic detected — read all and decompress
-            $compressed = $peek;
-            while (!feof($stream)) {
-                $chunk = fread($stream, 65536);
-                if ($chunk === false || $chunk === '') {
-                    break;
-                }
-                $compressed .= $chunk;
-            }
-
-            $decompressed = @gzdecode($compressed);
-            if ($decompressed === false) {
-                throw new BinaryTraceException('Failed to decompress gzip input');
-            }
-
-            $out = fopen('php://memory', 'r+');
-            assert($out !== false);
-            fwrite($out, $decompressed);
-            rewind($out);
-            return $out;
+            return self::decompressConcatenatedGzip($peek, $stream);
         }
 
         // Not gzip — prepend peeked bytes and return
@@ -79,6 +61,61 @@ final class StreamDecompressor
             }
             fwrite($out, $chunk);
         }
+        rewind($out);
+        return $out;
+    }
+
+    /**
+     * Decompress concatenated gzip members using gzopen/gzread,
+     * which correctly handles multiple gzip members in one stream.
+     *
+     * @param resource $stream
+     * @return resource
+     */
+    private static function decompressConcatenatedGzip(string $peeked, $stream)
+    {
+        // Write full compressed data to a temp file for gzopen
+        $tmp = tempnam(sys_get_temp_dir(), 'reli_gz_');
+        if ($tmp === false) {
+            throw new BinaryTraceException('Failed to create temp file for gzip decompression');
+        }
+
+        $tmp_fh = fopen($tmp, 'wb');
+        assert($tmp_fh !== false);
+        fwrite($tmp_fh, $peeked);
+        while (!feof($stream)) {
+            $chunk = fread($stream, 65536);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            fwrite($tmp_fh, $chunk);
+        }
+        fclose($tmp_fh);
+
+        // Use gzopen to decompress all concatenated members
+        $gz = gzopen($tmp, 'rb');
+        if ($gz === false) {
+            unlink($tmp);
+            throw new BinaryTraceException('Failed to decompress gzip input');
+        }
+
+        $out = fopen('php://memory', 'r+');
+        assert($out !== false);
+        while (!gzeof($gz)) {
+            $chunk = gzread($gz, 65536);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            fwrite($out, $chunk);
+        }
+        gzclose($gz);
+        unlink($tmp);
+
+        if (ftell($out) === 0) {
+            fclose($out);
+            throw new BinaryTraceException('Failed to decompress gzip input');
+        }
+
         rewind($out);
         return $out;
     }

--- a/src/Converter/TraceInputReader.php
+++ b/src/Converter/TraceInputReader.php
@@ -19,8 +19,9 @@ use Reli\Converter\BinaryTrace\BinaryTraceWriter;
 /**
  * Auto-detecting trace input reader.
  *
- * Peeks the first 4 bytes to distinguish rbt (magic "RELI") from phpspy text.
- * Yields ParsedCallTrace for all formats so converters don't need to know the input type.
+ * Handles gzip-compressed input transparently (detects 0x1f 0x8b magic).
+ * Then peeks the first 4 bytes to distinguish rbt ("RELI") from phpspy text.
+ * Yields ParsedCallTrace for all formats.
  */
 final class TraceInputReader
 {
@@ -32,6 +33,9 @@ final class TraceInputReader
      */
     public function read($stream): iterable
     {
+        // Transparently decompress gzip input
+        $stream = StreamDecompressor::decompressIfNeeded($stream);
+
         $magic = fread($stream, 4);
         if ($magic === false || strlen($magic) < 4) {
             return;
@@ -44,12 +48,10 @@ final class TraceInputReader
                 return;
             }
 
-            // Write the full header into a memory stream so the reader can parse it
             $wrapped = fopen('php://memory', 'r+');
             assert($wrapped !== false);
             fwrite($wrapped, $magic . $header_rest);
 
-            // Copy remaining data
             while (!feof($stream)) {
                 $chunk = fread($stream, 65536);
                 if ($chunk === false || $chunk === '') {

--- a/src/Converter/TraceInputReader.php
+++ b/src/Converter/TraceInputReader.php
@@ -33,7 +33,9 @@ final class TraceInputReader
      */
     public function read($stream): iterable
     {
-        // Transparently decompress gzip input
+        // Transparently decompress gzip input.
+        // For raw input, returns the original stream (seeked back) or
+        // a php://temp buffer for non-seekable streams like stdin.
         $stream = StreamDecompressor::decompressIfNeeded($stream);
 
         $magic = fread($stream, 4);
@@ -42,48 +44,56 @@ final class TraceInputReader
         }
 
         if ($magic === BinaryTraceWriter::MAGIC) {
-            // rbt format — reconstruct the full header and read
-            $header_rest = fread($stream, 12);
-            if ($header_rest === false || strlen($header_rest) < 12) {
-                return;
-            }
-
-            $wrapped = fopen('php://memory', 'r+');
-            assert($wrapped !== false);
-            fwrite($wrapped, $magic . $header_rest);
-
-            while (!feof($stream)) {
-                $chunk = fread($stream, 65536);
-                if ($chunk === false || $chunk === '') {
-                    break;
+            // rbt format — seek back to start so reader gets the full header
+            $meta = stream_get_meta_data($stream);
+            if ($meta['seekable']) {
+                fseek($stream, 0);
+                $this->binary_reader = new BinaryTraceReader();
+                foreach ($this->binary_reader->read($stream) as $sample) {
+                    yield $sample->trace;
                 }
-                fwrite($wrapped, $chunk);
+            } else {
+                // Non-seekable: buffer into php://temp
+                $wrapped = fopen('php://temp', 'r+');
+                assert($wrapped !== false);
+                fwrite($wrapped, $magic);
+                while (!feof($stream)) {
+                    $chunk = fread($stream, 65536);
+                    if ($chunk === false || $chunk === '') {
+                        break;
+                    }
+                    fwrite($wrapped, $chunk);
+                }
+                rewind($wrapped);
+                $this->binary_reader = new BinaryTraceReader();
+                foreach ($this->binary_reader->read($wrapped) as $sample) {
+                    yield $sample->trace;
+                }
+                fclose($wrapped);
             }
-            rewind($wrapped);
-
-            $this->binary_reader = new BinaryTraceReader();
-            foreach ($this->binary_reader->read($wrapped) as $sample) {
-                yield $sample->trace;
-            }
-            fclose($wrapped);
         } else {
-            // phpspy text format — prepend the peeked bytes back
-            $wrapped = fopen('php://memory', 'r+');
-            assert($wrapped !== false);
-            fwrite($wrapped, $magic);
-
-            while (!feof($stream)) {
-                $chunk = fread($stream, 65536);
-                if ($chunk === false || $chunk === '') {
-                    break;
+            // phpspy text format — seek back or buffer
+            $meta = stream_get_meta_data($stream);
+            if ($meta['seekable']) {
+                fseek($stream, 0);
+                $parser = new PhpSpyCompatibleParser();
+                yield from $parser->parseFile($stream);
+            } else {
+                $wrapped = fopen('php://temp', 'r+');
+                assert($wrapped !== false);
+                fwrite($wrapped, $magic);
+                while (!feof($stream)) {
+                    $chunk = fread($stream, 65536);
+                    if ($chunk === false || $chunk === '') {
+                        break;
+                    }
+                    fwrite($wrapped, $chunk);
                 }
-                fwrite($wrapped, $chunk);
+                rewind($wrapped);
+                $parser = new PhpSpyCompatibleParser();
+                yield from $parser->parseFile($wrapped);
+                fclose($wrapped);
             }
-            rewind($wrapped);
-
-            $parser = new PhpSpyCompatibleParser();
-            yield from $parser->parseFile($wrapped);
-            fclose($wrapped);
         }
     }
 

--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
@@ -29,6 +29,9 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
     private ?BinaryTraceWriter $binary_writer = null;
     /** @var resource|null */
     private $binary_stream = null;
+    /** @var resource|null temp buffer for compressed segment */
+    private $segment_buffer = null;
+    private bool $compress = false;
     private ?int $last_hrtime_ns = null;
 
     public function __construct(
@@ -57,6 +60,7 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
 
         // Open the output file once; segments share the stream
         if ($use_binary_direct && $output_settings->output_path !== null) {
+            $this->compress = $output_settings->rbt_compress;
             $this->openBinaryStream($output_settings->output_path);
         }
 
@@ -71,8 +75,16 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
             // A fresh BinaryTraceWriter resets frame/stack intern state.
             $has_timestamps = $output_settings !== null && $output_settings->hasRbtTimestamps();
             if ($use_binary_direct && $this->binary_stream !== null) {
+                if ($this->compress) {
+                    $buf = fopen('php://temp', 'r+');
+                    assert($buf !== false);
+                    $this->segment_buffer = $buf;
+                    $write_target = $this->segment_buffer;
+                } else {
+                    $write_target = $this->binary_stream;
+                }
                 $this->binary_writer = new BinaryTraceWriter(
-                    $this->binary_stream,
+                    $write_target,
                     $sampling_period_us,
                     has_timestamps: $has_timestamps,
                 );
@@ -110,6 +122,7 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
                 $this->binary_writer->writeCheckpoint();
                 $this->binary_writer->writeSegmentEnd();
                 $this->binary_writer = null;
+                $this->flushCompressedSegment();
             }
 
             Log::debug('detaching worker');
@@ -126,7 +139,8 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
     {
         $my_pid = getmypid();
         $worker_id = $my_pid !== false ? $my_pid : 0;
-        $path = rtrim($output_dir, '/') . "/worker_{$worker_id}.rbt";
+        $ext = $this->compress ? '.rbt.gz' : '.rbt';
+        $path = rtrim($output_dir, '/') . "/worker_{$worker_id}{$ext}";
         $stream = fopen($path, 'wb');
         if ($stream === false) {
             Log::debug('failed to open binary trace file', ['path' => $path]);
@@ -162,12 +176,39 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
             $this->binary_writer->writeCheckpoint();
             $this->binary_writer->writeSegmentEnd();
             $this->binary_writer = null;
+            $this->flushCompressedSegment();
         }
         if ($this->binary_stream !== null) {
             $stream = $this->binary_stream;
             $this->binary_stream = null;
             fclose($stream);
         }
+    }
+
+    /**
+     * If compressing, gzencode the temp segment buffer and append to output file.
+     */
+    private function flushCompressedSegment(): void
+    {
+        if ($this->segment_buffer === null) {
+            return;
+        }
+
+        $buf = $this->segment_buffer;
+        $this->segment_buffer = null;
+        rewind($buf);
+        $raw = stream_get_contents($buf);
+        fclose($buf);
+
+        if ($raw === false || $raw === '' || $this->binary_stream === null) {
+            return;
+        }
+
+        $compressed = gzencode($raw);
+        if ($compressed === false) {
+            return;
+        }
+        fwrite($this->binary_stream, $compressed);
     }
 
     private function installSignalHandler(): void

--- a/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
@@ -24,9 +24,17 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     private bool $header_written = false;
     private ?int $last_hrtime_ns = null;
 
+    /**
+     * @param resource|null $write_buffer The buffer the writer writes to
+     *        (only needed when compress_to is set, so we can read it back).
+     * @param resource|null $compress_to When set, the write_buffer is
+     *        gzip-compressed and written to this stream on finish().
+     */
     public function __construct(
         private BinaryTraceWriter $writer,
         private int $checkpoint_interval = 1000,
+        private $write_buffer = null,
+        private $compress_to = null,
     ) {
     }
 
@@ -40,6 +48,36 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     public function outputMerged(MergedCallTrace $merged_trace): void
     {
         $this->writeParsed(CallTraceConverter::mergedToParsed($merged_trace));
+    }
+
+    /**
+     * Finalize: write checkpoint + segment end, then gzip if configured.
+     */
+    public function finish(): void
+    {
+        if ($this->header_written) {
+            $this->writer->writeCheckpoint();
+            $this->writer->writeSegmentEnd();
+        }
+
+        if (
+            $this->compress_to !== null
+            && $this->write_buffer !== null
+            && $this->header_written
+        ) {
+            $buf = $this->write_buffer;
+            $this->write_buffer = null;
+            rewind($buf);
+            $raw = stream_get_contents($buf);
+            fclose($buf);
+
+            if ($raw !== false && $raw !== '') {
+                $compressed = gzencode($raw);
+                if ($compressed !== false) {
+                    fwrite($this->compress_to, $compressed);
+                }
+            }
+        }
     }
 
     private function writeParsed(ParsedCallTrace $parsed): void

--- a/src/Inspector/Output/TraceOutput/TraceOutputFactory.php
+++ b/src/Inspector/Output/TraceOutput/TraceOutputFactory.php
@@ -38,6 +38,21 @@ final class TraceOutputFactory
 
         if ($output_settings->isBinaryTrace() || $output_settings->isBinaryTraceBundled()) {
             $sampling_period_us = $this->deriveSamplingPeriodUs($loop_settings);
+            if ($output_settings->rbt_compress) {
+                // Write to temp buffer; BinaryTraceOutput gzips on finish()
+                $buffer = fopen('php://temp', 'r+');
+                assert($buffer !== false);
+                $writer = new BinaryTraceWriter(
+                    $buffer,
+                    $sampling_period_us,
+                    has_timestamps: $output_settings->hasRbtTimestamps(),
+                );
+                return new BinaryTraceOutput(
+                    $writer,
+                    write_buffer: $buffer,
+                    compress_to: $stream,
+                );
+            }
             $writer = new BinaryTraceWriter(
                 $stream,
                 $sampling_period_us,

--- a/src/Inspector/Settings/OutputSettings/OutputSettings.php
+++ b/src/Inspector/Settings/OutputSettings/OutputSettings.php
@@ -25,6 +25,7 @@ final class OutputSettings
         public string $output_format,
         public ?string $output_path = null,
         public string $rbt_timestamps = 'none',
+        public bool $rbt_compress = false,
     ) {
     }
 

--- a/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
@@ -55,6 +55,12 @@ final class OutputSettingsFromConsoleInput
                 'timestamp mode for rbt format: none (compact, default) or delta (with timestamps)',
                 'none',
             )
+            ->addOption(
+                'rbt-compress',
+                null,
+                InputOption::VALUE_NONE,
+                'Gzip-compress completed rbt segments (daemon per-worker mode)',
+            )
         ;
     }
 
@@ -91,10 +97,13 @@ final class OutputSettingsFromConsoleInput
         /** @var string $rbt_timestamps */
         $rbt_timestamps = $input->getOption('rbt-timestamps');
 
+        $rbt_compress = (bool)$input->getOption('rbt-compress');
+
         return new OutputSettings(
             $output_format,
             $output_path,
             $rbt_timestamps,
+            $rbt_compress,
         );
     }
 }

--- a/tests/Converter/BinaryTrace/CompressedSegmentTest.php
+++ b/tests/Converter/BinaryTrace/CompressedSegmentTest.php
@@ -183,11 +183,16 @@ final class CompressedSegmentTest extends BaseTestCase
 
     public function testFileRotationWithCompression(): void
     {
-        $streams = [];
-        $factory = function (int $index) use (&$streams) {
-            $s = fopen('php://memory', 'r+');
+        // Capture data written to each stream before the writer closes them
+        /** @var array<int, string> */
+        $captured = [];
+        $factory = function (int $index) use (&$captured) {
+            // Use a real temp file so data persists after fclose
+            $tmp = tempnam(sys_get_temp_dir(), "rbt_rot_test_{$index}_");
+            assert($tmp !== false);
+            $captured[$index] = $tmp;
+            $s = fopen($tmp, 'w+b');
             assert($s !== false);
-            $streams[$index] = $s;
             return $s;
         };
 
@@ -208,24 +213,26 @@ final class CompressedSegmentTest extends BaseTestCase
         $writer->writeTrace($trace, 100_000); // rotate
         $writer->finish();
 
-        // Each stream should contain gzip data
-        foreach ($streams as $index => $s) {
-            rewind($s);
-            $magic = fread($s, 2);
+        // Writer has closed all streams. Read from temp files.
+        $this->assertCount(3, $captured);
+        foreach ($captured as $index => $path) {
+            $data = file_get_contents($path);
+            $this->assertNotEmpty($data, "File {$index} should have data");
             $this->assertSame(
                 "\x1f\x8b",
-                $magic,
-                "Stream {$index} should start with gzip magic",
+                substr($data, 0, 2),
+                "File {$index} should start with gzip magic",
             );
 
-            // Each should be independently decompressible and readable
-            rewind($s);
+            // Each should be independently decompressible
+            $s = fopen($path, 'rb');
+            assert($s !== false);
             $decompressed = StreamDecompressor::decompressIfNeeded($s);
             $reader = new BinaryTraceReader();
             $results = iterator_to_array($reader->read($decompressed));
             fclose($decompressed);
             $this->assertGreaterThanOrEqual(1, count($results));
-            fclose($s);
+            unlink($path);
         }
     }
 
@@ -236,12 +243,15 @@ final class CompressedSegmentTest extends BaseTestCase
     public function testFileRotationCompressCallsFactoryPerSegment(): void
     {
         $factory_calls = [];
-        $streams = [];
-        $factory = function (int $index) use (&$factory_calls, &$streams) {
+        /** @var array<int, string> */
+        $paths = [];
+        $factory = function (int $index) use (&$factory_calls, &$paths) {
             $factory_calls[] = $index;
-            $s = fopen('php://memory', 'r+');
+            $tmp = tempnam(sys_get_temp_dir(), "rbt_fc_test_{$index}_");
+            assert($tmp !== false);
+            $paths[$index] = $tmp;
+            $s = fopen($tmp, 'w+b');
             assert($s !== false);
-            $streams[$index] = $s;
             return $s;
         };
 
@@ -260,69 +270,48 @@ final class CompressedSegmentTest extends BaseTestCase
             new ParsedCallFrame('func_b', '/b.php', 2),
         );
 
-        // Segment 0: t=0..29ms
         $writer->writeTrace($traceA, 0);
         $writer->writeTrace($traceA, 10_000);
-
-        // Segment 1: t=30..59ms (rotation)
-        $writer->writeTrace($traceB, 30_000);
+        $writer->writeTrace($traceB, 30_000);  // rotate
         $writer->writeTrace($traceB, 40_000);
-
-        // Segment 2: t=60ms+ (rotation)
-        $writer->writeTrace($traceA, 60_000);
-
+        $writer->writeTrace($traceA, 60_000);  // rotate
         $writer->finish();
 
-        // Factory should be called exactly 3 times (indices 0, 1, 2)
+        // Factory called exactly 3 times
         $this->assertSame([0, 1, 2], $factory_calls);
-        $this->assertCount(3, $streams);
+        $this->assertCount(3, $paths);
 
-        // Each stream should be independent gzip data
-        foreach ($streams as $index => $s) {
-            rewind($s);
-            $data = stream_get_contents($s);
-            $this->assertNotEmpty($data, "Stream {$index} should have data");
-
-            // Each should start with gzip magic
+        // Each file is independent gzip with valid rbt content
+        foreach ($paths as $index => $path) {
+            $data = file_get_contents($path);
+            $this->assertNotEmpty($data, "File {$index} should have data");
             $this->assertSame(
                 "\x1f\x8b",
                 substr($data, 0, 2),
-                "Stream {$index} should be gzip",
-            );
-
-            // Each should decompress independently to valid rbt
-            rewind($s);
-            $decompressed = StreamDecompressor::decompressIfNeeded($s);
-            $reader = new BinaryTraceReader();
-            $samples = iterator_to_array($reader->read($decompressed));
-            fclose($decompressed);
-
-            $this->assertGreaterThanOrEqual(
-                1,
-                count($samples),
-                "Stream {$index} should have samples",
+                "File {$index} should be gzip",
             );
         }
 
-        // Verify content: segment 0 has func_a, segment 1 has func_b
-        rewind($streams[0]);
-        $d0 = StreamDecompressor::decompressIfNeeded($streams[0]);
+        // Segment 0 → func_a, Segment 1 → func_b
+        $s0 = fopen($paths[0], 'rb');
+        assert($s0 !== false);
+        $d0 = StreamDecompressor::decompressIfNeeded($s0);
         $r0 = new BinaryTraceReader();
-        $s0 = iterator_to_array($r0->read($d0));
+        $samples0 = iterator_to_array($r0->read($d0));
         fclose($d0);
-        $this->assertSame(
-            'func_a',
-            $s0[0]->trace->call_frames[0]->function_name,
-        );
+        $this->assertSame('func_a', $samples0[0]->trace->call_frames[0]->function_name);
 
-        rewind($streams[1]);
-        $d1 = StreamDecompressor::decompressIfNeeded($streams[1]);
+        $s1 = fopen($paths[1], 'rb');
+        assert($s1 !== false);
+        $d1 = StreamDecompressor::decompressIfNeeded($s1);
         $r1 = new BinaryTraceReader();
-        $s1 = iterator_to_array($r1->read($d1));
+        $samples1 = iterator_to_array($r1->read($d1));
         fclose($d1);
-        $this->assertSame(
-            'func_b',
-            $s1[0]->trace->call_frames[0]->function_name,
-        );
+        $this->assertSame('func_b', $samples1[0]->trace->call_frames[0]->function_name);
+
+        // Cleanup
+        foreach ($paths as $path) {
+            @unlink($path);
+        }
     }
 }

--- a/tests/Converter/BinaryTrace/CompressedSegmentTest.php
+++ b/tests/Converter/BinaryTrace/CompressedSegmentTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter\BinaryTrace;
+
+use Reli\BaseTestCase;
+use Reli\Converter\ParsedCallFrame;
+use Reli\Converter\ParsedCallTrace;
+use Reli\Converter\StreamDecompressor;
+
+final class CompressedSegmentTest extends BaseTestCase
+{
+    public function testCompressedSegmentsProduceConcatenatedGzip(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new SegmentedBinaryTraceWriter(
+            stream: $stream,
+            sampling_period_us: 10000,
+            segment_duration_us: 50_000,
+            compress_completed_segments: true,
+        );
+
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('func', '/file.php', 1),
+        );
+
+        // Write samples across 2 segments
+        $writer->writeTrace($trace, 0);
+        $writer->writeTrace($trace, 30_000);
+        $writer->writeTrace($trace, 50_000);  // triggers rotation
+        $writer->writeTrace($trace, 80_000);
+        $writer->finish();
+
+        $size = ftell($stream);
+        $this->assertGreaterThan(0, $size);
+
+        // The output should start with gzip magic
+        rewind($stream);
+        $magic = fread($stream, 2);
+        $this->assertSame("\x1f\x8b", $magic);
+
+        // Decompress (handles concatenated gzip members)
+        rewind($stream);
+        $decompressed = StreamDecompressor::decompressIfNeeded($stream);
+        fclose($stream);
+
+        // Read the decompressed data as multi-segment rbt
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($decompressed));
+        fclose($decompressed);
+
+        $this->assertCount(4, $results);
+    }
+
+    public function testCompressedSegmentsReadableByConverters(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new SegmentedBinaryTraceWriter(
+            stream: $stream,
+            sampling_period_us: 10000,
+            segment_duration_us: 30_000,
+            compress_completed_segments: true,
+        );
+
+        $traceA = new ParsedCallTrace(
+            new ParsedCallFrame('func_a', '/a.php', 1),
+        );
+        $traceB = new ParsedCallTrace(
+            new ParsedCallFrame('func_b', '/b.php', 2),
+        );
+
+        $writer->writeTrace($traceA, 0);
+        $writer->writeTrace($traceA, 10_000);
+        $writer->writeTrace($traceB, 30_000); // rotate
+        $writer->writeTrace($traceB, 40_000);
+        $writer->finish();
+
+        rewind($stream);
+
+        // Use StreamDecompressor → BinaryTraceReader → FoldedStacksFormatter
+        $decompressed = StreamDecompressor::decompressIfNeeded($stream);
+        $reader = new BinaryTraceReader();
+        $formatter = new FoldedStacksFormatter();
+        $result = $formatter->format($reader->read($decompressed));
+        fclose($stream);
+        fclose($decompressed);
+
+        $this->assertStringContainsString('func_a', $result);
+        $this->assertStringContainsString('func_b', $result);
+    }
+
+    public function testUncompressedSegmentsStillWork(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        // compress_completed_segments=false (default)
+        $writer = new SegmentedBinaryTraceWriter(
+            stream: $stream,
+            sampling_period_us: 10000,
+            segment_duration_us: 50_000,
+        );
+
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('func', '/file.php', 1),
+        );
+
+        $writer->writeTrace($trace, 0);
+        $writer->writeTrace($trace, 50_000);
+        $writer->finish();
+
+        // Should start with RELI magic, not gzip magic
+        rewind($stream);
+        $magic = fread($stream, 4);
+        $this->assertSame('RELI', $magic);
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(2, $results);
+    }
+
+    public function testConcatenatedGzipVsRawSizeComparison(): void
+    {
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('App\\Service::process', '/app/Service.php', 42),
+            new ParsedCallFrame('main', '/app/index.php', 10),
+        );
+
+        // Raw (uncompressed)
+        $raw_stream = fopen('php://memory', 'r+');
+        assert($raw_stream !== false);
+        $raw_writer = new SegmentedBinaryTraceWriter(
+            stream: $raw_stream,
+            sampling_period_us: 10000,
+            segment_duration_us: 50_000,
+        );
+        for ($i = 0; $i < 100; $i++) {
+            $raw_writer->writeTrace($trace, $i * 10_000);
+        }
+        $raw_writer->finish();
+        $raw_size = ftell($raw_stream);
+        fclose($raw_stream);
+
+        // Compressed
+        $gz_stream = fopen('php://memory', 'r+');
+        assert($gz_stream !== false);
+        $gz_writer = new SegmentedBinaryTraceWriter(
+            stream: $gz_stream,
+            sampling_period_us: 10000,
+            segment_duration_us: 50_000,
+            compress_completed_segments: true,
+        );
+        for ($i = 0; $i < 100; $i++) {
+            $gz_writer->writeTrace($trace, $i * 10_000);
+        }
+        $gz_writer->finish();
+        $gz_size = ftell($gz_stream);
+        fclose($gz_stream);
+
+        $this->assertLessThan(
+            $raw_size,
+            $gz_size,
+            'Compressed segments should be smaller than raw',
+        );
+    }
+
+    public function testFileRotationWithCompression(): void
+    {
+        $streams = [];
+        $factory = function (int $index) use (&$streams) {
+            $s = fopen('php://memory', 'r+');
+            assert($s !== false);
+            $streams[$index] = $s;
+            return $s;
+        };
+
+        $writer = new SegmentedBinaryTraceWriter(
+            stream: null,
+            sampling_period_us: 10000,
+            segment_duration_us: 50_000,
+            stream_factory: $factory,
+            compress_completed_segments: true,
+        );
+
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('func', '/file.php', 1),
+        );
+
+        $writer->writeTrace($trace, 0);
+        $writer->writeTrace($trace, 50_000); // rotate
+        $writer->writeTrace($trace, 100_000); // rotate
+        $writer->finish();
+
+        // Each stream should contain gzip data
+        foreach ($streams as $index => $s) {
+            rewind($s);
+            $magic = fread($s, 2);
+            $this->assertSame(
+                "\x1f\x8b",
+                $magic,
+                "Stream {$index} should start with gzip magic",
+            );
+
+            // Each should be independently decompressible and readable
+            rewind($s);
+            $decompressed = StreamDecompressor::decompressIfNeeded($s);
+            $reader = new BinaryTraceReader();
+            $results = iterator_to_array($reader->read($decompressed));
+            fclose($decompressed);
+            $this->assertGreaterThanOrEqual(1, count($results));
+            fclose($s);
+        }
+    }
+}

--- a/tests/Converter/BinaryTrace/CompressedSegmentTest.php
+++ b/tests/Converter/BinaryTrace/CompressedSegmentTest.php
@@ -228,4 +228,101 @@ final class CompressedSegmentTest extends BaseTestCase
             fclose($s);
         }
     }
+
+    /**
+     * Verify that compress + file rotation creates separate streams per segment
+     * and the factory is called the expected number of times.
+     */
+    public function testFileRotationCompressCallsFactoryPerSegment(): void
+    {
+        $factory_calls = [];
+        $streams = [];
+        $factory = function (int $index) use (&$factory_calls, &$streams) {
+            $factory_calls[] = $index;
+            $s = fopen('php://memory', 'r+');
+            assert($s !== false);
+            $streams[$index] = $s;
+            return $s;
+        };
+
+        $writer = new SegmentedBinaryTraceWriter(
+            stream: null,
+            sampling_period_us: 10000,
+            segment_duration_us: 30_000,
+            stream_factory: $factory,
+            compress_completed_segments: true,
+        );
+
+        $traceA = new ParsedCallTrace(
+            new ParsedCallFrame('func_a', '/a.php', 1),
+        );
+        $traceB = new ParsedCallTrace(
+            new ParsedCallFrame('func_b', '/b.php', 2),
+        );
+
+        // Segment 0: t=0..29ms
+        $writer->writeTrace($traceA, 0);
+        $writer->writeTrace($traceA, 10_000);
+
+        // Segment 1: t=30..59ms (rotation)
+        $writer->writeTrace($traceB, 30_000);
+        $writer->writeTrace($traceB, 40_000);
+
+        // Segment 2: t=60ms+ (rotation)
+        $writer->writeTrace($traceA, 60_000);
+
+        $writer->finish();
+
+        // Factory should be called exactly 3 times (indices 0, 1, 2)
+        $this->assertSame([0, 1, 2], $factory_calls);
+        $this->assertCount(3, $streams);
+
+        // Each stream should be independent gzip data
+        foreach ($streams as $index => $s) {
+            rewind($s);
+            $data = stream_get_contents($s);
+            $this->assertNotEmpty($data, "Stream {$index} should have data");
+
+            // Each should start with gzip magic
+            $this->assertSame(
+                "\x1f\x8b",
+                substr($data, 0, 2),
+                "Stream {$index} should be gzip",
+            );
+
+            // Each should decompress independently to valid rbt
+            rewind($s);
+            $decompressed = StreamDecompressor::decompressIfNeeded($s);
+            $reader = new BinaryTraceReader();
+            $samples = iterator_to_array($reader->read($decompressed));
+            fclose($decompressed);
+
+            $this->assertGreaterThanOrEqual(
+                1,
+                count($samples),
+                "Stream {$index} should have samples",
+            );
+        }
+
+        // Verify content: segment 0 has func_a, segment 1 has func_b
+        rewind($streams[0]);
+        $d0 = StreamDecompressor::decompressIfNeeded($streams[0]);
+        $r0 = new BinaryTraceReader();
+        $s0 = iterator_to_array($r0->read($d0));
+        fclose($d0);
+        $this->assertSame(
+            'func_a',
+            $s0[0]->trace->call_frames[0]->function_name,
+        );
+
+        rewind($streams[1]);
+        $d1 = StreamDecompressor::decompressIfNeeded($streams[1]);
+        $r1 = new BinaryTraceReader();
+        $s1 = iterator_to_array($r1->read($d1));
+        fclose($d1);
+        $this->assertSame(
+            'func_b',
+            $s1[0]->trace->call_frames[0]->function_name,
+        );
+    }
 }

--- a/tests/Converter/BinaryTrace/SegmentedBinaryTraceWriterTest.php
+++ b/tests/Converter/BinaryTrace/SegmentedBinaryTraceWriterTest.php
@@ -129,11 +129,14 @@ final class SegmentedBinaryTraceWriterTest extends BaseTestCase
 
     public function testFileRotationMode(): void
     {
-        $streams = [];
-        $factory = function (int $index) use (&$streams) {
-            $stream = fopen('php://memory', 'r+');
+        /** @var array<int, string> */
+        $paths = [];
+        $factory = function (int $index) use (&$paths) {
+            $tmp = tempnam(sys_get_temp_dir(), "rbt_rot_{$index}_");
+            assert($tmp !== false);
+            $paths[$index] = $tmp;
+            $stream = fopen($tmp, 'w+b');
             assert($stream !== false);
-            $streams[$index] = $stream;
             return $stream;
         };
 
@@ -153,16 +156,18 @@ final class SegmentedBinaryTraceWriterTest extends BaseTestCase
         $writer->writeTrace($trace, 100_000); // triggers rotation
         $writer->finish();
 
-        // Should have created 3 streams (segments 0, 1, 2)
-        $this->assertCount(3, $streams);
+        // Should have created 3 files (segments 0, 1, 2)
+        $this->assertCount(3, $paths);
 
-        // Each stream should be independently readable
+        // Each file should be independently readable
         $reader = new BinaryTraceReader();
-        foreach ($streams as $index => $stream) {
-            rewind($stream);
+        foreach ($paths as $index => $path) {
+            $stream = fopen($path, 'rb');
+            assert($stream !== false);
             $results = iterator_to_array($reader->read($stream));
-            $this->assertGreaterThanOrEqual(1, count($results), "Segment {$index} should have samples");
             fclose($stream);
+            $this->assertGreaterThanOrEqual(1, count($results), "Segment {$index} should have samples");
+            unlink($path);
         }
     }
 

--- a/tests/Converter/GzipTransparencyTest.php
+++ b/tests/Converter/GzipTransparencyTest.php
@@ -54,7 +54,7 @@ final class GzipTransparencyTest extends BaseTestCase
 
         $decompressed = StreamDecompressor::decompressIfNeeded($stream);
         $content = stream_get_contents($decompressed);
-        fclose($stream);
+        // For raw seekable input, decompressed IS the original stream (no copy)
         fclose($decompressed);
 
         $this->assertSame($raw, $content);
@@ -239,7 +239,6 @@ final class GzipTransparencyTest extends BaseTestCase
         $result = StreamDecompressor::decompressIfNeeded($stream);
         rewind($result);
         $content = stream_get_contents($result);
-        fclose($stream);
         fclose($result);
 
         $this->assertStringStartsWith('0 func', $content);

--- a/tests/Converter/GzipTransparencyTest.php
+++ b/tests/Converter/GzipTransparencyTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+use Reli\BaseTestCase;
+use Reli\Converter\BinaryTrace\BinaryTraceException;
+use Reli\Converter\BinaryTrace\BinaryTraceReader;
+use Reli\Converter\BinaryTrace\BinaryTraceWriter;
+use Reli\Converter\BinaryTrace\FoldedStacksFormatter;
+use Reli\Converter\BinaryTrace\PprofEncoder;
+
+final class GzipTransparencyTest extends BaseTestCase
+{
+    private function createRbtData(): string
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $writer->writeHeader();
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('App\\Controller::index', '/app/Controller.php', 42),
+            new ParsedCallFrame('main', '/app/index.php', 10),
+        );
+        $writer->writeTrace($trace);
+        $writer->writeTrace($trace);
+        $writer->writeTrace($trace);
+        $writer->writeCheckpoint();
+        $writer->writeSegmentEnd();
+        rewind($stream);
+        $data = stream_get_contents($stream);
+        fclose($stream);
+        assert($data !== false);
+        return $data;
+    }
+
+    public function testDecompressRawRbt(): void
+    {
+        $raw = $this->createRbtData();
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $raw);
+        rewind($stream);
+
+        $decompressed = StreamDecompressor::decompressIfNeeded($stream);
+        $content = stream_get_contents($decompressed);
+        fclose($stream);
+        fclose($decompressed);
+
+        $this->assertSame($raw, $content);
+    }
+
+    public function testDecompressGzippedRbt(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $decompressed = StreamDecompressor::decompressIfNeeded($stream);
+        $content = stream_get_contents($decompressed);
+        fclose($stream);
+        fclose($decompressed);
+
+        $this->assertSame($raw, $content);
+    }
+
+    public function testTraceInputReaderReadsGzippedRbt(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(3, $results);
+        $this->assertSame(
+            'App\\Controller::index',
+            $results[0]->call_frames[0]->function_name,
+        );
+    }
+
+    public function testTraceInputReaderReadsRawRbt(): void
+    {
+        $raw = $this->createRbtData();
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $raw);
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(3, $results);
+    }
+
+    public function testGzippedRbtToFolded(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $formatter = new FoldedStacksFormatter();
+        $result = $formatter->format($reader->read($stream));
+        fclose($stream);
+
+        $this->assertStringContainsString('App\\Controller::index', $result);
+        $this->assertStringContainsString(' 3', $result);
+    }
+
+    public function testGzippedRbtToPprof(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $encoder = new PprofEncoder();
+        $data = $encoder->encode($reader->read($stream));
+        fclose($stream);
+
+        $this->assertNotEmpty($data);
+    }
+
+    public function testGzippedRbtRecovery(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $decompressed = StreamDecompressor::decompressIfNeeded($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->readWithRecovery($decompressed));
+        fclose($stream);
+        fclose($decompressed);
+
+        $this->assertCount(3, $results);
+    }
+
+    public function testRawAndGzipDecodeResultsMatch(): void
+    {
+        $raw = $this->createRbtData();
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+
+        // Read raw
+        $stream_raw = fopen('php://memory', 'r+');
+        assert($stream_raw !== false);
+        fwrite($stream_raw, $raw);
+        rewind($stream_raw);
+        $reader_raw = new TraceInputReader();
+        $results_raw = iterator_to_array($reader_raw->read($stream_raw));
+        fclose($stream_raw);
+
+        // Read gzipped
+        $stream_gz = fopen('php://memory', 'r+');
+        assert($stream_gz !== false);
+        fwrite($stream_gz, $compressed);
+        rewind($stream_gz);
+        $reader_gz = new TraceInputReader();
+        $results_gz = iterator_to_array($reader_gz->read($stream_gz));
+        fclose($stream_gz);
+
+        $this->assertCount(count($results_raw), $results_gz);
+        foreach ($results_raw as $i => $raw_trace) {
+            $gz_trace = $results_gz[$i];
+            $this->assertSame(
+                count($raw_trace->call_frames),
+                count($gz_trace->call_frames),
+            );
+            foreach ($raw_trace->call_frames as $j => $raw_frame) {
+                $gz_frame = $gz_trace->call_frames[$j];
+                $this->assertSame($raw_frame->function_name, $gz_frame->function_name);
+                $this->assertSame($raw_frame->file_name, $gz_frame->file_name);
+                $this->assertSame($raw_frame->lineno, $gz_frame->lineno);
+            }
+        }
+    }
+
+    public function testCorruptGzipThrows(): void
+    {
+        // Valid gzip magic but corrupt data
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, "\x1f\x8b\x08\x00corrupt_garbage_data");
+        rewind($stream);
+
+        $this->expectException(BinaryTraceException::class);
+        $this->expectExceptionMessage('Failed to decompress gzip input');
+        StreamDecompressor::decompressIfNeeded($stream);
+    }
+
+    public function testGzipMagicDetection(): void
+    {
+        // Not gzip — phpspy text starting with '0'
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, "0 func /file.php:1\n\n");
+        rewind($stream);
+
+        $result = StreamDecompressor::decompressIfNeeded($stream);
+        rewind($result);
+        $content = stream_get_contents($result);
+        fclose($stream);
+        fclose($result);
+
+        $this->assertStringStartsWith('0 func', $content);
+    }
+}

--- a/tests/Converter/TraceInputReaderTest.php
+++ b/tests/Converter/TraceInputReaderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+use Reli\BaseTestCase;
+use Reli\Converter\BinaryTrace\BinaryTraceWriter;
+
+final class TraceInputReaderTest extends BaseTestCase
+{
+    public function testReadPhpspyText(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, "0 func /file.php:1\n1 main /index.php:5\n\n");
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('func', $results[0]->call_frames[0]->function_name);
+        $this->assertSame('main', $results[0]->call_frames[1]->function_name);
+        $this->assertNull($reader->getBinaryReader());
+    }
+
+    public function testReadRbt(): void
+    {
+        $rbt_stream = fopen('php://memory', 'r+');
+        assert($rbt_stream !== false);
+        $writer = new BinaryTraceWriter($rbt_stream, 10000);
+        $writer->writeHeader();
+        $writer->writeTrace(new ParsedCallTrace(
+            new ParsedCallFrame('func', '/file.php', 1),
+        ));
+        $writer->writeSegmentEnd();
+        rewind($rbt_stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($rbt_stream));
+        fclose($rbt_stream);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('func', $results[0]->call_frames[0]->function_name);
+        $this->assertNotNull($reader->getBinaryReader());
+    }
+
+    public function testReadGzippedRbt(): void
+    {
+        // Create raw rbt
+        $raw_stream = fopen('php://memory', 'r+');
+        assert($raw_stream !== false);
+        $writer = new BinaryTraceWriter($raw_stream, 10000);
+        $writer->writeHeader();
+        $writer->writeTrace(new ParsedCallTrace(
+            new ParsedCallFrame('func', '/file.php', 1),
+        ));
+        $writer->writeSegmentEnd();
+        rewind($raw_stream);
+        $raw = stream_get_contents($raw_stream);
+        fclose($raw_stream);
+        assert($raw !== false);
+
+        // Gzip it
+        $compressed = gzencode($raw);
+        assert($compressed !== false);
+        $gz_stream = fopen('php://memory', 'r+');
+        assert($gz_stream !== false);
+        fwrite($gz_stream, $compressed);
+        rewind($gz_stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($gz_stream));
+        fclose($gz_stream);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('func', $results[0]->call_frames[0]->function_name);
+    }
+
+    public function testReadGzippedPhpspyText(): void
+    {
+        $text = "0 func /file.php:1\n1 main /index.php:5\n\n";
+        $compressed = gzencode($text);
+        assert($compressed !== false);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $compressed);
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('func', $results[0]->call_frames[0]->function_name);
+    }
+
+    public function testReadEmptyStream(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testReadTooShortStream(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, 'ab'); // 2 bytes — not gzip, not enough for magic
+        rewind($stream);
+
+        $reader = new TraceInputReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(0, $results);
+    }
+}

--- a/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
+++ b/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\TraceOutput;
+
+use Reli\BaseTestCase;
+use Reli\Converter\BinaryTrace\BinaryTraceReader;
+use Reli\Converter\BinaryTrace\BinaryTraceWriter;
+use Reli\Converter\StreamDecompressor;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
+use Reli\Lib\PhpProcessReader\CallTraceReader\MergedCallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\MergedCallTrace;
+use Reli\Lib\PhpProcessReader\CallTraceReader\NativeCallFrame;
+
+final class BinaryTraceOutputTest extends BaseTestCase
+{
+    public function testBasicOutput(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $trace = new CallTrace(
+            new CallFrame('App', 'run', '/app.php', null),
+        );
+        $output->output($trace);
+        $output->output($trace);
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(2, $results);
+        $this->assertSame('App::run', $results[0]->trace->call_frames[0]->function_name);
+    }
+
+    public function testFinishWithNoSamplesIsNoop(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        // Never call output(), so header_written = false
+        $output->finish();
+
+        // Stream should be empty (no header, no events)
+        $this->assertSame(0, ftell($stream));
+        fclose($stream);
+    }
+
+    public function testFinishWithCompressProducesGzip(): void
+    {
+        $buffer = fopen('php://temp', 'r+');
+        assert($buffer !== false);
+        $dest = fopen('php://memory', 'r+');
+        assert($dest !== false);
+
+        $writer = new BinaryTraceWriter($buffer, 10000);
+        $output = new BinaryTraceOutput(
+            $writer,
+            write_buffer: $buffer,
+            compress_to: $dest,
+        );
+
+        $trace = new CallTrace(
+            new CallFrame('', 'main', '/index.php', null),
+        );
+        $output->output($trace);
+        $output->output($trace);
+        $output->output($trace);
+        $output->finish();
+
+        // dest should contain gzip data
+        rewind($dest);
+        $magic = fread($dest, 2);
+        $this->assertSame("\x1f\x8b", $magic);
+
+        // Decompress and verify
+        rewind($dest);
+        $decompressed = StreamDecompressor::decompressIfNeeded($dest);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($decompressed));
+        fclose($decompressed);
+        fclose($dest);
+
+        $this->assertCount(3, $results);
+        $this->assertSame('main', $results[0]->trace->call_frames[0]->function_name);
+    }
+
+    public function testFinishCompressWithNoSamplesDoesNotWriteGzip(): void
+    {
+        $buffer = fopen('php://temp', 'r+');
+        assert($buffer !== false);
+        $dest = fopen('php://memory', 'r+');
+        assert($dest !== false);
+
+        $writer = new BinaryTraceWriter($buffer, 10000);
+        $output = new BinaryTraceOutput(
+            $writer,
+            write_buffer: $buffer,
+            compress_to: $dest,
+        );
+
+        $output->finish();
+
+        // dest should be empty — no gzip output when no samples
+        $this->assertSame(0, ftell($dest));
+        fclose($dest);
+    }
+
+    public function testOutputMergedWithNativeFrames(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $merged = new MergedCallTrace(
+            MergedCallFrame::fromNative(
+                new NativeCallFrame('zend_execute', 'libphp.so', 0x42, 0x7f00),
+            ),
+            MergedCallFrame::fromPhp(
+                new CallFrame('App', 'run', '/app.php', null),
+            ),
+        );
+        $output->outputMerged($merged);
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        $frames = $results[0]->trace->call_frames;
+        $this->assertCount(2, $frames);
+        $this->assertTrue($frames[0]->isNative());
+        $this->assertSame('zend_execute', $frames[0]->function_name);
+        $this->assertFalse($frames[1]->isNative());
+        $this->assertSame('App::run', $frames[1]->function_name);
+    }
+
+    public function testCheckpointInterval(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        // Very low checkpoint interval to trigger it
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer, checkpoint_interval: 2);
+
+        $trace = new CallTrace(
+            new CallFrame('', 'func', '/file.php', null),
+        );
+        $output->output($trace);
+        $output->output($trace); // triggers checkpoint
+        $output->output($trace);
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(3, $results);
+    }
+}

--- a/tests/Inspector/Output/TraceOutput/TraceOutputFactoryTest.php
+++ b/tests/Inspector/Output/TraceOutput/TraceOutputFactoryTest.php
@@ -102,4 +102,65 @@ class TraceOutputFactoryTest extends BaseTestCase
         fseek($buffer, 0);
         $this->assertSame('formatted', fread($buffer, 4096));
     }
+
+    public function testFromSettingsCreatesRbtOutput()
+    {
+        $buffer = fopen('php://memory', 'r+');
+        assert($buffer !== false);
+
+        $trace_formatter_factory = \Mockery::mock(TraceFormatterFactory::class);
+        $trace_output_factory = new TraceOutputFactory($trace_formatter_factory, $buffer);
+
+        $output_settings = new OutputSettings('rbt');
+        $loop_settings = new \Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings(
+            10_000_000,
+            'q',
+            10,
+            false,
+        );
+
+        $trace_output = $trace_output_factory->fromSettingsAndConsoleOutput(
+            new StreamOutput(fopen('php://memory', 'w')),
+            $output_settings,
+            $loop_settings,
+        );
+
+        $this->assertInstanceOf(BinaryTraceOutput::class, $trace_output);
+    }
+
+    public function testFromSettingsCreatesCompressedRbtOutput()
+    {
+        $buffer = fopen('php://memory', 'r+');
+        assert($buffer !== false);
+
+        $trace_formatter_factory = \Mockery::mock(TraceFormatterFactory::class);
+        $trace_output_factory = new TraceOutputFactory($trace_formatter_factory, $buffer);
+
+        $output_settings = new OutputSettings('rbt', rbt_compress: true);
+        $loop_settings = new \Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings(
+            10_000_000,
+            'q',
+            10,
+            false,
+        );
+
+        $trace_output = $trace_output_factory->fromSettingsAndConsoleOutput(
+            new StreamOutput(fopen('php://memory', 'w')),
+            $output_settings,
+            $loop_settings,
+        );
+
+        $this->assertInstanceOf(BinaryTraceOutput::class, $trace_output);
+
+        // Write a trace and finish — should produce gzip in the buffer
+        $test_trace = new CallTrace(
+            new CallFrame('', 'func', '/file.php', null)
+        );
+        $trace_output->output($test_trace);
+        $trace_output->finish();
+
+        fseek($buffer, 0);
+        $magic = fread($buffer, 2);
+        $this->assertSame("\x1f\x8b", $magic, 'Output should be gzip');
+    }
 }

--- a/tests/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInputTest.php
@@ -27,6 +27,7 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('template')->andReturns(null);
         $input->expects()->getOption('output')->andReturns(null);
         $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
         $config = Mockery::mock(Config::class);
 
         $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
@@ -41,6 +42,7 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('template')->andReturns('test');
         $input->expects()->getOption('output')->andReturns(null);
         $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
         $config = Mockery::mock(Config::class);
 
         $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
@@ -55,6 +57,7 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $input->expects()->getOption('template')->andReturns(null);
         $input->allows()->getOption('output')->andReturns(null);
         $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
         $config = Mockery::mock(Config::class);
         $config->expects()->get('output.template.default')->andReturns('test');
 
@@ -95,6 +98,7 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('template')->andReturns(null);
         $input->expects()->getOption('output')->andReturns(null);
         $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
         $config = Mockery::mock(Config::class);
 
         $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
@@ -109,6 +113,7 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $input->allows()->getOption('template')->andReturns(null);
         $input->expects()->getOption('output')->andReturns(null);
         $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
         $config = Mockery::mock(Config::class);
 
         $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);


### PR DESCRIPTION
## Summary

Add transparent gzip read/write support for `.rbt` files, including per-segment compression for daemon long-run use.

### Reading (transparent)

All reader paths auto-detect gzip by checking for the gzip magic (`0x1f 0x8b`). Both raw `.rbt` and `.rbt.gz` work identically:

```bash
reli converter:folded < trace.rbt
reli converter:folded < trace.rbt.gz
```

`StreamDecompressor` handles concatenated gzip members (RFC 1952) using `gzopen`/`gzread`, so files produced by `--rbt-compress` are correctly decompressed.

### Writing

**Offline**: `converter:rbt --compress` produces gzip-compressed output.

**Daemon per-segment compression** (`--rbt-compress`): each completed segment is gzip-compressed and appended to a single `.rbt.gz` per worker. No raw data touches disk.

```bash
# Raw per-worker files (default, recovery/tail friendly)
reli inspector:daemon -F rbt -o /path/to/dir/

# Compressed per-worker files (space efficient)
reli inspector:daemon -F rbt --rbt-compress -o /path/to/dir/
# Produces worker_{pid}.rbt.gz with concatenated gzip members
```

### Design

- `.rbt` format itself is unchanged — gzip is an external compression layer
- Raw `.rbt` remains default for live capture (append-only, crash recovery, tail)
- `.rbt.gz` for archival, transfer, Pyroscope upload
- Concatenated gzip members are RFC 1952 compliant

## Test plan

- [x] Raw `.rbt` reads unchanged
- [x] Gzip-compressed `.rbt.gz` reads transparently
- [x] Concatenated gzip members (multi-segment) decompress correctly
- [x] Raw and gzip decode results match
- [x] `.rbt.gz` → folded / pprof / recover all work
- [x] Corrupt gzip produces clear error
- [x] Gzip magic detection vs raw/phpspy input
- [x] `--rbt-compress` produces concatenated gzip segments
- [x] File rotation + compress produces per-file `.rbt.gz`
- [x] Compressed < raw size
- [x] Uncompressed segments unchanged
- [x] phpcs clean, psalm 0 errors

https://claude.ai/code/session_01XfkhCa5wgNKPC4CdPJWjy5