### PR TITLE
Add CPU usage trigger and lifecycle actions to watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Options:
 ./reli inspector:watch --target-regex="php-fpm" --memory-usage=512M --action=log
 
 # Watch for a specific function in the call stack
-./reli inspector:watch -p <pid> --watch-function="App\Service::process" --action=trace
+./reli inspector:watch -p <pid> --watch-function="App\Service::process" --action=trace-once
 
 # Monitor a PHP variable
 ./reli inspector:watch -p <pid> --watch-var='global::$cache:count_gt:10000'

--- a/docs/internals/watch-command-architecture.md
+++ b/docs/internals/watch-command-architecture.md
@@ -23,13 +23,18 @@ WatchCommand::execute()
   └── LoopBuilder middleware chain:
        ├── HeapStatsReader::read()              (always, Tier 1)
        ├── RssReader::read()                    (if RssUsageTrigger)
-       ├── CallTraceReader::readCallTrace()     (if Tier 2 trigger)
+       ├── CpuUsageReader::read()               (if CpuUsageTrigger)
+       ├── CallTraceReader::readCallTrace()     (if Tier 2 trigger OR tracing)
        ├── HeapStatsReader::hasException()      (if ExceptionDetectionTrigger)
        ├── VariableReader::readVariables()      (if VariableValueTrigger)
        ├── WatchContext construction
+       ├── TraceSession::recordSample()         (if tracing active)
+       ├── TriggerStateTracker phase detection
+       ├── on-enter / on-exit action execution
        ├── Trigger evaluation → merged TriggerEvent
        ├── CooldownManager check
-       └── Action execution (once per poll, not per trigger)
+       ├── Regular action execution (once per poll, not per trigger)
+       └── Dynamic sleep (poll_interval or trace_interval)
 ```
 
 ### Daemon Mode
@@ -57,12 +62,22 @@ WatchCommand::executeDaemonMode()
 
 | Tier | What's Read | Cost | Triggers |
 |------|-------------|------|----------|
-| 1 | ZendMmHeap stats only | < 1ms | MemoryLimit, GrowthRate, PeakWatch, RssUsage |
+| 1 | ZendMmHeap stats only | < 1ms | MemoryLimit, GrowthRate, PeakWatch, RssUsage, CpuUsage |
 | 2 | + Call trace | ~ms | FunctionDetection, TraceDepth |
 | 3 | + EG exception, variables | ~10ms | ExceptionDetection, VariableValue |
 
-Only reads what the active triggers require. `needs_call_trace` and
-`needs_exception_check` are computed at startup from trigger types.
+Only reads what the active triggers require. `needs_call_trace`,
+`needs_cpu`, and `needs_exception_check` are computed at startup
+from trigger types.
+
+### CpuUsageTrigger
+
+Reads `/proc/[pid]/stat` utime+stime fields. Computes delta CPU% between
+polls using `SC_CLK_TCK`. First poll always returns null (needs two samples).
+
+Supports hysteresis (separate enter/exit thresholds) and sustain duration
+(must stay above threshold for N seconds before entering). Internal state
+machine: INACTIVE → (cpu >= enter for sustain_s) → ACTIVE → (cpu < exit) → INACTIVE.
 
 ### Event Merging
 
@@ -161,14 +176,60 @@ root name + list of `['[]', key]` or `['->', prop]` segments.
    `frameMatchesFunction()` with strict exact match on
    `ZendFunction::getFullyQualifiedFunctionName()`.
 
+## Trigger State Tracking (on-enter / on-exit)
+
+`TriggerStateTracker` wraps trigger evaluation to detect state transitions:
+
+```
+TriggerPhase (enum):
+  ENTER   — was inactive, now active   → execute --on-enter actions
+  EXIT    — was active, now inactive   → execute --on-exit actions
+  ACTIVE  — still active               → execute --action with cooldown
+  null    — still inactive             → no action
+
+Poll loop:
+  for each trigger:
+    event = trigger.evaluate(context)
+    phase = state_tracker.update(trigger.name, event !== null)
+    ENTER  → on-enter actions (once, no cooldown)
+    EXIT   → on-exit actions (once) + cooldown.recordClear
+    ACTIVE → regular --action (with cooldown)
+```
+
+This preserves full backward compatibility. Without `--on-enter`/`--on-exit`,
+the existing `--action` behavior is unchanged.
+
+### Continuous Tracing (TraceSession)
+
+`TraceSession` manages the lifecycle of `.rbt` trace recording:
+
+```
+ContinuousTraceAction (on-enter) → TraceSession.start()
+Poll loop: if session.isActive() → session.recordSample(call_trace)
+StopTraceAction (on-exit) → TraceSession.stop() → finalize .rbt
+```
+
+**Dynamic poll interval:** When trace session is active, the poll loop
+switches from `--poll-interval` (default 1s) to `--trace-interval`
+(default 10ms) for higher sampling resolution.
+
+**Interaction with other actions:** The watch monitoring loop continues
+normally during tracing. Other triggers evaluate at the same frequency.
+Memory dumps (which ptrace-stop the target) naturally pause tracing.
+
+**Daemon mode:** Continuous tracing is single-process mode only (v1).
+One-shot `trace-once` and lifecycle actions (log, exec) work in daemon mode.
+
 ## Action System
 
-| Action | Single-Process | Daemon |
-|--------|---------------|--------|
-| trace | TraceAction (reads or reuses from context) | DaemonTraceAction (from WatchTriggerMessage) |
-| log | LogAction (stderr or file) | LogAction (same) |
-| exec | ExecAction (fire-and-forget, /dev/null) | ExecAction (same) |
-| memory-dump | MemoryDumpAction (MemoryDumper) | DaemonMemoryDumpAction (MemoryDumper + WatchContext addresses) |
+| Action | Type | Single-Process | Daemon |
+|--------|------|---------------|--------|
+| trace-once | one-shot | TraceAction (reads or reuses from context) | DaemonTraceAction (from WatchTriggerMessage) |
+| trace | stateful | ContinuousTraceAction → TraceSession.start() | not supported (v1) |
+| stop-trace | stateful | StopTraceAction → TraceSession.stop() | not supported (v1) |
+| log | one-shot | LogAction (stderr or file) | LogAction (same) |
+| exec | one-shot | ExecAction (fire-and-forget, /dev/null) | ExecAction (same) |
+| memory-dump | one-shot | MemoryDumpAction (MemoryDumper) | DaemonMemoryDumpAction (MemoryDumper + WatchContext addresses) |
 
 ### MemoryDumper
 

--- a/docs/internals/watch-command-architecture.md
+++ b/docs/internals/watch-command-architecture.md
@@ -217,16 +217,22 @@ switches from `--poll-interval` (default 1s) to `--trace-interval`
 normally during tracing. Other triggers evaluate at the same frequency.
 Memory dumps (which ptrace-stop the target) naturally pause tracing.
 
-**Daemon mode:** Continuous tracing is single-process mode only (v1).
-One-shot `trace-once` and lifecycle actions (log, exec) work in daemon mode.
+**CPU sampling window stability:** CpuUsageReader uses a minimum 0.5s
+sampling window regardless of poll frequency. When tracing at 10ms, the
+CPU% is still averaged over 0.5s, preventing noisy exit transitions.
+
+**Daemon mode:** Each worker manages its own TraceSession locally.
+Workers detect trigger state transitions via TriggerStateTracker and
+start/stop traces autonomously. `WatchTraceNotifyMessage` notifies the
+controller for logging purposes; no trace data flows through the channel.
 
 ## Action System
 
 | Action | Type | Single-Process | Daemon |
 |--------|------|---------------|--------|
 | trace-once | one-shot | TraceAction (reads or reuses from context) | DaemonTraceAction (from WatchTriggerMessage) |
-| trace | stateful | ContinuousTraceAction → TraceSession.start() | not supported (v1) |
-| stop-trace | stateful | StopTraceAction → TraceSession.stop() | not supported (v1) |
+| trace | stateful | ContinuousTraceAction → TraceSession.start() | Worker-local TraceSession |
+| stop-trace | stateful | StopTraceAction → TraceSession.stop() | Worker-local TraceSession.stop() |
 | log | one-shot | LogAction (stderr or file) | LogAction (same) |
 | exec | one-shot | ExecAction (fire-and-forget, /dev/null) | ExecAction (same) |
 | memory-dump | one-shot | MemoryDumpAction (MemoryDumper) | DaemonMemoryDumpAction (MemoryDumper + WatchContext addresses) |
@@ -260,19 +266,26 @@ the restart-resilient mechanisms instead.
 Controller                          Worker (subprocess)
 ─────────                           ──────
 sendSettings(WatchSettings)    →    receiveSettings()
-                                      ↓ build triggers + cooldown
+                                      ↓ build triggers + cooldown + state tracker
 sendAttach(WatchTargetDescriptor) → receiveAttach()
                                       ↓ poll loop:
                                       │  HeapStatsReader.read()
-                                      │  CallTraceReader (if needed)
-                                      │  hasException() (if needed)
+                                      │  CpuUsageReader.read() (if needed)
+                                      │  CallTraceReader (if needed OR tracing)
                                       │  readVariables() (if needed)
-                                      │  trigger.evaluate()
+                                      │  TraceSession.recordSample() (if tracing)
+                                      │  trigger.evaluate() + state tracking
+                                      │  on ENTER: TraceSession.start()
+receiveMessage()               ←       sendTraceNotify(STARTED)
+                                      │  on EXIT: TraceSession.stop()
+receiveMessage()               ←       sendTraceNotify(STOPPED)
                                       │  cooldown check
                                       │  if fired:
-receiveTriggerOrDetach()       ←       sendTrigger(WatchTriggerMessage)
+receiveMessage()               ←       sendTrigger(WatchTriggerMessage)
+                                      │  dynamic sleep (trace/poll interval)
                                       ↓ on process exit:
-receiveTriggerOrDetach()       ←       sendDetach(WatchDetachMessage)
+                                      │  TraceSession.stop() if active
+receiveMessage()               ←       sendDetach(WatchDetachMessage)
 ```
 
 Worker handles per-process cooldown/backoff internally.

--- a/docs/internals/watch-command-architecture.md
+++ b/docs/internals/watch-command-architecture.md
@@ -223,8 +223,9 @@ CPU% is still averaged over 0.5s, preventing noisy exit transitions.
 
 **Daemon mode:** Each worker manages its own TraceSession locally.
 Workers detect trigger state transitions via TriggerStateTracker and
-start/stop traces autonomously. `WatchTraceNotifyMessage` notifies the
-controller for logging purposes; no trace data flows through the channel.
+start/stop traces autonomously. Two messages flow on EXIT:
+`WatchTraceNotifyMessage` (trace lifecycle) and `WatchTriggerExitMessage`
+(on-exit one-shot actions). No trace sample data flows through the channel.
 
 ## Action System
 
@@ -275,21 +276,48 @@ sendAttach(WatchTargetDescriptor) → receiveAttach()
                                       │  readVariables() (if needed)
                                       │  TraceSession.recordSample() (if tracing)
                                       │  trigger.evaluate() + state tracking
-                                      │  on ENTER: TraceSession.start()
+                                      │
+                                      │  on ENTER:
+                                      │    TraceSession.start() (if continuous trace)
 receiveMessage()               ←       sendTraceNotify(STARTED)
-                                      │  on EXIT: TraceSession.stop()
+                                      │
+                                      │  on EXIT:
+                                      │    TraceSession.stop() (if tracing)
 receiveMessage()               ←       sendTraceNotify(STOPPED)
-                                      │  cooldown check
-                                      │  if fired:
+receiveMessage()               ←       sendTriggerExit(WatchTriggerExitMessage)
+  → on-exit actions (log, exec)       │
+                                      │  while ACTIVE (cooldown check):
 receiveMessage()               ←       sendTrigger(WatchTriggerMessage)
+  → on-enter actions (1st time)       │
+  → regular actions                   │
                                       │  dynamic sleep (trace/poll interval)
                                       ↓ on process exit:
                                       │  TraceSession.stop() if active
 receiveMessage()               ←       sendDetach(WatchDetachMessage)
+  → on-exit for remaining active      │
 ```
+
+### Message Types (Worker → Controller)
+
+| Message | When | Controller action |
+|---------|------|-------------------|
+| `WatchTriggerMessage` | Trigger fires (condition true + cooldown) | Execute on-enter (1st), regular actions |
+| `WatchTriggerExitMessage` | Trigger condition clears | Execute on-exit actions (log, exec) |
+| `WatchTraceNotifyMessage` | Trace session starts or stops | Log notification |
+| `WatchDetachMessage` | Process exits or read failures | Clean up, execute on-exit for any remaining active triggers |
 
 Worker handles per-process cooldown/backoff internally.
 Controller handles global max-triggers counter.
+
+### Responsibility Split
+
+| Concern | Single-process | Daemon |
+|---------|---------------|--------|
+| Trigger evaluation | WatchCommand poll loop | Worker poll loop |
+| State tracking (enter/exit) | TriggerStateTracker in command | TriggerStateTracker in worker |
+| Continuous trace (stateful) | TraceSession in command | TraceSession in worker (local .rbt) |
+| One-shot on-enter/on-exit (log, exec) | Direct execution | Worker sends message → controller executes |
+| Regular actions with cooldown | Direct execution | Worker sends trigger → controller executes |
 
 ### WatchTargetDescriptor vs TargetProcessDescriptor
 

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -152,6 +152,30 @@ Variable names support path expressions for nested array keys and object propert
 --watch-var='local::<main>()$counter:gt:1000'
 ```
 
+### CPU Usage (`--cpu-usage=<percent>`)
+
+Fires when the process's CPU usage exceeds the threshold. Reads from `/proc/[pid]/stat` (user + system time).
+
+```bash
+reli inspector:watch -p <pid> --cpu-usage=80
+```
+
+Supports **hysteresis** to prevent rapid toggling around a single boundary:
+
+```bash
+# Enter when CPU >= 80%, exit when CPU < 60%
+reli inspector:watch -p <pid> --cpu-usage=80 --cpu-usage-exit=60
+```
+
+Supports **sustain duration** — the condition must hold continuously before entering:
+
+```bash
+# CPU must stay >= 80% for 5 seconds before triggering
+reli inspector:watch -p <pid> --cpu-usage=80 --cpu-sustain=5
+```
+
+Note: the first poll always returns null (needs two samples to compute delta), so the trigger never fires on the very first poll.
+
 ### Combining Triggers
 
 Multiple triggers can be active simultaneously. When multiple triggers fire in the same poll cycle, actions execute **once** with a merged event:
@@ -168,7 +192,46 @@ Output: `[TRIGGERED] PID=1234 | trigger=memory-usage+memory-peak-watch | ...`
 
 ## Actions
 
-Actions define **what to do** when a trigger fires. Default: `memory-dump`.
+Actions define **what to do** when a trigger fires.
+
+There are three categories:
+
+| Category | Actions | When |
+|----------|---------|------|
+| One-shot | `memory-dump`, `trace-once`, `log`, `exec` | Fires each time (with cooldown) |
+| Stateful start | `trace` | Starts continuous trace recording |
+| Stateful stop | `stop-trace` | Stops continuous trace recording |
+
+### `--action` (Regular Actions)
+
+Regular actions fire while the trigger condition is active, subject to cooldown. Default: `memory-dump`.
+
+### `--on-enter` / `--on-exit` (Lifecycle Actions)
+
+Lifecycle actions fire exactly once on state transitions:
+
+- `--on-enter=<action>`: fires when the trigger condition **becomes true**
+- `--on-exit=<action>`: fires when the trigger condition **becomes false**
+
+Both are repeatable. Combine with `--action` for mixed behavior:
+
+```bash
+# On CPU spike: start tracing + log; on recovery: stop tracing + log
+reli inspector:watch -p <pid> \
+  --cpu-usage=80 --cpu-usage-exit=60 --cpu-sustain=5 \
+  --on-enter=trace --on-enter=log \
+  --on-exit=stop-trace --on-exit=log \
+  --trace-interval=10
+```
+
+```bash
+# Mixed: start tracing on enter, also take memory dumps while active
+reli inspector:watch -p <pid> \
+  --cpu-usage=80 --cpu-usage-exit=60 \
+  --on-enter=trace \
+  --on-exit=stop-trace \
+  --action=memory-dump
+```
 
 ### Memory Dump (`--action=memory-dump`)
 
@@ -180,13 +243,32 @@ reli inspector:watch -p <pid> --memory-usage=256M --action=memory-dump
 
 Output files: `<output-dir>/watch-<pid>-<timestamp>.dump`
 
-### Trace Capture (`--action=trace`)
+### Trace Snapshot (`--action=trace-once`)
 
-Outputs the call trace at the moment the trigger fires.
+Outputs the call trace at the moment the trigger fires (one-shot).
 
 ```bash
-reli inspector:watch -p <pid> --watch-function="sleep" --action=trace
+reli inspector:watch -p <pid> --watch-function="sleep" --action=trace-once
 ```
+
+> For backward compatibility, `--action=trace` is mapped to `trace-once`.
+
+### Continuous Trace (`--on-enter=trace` / `--on-exit=stop-trace`)
+
+Starts/stops a continuous `.rbt` trace recording that samples the call stack at `--trace-interval` frequency while the trigger condition holds.
+
+```bash
+reli inspector:watch -p <pid> \
+  --cpu-usage=80 --cpu-usage-exit=60 \
+  --on-enter=trace --on-exit=stop-trace \
+  --trace-interval=10
+```
+
+Output files: `<output-dir>/watch-trace-<pid>-<timestamp>.rbt`
+
+During continuous tracing, the poll interval automatically switches to `--trace-interval` (default: 10ms) for higher sampling resolution. When tracing stops, it reverts to `--poll-interval`.
+
+The trace session can coexist with other actions — memory dumps, log events, and exec commands continue to work during tracing.
 
 ### Event Log (`--action=log`)
 
@@ -311,7 +393,13 @@ Global `--max-triggers` (or `--oneshot`) is a single counter across all workers.
 | `--watch-function` | — | Trigger on function in call stack |
 | `--trace-depth-limit` | — | Trigger on call stack depth |
 | `--watch-var` | — | Trigger on variable value condition (repeatable) |
-| `--action` | `memory-dump` | Actions to execute (repeatable) |
+| `--cpu-usage` | — | Trigger on process CPU usage (percent) |
+| `--cpu-usage-exit` | same as enter | CPU exit threshold (hysteresis) |
+| `--cpu-sustain` | `0` | Seconds CPU must stay above threshold |
+| `--action` | `memory-dump` | Regular actions while active (repeatable) |
+| `--on-enter` | — | Actions on enter transition (repeatable) |
+| `--on-exit` | — | Actions on exit transition (repeatable) |
+| `--trace-interval` | `10` | Sampling interval (ms) during tracing |
 | `--action-exec-command` | — | Command for exec action |
 | `--action-output-dir` | `.` | Output directory for dumps and logs |
 | `--log-file` | stderr | Log file path for log action |

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -253,7 +253,7 @@ Outputs the call trace at the moment the trigger fires (one-shot).
 reli inspector:watch -p <pid> --watch-function="sleep" --action=trace-once
 ```
 
-> For backward compatibility, `--action=trace` is mapped to `trace-once`.
+`trace` in `--action` means `trace-once` (one-shot). For continuous recording, use `--on-enter=trace` with `--on-exit=stop-trace`.
 
 ### Continuous Trace (`--on-enter=trace` / `--on-exit=stop-trace`)
 

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -176,6 +176,8 @@ reli inspector:watch -p <pid> --cpu-usage=80 --cpu-sustain=5
 
 Note: the first poll always returns null (needs two samples to compute delta), so the trigger never fires on the very first poll.
 
+**Sampling window:** CPU% is calculated over a minimum 0.5-second window regardless of `--poll-interval` or `--trace-interval`. When tracing at 10ms intervals, the CPU% still reflects the average over the last 0.5s, preventing noisy readings from causing premature exit transitions.
+
 ### Combining Triggers
 
 Multiple triggers can be active simultaneously. When multiple triggers fire in the same poll cycle, actions execute **once** with a merged event:
@@ -269,6 +271,8 @@ Output files: `<output-dir>/watch-trace-<pid>-<timestamp>.rbt`
 During continuous tracing, the poll interval automatically switches to `--trace-interval` (default: 10ms) for higher sampling resolution. When tracing stops, it reverts to `--poll-interval`.
 
 The trace session can coexist with other actions — memory dumps, log events, and exec commands continue to work during tracing.
+
+In **daemon mode**, each worker manages its own trace session locally. Trace files are written to `--action-output-dir` with per-PID filenames. The controller receives notifications when traces start and stop.
 
 ### Event Log (`--action=log`)
 

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -443,7 +443,8 @@ final class WatchCommand extends Command
                     // Target may be between requests or temporarily
                     // unreadable. Skip this poll, try next cycle.
                     $previous_context = null;
-                    $this->dynamicSleep($loop_start, $trace_session->isActive() ? $trace_interval_ns : $poll_interval_ns);
+                    $sleep_ns = $trace_session->isActive() ? $trace_interval_ns : $poll_interval_ns;
+                    $this->dynamicSleep($loop_start, $sleep_ns);
                     return true;
                 }
 

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -20,6 +20,7 @@ use Reli\Inspector\Watch\Daemon\Context\PhpWatchContextCreator;
 use Reli\Inspector\Watch\Daemon\Controller\PhpWatchControllerInterface;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Output\TraceOutput\TraceOutputFactory;
 use Reli\Inspector\RetryingLoopProvider;
@@ -660,7 +661,8 @@ final class WatchCommand extends Command
             $disk_tracker,
         );
 
-        // Build daemon lifecycle actions (trace/stop-trace not supported in daemon mode yet)
+        // Build daemon lifecycle actions for controller-side one-shot actions (log, exec).
+        // trace/stop-trace are handled worker-side via TraceSession.
         $on_enter_actions = $this->action_factory->buildDaemonLifecycleActions(
             $watch_settings->on_enter_actions,
             $watch_settings,
@@ -826,6 +828,31 @@ final class WatchCommand extends Command
                                     $result->pid,
                                     $result->trace_path ?? '',
                                 ));
+                            }
+                        } elseif ($result instanceof WatchTriggerExitMessage) {
+                            // Trigger condition cleared — execute on-exit actions
+                            if ($has_daemon_lifecycle) {
+                                $state_key = $result->pid . ':' . $result->event->trigger_name;
+                                $daemon_state_tracker->update($state_key, false);
+                                $exit_context = new WatchContext(
+                                    pid: $result->pid,
+                                    heap_stats: new HeapStats(0, 0, 0, 0),
+                                    call_trace: null,
+                                    timestamp: $result->event->timestamp,
+                                    previous: null,
+                                );
+                                $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
+                                if (!$quiet) {
+                                    $output->writeln(sprintf(
+                                        '<info>[EXIT] PID=%d | trigger=%s | %s</info>',
+                                        $result->pid,
+                                        $result->event->trigger_name,
+                                        $result->event->description,
+                                    ));
+                                }
+                                foreach ($on_exit_actions as $action) {
+                                    $action->execute($result->event, $process, $exit_context);
+                                }
                             }
                         } elseif ($result instanceof WatchTriggerMessage) {
                             $global_trigger_count++;

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Daemon\Searcher\Context\PhpSearcherContextCreator;
 use Reli\Inspector\Watch\Daemon\Context\PhpWatchContextCreator;
 use Reli\Inspector\Watch\Daemon\Controller\PhpWatchControllerInterface;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Output\TraceOutput\TraceOutputFactory;
 use Reli\Inspector\RetryingLoopProvider;
@@ -815,12 +816,21 @@ final class WatchCommand extends Command
                     &$exhausted_pids,
                 ) {
                     while (1) {
-                        $result = $worker->receiveTriggerOrDetach();
-                        if ($result instanceof WatchTriggerMessage) {
+                        $result = $worker->receiveMessage();
+                        if ($result instanceof WatchTraceNotifyMessage) {
+                            if (!$quiet) {
+                                $label = $result->started ? 'TRACE STARTED' : 'TRACE STOPPED';
+                                $output->writeln(sprintf(
+                                    '<info>[%s] PID=%d | %s</info>',
+                                    $label,
+                                    $result->pid,
+                                    $result->trace_path ?? '',
+                                ));
+                            }
+                        } elseif ($result instanceof WatchTriggerMessage) {
                             $global_trigger_count++;
 
                             if ($max_triggers > 0 && $global_trigger_count > $max_triggers) {
-                                // Silently drop — already past limit
                                 continue;
                             }
 
@@ -837,7 +847,8 @@ final class WatchCommand extends Command
 
                             $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
 
-                            // Lifecycle handling for daemon mode
+                            // Lifecycle handling for one-shot on-enter actions (log, exec, etc.)
+                            // Continuous trace is handled worker-side.
                             if ($has_daemon_lifecycle) {
                                 $state_key = $result->pid . ':' . $result->event->trigger_name;
                                 $phase = $daemon_state_tracker->update($state_key, true);
@@ -871,7 +882,6 @@ final class WatchCommand extends Command
                                 $action->execute($result->event, $process, $context);
                             }
 
-                            // Cancel all workers when global limit reached
                             if ($max_triggers > 0 && $global_trigger_count >= $max_triggers) {
                                 if (!$quiet) {
                                     $output->writeln(sprintf(
@@ -885,36 +895,35 @@ final class WatchCommand extends Command
                                 return;
                             }
                         } else {
-                            // Process detached — fire on-exit if lifecycle is active
+                            // WatchDetachMessage — fire on-exit for one-shot actions
                             if ($has_daemon_lifecycle) {
-                                // Mark all triggers for this PID as inactive
-                                foreach ($triggers as $trigger) {
-                                    $state_key = $result->pid . ':' . $trigger->name();
-                                    $phase = $daemon_state_tracker->update($state_key, false);
-                                    if ($phase === TriggerPhase::EXIT) {
-                                        $exit_event = new TriggerEvent(
-                                            trigger_name: $trigger->name(),
-                                            description: 'process detached',
-                                            timestamp: \microtime(true),
-                                        );
-                                        $exit_context = new WatchContext(
-                                            pid: $result->pid,
-                                            heap_stats: new HeapStats(0, 0, 0, 0),
-                                            call_trace: null,
-                                            timestamp: \microtime(true),
-                                            previous: null,
-                                        );
-                                        $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
-                                        if (!$quiet) {
-                                            $output->writeln(sprintf(
-                                                '<info>[EXIT] PID=%d | trigger=%s | process detached</info>',
-                                                $result->pid,
-                                                $trigger->name(),
-                                            ));
-                                        }
-                                        foreach ($on_exit_actions as $action) {
-                                            $action->execute($exit_event, $process, $exit_context);
-                                        }
+                                $cleared = $daemon_state_tracker->clearPrefix($result->pid . ':');
+                                if (count($cleared) > 0) {
+                                    $exit_event = new TriggerEvent(
+                                        trigger_name: implode('+', array_map(
+                                            fn (string $k) => explode(':', $k, 2)[1] ?? $k,
+                                            $cleared,
+                                        )),
+                                        description: 'process detached',
+                                        timestamp: \microtime(true),
+                                    );
+                                    $exit_context = new WatchContext(
+                                        pid: $result->pid,
+                                        heap_stats: new HeapStats(0, 0, 0, 0),
+                                        call_trace: null,
+                                        timestamp: \microtime(true),
+                                        previous: null,
+                                    );
+                                    $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
+                                    if (!$quiet) {
+                                        $output->writeln(sprintf(
+                                            '<info>[EXIT] PID=%d | %s | process detached</info>',
+                                            $result->pid,
+                                            $exit_event->trigger_name,
+                                        ));
+                                    }
+                                    foreach ($on_exit_actions as $action) {
+                                        $action->execute($exit_event, $process, $exit_context);
                                     }
                                 }
                             }

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -39,13 +39,18 @@ use Revolt\EventLoop;
 use Reli\Inspector\Watch\Action\ActionInterface;
 use Reli\Inspector\Watch\ActionFactory;
 use Reli\Inspector\Watch\CooldownManager;
+use Reli\Inspector\Watch\CpuUsageReader;
 use Reli\Inspector\Watch\DiskUsageTracker;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\HeapStatsReader;
 use Reli\Inspector\Watch\RssReader;
+use Reli\Inspector\Watch\TraceSession;
 use Reli\Inspector\Watch\TriggerFactory;
+use Reli\Inspector\Watch\TriggerPhase;
+use Reli\Inspector\Watch\TriggerStateTracker;
 use Reli\Inspector\Watch\VariableReader;
 use Reli\Inspector\Watch\VariableSpec;
+use Reli\Inspector\Watch\Trigger\CpuUsageTrigger;
 use Reli\Inspector\Watch\Trigger\RssUsageTrigger;
 use Reli\Inspector\Watch\Trigger\TriggerInterface;
 use Reli\Inspector\Watch\Trigger\VariableValueTrigger;
@@ -76,6 +81,7 @@ final class WatchCommand extends Command
         private PhpVersionDetector $php_version_detector,
         private HeapStatsReader $heap_stats_reader,
         private RssReader $rss_reader,
+        private CpuUsageReader $cpu_usage_reader,
         private VariableReader $variable_reader,
         private CallTraceReader $call_trace_reader,
         private TriggerFactory $trigger_factory,
@@ -183,6 +189,7 @@ final class WatchCommand extends Command
         // Check what each trigger needs
         $needs_call_trace = false;
         $needs_rss = false;
+        $needs_cpu = false;
         /** @var list<VariableSpec> $var_specs */
         $var_specs = [];
         foreach ($triggers as $trigger) {
@@ -192,6 +199,9 @@ final class WatchCommand extends Command
             if ($trigger instanceof RssUsageTrigger) {
                 $needs_rss = true;
             }
+            if ($trigger instanceof CpuUsageTrigger) {
+                $needs_cpu = true;
+            }
             if ($trigger instanceof VariableValueTrigger) {
                 $var_specs[] = new VariableSpec(
                     scope: $trigger->scope,
@@ -200,6 +210,10 @@ final class WatchCommand extends Command
                 );
             }
         }
+
+        // Determine if on-enter/on-exit lifecycle is active
+        $has_lifecycle = count($watch_settings->on_enter_actions) > 0
+            || count($watch_settings->on_exit_actions) > 0;
 
         // Build actions
         $trace_output = $this->trace_output_factory->fromSettingsAndConsoleOutput(
@@ -227,6 +241,40 @@ final class WatchCommand extends Command
             $disk_tracker,
         );
 
+        // Build trace session for continuous tracing
+        $trace_session = new TraceSession(
+            $watch_settings->action_output_dir,
+            $watch_settings->trace_interval_ms * 1000,
+        );
+
+        // Build lifecycle actions (on-enter / on-exit)
+        $on_enter_actions = $this->action_factory->buildLifecycleActions(
+            $watch_settings->on_enter_actions,
+            $watch_settings,
+            $trace_output,
+            $target_php_settings->php_version,
+            $eg_address,
+            $sg_address,
+            $cg_address,
+            $get_trace_settings->depth,
+            $target_php_settings,
+            $disk_tracker,
+            $trace_session,
+        );
+        $on_exit_actions = $this->action_factory->buildLifecycleActions(
+            $watch_settings->on_exit_actions,
+            $watch_settings,
+            $trace_output,
+            $target_php_settings->php_version,
+            $eg_address,
+            $sg_address,
+            $cg_address,
+            $get_trace_settings->depth,
+            $target_php_settings,
+            $disk_tracker,
+            $trace_session,
+        );
+
         // Build cooldown
         // CooldownManager handles per-trigger cooldown/backoff only.
         // Global max-triggers is managed via $action_count above.
@@ -238,6 +286,8 @@ final class WatchCommand extends Command
             max_triggers: 0,
         );
 
+        $state_tracker = new TriggerStateTracker();
+
         $php_version = $target_php_settings->php_version;
         $depth = $get_trace_settings->depth;
         $stop_process = (bool)($input->getOption('stop-process') ?? false);
@@ -247,20 +297,40 @@ final class WatchCommand extends Command
         $poll_count = 0;
         $action_count = 0;
 
+        // Use sleep=0 in middleware; timing is managed inside the closure
+        // to support dynamic interval (poll_interval vs trace_interval).
         $loop_settings = new TraceLoopSettings(
-            sleep_nano_seconds: $watch_settings->poll_interval_ms * 1000 * 1000,
+            sleep_nano_seconds: 0,
             cancel_key: 'q',
             max_retries: 0, // no retry — we handle errors per poll
             stop_process: false,
         );
 
+        $poll_interval_ns = $watch_settings->poll_interval_ms * 1000 * 1000;
+        $trace_interval_ns = $watch_settings->trace_interval_ms * 1000 * 1000;
+
         if (!$quiet) {
+            $action_names = array_map(fn (ActionInterface $a) => $a->name(), $actions);
+            $enter_names = array_map(fn (ActionInterface $a) => $a->name(), $on_enter_actions);
+            $exit_names = array_map(fn (ActionInterface $a) => $a->name(), $on_exit_actions);
+            $all_action_desc = implode(',', $action_names);
+            if (count($enter_names) > 0) {
+                $all_action_desc .= ' on-enter=' . implode(',', $enter_names);
+            }
+            if (count($exit_names) > 0) {
+                $all_action_desc .= ' on-exit=' . implode(',', $exit_names);
+            }
             $output->writeln(sprintf(
-                '<info>[watch] Monitoring PID=%d | triggers=%s | actions=%s</info>',
+                '<info>[watch] Monitoring PID=%d | triggers=%s | %s</info>',
                 $process_specifier->pid,
                 implode(',', array_map(fn (TriggerInterface $t) => $t->name(), $triggers)),
-                implode(',', array_map(fn (ActionInterface $a) => $a->name(), $actions)),
+                $all_action_desc,
             ));
+        }
+
+        // Prime the CPU reader with a first sample (always returns null on first call)
+        if ($needs_cpu) {
+            $this->cpu_usage_reader->read($process_specifier->pid);
         }
 
         $this->loop_provider->getMainLoop(
@@ -275,18 +345,27 @@ final class WatchCommand extends Command
                 $stop_process,
                 $needs_call_trace,
                 $needs_rss,
+                $needs_cpu,
+                $has_lifecycle,
                 $var_specs,
                 $triggers,
                 $actions,
+                $on_enter_actions,
+                $on_exit_actions,
                 $cooldown,
+                $state_tracker,
+                $trace_session,
                 $disk_tracker,
                 $quiet,
                 $watch_settings,
                 $output,
+                $poll_interval_ns,
+                $trace_interval_ns,
                 &$previous_context,
                 &$poll_count,
                 &$action_count,
             ): bool {
+                $loop_start = \hrtime(true);
                 $poll_count++;
                 $now = microtime(true);
 
@@ -295,6 +374,7 @@ final class WatchCommand extends Command
                     $watch_settings->max_triggers > 0
                     && $action_count >= $watch_settings->max_triggers
                 ) {
+                    $trace_session->stop();
                     return false;
                 }
 
@@ -322,8 +402,9 @@ final class WatchCommand extends Command
                         $eg_address,
                     );
 
+                    // Read call trace if triggers need it OR tracing is active
                     $call_trace = null;
-                    if ($needs_call_trace) {
+                    if ($needs_call_trace || $trace_session->isActive()) {
                         $call_trace = $this->call_trace_reader
                             ->readCallTrace(
                                 $process_specifier->pid,
@@ -351,10 +432,16 @@ final class WatchCommand extends Command
                     if ($needs_rss) {
                         $rss_bytes = $this->rss_reader->read($process_specifier->pid);
                     }
+
+                    $cpu_percent = null;
+                    if ($needs_cpu) {
+                        $cpu_percent = $this->cpu_usage_reader->read($process_specifier->pid);
+                    }
                 } catch (\Throwable) {
                     // Target may be between requests or temporarily
                     // unreadable. Skip this poll, try next cycle.
                     $previous_context = null;
+                    $this->dynamicSleep($loop_start, $trace_session->isActive() ? $trace_interval_ns : $poll_interval_ns);
                     return true;
                 }
 
@@ -366,45 +453,92 @@ final class WatchCommand extends Command
                     previous: $previous_context,
                     variable_values: $variable_values,
                     rss_bytes: $rss_bytes,
+                    cpu_usage_percent: $cpu_percent,
                 );
 
-                // Evaluate triggers — collect all fired events in this poll
+                // Record trace sample if continuous tracing is active
+                if ($trace_session->isActive() && $call_trace !== null) {
+                    $trace_session->recordSample($call_trace);
+                }
+
+                // Evaluate triggers with lifecycle tracking
                 /** @var list<TriggerEvent> $fired_events */
                 $fired_events = [];
                 foreach ($triggers as $trigger) {
                     $event = $trigger->evaluate($context);
+                    $is_active = $event !== null;
+
+                    if ($has_lifecycle) {
+                        $phase = $state_tracker->update($trigger->name(), $is_active);
+
+                        if ($phase === TriggerPhase::ENTER && $event !== null) {
+                            if (!$quiet) {
+                                $output->writeln(sprintf(
+                                    '<info>[ENTER] PID=%d | trigger=%s | %s</info>',
+                                    $process_specifier->pid,
+                                    $event->trigger_name,
+                                    $event->description,
+                                ));
+                            }
+                            foreach ($on_enter_actions as $action) {
+                                $action->execute($event, $process_specifier, $context);
+                            }
+                        } elseif ($phase === TriggerPhase::EXIT) {
+                            $exit_event = new TriggerEvent(
+                                trigger_name: $trigger->name(),
+                                description: 'condition cleared',
+                                timestamp: $now,
+                            );
+                            if (!$quiet) {
+                                $output->writeln(sprintf(
+                                    '<info>[EXIT] PID=%d | trigger=%s | condition cleared</info>',
+                                    $process_specifier->pid,
+                                    $trigger->name(),
+                                ));
+                            }
+                            foreach ($on_exit_actions as $action) {
+                                $action->execute($exit_event, $process_specifier, $context);
+                            }
+                            $cooldown->recordClear($trigger->name());
+                            continue;
+                        }
+                    }
+
                     if ($event === null) {
                         $cooldown->recordClear($trigger->name());
                         continue;
                     }
 
-                    if (!$cooldown->canFire($trigger->name(), $now)) {
-                        if (!$quiet) {
-                            $reason = $cooldown->getSkipReason($trigger->name(), $now);
+                    // Regular action path (fires while active, with cooldown)
+                    if (count($actions) > 0) {
+                        if (!$cooldown->canFire($trigger->name(), $now)) {
+                            if (!$quiet && !$has_lifecycle) {
+                                $reason = $cooldown->getSkipReason($trigger->name(), $now);
+                                $output->writeln(sprintf(
+                                    '<comment>[SKIPPED] PID=%d | trigger=%s | reason=%s</comment>',
+                                    $process_specifier->pid,
+                                    $trigger->name(),
+                                    $reason ?? 'cooldown',
+                                ));
+                            }
+                            continue;
+                        }
+
+                        $cooldown->recordFire($trigger->name(), $now);
+                        $fired_events[] = $event;
+
+                        if (!$quiet && !$has_lifecycle) {
                             $output->writeln(sprintf(
-                                '<comment>[SKIPPED] PID=%d | trigger=%s | reason=%s</comment>',
+                                '<info>[TRIGGERED] PID=%d | trigger=%s | %s</info>',
                                 $process_specifier->pid,
-                                $trigger->name(),
-                                $reason ?? 'cooldown',
+                                $event->trigger_name,
+                                $event->description,
                             ));
                         }
-                        continue;
-                    }
-
-                    $cooldown->recordFire($trigger->name(), $now);
-                    $fired_events[] = $event;
-
-                    if (!$quiet) {
-                        $output->writeln(sprintf(
-                            '<info>[TRIGGERED] PID=%d | trigger=%s | %s</info>',
-                            $process_specifier->pid,
-                            $event->trigger_name,
-                            $event->description,
-                        ));
                     }
                 }
 
-                // Execute actions once per poll (not per trigger)
+                // Execute regular actions once per poll (not per trigger)
                 if (count($fired_events) > 0) {
                     $action_count++;
                     $merged_event = count($fired_events) === 1
@@ -434,8 +568,10 @@ final class WatchCommand extends Command
 
                 // Update status line (single process mode)
                 if (!$quiet && $poll_count % 10 === 0) {
+                    $tracing_indicator = $trace_session->isActive() ? ' | TRACING' : '';
+                    $cpu_indicator = $cpu_percent !== null ? sprintf(' | cpu=%.1f%%', $cpu_percent) : '';
                     $output->write(sprintf(
-                        "\r<info>[watching]</info> PID=%d | mem=%s/%s | polls=%d | triggers=%d | disk=%s",
+                        "\r<info>[watching]</info> PID=%d | mem=%s/%s%s | polls=%d | triggers=%d | disk=%s%s",
                         $process_specifier->pid,
                         HeapStats::humanReadableBytes($heap_stats->size),
                         HeapStats::humanReadableBytes(
@@ -443,18 +579,27 @@ final class WatchCommand extends Command
                                 ? $heap_stats->limit
                                 : $heap_stats->real_size
                         ),
+                        $cpu_indicator,
                         $poll_count,
                         $cooldown->getTotalFires(),
                         HeapStats::humanReadableBytes($disk_tracker->getTotalBytes()),
+                        $tracing_indicator,
                     ));
                 }
 
                 $previous_context = $context;
 
+                // Dynamic sleep: use trace_interval when tracing, poll_interval otherwise
+                $interval_ns = $trace_session->isActive() ? $trace_interval_ns : $poll_interval_ns;
+                $this->dynamicSleep($loop_start, $interval_ns);
+
                 return true;
             },
             $loop_settings,
         )->invoke();
+
+        // Ensure trace session is finalized on exit
+        $trace_session->stop();
 
         if (!$quiet) {
             $output->writeln('');
@@ -462,6 +607,18 @@ final class WatchCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Sleep for the remaining interval, accounting for elapsed execution time.
+     */
+    private function dynamicSleep(int $start_hrtime_ns, int $interval_ns): void
+    {
+        $elapsed = \hrtime(true) - $start_hrtime_ns;
+        $wait = $interval_ns - $elapsed;
+        if ($wait > 0) {
+            \time_nanosleep(0, (int)$wait);
+        }
     }
 
     /**
@@ -501,6 +658,20 @@ final class WatchCommand extends Command
             $trace_output,
             $disk_tracker,
         );
+
+        // Build daemon lifecycle actions (trace/stop-trace not supported in daemon mode yet)
+        $on_enter_actions = $this->action_factory->buildDaemonLifecycleActions(
+            $watch_settings->on_enter_actions,
+            $watch_settings,
+            $trace_output,
+        );
+        $on_exit_actions = $this->action_factory->buildDaemonLifecycleActions(
+            $watch_settings->on_exit_actions,
+            $watch_settings,
+            $trace_output,
+        );
+        $has_daemon_lifecycle = count($on_enter_actions) > 0 || count($on_exit_actions) > 0;
+        $daemon_state_tracker = new TriggerStateTracker();
 
         // Per-process cooldown/backoff is handled inside each worker.
         // Global max-triggers is enforced here in the controller as a single counter.
@@ -630,6 +801,10 @@ final class WatchCommand extends Command
                     $idx,
                     $worker,
                     $actions,
+                    $on_enter_actions,
+                    $on_exit_actions,
+                    $has_daemon_lifecycle,
+                    $daemon_state_tracker,
                     $output,
                     $quiet,
                     $max_triggers,
@@ -649,17 +824,6 @@ final class WatchCommand extends Command
                                 continue;
                             }
 
-                            if (!$quiet) {
-                                $output->writeln(sprintf(
-                                    '<info>[TRIGGERED] PID=%d | trigger=%s | %s (%d/%s)</info>',
-                                    $result->pid,
-                                    $result->event->trigger_name,
-                                    $result->event->description,
-                                    $global_trigger_count,
-                                    $max_triggers > 0 ? (string)$max_triggers : 'unlimited',
-                                ));
-                            }
-
                             $context = new WatchContext(
                                 pid: $result->pid,
                                 heap_stats: $result->heap_stats,
@@ -671,12 +835,40 @@ final class WatchCommand extends Command
                                 daemon_php_version: $result->php_version,
                             );
 
+                            $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
+
+                            // Lifecycle handling for daemon mode
+                            if ($has_daemon_lifecycle) {
+                                $state_key = $result->pid . ':' . $result->event->trigger_name;
+                                $phase = $daemon_state_tracker->update($state_key, true);
+                                if ($phase === TriggerPhase::ENTER) {
+                                    if (!$quiet) {
+                                        $output->writeln(sprintf(
+                                            '<info>[ENTER] PID=%d | trigger=%s | %s</info>',
+                                            $result->pid,
+                                            $result->event->trigger_name,
+                                            $result->event->description,
+                                        ));
+                                    }
+                                    foreach ($on_enter_actions as $action) {
+                                        $action->execute($result->event, $process, $context);
+                                    }
+                                }
+                            }
+
+                            if (!$quiet && !$has_daemon_lifecycle) {
+                                $output->writeln(sprintf(
+                                    '<info>[TRIGGERED] PID=%d | trigger=%s | %s (%d/%s)</info>',
+                                    $result->pid,
+                                    $result->event->trigger_name,
+                                    $result->event->description,
+                                    $global_trigger_count,
+                                    $max_triggers > 0 ? (string)$max_triggers : 'unlimited',
+                                ));
+                            }
+
                             foreach ($actions as $action) {
-                                $action->execute(
-                                    $result->event,
-                                    new \Reli\Lib\Process\ProcessSpecifier($result->pid),
-                                    $context,
-                                );
+                                $action->execute($result->event, $process, $context);
                             }
 
                             // Cancel all workers when global limit reached
@@ -693,6 +885,40 @@ final class WatchCommand extends Command
                                 return;
                             }
                         } else {
+                            // Process detached — fire on-exit if lifecycle is active
+                            if ($has_daemon_lifecycle) {
+                                // Mark all triggers for this PID as inactive
+                                foreach ($triggers as $trigger) {
+                                    $state_key = $result->pid . ':' . $trigger->name();
+                                    $phase = $daemon_state_tracker->update($state_key, false);
+                                    if ($phase === TriggerPhase::EXIT) {
+                                        $exit_event = new TriggerEvent(
+                                            trigger_name: $trigger->name(),
+                                            description: 'process detached',
+                                            timestamp: \microtime(true),
+                                        );
+                                        $exit_context = new WatchContext(
+                                            pid: $result->pid,
+                                            heap_stats: new HeapStats(0, 0, 0, 0),
+                                            call_trace: null,
+                                            timestamp: \microtime(true),
+                                            previous: null,
+                                        );
+                                        $process = new \Reli\Lib\Process\ProcessSpecifier($result->pid);
+                                        if (!$quiet) {
+                                            $output->writeln(sprintf(
+                                                '<info>[EXIT] PID=%d | trigger=%s | process detached</info>',
+                                                $result->pid,
+                                                $trigger->name(),
+                                            ));
+                                        }
+                                        foreach ($on_exit_actions as $action) {
+                                            $action->execute($exit_event, $process, $exit_context);
+                                        }
+                                    }
+                                }
+                            }
+
                             if (!$quiet) {
                                 $output->writeln(sprintf(
                                     '<comment>[-process] PID=%d detached from worker %d</comment>',

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -167,6 +167,12 @@ final class WatchCommand extends Command
             $process_specifier,
             $target_php_settings,
         );
+        // psalm loses track of the narrowed template parameter after reassignment
+        // in the closure's use clause. Capture into a fresh variable so the
+        // narrowed type `TargetPhpSettings<value-of<ALL_SUPPORTED_VERSIONS>>`
+        // flows into the poll loop closure.
+        /** @var \Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $narrowed_target_php_settings */
+        $narrowed_target_php_settings = $target_php_settings;
 
         $eg_address = $this->retrying_loop_provider->do(
             try: fn () => $this->php_globals_finder->findExecutorGlobals(
@@ -338,7 +344,7 @@ final class WatchCommand extends Command
         $this->loop_provider->getMainLoop(
             function () use (
                 $process_specifier,
-                $target_php_settings,
+                $narrowed_target_php_settings,
                 $eg_address,
                 $sg_address,
                 $cg_address,
@@ -400,7 +406,7 @@ final class WatchCommand extends Command
 
                     $heap_stats = $this->heap_stats_reader->read(
                         $process_specifier,
-                        $target_php_settings,
+                        $narrowed_target_php_settings,
                         $eg_address,
                     );
 
@@ -424,7 +430,7 @@ final class WatchCommand extends Command
                             ->readVariables(
                                 $var_specs,
                                 $process_specifier,
-                                $target_php_settings,
+                                $narrowed_target_php_settings,
                                 $eg_address,
                                 $cg_address,
                             );
@@ -922,7 +928,7 @@ final class WatchCommand extends Command
                                 $cancellation->cancel();
                                 return;
                             }
-                        } else {
+                        } elseif ($result instanceof WatchDetachMessage) {
                             // WatchDetachMessage — fire on-exit for one-shot actions
                             if ($has_daemon_lifecycle) {
                                 $cleared = $daemon_state_tracker->clearPrefix($result->pid . ':');

--- a/src/Inspector/Settings/WatchSettings/WatchSettings.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettings.php
@@ -23,6 +23,7 @@ final class WatchSettings
     public const BACKOFF_MULTIPLIER_DEFAULT = 2.0;
     public const BACKOFF_MAX_SECONDS_DEFAULT = 3600;
     public const STATUS_INTERVAL_SECONDS_DEFAULT = 60;
+    public const TRACE_INTERVAL_MS_DEFAULT = 10;
 
     public function __construct(
         public int $poll_interval_ms,
@@ -52,6 +53,17 @@ final class WatchSettings
         public ?string $memory_output_format,
         public bool $include_binary = false,
         public ?string $memory_limit = null,
+        // CPU trigger configs (all optional, added after existing params)
+        public ?float $cpu_usage_percent = null,
+        public ?float $cpu_usage_exit_percent = null,
+        public float $cpu_sustain_seconds = 0.0,
+        // Lifecycle action configs
+        /** @var list<string> Actions to execute on enter transition */
+        public array $on_enter_actions = [],
+        /** @var list<string> Actions to execute on exit transition */
+        public array $on_exit_actions = [],
+        /** Sampling interval (ms) during continuous tracing */
+        public int $trace_interval_ms = self::TRACE_INTERVAL_MS_DEFAULT,
     ) {
     }
 }

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -72,13 +72,48 @@ final class WatchSettingsFromConsoleInput
                     . ' (format: scope::name:op:value,'
                     . ' e.g. global::cache:count_gt:10000)',
             )
+            // CPU trigger options
+            ->addOption(
+                'cpu-usage',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'trigger when process CPU usage exceeds percent (e.g., 80)',
+            )
+            ->addOption(
+                'cpu-usage-exit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'CPU percent below which the trigger exits'
+                    . ' (hysteresis, default: same as --cpu-usage)',
+            )
+            ->addOption(
+                'cpu-sustain',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'seconds the CPU must stay above threshold before entering (default: 0)',
+            )
             // Action options
             ->addOption(
                 'action',
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                'actions to execute on trigger (memory-dump, trace, log, exec)',
+                'actions to execute while active with cooldown'
+                    . ' (memory-dump, trace-once, log, exec)',
                 ['memory-dump'],
+            )
+            ->addOption(
+                'on-enter',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'actions on enter transition (trace, trace-once, memory-dump, log, exec)',
+                [],
+            )
+            ->addOption(
+                'on-exit',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'actions on exit transition (stop-trace, trace-once, memory-dump, log, exec)',
+                [],
             )
             ->addOption(
                 'action-exec-command',
@@ -162,6 +197,12 @@ final class WatchSettingsFromConsoleInput
                 'status summary interval in seconds for daemon mode (default: 60)',
             )
             ->addOption(
+                'trace-interval',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'sampling interval in ms during continuous tracing (default: 10)',
+            )
+            ->addOption(
                 'include-binary',
                 null,
                 InputOption::VALUE_NONE,
@@ -199,6 +240,13 @@ final class WatchSettingsFromConsoleInput
         $trace_depth_str = NullableCast::toString($input->getOption('trace-depth-limit'));
         $trace_depth_limit = $trace_depth_str !== null ? (int)$trace_depth_str : null;
 
+        $cpu_usage_str = NullableCast::toString($input->getOption('cpu-usage'));
+        $cpu_usage_percent = $cpu_usage_str !== null ? (float)$cpu_usage_str : null;
+        $cpu_exit_str = NullableCast::toString($input->getOption('cpu-usage-exit'));
+        $cpu_usage_exit_percent = $cpu_exit_str !== null ? (float)$cpu_exit_str : $cpu_usage_percent;
+        $cpu_sustain_str = NullableCast::toString($input->getOption('cpu-sustain'));
+        $cpu_sustain_seconds = $cpu_sustain_str !== null ? (float)$cpu_sustain_str : 0.0;
+
         $poll_interval = (int)($input->getOption('poll-interval') ?? WatchSettings::POLL_INTERVAL_MS_DEFAULT);
         $poll_interval = max($poll_interval, 100);
 
@@ -209,6 +257,16 @@ final class WatchSettingsFromConsoleInput
 
         /** @var list<string> $actions */
         $actions = $input->getOption('action');
+        // Map legacy 'trace' action name to 'trace-once' for backward compat
+        $actions = \array_map(
+            fn (string $a): string => $a === 'trace' ? 'trace-once' : $a,
+            $actions,
+        );
+
+        /** @var list<string> $on_enter_actions */
+        $on_enter_actions = $input->getOption('on-enter');
+        /** @var list<string> $on_exit_actions */
+        $on_exit_actions = $input->getOption('on-exit');
 
         // --oneshot=N is an alias for --max-triggers=N
         $max_triggers_raw = (string)(
@@ -264,6 +322,15 @@ final class WatchSettingsFromConsoleInput
             memory_output_format: NullableCast::toString($input->getOption('memory-output-format')),
             include_binary: (bool)$input->getOption('include-binary'),
             memory_limit: NullableCast::toString($input->getOption('memory-limit')),
+            cpu_usage_percent: $cpu_usage_percent,
+            cpu_usage_exit_percent: $cpu_usage_exit_percent,
+            cpu_sustain_seconds: $cpu_sustain_seconds,
+            on_enter_actions: $on_enter_actions,
+            on_exit_actions: $on_exit_actions,
+            trace_interval_ms: (int)(
+                $input->getOption('trace-interval')
+                ?? WatchSettings::TRACE_INTERVAL_MS_DEFAULT
+            ),
         );
     }
 

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -257,11 +257,6 @@ final class WatchSettingsFromConsoleInput
 
         /** @var list<string> $actions */
         $actions = $input->getOption('action');
-        // Map legacy 'trace' action name to 'trace-once' for backward compat
-        $actions = \array_map(
-            fn (string $a): string => $a === 'trace' ? 'trace-once' : $a,
-            $actions,
-        );
 
         /** @var list<string> $on_enter_actions */
         $on_enter_actions = $input->getOption('on-enter');

--- a/src/Inspector/Watch/Action/ContinuousTraceAction.php
+++ b/src/Inspector/Watch/Action/ContinuousTraceAction.php
@@ -13,26 +13,30 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Watch\Action;
 
-use Reli\Inspector\Output\TraceOutput\TraceOutput;
+use Reli\Inspector\Watch\TraceSession;
 use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Process\ProcessSpecifier;
 
 /**
- * Trace action for daemon mode.
- * Outputs the call trace already available in WatchContext (received from worker).
+ * Starts a continuous trace recording session.
+ *
+ * Intended for use as an on-enter action. The actual per-sample
+ * recording is driven by the watch poll loop calling
+ * TraceSession::recordSample(). Use StopTraceAction as the
+ * on-exit counterpart.
  */
-final class DaemonTraceAction implements ActionInterface
+final class ContinuousTraceAction implements ActionInterface
 {
     public function __construct(
-        private TraceOutput $trace_output,
+        private TraceSession $trace_session,
     ) {
     }
 
     #[\Override]
     public function name(): string
     {
-        return 'trace-once';
+        return 'trace';
     }
 
     #[\Override]
@@ -41,8 +45,6 @@ final class DaemonTraceAction implements ActionInterface
         ProcessSpecifier $process,
         WatchContext $context,
     ): void {
-        if ($context->call_trace !== null) {
-            $this->trace_output->output($context->call_trace);
-        }
+        $this->trace_session->start($process->pid, $context->timestamp);
     }
 }

--- a/src/Inspector/Watch/Action/StopTraceAction.php
+++ b/src/Inspector/Watch/Action/StopTraceAction.php
@@ -13,26 +13,28 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Watch\Action;
 
-use Reli\Inspector\Output\TraceOutput\TraceOutput;
+use Reli\Inspector\Watch\TraceSession;
 use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Process\ProcessSpecifier;
 
 /**
- * Trace action for daemon mode.
- * Outputs the call trace already available in WatchContext (received from worker).
+ * Stops the continuous trace recording session.
+ *
+ * Intended for use as an on-exit action, paired with
+ * ContinuousTraceAction on-enter.
  */
-final class DaemonTraceAction implements ActionInterface
+final class StopTraceAction implements ActionInterface
 {
     public function __construct(
-        private TraceOutput $trace_output,
+        private TraceSession $trace_session,
     ) {
     }
 
     #[\Override]
     public function name(): string
     {
-        return 'trace-once';
+        return 'stop-trace';
     }
 
     #[\Override]
@@ -41,8 +43,6 @@ final class DaemonTraceAction implements ActionInterface
         ProcessSpecifier $process,
         WatchContext $context,
     ): void {
-        if ($context->call_trace !== null) {
-            $this->trace_output->output($context->call_trace);
-        }
+        $this->trace_session->stop();
     }
 }

--- a/src/Inspector/Watch/Action/TraceAction.php
+++ b/src/Inspector/Watch/Action/TraceAction.php
@@ -41,7 +41,7 @@ final class TraceAction implements ActionInterface
     #[\Override]
     public function name(): string
     {
-        return 'trace';
+        return 'trace-once';
     }
 
     #[\Override]

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -209,7 +209,7 @@ final class ActionFactory
                 'exec' => $settings->action_exec_command !== null
                     ? new ExecAction($settings->action_exec_command)
                     : null,
-                // trace / stop-trace not supported in daemon mode yet
+                // trace / stop-trace handled worker-side in daemon mode
                 default => null,
             };
             if ($action !== null) {

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -28,8 +28,6 @@ use Reli\Inspector\Watch\Action\TraceAction;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
-/** @phpstan-import-type PhpVersionString from \Reli\Lib\PhpInternals\ZendTypeReader */
-
 final class ActionFactory
 {
     public function __construct(
@@ -150,6 +148,7 @@ final class ActionFactory
     /**
      * Build on-enter lifecycle actions for single-process mode.
      *
+     * @param list<string> $action_names
      * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      * @return list<ActionInterface>
      */
@@ -191,6 +190,7 @@ final class ActionFactory
     /**
      * Build on-enter / on-exit lifecycle actions for daemon mode.
      *
+     * @param list<string> $action_names
      * @return list<ActionInterface>
      */
     public function buildDaemonLifecycleActions(

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -111,7 +111,6 @@ final class ActionFactory
 
         foreach ($settings->actions as $action_name) {
             switch ($action_name) {
-                case 'trace':
                 case 'trace-once':
                     $actions[] = new DaemonTraceAction($trace_output);
                     break;
@@ -236,7 +235,7 @@ final class ActionFactory
         DiskUsageTracker $disk_tracker,
     ): ?ActionInterface {
         return match ($action_name) {
-            'trace', 'trace-once' => new TraceAction(
+            'trace-once' => new TraceAction(
                 $this->call_trace_reader,
                 $trace_output,
                 $php_version,

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -18,13 +18,17 @@ use Reli\Inspector\Output\TraceOutput\TraceOutput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Inspector\Settings\WatchSettings\WatchSettings;
 use Reli\Inspector\Watch\Action\ActionInterface;
+use Reli\Inspector\Watch\Action\ContinuousTraceAction;
 use Reli\Inspector\Watch\Action\DaemonTraceAction;
 use Reli\Inspector\Watch\Action\ExecAction;
 use Reli\Inspector\Watch\Action\LogAction;
 use Reli\Inspector\Watch\Action\MemoryDumpAction;
+use Reli\Inspector\Watch\Action\StopTraceAction;
 use Reli\Inspector\Watch\Action\TraceAction;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
+
+/** @phpstan-import-type PhpVersionString from \Reli\Lib\PhpInternals\ZendTypeReader */
 
 final class ActionFactory
 {
@@ -108,6 +112,7 @@ final class ActionFactory
         foreach ($settings->actions as $action_name) {
             switch ($action_name) {
                 case 'trace':
+                case 'trace-once':
                     $actions[] = new DaemonTraceAction($trace_output);
                     break;
                 case 'log':
@@ -144,6 +149,77 @@ final class ActionFactory
     }
 
     /**
+     * Build on-enter lifecycle actions for single-process mode.
+     *
+     * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     * @return list<ActionInterface>
+     */
+    public function buildLifecycleActions(
+        array $action_names,
+        WatchSettings $settings,
+        TraceOutput $trace_output,
+        string $php_version,
+        int $eg_address,
+        int $sg_address,
+        int $cg_address,
+        int $depth,
+        TargetPhpSettings $target_php_settings,
+        DiskUsageTracker $disk_tracker,
+        TraceSession $trace_session,
+    ): array {
+        $actions = [];
+        foreach ($action_names as $name) {
+            $action = $this->buildLifecycleAction(
+                $name,
+                $settings,
+                $trace_output,
+                $php_version,
+                $eg_address,
+                $sg_address,
+                $cg_address,
+                $depth,
+                $target_php_settings,
+                $disk_tracker,
+                $trace_session,
+            );
+            if ($action !== null) {
+                $actions[] = $action;
+            }
+        }
+        return $actions;
+    }
+
+    /**
+     * Build on-enter / on-exit lifecycle actions for daemon mode.
+     *
+     * @return list<ActionInterface>
+     */
+    public function buildDaemonLifecycleActions(
+        array $action_names,
+        WatchSettings $settings,
+        TraceOutput $trace_output,
+    ): array {
+        $actions = [];
+        foreach ($action_names as $name) {
+            $action = match ($name) {
+                'trace-once' => new DaemonTraceAction($trace_output),
+                'log' => $settings->log_file !== null
+                    ? LogAction::toFile($settings->log_file)
+                    : new LogAction(),
+                'exec' => $settings->action_exec_command !== null
+                    ? new ExecAction($settings->action_exec_command)
+                    : null,
+                // trace / stop-trace not supported in daemon mode yet
+                default => null,
+            };
+            if ($action !== null) {
+                $actions[] = $action;
+            }
+        }
+        return $actions;
+    }
+
+    /**
      * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
      * @psalm-suppress InvalidArgument
      */
@@ -160,7 +236,56 @@ final class ActionFactory
         DiskUsageTracker $disk_tracker,
     ): ?ActionInterface {
         return match ($action_name) {
-            'trace' => new TraceAction(
+            'trace', 'trace-once' => new TraceAction(
+                $this->call_trace_reader,
+                $trace_output,
+                $php_version,
+                $eg_address,
+                $sg_address,
+                $depth,
+            ),
+            'log' => $settings->log_file !== null
+                ? LogAction::toFile($settings->log_file)
+                : new LogAction(),
+            /** @psalm-suppress InvalidArgument */
+            'memory-dump' => new MemoryDumpAction(
+                $this->memory_dumper,
+                $this->process_stopper,
+                $target_php_settings,
+                $eg_address,
+                $cg_address,
+                $settings->action_output_dir,
+                $disk_tracker,
+                $settings->include_binary,
+            ),
+            'exec' => $settings->action_exec_command !== null
+                ? new ExecAction($settings->action_exec_command)
+                : null,
+            default => null,
+        };
+    }
+
+    /**
+     * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     * @psalm-suppress InvalidArgument
+     */
+    private function buildLifecycleAction(
+        string $action_name,
+        WatchSettings $settings,
+        TraceOutput $trace_output,
+        string $php_version,
+        int $eg_address,
+        int $sg_address,
+        int $cg_address,
+        int $depth,
+        TargetPhpSettings $target_php_settings,
+        DiskUsageTracker $disk_tracker,
+        TraceSession $trace_session,
+    ): ?ActionInterface {
+        return match ($action_name) {
+            'trace' => new ContinuousTraceAction($trace_session),
+            'stop-trace' => new StopTraceAction($trace_session),
+            'trace-once' => new TraceAction(
                 $this->call_trace_reader,
                 $trace_output,
                 $php_version,

--- a/src/Inspector/Watch/CpuUsageReader.php
+++ b/src/Inspector/Watch/CpuUsageReader.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Reads per-process CPU usage from /proc/[pid]/stat.
+ *
+ * /proc/[pid]/stat fields (1-indexed):
+ *   14: utime — user mode jiffies
+ *   15: stime — kernel mode jiffies
+ *
+ * CPU% = delta(utime + stime) / delta(wall_time) * 100 / SC_CLK_TCK
+ *
+ * Returns percentage (0.0–N*100.0 for N cores) for the single process.
+ */
+final class CpuUsageReader
+{
+    private int $clk_tck;
+
+    /** @var array<int, array{ticks: int, time: float}> previous sample per PID */
+    private array $previous = [];
+
+    public function __construct()
+    {
+        $this->clk_tck = self::detectClkTck();
+    }
+
+    private static function detectClkTck(): int
+    {
+        if (\function_exists('posix_sysconf') && \defined('POSIX_SC_CLK_TCK')) {
+            /** @var int $val */
+            $val = \posix_sysconf(\POSIX_SC_CLK_TCK);
+            if ($val > 0) {
+                return $val;
+            }
+        }
+        return 100; // Linux default
+    }
+
+    /**
+     * Read CPU usage percentage for the given PID.
+     *
+     * First call for a PID always returns null (no delta yet).
+     *
+     * @return float|null CPU usage in percent (e.g. 85.3), or null if unreadable / first sample
+     */
+    public function read(int $pid): ?float
+    {
+        $content = @\file_get_contents("/proc/{$pid}/stat");
+        if ($content === false) {
+            return null;
+        }
+
+        // /proc/[pid]/stat format: pid (comm) state field4 field5 ... field14(utime) field15(stime) ...
+        // comm may contain spaces and parentheses, so find the last ')' first
+        $close_paren = \strrpos($content, ')');
+        if ($close_paren === false) {
+            return null;
+        }
+        $after_comm = \substr($content, $close_paren + 2); // skip ") "
+        $fields = \explode(' ', $after_comm);
+
+        // After comm: field3=state, field4, ..., field14=utime(index 11), field15=stime(index 12)
+        if (!isset($fields[12])) {
+            return null;
+        }
+
+        $utime = (int)$fields[11];
+        $stime = (int)$fields[12];
+        $total_ticks = $utime + $stime;
+        $now = \microtime(true);
+
+        $prev = $this->previous[$pid] ?? null;
+        $this->previous[$pid] = ['ticks' => $total_ticks, 'time' => $now];
+
+        if ($prev === null) {
+            return null;
+        }
+
+        $dt = $now - $prev['time'];
+        if ($dt <= 0.0) {
+            return null;
+        }
+
+        $dticks = $total_ticks - $prev['ticks'];
+        if ($dticks < 0) {
+            // Counter wrapped or process restarted
+            return null;
+        }
+
+        // ticks / clk_tck = CPU seconds consumed
+        // CPU% = (CPU seconds / wall seconds) * 100
+        return ($dticks / $this->clk_tck) / $dt * 100.0;
+    }
+
+    /**
+     * Clear stored state for a PID (e.g. when process exits).
+     */
+    public function clear(int $pid): void
+    {
+        unset($this->previous[$pid]);
+    }
+}

--- a/src/Inspector/Watch/CpuUsageReader.php
+++ b/src/Inspector/Watch/CpuUsageReader.php
@@ -102,7 +102,7 @@ final class CpuUsageReader
             return null;
         }
 
-        $percent = ($dticks / $this->clk_tck) / $dt * 100.0;
+        $percent = ((float)$dticks / (float)$this->clk_tck) / $dt * 100.0;
         $this->baseline[$pid] = ['ticks' => $total_ticks, 'time' => $now];
         $this->last_percent[$pid] = $percent;
         return $percent;

--- a/src/Inspector/Watch/CpuUsageReader.php
+++ b/src/Inspector/Watch/CpuUsageReader.php
@@ -23,16 +23,31 @@ namespace Reli\Inspector\Watch;
  * CPU% = delta(utime + stime) / delta(wall_time) * 100 / SC_CLK_TCK
  *
  * Returns percentage (0.0–N*100.0 for N cores) for the single process.
+ *
+ * To avoid noisy readings when the poll interval is very short (e.g. 10ms
+ * during continuous tracing), a minimum sampling window is enforced. The
+ * baseline sample is only replaced when at least $min_window_seconds have
+ * elapsed, so shorter polls reuse the same baseline and produce a stable
+ * moving-average CPU%.
  */
 final class CpuUsageReader
 {
     private int $clk_tck;
 
-    /** @var array<int, array{ticks: int, time: float}> previous sample per PID */
-    private array $previous = [];
+    /** @var array<int, array{ticks: int, time: float}> baseline sample per PID */
+    private array $baseline = [];
 
-    public function __construct()
-    {
+    /** @var array<int, float> last computed CPU% per PID (returned when window not yet elapsed) */
+    private array $last_percent = [];
+
+    /**
+     * @param float $min_window_seconds Minimum time window for CPU% calculation.
+     *        Shorter polls reuse the previous baseline. Default 0.5s gives
+     *        a good balance between responsiveness and noise reduction.
+     */
+    public function __construct(
+        private float $min_window_seconds = 0.5,
+    ) {
         $this->clk_tck = self::detectClkTck();
     }
 
@@ -51,18 +66,61 @@ final class CpuUsageReader
     /**
      * Read CPU usage percentage for the given PID.
      *
-     * First call for a PID always returns null (no delta yet).
+     * First call for a PID always returns null (no baseline yet).
+     * Subsequent calls within min_window_seconds of the baseline
+     * return the last computed value without updating the baseline.
      *
      * @return float|null CPU usage in percent (e.g. 85.3), or null if unreadable / first sample
      */
     public function read(int $pid): ?float
+    {
+        $sample = $this->readSample($pid);
+        if ($sample === null) {
+            return null;
+        }
+        [$total_ticks, $now] = $sample;
+
+        $base = $this->baseline[$pid] ?? null;
+        if ($base === null) {
+            // First sample — store as baseline, no CPU% yet
+            $this->baseline[$pid] = ['ticks' => $total_ticks, 'time' => $now];
+            return null;
+        }
+
+        $dt = $now - $base['time'];
+        if ($dt < $this->min_window_seconds) {
+            // Window not yet elapsed — return last known value
+            return $this->last_percent[$pid] ?? null;
+        }
+
+        // Window elapsed — compute new CPU% and rotate baseline
+        $dticks = $total_ticks - $base['ticks'];
+        if ($dticks < 0) {
+            // Counter wrapped or process restarted — reset
+            $this->baseline[$pid] = ['ticks' => $total_ticks, 'time' => $now];
+            unset($this->last_percent[$pid]);
+            return null;
+        }
+
+        $percent = ($dticks / $this->clk_tck) / $dt * 100.0;
+        $this->baseline[$pid] = ['ticks' => $total_ticks, 'time' => $now];
+        $this->last_percent[$pid] = $percent;
+        return $percent;
+    }
+
+    /**
+     * Read raw ticks from /proc/[pid]/stat.
+     *
+     * @return array{int, float}|null [total_ticks, timestamp] or null
+     */
+    private function readSample(int $pid): ?array
     {
         $content = @\file_get_contents("/proc/{$pid}/stat");
         if ($content === false) {
             return null;
         }
 
-        // /proc/[pid]/stat format: pid (comm) state field4 field5 ... field14(utime) field15(stime) ...
+        // /proc/[pid]/stat format: pid (comm) state field4 ... field14(utime) field15(stime) ...
         // comm may contain spaces and parentheses, so find the last ')' first
         $close_paren = \strrpos($content, ')');
         if ($close_paren === false) {
@@ -78,30 +136,7 @@ final class CpuUsageReader
 
         $utime = (int)$fields[11];
         $stime = (int)$fields[12];
-        $total_ticks = $utime + $stime;
-        $now = \microtime(true);
-
-        $prev = $this->previous[$pid] ?? null;
-        $this->previous[$pid] = ['ticks' => $total_ticks, 'time' => $now];
-
-        if ($prev === null) {
-            return null;
-        }
-
-        $dt = $now - $prev['time'];
-        if ($dt <= 0.0) {
-            return null;
-        }
-
-        $dticks = $total_ticks - $prev['ticks'];
-        if ($dticks < 0) {
-            // Counter wrapped or process restarted
-            return null;
-        }
-
-        // ticks / clk_tck = CPU seconds consumed
-        // CPU% = (CPU seconds / wall seconds) * 100
-        return ($dticks / $this->clk_tck) / $dt * 100.0;
+        return [$utime + $stime, \microtime(true)];
     }
 
     /**
@@ -109,6 +144,6 @@ final class CpuUsageReader
      */
     public function clear(int $pid): void
     {
-        unset($this->previous[$pid]);
+        unset($this->baseline[$pid], $this->last_percent[$pid]);
     }
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
@@ -20,6 +20,7 @@ use Reli\Inspector\Settings\WatchSettings\WatchSettings;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
@@ -101,17 +102,17 @@ final class PhpWatchController implements PhpWatchControllerInterface
     }
 
     #[\Override]
-    public function receiveTriggerOrDetach(): WatchTriggerMessage|WatchDetachMessage
+    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage
     {
         return $this->auto_context_recovering->withAutoRecover(
-            function (PhpWatchControllerProtocolInterface $protocol): WatchTriggerMessage|WatchDetachMessage {
-                $message = $protocol->receiveTriggerOrDetach();
+            function (PhpWatchControllerProtocolInterface $protocol): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage {
+                $message = $protocol->receiveMessage();
                 if ($message instanceof WatchDetachMessage) {
                     $this->attach_already_sent = null;
                 }
                 return $message;
             },
-            'failed to receive trigger or detach from watch worker',
+            'failed to receive message from watch worker',
         );
     }
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
@@ -20,9 +20,7 @@ use Reli\Inspector\Settings\WatchSettings\WatchSettings;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchWorkerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
 final class PhpWatchController implements PhpWatchControllerInterface
@@ -103,10 +101,10 @@ final class PhpWatchController implements PhpWatchControllerInterface
     }
 
     #[\Override]
-    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage
+    public function receiveMessage(): WatchWorkerMessage
     {
         return $this->auto_context_recovering->withAutoRecover(
-            function (PhpWatchControllerProtocolInterface $protocol): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage {
+            function (PhpWatchControllerProtocolInterface $protocol): WatchWorkerMessage {
                 $message = $protocol->receiveMessage();
                 if ($message instanceof WatchDetachMessage) {
                     $this->attach_already_sent = null;

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchController.php
@@ -21,6 +21,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
@@ -102,10 +103,10 @@ final class PhpWatchController implements PhpWatchControllerInterface
     }
 
     #[\Override]
-    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage
+    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage
     {
         return $this->auto_context_recovering->withAutoRecover(
-            function (PhpWatchControllerProtocolInterface $protocol): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage {
+            function (PhpWatchControllerProtocolInterface $protocol): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage {
                 $message = $protocol->receiveMessage();
                 if ($message instanceof WatchDetachMessage) {
                     $this->attach_already_sent = null;

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettings;
 use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
 use Reli\Inspector\Settings\WatchSettings\WatchSettings;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 
 interface PhpWatchControllerInterface
@@ -35,5 +36,5 @@ interface PhpWatchControllerInterface
         \Reli\Inspector\Watch\Daemon\Searcher\WatchTargetDescriptor $process_descriptor,
     ): void;
 
-    public function receiveTriggerOrDetach(): WatchTriggerMessage|WatchDetachMessage;
+    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage;
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
@@ -16,10 +16,7 @@ namespace Reli\Inspector\Watch\Daemon\Controller;
 use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettings;
 use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
 use Reli\Inspector\Settings\WatchSettings\WatchSettings;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchWorkerMessage;
 
 interface PhpWatchControllerInterface
 {
@@ -37,5 +34,5 @@ interface PhpWatchControllerInterface
         \Reli\Inspector\Watch\Daemon\Searcher\WatchTargetDescriptor $process_descriptor,
     ): void;
 
-    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage;
+    public function receiveMessage(): WatchWorkerMessage;
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerInterface.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
 use Reli\Inspector\Settings\WatchSettings\WatchSettings;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 
 interface PhpWatchControllerInterface
@@ -36,5 +37,5 @@ interface PhpWatchControllerInterface
         \Reli\Inspector\Watch\Daemon\Searcher\WatchTargetDescriptor $process_descriptor,
     ): void;
 
-    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage;
+    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage;
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
@@ -15,11 +15,8 @@ namespace Reli\Inspector\Watch\Daemon\Controller;
 
 use Amp\Sync\Channel;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchWorkerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
 final class PhpWatchControllerProtocol implements PhpWatchControllerProtocolInterface
@@ -48,9 +45,9 @@ final class PhpWatchControllerProtocol implements PhpWatchControllerProtocolInte
     }
 
     #[\Override]
-    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage
+    public function receiveMessage(): WatchWorkerMessage
     {
-        /** @var WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage */
+        /** @var WatchWorkerMessage */
         return $this->channel->receive();
     }
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
@@ -17,6 +17,7 @@ use Amp\Sync\Channel;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
@@ -46,9 +47,9 @@ final class PhpWatchControllerProtocol implements PhpWatchControllerProtocolInte
     }
 
     #[\Override]
-    public function receiveTriggerOrDetach(): WatchTriggerMessage|WatchDetachMessage
+    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage
     {
-        /** @var WatchTriggerMessage|WatchDetachMessage */
+        /** @var WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage */
         return $this->channel->receive();
     }
 }

--- a/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
+++ b/src/Inspector/Watch/Daemon/Controller/PhpWatchControllerProtocol.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchControllerProtocolInterface;
 
@@ -47,9 +48,9 @@ final class PhpWatchControllerProtocol implements PhpWatchControllerProtocolInte
     }
 
     #[\Override]
-    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage
+    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage
     {
-        /** @var WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage */
+        /** @var WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage */
         return $this->channel->receive();
     }
 }

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchTraceNotifyMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchTraceNotifyMessage.php
@@ -19,7 +19,7 @@ namespace Reli\Inspector\Watch\Daemon\Protocol\Message;
  * Sent when the worker autonomously starts or stops a continuous trace
  * session based on trigger state transitions.
  */
-final class WatchTraceNotifyMessage
+final class WatchTraceNotifyMessage implements WatchWorkerMessage
 {
     public function __construct(
         public readonly int $pid,

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchTraceNotifyMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchTraceNotifyMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Daemon\Protocol\Message;
+
+/**
+ * Notification from worker to controller about trace session lifecycle.
+ *
+ * Sent when the worker autonomously starts or stops a continuous trace
+ * session based on trigger state transitions.
+ */
+final class WatchTraceNotifyMessage
+{
+    public function __construct(
+        public readonly int $pid,
+        public readonly bool $started,
+        public readonly ?string $trace_path,
+    ) {
+    }
+}

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerExitMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerExitMessage.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Daemon\Protocol\Message;
+
+use Reli\Inspector\Watch\TriggerEvent;
+
+/**
+ * Sent from worker to controller when a trigger condition clears (EXIT phase).
+ *
+ * This allows the controller to execute on-exit one-shot actions (log, exec)
+ * at the moment the condition is no longer met, not just on process detach.
+ */
+final class WatchTriggerExitMessage
+{
+    public function __construct(
+        public readonly int $pid,
+        public readonly TriggerEvent $event,
+    ) {
+    }
+}

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerExitMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerExitMessage.php
@@ -21,7 +21,7 @@ use Reli\Inspector\Watch\TriggerEvent;
  * This allows the controller to execute on-exit one-shot actions (log, exec)
  * at the moment the condition is no longer met, not just on process detach.
  */
-final class WatchTriggerExitMessage
+final class WatchTriggerExitMessage implements WatchWorkerMessage
 {
     public function __construct(
         public readonly int $pid,

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchTriggerMessage.php
@@ -17,7 +17,7 @@ use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\TriggerEvent;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
-final class WatchTriggerMessage
+final class WatchTriggerMessage implements WatchWorkerMessage
 {
     public function __construct(
         public readonly int $pid,

--- a/src/Inspector/Watch/Daemon/Protocol/Message/WatchWorkerMessage.php
+++ b/src/Inspector/Watch/Daemon/Protocol/Message/WatchWorkerMessage.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Watch\Daemon\Protocol\Message;
 
-final class WatchDetachMessage implements WatchWorkerMessage
+/**
+ * Marker interface for all messages sent from watch worker to controller.
+ *
+ * Implemented by WatchTriggerMessage, WatchTriggerExitMessage,
+ * WatchTraceNotifyMessage, and WatchDetachMessage.
+ */
+interface WatchWorkerMessage
 {
-    public function __construct(
-        public readonly int $pid,
-    ) {
-    }
 }

--- a/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
+++ b/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Watch\Daemon\Protocol;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Lib\Amphp\MessageProtocolInterface;
 
@@ -25,5 +26,5 @@ interface PhpWatchControllerProtocolInterface extends MessageProtocolInterface
 
     public function sendAttach(WatchAttachMessage $message): void;
 
-    public function receiveTriggerOrDetach(): WatchTriggerMessage|WatchDetachMessage;
+    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage;
 }

--- a/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
+++ b/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
@@ -14,11 +14,8 @@ declare(strict_types=1);
 namespace Reli\Inspector\Watch\Daemon\Protocol;
 
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
-use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchWorkerMessage;
 use Reli\Lib\Amphp\MessageProtocolInterface;
 
 interface PhpWatchControllerProtocolInterface extends MessageProtocolInterface
@@ -27,5 +24,5 @@ interface PhpWatchControllerProtocolInterface extends MessageProtocolInterface
 
     public function sendAttach(WatchAttachMessage $message): void;
 
-    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage;
+    public function receiveMessage(): WatchWorkerMessage;
 }

--- a/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
+++ b/src/Inspector/Watch/Daemon/Protocol/PhpWatchControllerProtocolInterface.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Lib\Amphp\MessageProtocolInterface;
 
@@ -26,5 +27,5 @@ interface PhpWatchControllerProtocolInterface extends MessageProtocolInterface
 
     public function sendAttach(WatchAttachMessage $message): void;
 
-    public function receiveMessage(): WatchTriggerMessage|WatchDetachMessage|WatchTraceNotifyMessage;
+    public function receiveMessage(): WatchTriggerMessage|WatchTriggerExitMessage|WatchDetachMessage|WatchTraceNotifyMessage;
 }

--- a/src/Inspector/Watch/Daemon/Protocol/PhpWatchWorkerProtocolInterface.php
+++ b/src/Inspector/Watch/Daemon/Protocol/PhpWatchWorkerProtocolInterface.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Watch\Daemon\Protocol;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Lib\Amphp\MessageProtocolInterface;
 
@@ -26,6 +27,8 @@ interface PhpWatchWorkerProtocolInterface extends MessageProtocolInterface
     public function receiveAttach(): WatchAttachMessage;
 
     public function sendTrigger(WatchTriggerMessage $message): void;
+
+    public function sendTraceNotify(WatchTraceNotifyMessage $message): void;
 
     public function sendDetach(WatchDetachMessage $message): void;
 }

--- a/src/Inspector/Watch/Daemon/Protocol/PhpWatchWorkerProtocolInterface.php
+++ b/src/Inspector/Watch/Daemon/Protocol/PhpWatchWorkerProtocolInterface.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Lib\Amphp\MessageProtocolInterface;
 
@@ -27,6 +28,8 @@ interface PhpWatchWorkerProtocolInterface extends MessageProtocolInterface
     public function receiveAttach(): WatchAttachMessage;
 
     public function sendTrigger(WatchTriggerMessage $message): void;
+
+    public function sendTriggerExit(WatchTriggerExitMessage $message): void;
 
     public function sendTraceNotify(WatchTraceNotifyMessage $message): void;
 

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Watch\CooldownManager;
 use Reli\Inspector\Watch\CpuUsageReader;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 use Reli\Inspector\Watch\HeapStats;
@@ -270,6 +271,15 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                                         trace_path: $path,
                                     ));
                                 }
+                                // Notify controller so it can execute on-exit actions
+                                $this->protocol->sendTriggerExit(new WatchTriggerExitMessage(
+                                    pid: $descriptor->pid,
+                                    event: new \Reli\Inspector\Watch\TriggerEvent(
+                                        trigger_name: $trigger->name(),
+                                        description: 'condition cleared',
+                                        timestamp: $now,
+                                    ),
+                                ));
                                 $cooldown->recordClear($trigger->name());
                                 continue;
                             }

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -16,11 +16,15 @@ namespace Reli\Inspector\Watch\Daemon\Worker;
 use Reli\Inspector\Watch\CooldownManager;
 use Reli\Inspector\Watch\CpuUsageReader;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Inspector\Watch\HeapStatsReader;
 use Reli\Inspector\Watch\RssReader;
+use Reli\Inspector\Watch\TraceSession;
+use Reli\Inspector\Watch\TriggerPhase;
+use Reli\Inspector\Watch\TriggerStateTracker;
 use Reli\Inspector\Watch\VariableReader;
 use Reli\Inspector\Watch\VariableSpec;
 use Reli\Inspector\Watch\Trigger\CpuUsageTrigger;
@@ -34,6 +38,7 @@ use Reli\Inspector\Watch\Trigger\TriggerInterface;
 use Reli\Inspector\Watch\Trigger\VariableValueTrigger;
 use Reli\Inspector\Watch\WatchContext;
 use Reli\Lib\Amphp\WorkerEntryPointInterface;
+use Reli\Lib\Directory\AppDirectory;
 use Reli\Lib\Log\Log;
 use Reli\Lib\Loop\LoopCondition\InfiniteLoopCondition;
 use Reli\Lib\Loop\LoopCondition\LoopConditionInterface;
@@ -92,6 +97,11 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
             }
         }
 
+        // Determine if continuous tracing is requested
+        $has_continuous_trace = \in_array('trace', $watch_settings->on_enter_actions, true);
+        // When tracing, always read call traces regardless of trigger requirements
+        $needs_call_trace_for_triggers = $needs_call_trace;
+
         // Worker handles cooldown/backoff per-process.
         // Global max_triggers is enforced by the controller (not here),
         // since it must be a single counter across all workers.
@@ -104,6 +114,17 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         );
 
         $poll_sleep_us = $watch_settings->poll_interval_ms * 1000;
+        $trace_sleep_us = $watch_settings->trace_interval_ms * 1000;
+
+        // Lifecycle state tracking for on-enter/on-exit
+        $has_lifecycle = count($watch_settings->on_enter_actions) > 0
+            || count($watch_settings->on_exit_actions) > 0;
+        $state_tracker = new TriggerStateTracker();
+
+        // Ensure output directory exists for trace files
+        if ($has_continuous_trace) {
+            AppDirectory::ensureDirectoryExists($watch_settings->action_output_dir);
+        }
 
         while ($this->loop_condition->shouldContinue()) {
             $attach_message = $this->protocol->receiveAttach();
@@ -125,6 +146,14 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
             $consecutive_failures = 0;
             $max_consecutive_failures = 10;
 
+            // Per-process trace session (worker-local .rbt file)
+            $trace_session = $has_continuous_trace
+                ? new TraceSession(
+                    $watch_settings->action_output_dir,
+                    $watch_settings->trace_interval_ms * 1000,
+                )
+                : null;
+
             // Prime CPU reader for this process
             if ($needs_cpu) {
                 $this->cpu_usage_reader->read($descriptor->pid);
@@ -132,6 +161,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
 
             try {
                 while ($this->loop_condition->shouldContinue()) {
+                    $loop_start = \hrtime(true);
                     $now = microtime(true);
                     $call_trace = null;
                     $rss_bytes = null;
@@ -145,7 +175,8 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                             $descriptor->eg_address,
                         );
 
-                        if ($needs_call_trace) {
+                        // Read call trace if triggers need it OR tracing is active
+                        if ($needs_call_trace_for_triggers || ($trace_session?->isActive() ?? false)) {
                             $call_trace = $this->call_trace_reader
                                 ->readCallTrace(
                                     $descriptor->pid,
@@ -186,7 +217,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                             break;
                         }
                         $previous_context = null;
-                        usleep($poll_sleep_us);
+                        $this->dynamicSleep($loop_start, ($trace_session?->isActive() ?? false) ? $trace_sleep_us : $poll_sleep_us);
                         continue;
                     }
                     $consecutive_failures = 0;
@@ -205,9 +236,45 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                         cpu_usage_percent: $cpu_percent,
                     );
 
-                    // Evaluate triggers (with cooldown/rate limiting in worker)
+                    // Record trace sample if continuous tracing is active
+                    if ($trace_session?->isActive() && $call_trace !== null) {
+                        $trace_session->recordSample($call_trace);
+                    }
+
+                    // Evaluate triggers with lifecycle tracking
                     foreach ($triggers as $trigger) {
                         $event = $trigger->evaluate($context);
+                        $is_active = $event !== null;
+
+                        if ($has_lifecycle) {
+                            $phase = $state_tracker->update($trigger->name(), $is_active);
+
+                            if ($phase === TriggerPhase::ENTER) {
+                                // Start continuous trace on enter
+                                if ($trace_session !== null && $event !== null) {
+                                    $trace_session->start($descriptor->pid, $now);
+                                    $this->protocol->sendTraceNotify(new WatchTraceNotifyMessage(
+                                        pid: $descriptor->pid,
+                                        started: true,
+                                        trace_path: $trace_session->getCurrentPath(),
+                                    ));
+                                }
+                            } elseif ($phase === TriggerPhase::EXIT) {
+                                // Stop continuous trace on exit
+                                if ($trace_session?->isActive()) {
+                                    $path = $trace_session->getCurrentPath();
+                                    $trace_session->stop();
+                                    $this->protocol->sendTraceNotify(new WatchTraceNotifyMessage(
+                                        pid: $descriptor->pid,
+                                        started: false,
+                                        trace_path: $path,
+                                    ));
+                                }
+                                $cooldown->recordClear($trigger->name());
+                                continue;
+                            }
+                        }
+
                         if ($event === null) {
                             $cooldown->recordClear($trigger->name());
                             continue;
@@ -228,7 +295,12 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                     }
 
                     $previous_context = $context;
-                    usleep($poll_sleep_us);
+
+                    // Dynamic sleep: trace_interval when tracing, poll_interval otherwise
+                    $this->dynamicSleep(
+                        $loop_start,
+                        ($trace_session?->isActive() ?? false) ? $trace_sleep_us : $poll_sleep_us,
+                    );
                 }
             } catch (\Throwable $e) {
                 Log::debug('watch worker: exception', [
@@ -237,11 +309,37 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                 ]);
             }
 
+            // Stop trace session on detach
+            if ($trace_session?->isActive()) {
+                $path = $trace_session->getCurrentPath();
+                $trace_session->stop();
+                $this->protocol->sendTraceNotify(new WatchTraceNotifyMessage(
+                    pid: $descriptor->pid,
+                    started: false,
+                    trace_path: $path,
+                ));
+            }
+
             if ($needs_cpu) {
                 $this->cpu_usage_reader->clear($descriptor->pid);
             }
             $this->protocol->sendDetach(new WatchDetachMessage($descriptor->pid));
             Log::debug('watch worker: detached', ['pid' => $descriptor->pid]);
+        }
+    }
+
+    /**
+     * Sleep for the remaining interval, accounting for elapsed time.
+     *
+     * @param int $start hrtime(true) at loop start
+     * @param int $interval_us target interval in microseconds
+     */
+    private function dynamicSleep(int $start, int $interval_us): void
+    {
+        $elapsed_us = (int)((\hrtime(true) - $start) / 1000);
+        $wait = $interval_us - $elapsed_us;
+        if ($wait > 0) {
+            \usleep($wait);
         }
     }
 

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Watch\Daemon\Worker;
 
 use Reli\Inspector\Watch\CooldownManager;
+use Reli\Inspector\Watch\CpuUsageReader;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
@@ -22,6 +23,7 @@ use Reli\Inspector\Watch\HeapStatsReader;
 use Reli\Inspector\Watch\RssReader;
 use Reli\Inspector\Watch\VariableReader;
 use Reli\Inspector\Watch\VariableSpec;
+use Reli\Inspector\Watch\Trigger\CpuUsageTrigger;
 use Reli\Inspector\Watch\Trigger\FunctionDetectionTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryGrowthRateTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryUsageTrigger;
@@ -44,6 +46,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
     public function __construct(
         private HeapStatsReader $heap_stats_reader,
         private RssReader $rss_reader,
+        private CpuUsageReader $cpu_usage_reader,
         private CallTraceReader $call_trace_reader,
         private VariableReader $variable_reader,
         private PhpWatchWorkerProtocolInterface $protocol,
@@ -67,6 +70,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         $triggers = $this->buildTriggers($watch_settings);
         $needs_call_trace = false;
         $needs_rss = false;
+        $needs_cpu = false;
         /** @var list<VariableSpec> $var_specs */
         $var_specs = [];
         foreach ($triggers as $trigger) {
@@ -75,6 +79,9 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
             }
             if ($trigger instanceof RssUsageTrigger) {
                 $needs_rss = true;
+            }
+            if ($trigger instanceof CpuUsageTrigger) {
+                $needs_cpu = true;
             }
             if ($trigger instanceof VariableValueTrigger) {
                 $var_specs[] = new VariableSpec(
@@ -118,6 +125,11 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
             $consecutive_failures = 0;
             $max_consecutive_failures = 10;
 
+            // Prime CPU reader for this process
+            if ($needs_cpu) {
+                $this->cpu_usage_reader->read($descriptor->pid);
+            }
+
             try {
                 while ($this->loop_condition->shouldContinue()) {
                     $now = microtime(true);
@@ -159,6 +171,11 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                         if ($needs_rss) {
                             $rss_bytes = $this->rss_reader->read($descriptor->pid);
                         }
+
+                        $cpu_percent = null;
+                        if ($needs_cpu) {
+                            $cpu_percent = $this->cpu_usage_reader->read($descriptor->pid);
+                        }
                     } catch (\Throwable) {
                         $consecutive_failures++;
                         if ($consecutive_failures >= $max_consecutive_failures) {
@@ -176,6 +193,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
 
                     assert(isset($heap_stats));
                     assert(isset($variable_values));
+                    assert(isset($cpu_percent));
 
                     $context = new WatchContext(
                         pid: $descriptor->pid,
@@ -185,6 +203,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                         previous: $previous_context,
                         variable_values: $variable_values,
                         rss_bytes: $rss_bytes,
+                        cpu_usage_percent: $cpu_percent,
                     );
 
                     // Evaluate triggers (with cooldown/rate limiting in worker)
@@ -219,6 +238,9 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                 ]);
             }
 
+            if ($needs_cpu) {
+                $this->cpu_usage_reader->clear($descriptor->pid);
+            }
             $this->protocol->sendDetach(new WatchDetachMessage($descriptor->pid));
             Log::debug('watch worker: detached', ['pid' => $descriptor->pid]);
         }
@@ -243,6 +265,13 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
         }
         if ($settings->rss_usage_bytes !== null) {
             $triggers[] = new RssUsageTrigger($settings->rss_usage_bytes);
+        }
+        if ($settings->cpu_usage_percent !== null) {
+            $triggers[] = new CpuUsageTrigger(
+                enter_percent: $settings->cpu_usage_percent,
+                exit_percent: $settings->cpu_usage_exit_percent ?? $settings->cpu_usage_percent,
+                sustain_seconds: $settings->cpu_sustain_seconds,
+            );
         }
         if ($settings->watch_function !== null) {
             $triggers[] = new FunctionDetectionTrigger($settings->watch_function);

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -166,6 +166,7 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                     $now = microtime(true);
                     $call_trace = null;
                     $rss_bytes = null;
+                    $cpu_percent = null;
 
                     // Read process state. Skip poll on failure
                     // (target may be between requests).
@@ -218,7 +219,8 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
                             break;
                         }
                         $previous_context = null;
-                        $this->dynamicSleep($loop_start, ($trace_session?->isActive() ?? false) ? $trace_sleep_us : $poll_sleep_us);
+                        $tracing = $trace_session?->isActive() ?? false;
+                        $this->dynamicSleep($loop_start, $tracing ? $trace_sleep_us : $poll_sleep_us);
                         continue;
                     }
                     $consecutive_failures = 0;

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchEntryPoint.php
@@ -193,7 +193,6 @@ final class PhpWatchEntryPoint implements WorkerEntryPointInterface
 
                     assert(isset($heap_stats));
                     assert(isset($variable_values));
-                    assert(isset($cpu_percent));
 
                     $context = new WatchContext(
                         pid: $descriptor->pid,

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchWorkerProtocol.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchWorkerProtocol.php
@@ -17,6 +17,7 @@ use Amp\Sync\Channel;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 
@@ -49,6 +50,12 @@ final class PhpWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
 
     #[\Override]
     public function sendTrigger(WatchTriggerMessage $message): void
+    {
+        $this->channel->send($message);
+    }
+
+    #[\Override]
+    public function sendTraceNotify(WatchTraceNotifyMessage $message): void
     {
         $this->channel->send($message);
     }

--- a/src/Inspector/Watch/Daemon/Worker/PhpWatchWorkerProtocol.php
+++ b/src/Inspector/Watch/Daemon/Worker/PhpWatchWorkerProtocol.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 
@@ -50,6 +51,12 @@ final class PhpWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
 
     #[\Override]
     public function sendTrigger(WatchTriggerMessage $message): void
+    {
+        $this->channel->send($message);
+    }
+
+    #[\Override]
+    public function sendTriggerExit(WatchTriggerExitMessage $message): void
     {
         $this->channel->send($message);
     }

--- a/src/Inspector/Watch/TraceSession.php
+++ b/src/Inspector/Watch/TraceSession.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use Reli\Converter\BinaryTrace\BinaryTraceWriter;
+use Reli\Inspector\Output\TraceOutput\BinaryTraceOutput;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
+
+/**
+ * Manages the lifecycle of a continuous trace recording within watch.
+ *
+ * - start(): create a new .rbt file and begin recording
+ * - recordSample(): write a trace sample (called each poll while active)
+ * - stop(): finalize and close the .rbt file
+ *
+ * Only one session can be active at a time per instance.
+ */
+final class TraceSession
+{
+    private ?BinaryTraceOutput $output = null;
+    private ?string $current_path = null;
+
+    /**
+     * @param string $output_dir  Directory for trace output files
+     * @param int $sampling_period_us  Sampling period in microseconds for .rbt header
+     */
+    public function __construct(
+        private string $output_dir,
+        private int $sampling_period_us = 10000,
+    ) {
+    }
+
+    /**
+     * Start a new trace recording session.
+     *
+     * If a session is already active, this is a no-op.
+     */
+    public function start(int $pid, float $timestamp): void
+    {
+        if ($this->output !== null) {
+            return;
+        }
+
+        $date = \date('Ymd-His', (int)$timestamp);
+        $ms = \sprintf('%03d', (int)(($timestamp - \floor($timestamp)) * 1000));
+        $this->current_path = \sprintf(
+            '%s/watch-trace-%d-%s.%s.rbt',
+            $this->output_dir,
+            $pid,
+            $date,
+            $ms,
+        );
+
+        $stream = \fopen($this->current_path, 'wb');
+        if ($stream === false) {
+            throw new \RuntimeException("Failed to open trace output: {$this->current_path}");
+        }
+
+        $writer = new BinaryTraceWriter(
+            $stream,
+            $this->sampling_period_us,
+            has_timestamps: true,
+        );
+        $this->output = new BinaryTraceOutput($writer);
+    }
+
+    /**
+     * Record a trace sample. No-op if no session is active.
+     */
+    public function recordSample(CallTrace $call_trace): void
+    {
+        $this->output?->output($call_trace);
+    }
+
+    /**
+     * Stop the current trace recording session.
+     *
+     * Finalizes the .rbt file (checkpoint + segment end).
+     */
+    public function stop(): void
+    {
+        if ($this->output === null) {
+            return;
+        }
+        $this->output->finish();
+        $this->output = null;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->output !== null;
+    }
+
+    /**
+     * Path of the current (or most recently completed) trace file.
+     */
+    public function getCurrentPath(): ?string
+    {
+        return $this->current_path;
+    }
+}

--- a/src/Inspector/Watch/TraceSession.php
+++ b/src/Inspector/Watch/TraceSession.php
@@ -53,7 +53,7 @@ final class TraceSession
         }
 
         $date = \date('Ymd-His', (int)$timestamp);
-        $ms = \sprintf('%03d', (int)(($timestamp - \floor($timestamp)) * 1000));
+        $ms = \sprintf('%03d', (int)(($timestamp - \floor($timestamp)) * 1000.0));
         $this->current_path = \sprintf(
             '%s/watch-trace-%d-%s.%s.rbt',
             $this->output_dir,

--- a/src/Inspector/Watch/Trigger/CpuUsageTrigger.php
+++ b/src/Inspector/Watch/Trigger/CpuUsageTrigger.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Trigger;
+
+use Reli\Inspector\Watch\TriggerEvent;
+use Reli\Inspector\Watch\WatchContext;
+
+/**
+ * Fires when process CPU usage exceeds a threshold.
+ *
+ * Supports hysteresis: enter threshold can differ from exit threshold
+ * to prevent rapid on/off toggling around a single boundary.
+ *
+ * Supports sustain duration: the enter condition must be met
+ * continuously for a specified duration before the trigger activates.
+ *
+ * Once active, the trigger stays active (returns TriggerEvent) until
+ * CPU drops below the exit threshold.
+ */
+final class CpuUsageTrigger implements TriggerInterface
+{
+    private bool $is_active = false;
+    private ?float $sustained_since = null;
+
+    /**
+     * @param float $enter_percent  CPU% threshold to enter (e.g. 80.0)
+     * @param float $exit_percent   CPU% threshold to exit  (e.g. 60.0)
+     * @param float $sustain_seconds How long the enter condition must hold (0 = immediate)
+     */
+    public function __construct(
+        private float $enter_percent,
+        private float $exit_percent,
+        private float $sustain_seconds = 0.0,
+    ) {
+    }
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'cpu-usage';
+    }
+
+    #[\Override]
+    public function requiresCallTrace(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function requiresDeepInspection(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function evaluate(WatchContext $context): ?TriggerEvent
+    {
+        $cpu = $context->cpu_usage_percent;
+        if ($cpu === null) {
+            return null;
+        }
+
+        if (!$this->is_active) {
+            // Check enter condition
+            if ($cpu >= $this->enter_percent) {
+                if ($this->sustain_seconds > 0.0) {
+                    if ($this->sustained_since === null) {
+                        $this->sustained_since = $context->timestamp;
+                    }
+                    if ($context->timestamp - $this->sustained_since < $this->sustain_seconds) {
+                        return null; // not sustained long enough yet
+                    }
+                }
+                $this->is_active = true;
+                $this->sustained_since = null;
+                return new TriggerEvent(
+                    trigger_name: $this->name(),
+                    description: sprintf(
+                        'cpu=%.1f%%>=%.0f%%',
+                        $cpu,
+                        $this->enter_percent,
+                    ),
+                    timestamp: $context->timestamp,
+                    value: $cpu,
+                );
+            }
+            // Below enter threshold — reset sustain timer
+            $this->sustained_since = null;
+            return null;
+        }
+
+        // Active: check exit condition
+        if ($cpu < $this->exit_percent) {
+            $this->is_active = false;
+            $this->sustained_since = null;
+            return null;
+        }
+
+        return new TriggerEvent(
+            trigger_name: $this->name(),
+            description: sprintf(
+                'cpu=%.1f%% (active, exit<%.0f%%)',
+                $cpu,
+                $this->exit_percent,
+            ),
+            timestamp: $context->timestamp,
+            value: $cpu,
+        );
+    }
+}

--- a/src/Inspector/Watch/TriggerFactory.php
+++ b/src/Inspector/Watch/TriggerFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Watch;
 
 use Reli\Inspector\Settings\WatchSettings\WatchSettings;
+use Reli\Inspector\Watch\Trigger\CpuUsageTrigger;
 use Reli\Inspector\Watch\Trigger\FunctionDetectionTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryGrowthRateTrigger;
 use Reli\Inspector\Watch\Trigger\MemoryUsageTrigger;
@@ -50,6 +51,13 @@ final class TriggerFactory
         if ($settings->rss_usage_bytes !== null) {
             $triggers[] = new RssUsageTrigger(
                 $settings->rss_usage_bytes,
+            );
+        }
+        if ($settings->cpu_usage_percent !== null) {
+            $triggers[] = new CpuUsageTrigger(
+                enter_percent: $settings->cpu_usage_percent,
+                exit_percent: $settings->cpu_usage_exit_percent ?? $settings->cpu_usage_percent,
+                sustain_seconds: $settings->cpu_sustain_seconds,
             );
         }
 

--- a/src/Inspector/Watch/TriggerPhase.php
+++ b/src/Inspector/Watch/TriggerPhase.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Represents a trigger state transition detected by TriggerStateTracker.
+ */
+enum TriggerPhase
+{
+    /** Condition just became true (was inactive, now active) */
+    case ENTER;
+
+    /** Condition just became false (was active, now inactive) */
+    case EXIT;
+
+    /** Condition is still true (no transition) */
+    case ACTIVE;
+}

--- a/src/Inspector/Watch/TriggerStateTracker.php
+++ b/src/Inspector/Watch/TriggerStateTracker.php
@@ -55,4 +55,26 @@ final class TriggerStateTracker
     {
         return \in_array(true, $this->states, true);
     }
+
+    /**
+     * Clear all state entries matching a key prefix.
+     *
+     * Used in daemon mode to clean up all trigger states for a PID
+     * (where keys are "pid:trigger_name").
+     *
+     * @return list<string> keys that transitioned from active to cleared
+     */
+    public function clearPrefix(string $prefix): array
+    {
+        $cleared = [];
+        foreach ($this->states as $key => $active) {
+            if (\str_starts_with($key, $prefix)) {
+                if ($active) {
+                    $cleared[] = $key;
+                }
+                unset($this->states[$key]);
+            }
+        }
+        return $cleared;
+    }
 }

--- a/src/Inspector/Watch/TriggerStateTracker.php
+++ b/src/Inspector/Watch/TriggerStateTracker.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Tracks per-trigger active/inactive state and detects transitions.
+ *
+ * Wraps the existing trigger evaluation to provide on-enter / on-exit
+ * lifecycle semantics without changing TriggerInterface.
+ */
+final class TriggerStateTracker
+{
+    /** @var array<string, bool> trigger name → currently active */
+    private array $states = [];
+
+    /**
+     * Update state for a trigger and return the phase.
+     *
+     * @return TriggerPhase|null ENTER, EXIT, ACTIVE, or null (still inactive)
+     */
+    public function update(string $trigger_name, bool $is_active): ?TriggerPhase
+    {
+        $was_active = $this->states[$trigger_name] ?? false;
+        $this->states[$trigger_name] = $is_active;
+
+        if (!$was_active && $is_active) {
+            return TriggerPhase::ENTER;
+        }
+        if ($was_active && !$is_active) {
+            return TriggerPhase::EXIT;
+        }
+        if ($is_active) {
+            return TriggerPhase::ACTIVE;
+        }
+        return null; // was inactive, still inactive
+    }
+
+    public function isActive(string $trigger_name): bool
+    {
+        return $this->states[$trigger_name] ?? false;
+    }
+
+    public function hasAnyActive(): bool
+    {
+        return \in_array(true, $this->states, true);
+    }
+}

--- a/src/Inspector/Watch/WatchContext.php
+++ b/src/Inspector/Watch/WatchContext.php
@@ -30,6 +30,8 @@ final class WatchContext
         public readonly array $variable_values = [],
         /** RSS (Resident Set Size) in bytes, read from /proc/[pid]/statm */
         public readonly ?int $rss_bytes = null,
+        /** CPU usage percentage for this PID (from CpuUsageReader), null if unavailable */
+        public readonly ?float $cpu_usage_percent = null,
         /** Daemon mode: EG address from WatchTriggerMessage */
         public readonly int $daemon_eg_address = 0,
         /** Daemon mode: CG address from WatchTriggerMessage */

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -30,7 +30,12 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'watch-function' => null,
             'trace-depth-limit' => null,
             'watch-var' => [],
+            'cpu-usage' => null,
+            'cpu-usage-exit' => null,
+            'cpu-sustain' => null,
             'action' => ['memory-dump'],
+            'on-enter' => [],
+            'on-exit' => [],
             'action-exec-command' => null,
             'action-output-dir' => null,
             'log-file' => null,
@@ -44,6 +49,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'backoff-multiplier' => null,
             'backoff-max' => null,
             'status-interval' => null,
+            'trace-interval' => null,
             'quiet-watch' => false,
             'include-binary' => false,
             'memory-limit' => null,
@@ -177,7 +183,8 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
                 'action' => ['trace', 'log'],
             ]));
 
-        $this->assertSame(['trace', 'log'], $settings->actions);
+        // 'trace' is mapped to 'trace-once' for backward compatibility
+        $this->assertSame(['trace-once', 'log'], $settings->actions);
     }
 
     public function testMaxDumpSize(): void

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -180,10 +180,9 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
     {
         $settings = (new WatchSettingsFromConsoleInput())
             ->createSettings($this->makeInput([
-                'action' => ['trace', 'log'],
+                'action' => ['trace-once', 'log'],
             ]));
 
-        // 'trace' is mapped to 'trace-once' for backward compatibility
         $this->assertSame(['trace-once', 'log'], $settings->actions);
     }
 

--- a/tests/Inspector/Watch/Action/DaemonTraceActionTest.php
+++ b/tests/Inspector/Watch/Action/DaemonTraceActionTest.php
@@ -29,7 +29,7 @@ class DaemonTraceActionTest extends BaseTestCase
     {
         $trace_output = Mockery::mock(TraceOutput::class);
         $action = new DaemonTraceAction($trace_output);
-        $this->assertSame('trace', $action->name());
+        $this->assertSame('trace-once', $action->name());
     }
 
     public function testOutputsTraceFromContext(): void

--- a/tests/Inspector/Watch/Action/TraceActionTest.php
+++ b/tests/Inspector/Watch/Action/TraceActionTest.php
@@ -42,7 +42,7 @@ class TraceActionTest extends BaseTestCase
             0x2000,
             100,
         );
-        $this->assertSame('trace', $action->name());
+        $this->assertSame('trace-once', $action->name());
     }
 
     public function testReusesTraceFromContext(): void

--- a/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
+++ b/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
@@ -80,7 +80,7 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
         $tps = new TargetPhpSettings(php_version: 'v84');
 
         $actions = $factory->buildActions(
-            $this->makeSettings(['actions' => ['trace']]),
+            $this->makeSettings(['actions' => ['trace-once']]),
             $output,
             'v84',
             0x1000,
@@ -189,7 +189,7 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
 
         $actions = $factory->buildActions(
             $this->makeSettings([
-                'actions' => ['trace', 'log', 'memory-dump', 'exec'],
+                'actions' => ['trace-once', 'log', 'memory-dump', 'exec'],
                 'action_exec_command' => 'curl http://example.com',
             ]),
             $output,

--- a/tests/Inspector/Watch/ActionFactoryTest.php
+++ b/tests/Inspector/Watch/ActionFactoryTest.php
@@ -86,7 +86,7 @@ class ActionFactoryTest extends BaseTestCase
         $output = Mockery::mock(TraceOutput::class);
 
         $actions = $factory->buildDaemonActions(
-            $this->makeSettings(['actions' => ['trace']]),
+            $this->makeSettings(['actions' => ['trace-once']]),
             $output,
             new DiskUsageTracker(1024 * 1024 * 1024),
         );
@@ -144,7 +144,7 @@ class ActionFactoryTest extends BaseTestCase
 
         $actions = $factory->buildDaemonActions(
             $this->makeSettings([
-                'actions' => ['trace', 'log', 'exec'],
+                'actions' => ['trace-once', 'log', 'exec'],
                 'action_exec_command' => 'curl http://localhost',
             ]),
             $output,

--- a/tests/Inspector/Watch/CpuUsageReaderTest.php
+++ b/tests/Inspector/Watch/CpuUsageReaderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use PHPUnit\Framework\TestCase;
+
+class CpuUsageReaderTest extends TestCase
+{
+    public function testMinWindowDefaultIsHalfSecond(): void
+    {
+        $reader = new CpuUsageReader();
+        // Just verify construction works with default
+        $this->assertInstanceOf(CpuUsageReader::class, $reader);
+    }
+
+    public function testCustomMinWindow(): void
+    {
+        $reader = new CpuUsageReader(min_window_seconds: 1.0);
+        $this->assertInstanceOf(CpuUsageReader::class, $reader);
+    }
+
+    public function testClearRemovesPidState(): void
+    {
+        $reader = new CpuUsageReader(min_window_seconds: 0.0);
+        $my_pid = getmypid();
+        if ($my_pid === false) {
+            $this->markTestSkipped('Cannot get PID');
+        }
+
+        // First read: returns null (no baseline)
+        $result = $reader->read($my_pid);
+        $this->assertNull($result);
+
+        // Clear state
+        $reader->clear($my_pid);
+
+        // After clear, first read should return null again
+        $result = $reader->read($my_pid);
+        $this->assertNull($result);
+    }
+
+    public function testReadNonExistentPidReturnsNull(): void
+    {
+        $reader = new CpuUsageReader();
+        // Use a PID that almost certainly doesn't exist
+        $this->assertNull($reader->read(999999999));
+    }
+}

--- a/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
+++ b/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
@@ -127,7 +127,7 @@ final class PhpWatchControllerTest extends BaseTestCase
 
         $protocol = Mockery::mock(PhpWatchControllerProtocolInterface::class);
         $protocol->expects()
-            ->receiveTriggerOrDetach()
+            ->receiveMessage()
             ->andReturn($triggerMsg)
         ;
 
@@ -143,7 +143,7 @@ final class PhpWatchControllerTest extends BaseTestCase
         ;
 
         $controller = new PhpWatchController($auto);
-        $result = $controller->receiveTriggerOrDetach();
+        $result = $controller->receiveMessage();
         $this->assertInstanceOf(WatchTriggerMessage::class, $result);
         $this->assertSame(123, $result->pid);
     }
@@ -154,7 +154,7 @@ final class PhpWatchControllerTest extends BaseTestCase
 
         $protocol = Mockery::mock(PhpWatchControllerProtocolInterface::class);
         $protocol->expects()
-            ->receiveTriggerOrDetach()
+            ->receiveMessage()
             ->andReturn($detachMsg)
         ;
 
@@ -170,7 +170,7 @@ final class PhpWatchControllerTest extends BaseTestCase
         ;
 
         $controller = new PhpWatchController($auto);
-        $result = $controller->receiveTriggerOrDetach();
+        $result = $controller->receiveMessage();
         $this->assertInstanceOf(WatchDetachMessage::class, $result);
         $this->assertSame(456, $result->pid);
     }

--- a/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
+++ b/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
@@ -128,6 +128,7 @@ class PhpWatchEntryPointRunTest extends TestCase
         $entry_point = new PhpWatchEntryPoint(
             heap_stats_reader: $this->createFailingHeapStatsReader(),
             rss_reader: new \Reli\Inspector\Watch\RssReader(),
+            cpu_usage_reader: new \Reli\Inspector\Watch\CpuUsageReader(),
             call_trace_reader: $this->createCallTraceReader(),
             variable_reader: $this->createVariableReader(),
             protocol: $protocol,
@@ -153,6 +154,7 @@ class PhpWatchEntryPointRunTest extends TestCase
         $entry_point = new PhpWatchEntryPoint(
             heap_stats_reader: $this->createFailingHeapStatsReader(),
             rss_reader: new \Reli\Inspector\Watch\RssReader(),
+            cpu_usage_reader: new \Reli\Inspector\Watch\CpuUsageReader(),
             call_trace_reader: $this->createCallTraceReader(),
             variable_reader: $this->createVariableReader(),
             protocol: $protocol,

--- a/tests/Inspector/Watch/Daemon/Worker/TestWatchWorkerProtocol.php
+++ b/tests/Inspector/Watch/Daemon/Worker/TestWatchWorkerProtocol.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerExitMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 
@@ -28,6 +29,8 @@ final class TestWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
     public ?WatchDetachMessage $detach_message = null;
     /** @var list<WatchTriggerMessage> */
     public array $triggers = [];
+    /** @var list<WatchTriggerExitMessage> */
+    public array $trigger_exits = [];
     /** @var list<WatchTraceNotifyMessage> */
     public array $trace_notifications = [];
 
@@ -57,6 +60,11 @@ final class TestWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
     public function sendTrigger(WatchTriggerMessage $message): void
     {
         $this->triggers[] = $message;
+    }
+
+    public function sendTriggerExit(WatchTriggerExitMessage $message): void
+    {
+        $this->trigger_exits[] = $message;
     }
 
     public function sendTraceNotify(WatchTraceNotifyMessage $message): void

--- a/tests/Inspector/Watch/Daemon/Worker/TestWatchWorkerProtocol.php
+++ b/tests/Inspector/Watch/Daemon/Worker/TestWatchWorkerProtocol.php
@@ -17,6 +17,7 @@ use Amp\Sync\Channel;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchAttachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchDetachMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchSettingsMessage;
+use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTraceNotifyMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\Message\WatchTriggerMessage;
 use Reli\Inspector\Watch\Daemon\Protocol\PhpWatchWorkerProtocolInterface;
 
@@ -27,6 +28,8 @@ final class TestWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
     public ?WatchDetachMessage $detach_message = null;
     /** @var list<WatchTriggerMessage> */
     public array $triggers = [];
+    /** @var list<WatchTraceNotifyMessage> */
+    public array $trace_notifications = [];
 
     public function __construct(
         private WatchSettingsMessage $settings_message,
@@ -54,6 +57,11 @@ final class TestWatchWorkerProtocol implements PhpWatchWorkerProtocolInterface
     public function sendTrigger(WatchTriggerMessage $message): void
     {
         $this->triggers[] = $message;
+    }
+
+    public function sendTraceNotify(WatchTraceNotifyMessage $message): void
+    {
+        $this->trace_notifications[] = $message;
     }
 
     public function sendDetach(WatchDetachMessage $message): void

--- a/tests/Inspector/Watch/TraceSessionTest.php
+++ b/tests/Inspector/Watch/TraceSessionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use PHPUnit\Framework\TestCase;
+
+class TraceSessionTest extends TestCase
+{
+    private string $tmpdir;
+
+    protected function setUp(): void
+    {
+        $this->tmpdir = sys_get_temp_dir() . '/reli-test-trace-session-' . getmypid();
+        @mkdir($this->tmpdir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up any generated files
+        $files = glob($this->tmpdir . '/*');
+        if ($files !== false) {
+            foreach ($files as $file) {
+                @unlink($file);
+            }
+        }
+        @rmdir($this->tmpdir);
+    }
+
+    public function testInitiallyInactive(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $this->assertFalse($session->isActive());
+        $this->assertNull($session->getCurrentPath());
+    }
+
+    public function testStartActivatesSession(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.123);
+
+        $this->assertTrue($session->isActive());
+        $this->assertNotNull($session->getCurrentPath());
+        $this->assertStringContainsString('watch-trace-1234-', $session->getCurrentPath());
+        $this->assertStringEndsWith('.rbt', $session->getCurrentPath());
+
+        $session->stop();
+    }
+
+    public function testStopDeactivatesSession(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $session->stop();
+
+        $this->assertFalse($session->isActive());
+    }
+
+    public function testDoubleStartIsNoop(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $path1 = $session->getCurrentPath();
+
+        $session->start(5678, 1700000001.0);
+        $path2 = $session->getCurrentPath();
+
+        // Path should not change — second start is no-op
+        $this->assertSame($path1, $path2);
+
+        $session->stop();
+    }
+
+    public function testDoubleStopIsNoop(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $session->stop();
+        // Should not throw
+        $session->stop();
+        $this->assertFalse($session->isActive());
+    }
+
+    public function testStopWithoutStartIsNoop(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        // Should not throw
+        $session->stop();
+        $this->assertFalse($session->isActive());
+    }
+
+    public function testOutputFileIsCreated(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $path = $session->getCurrentPath();
+        $this->assertNotNull($path);
+        $this->assertFileExists($path);
+        $session->stop();
+    }
+}

--- a/tests/Inspector/Watch/Trigger/CpuUsageTriggerTest.php
+++ b/tests/Inspector/Watch/Trigger/CpuUsageTriggerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Trigger;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\Watch\HeapStats;
+use Reli\Inspector\Watch\WatchContext;
+
+class CpuUsageTriggerTest extends TestCase
+{
+    public function testProperties(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+        $this->assertSame('cpu-usage', $trigger->name());
+        $this->assertFalse($trigger->requiresCallTrace());
+        $this->assertFalse($trigger->requiresDeepInspection());
+    }
+
+    public function testDoesNotFireWhenCpuIsNull(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+        $context = $this->makeContext(null, 1.0);
+
+        $this->assertNull($trigger->evaluate($context));
+    }
+
+    public function testDoesNotFireBelowEnterThreshold(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+
+        $this->assertNull($trigger->evaluate($this->makeContext(50.0, 1.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(79.9, 2.0)));
+    }
+
+    public function testFiresAtEnterThreshold(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+        $event = $trigger->evaluate($this->makeContext(80.0, 1.0));
+
+        $this->assertNotNull($event);
+        $this->assertSame('cpu-usage', $event->trigger_name);
+        $this->assertSame(80.0, $event->value);
+    }
+
+    public function testStaysActiveAboveExitThreshold(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+
+        // Enter
+        $event = $trigger->evaluate($this->makeContext(85.0, 1.0));
+        $this->assertNotNull($event);
+
+        // Still active (above exit threshold of 60%)
+        $event = $trigger->evaluate($this->makeContext(65.0, 2.0));
+        $this->assertNotNull($event);
+        $this->assertSame(65.0, $event->value);
+    }
+
+    public function testExitsBelowExitThreshold(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+
+        // Enter
+        $this->assertNotNull($trigger->evaluate($this->makeContext(85.0, 1.0)));
+
+        // Exit (below exit threshold of 60%)
+        $this->assertNull($trigger->evaluate($this->makeContext(55.0, 2.0)));
+    }
+
+    public function testHysteresis(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0);
+
+        // Enter at 85%
+        $this->assertNotNull($trigger->evaluate($this->makeContext(85.0, 1.0)));
+
+        // Drop to 65% — still active (between exit and enter)
+        $this->assertNotNull($trigger->evaluate($this->makeContext(65.0, 2.0)));
+
+        // Drop to 55% — exits
+        $this->assertNull($trigger->evaluate($this->makeContext(55.0, 3.0)));
+
+        // Rise to 70% — still inactive (below enter threshold)
+        $this->assertNull($trigger->evaluate($this->makeContext(70.0, 4.0)));
+
+        // Rise to 82% — enters again
+        $this->assertNotNull($trigger->evaluate($this->makeContext(82.0, 5.0)));
+    }
+
+    public function testSustainDuration(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0, sustain_seconds: 3.0);
+
+        // Above threshold but not sustained long enough
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 1.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(90.0, 2.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 3.0)));
+
+        // Now sustained for 3 seconds (3.0 - 1.0 = 2.0 < 3.0, so still waiting)
+        // At t=4.0 we have 4.0 - 1.0 = 3.0 >= 3.0 → enter
+        $event = $trigger->evaluate($this->makeContext(82.0, 4.0));
+        $this->assertNotNull($event);
+    }
+
+    public function testSustainResetWhenCpuDrops(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 60.0, sustain_seconds: 3.0);
+
+        // Above threshold
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 1.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(90.0, 2.0)));
+
+        // Drop below enter threshold — sustain timer resets
+        $this->assertNull($trigger->evaluate($this->makeContext(75.0, 3.0)));
+
+        // Go above again — timer restarts from t=4.0
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 4.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 5.0)));
+        $this->assertNull($trigger->evaluate($this->makeContext(85.0, 6.0)));
+
+        // 7.0 - 4.0 = 3.0 >= 3.0 → enter
+        $this->assertNotNull($trigger->evaluate($this->makeContext(85.0, 7.0)));
+    }
+
+    public function testSameThresholdForEnterAndExit(): void
+    {
+        $trigger = new CpuUsageTrigger(80.0, 80.0);
+
+        // Enter at 80%
+        $this->assertNotNull($trigger->evaluate($this->makeContext(80.0, 1.0)));
+
+        // Still at 80% — active (not below exit)
+        $this->assertNotNull($trigger->evaluate($this->makeContext(80.0, 2.0)));
+
+        // Drop to 79.9% — exits (< 80%)
+        $this->assertNull($trigger->evaluate($this->makeContext(79.9, 3.0)));
+    }
+
+    private function makeContext(?float $cpu_percent, float $timestamp): WatchContext
+    {
+        return new WatchContext(
+            pid: 1234,
+            heap_stats: new HeapStats(0, 0, 0, 0),
+            call_trace: null,
+            timestamp: $timestamp,
+            previous: null,
+            cpu_usage_percent: $cpu_percent,
+        );
+    }
+}

--- a/tests/Inspector/Watch/TriggerStateTrackerTest.php
+++ b/tests/Inspector/Watch/TriggerStateTrackerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use PHPUnit\Framework\TestCase;
+
+class TriggerStateTrackerTest extends TestCase
+{
+    public function testFirstActiveIsEnter(): void
+    {
+        $tracker = new TriggerStateTracker();
+        $this->assertSame(TriggerPhase::ENTER, $tracker->update('t1', true));
+    }
+
+    public function testFirstInactiveIsNull(): void
+    {
+        $tracker = new TriggerStateTracker();
+        $this->assertNull($tracker->update('t1', false));
+    }
+
+    public function testActiveToActiveIsActive(): void
+    {
+        $tracker = new TriggerStateTracker();
+        $tracker->update('t1', true); // ENTER
+        $this->assertSame(TriggerPhase::ACTIVE, $tracker->update('t1', true));
+    }
+
+    public function testActiveToInactiveIsExit(): void
+    {
+        $tracker = new TriggerStateTracker();
+        $tracker->update('t1', true); // ENTER
+        $this->assertSame(TriggerPhase::EXIT, $tracker->update('t1', false));
+    }
+
+    public function testInactiveToInactiveIsNull(): void
+    {
+        $tracker = new TriggerStateTracker();
+        $tracker->update('t1', false);
+        $this->assertNull($tracker->update('t1', false));
+    }
+
+    public function testFullLifecycle(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        // inactive → active = ENTER
+        $this->assertSame(TriggerPhase::ENTER, $tracker->update('t1', true));
+        // active → active = ACTIVE
+        $this->assertSame(TriggerPhase::ACTIVE, $tracker->update('t1', true));
+        $this->assertSame(TriggerPhase::ACTIVE, $tracker->update('t1', true));
+        // active → inactive = EXIT
+        $this->assertSame(TriggerPhase::EXIT, $tracker->update('t1', false));
+        // inactive → inactive = null
+        $this->assertNull($tracker->update('t1', false));
+        // inactive → active = ENTER again
+        $this->assertSame(TriggerPhase::ENTER, $tracker->update('t1', true));
+    }
+
+    public function testIndependentTriggers(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        $this->assertSame(TriggerPhase::ENTER, $tracker->update('t1', true));
+        $this->assertNull($tracker->update('t2', false));
+        $this->assertSame(TriggerPhase::ENTER, $tracker->update('t2', true));
+        $this->assertSame(TriggerPhase::ACTIVE, $tracker->update('t1', true));
+    }
+
+    public function testIsActive(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        $this->assertFalse($tracker->isActive('t1'));
+        $tracker->update('t1', true);
+        $this->assertTrue($tracker->isActive('t1'));
+        $tracker->update('t1', false);
+        $this->assertFalse($tracker->isActive('t1'));
+    }
+
+    public function testHasAnyActive(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        $this->assertFalse($tracker->hasAnyActive());
+        $tracker->update('t1', true);
+        $this->assertTrue($tracker->hasAnyActive());
+        $tracker->update('t1', false);
+        $this->assertFalse($tracker->hasAnyActive());
+
+        $tracker->update('t1', true);
+        $tracker->update('t2', true);
+        $this->assertTrue($tracker->hasAnyActive());
+        $tracker->update('t1', false);
+        $this->assertTrue($tracker->hasAnyActive()); // t2 still active
+        $tracker->update('t2', false);
+        $this->assertFalse($tracker->hasAnyActive());
+    }
+}

--- a/tests/Inspector/Watch/TriggerStateTrackerTest.php
+++ b/tests/Inspector/Watch/TriggerStateTrackerTest.php
@@ -106,4 +106,37 @@ class TriggerStateTrackerTest extends TestCase
         $tracker->update('t2', false);
         $this->assertFalse($tracker->hasAnyActive());
     }
+
+    public function testClearPrefixReturnsActiveKeys(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        $tracker->update('1234:cpu-usage', true);
+        $tracker->update('1234:memory-usage', true);
+        $tracker->update('5678:cpu-usage', true);
+
+        $cleared = $tracker->clearPrefix('1234:');
+        $this->assertCount(2, $cleared);
+        $this->assertContains('1234:cpu-usage', $cleared);
+        $this->assertContains('1234:memory-usage', $cleared);
+
+        // 1234 keys are gone
+        $this->assertFalse($tracker->isActive('1234:cpu-usage'));
+        $this->assertFalse($tracker->isActive('1234:memory-usage'));
+
+        // 5678 untouched
+        $this->assertTrue($tracker->isActive('5678:cpu-usage'));
+    }
+
+    public function testClearPrefixOnlyReturnsActive(): void
+    {
+        $tracker = new TriggerStateTracker();
+
+        $tracker->update('1:a', true);
+        $tracker->update('1:b', false); // inactive
+        $tracker->update('1:a', false); // now inactive
+
+        $cleared = $tracker->clearPrefix('1:');
+        $this->assertCount(0, $cleared); // both inactive
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds CPU usage monitoring and lifecycle-based actions (on-enter/on-exit) to the watch command, enabling more sophisticated trigger-based profiling workflows.

## Key Changes

### CPU Usage Trigger
- **New `CpuUsageTrigger`**: Monitors process CPU usage from `/proc/[pid]/stat` with support for:
  - Hysteresis (separate enter/exit thresholds to prevent rapid toggling)
  - Sustain duration (condition must hold continuously before triggering)
  - New `CpuUsageReader` that computes CPU% delta between polls using `SC_CLK_TCK`
- **Console options**: `--cpu-usage`, `--cpu-usage-exit`, `--cpu-sustain`

### Lifecycle Actions
- **New action types**: `ContinuousTraceAction` and `StopTraceAction` for stateful trace recording
- **New console options**: `--on-enter` and `--on-exit` for lifecycle-based action execution
- **`TriggerStateTracker`**: Detects state transitions (ENTER, EXIT, ACTIVE) without modifying `TriggerInterface`
- **`TriggerPhase` enum**: Represents trigger state transitions

### Continuous Trace Recording
- **New `TraceSession`**: Manages lifecycle of continuous `.rbt` trace files
  - `start()`: Creates new trace file on trigger enter
  - `recordSample()`: Records samples while active
  - `stop()`: Finalizes trace file on trigger exit
- Trace recording is driven by the watch poll loop and respects `--trace-interval-ms`

### Watch Loop Improvements
- Dynamic sleep management: Distinguishes between `poll_interval_ms` (trigger checks) and `trace_interval_ms` (trace sampling)
- Call trace is now read if either triggers need it OR continuous tracing is active
- Improved output formatting to show on-enter/on-exit actions separately

### Action Naming
- Renamed `TraceAction` and `DaemonTraceAction` from `trace` to `trace-once` to clarify they are one-shot
- New `trace` action (via `ContinuousTraceAction`) starts continuous recording

## Implementation Details

- CPU usage calculation: `(delta_ticks / CLK_TCK) / delta_time * 100.0`
- First CPU read always returns null (requires two samples for delta)
- Lifecycle actions execute exactly once per state transition, independent of cooldown
- Regular actions (`--action`) continue to fire with cooldown while trigger is active
- Both action types can be combined: e.g., start tracing on-enter, take memory dumps while active, stop on-exit

## Tests Added

- `CpuUsageTriggerTest`: Comprehensive hysteresis and sustain duration testing
- `TraceSessionTest`: Lifecycle and file creation testing
- `TriggerStateTrackerTest`: State transition detection testing

https://claude.ai/code/session_0126prrrxr3gbVaPzbxbfcBV