### PR TITLE
Add --trace-var option to inspector:trace for per-sample variable annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Reli is a sampling profiler (or a VM state inspector) written in PHP. It can rea
 - [Automatic memory analysis report](docs/memory-report.md): generate prioritized findings from a memory snapshot — dominant classes, cycles, choke points, blame allocation, and more
 - [Condition-based monitoring](docs/watch-command.md): automatically trigger memory dumps, trace captures, or alerts when memory thresholds, function calls, or variable conditions are met
 - [Variable inspection](docs/peek-var-command.md): read PHP variable values from a running process without modifying it
+- [Per-sample variable peek in traces](docs/trace-var-command.md): attach PHP variable values (request URI, user id, SQL query, ...) to each trace sample so you can join runtime state to hot stacks
 - [Sidecar daemon](docs/sidecar.md): run a daemon that accepts on-demand memory dump requests from PHP processes via Unix socket — no FFI needed in the application, ideal for memory_limit crash analysis and CI regression detection
 
 ## How it works
@@ -412,6 +413,43 @@ See [docs/watch-command.md](docs/watch-command.md) for full documentation.
 Supported scopes: `global::$var`, `local::func()$var`, `static::Class::$prop`, `func_static::func()$var`.
 
 See [docs/peek-var-command.md](docs/peek-var-command.md) for full documentation.
+
+## [Experimental] Trace Var Peek: Per-Sample Variable Inspection in Traces
+
+`inspector:trace --trace-var` attaches PHP variable values to every trace sample, so you can correlate runtime state (request URI, user id, SQL query, ...) with the hot stacks that produced it — no separate tool, no log join.
+
+```bash
+# Tag every sample with the current request URI
+./reli inspector:trace -p <pid> --trace-var='global::$request_uri'
+
+# Multiple variables — each becomes its own annotation line
+./reli inspector:trace -p <pid> \
+  --trace-var='global::$request_uri' \
+  --trace-var='local::App\Controller::handle()$user_id'
+
+# Skip reads when a specific function isn't on the stack (cheap gate)
+./reli inspector:trace -p <pid> \
+  --trace-var='local::App\PDOProxy::execute()$query' \
+  --trace-var-on-function='App\PDOProxy::execute'
+
+# Binary (rbt) output — annotations ride on SAMPLE_ANNOTATION events
+./reli inspector:trace -p <pid> -F rbt -o trace.rbt \
+  --trace-var='global::$counter'
+```
+
+Sample phpspy output:
+
+```
+0 App\Controller::handle /app/src/Controller.php:17
+1 <main> /app/public/index.php:9
+# global::$request_uri = (string) "/users/1234"
+# local::App\Controller::handle()$user_id = (int) 1234
+
+```
+
+The same expression grammar as `inspector:peek-var --var` is supported, including nested access (`[key]`, `->prop`). Works with `inspector:daemon` in all three output modes (per-worker `rbt`, `rbt-bundled`, and template text), and with `--with-native-trace` for merged native+PHP traces.
+
+See [docs/trace-var-command.md](docs/trace-var-command.md) for full documentation — including rate-limit options (`--trace-var-every`, `--trace-var-on-function`), RLE implications in rbt, and daemon mode behaviour.
 
 ## Examples
 ### Trace a script

--- a/config/di.php
+++ b/config/di.php
@@ -21,6 +21,8 @@ use Reli\Inspector\Daemon\Reader\Worker\PhpReaderTraceLoop;
 use Reli\Inspector\Daemon\Reader\Worker\PhpReaderTraceLoopInterface;
 use Reli\Inspector\Output\TraceFormatter\Templated\TemplatePathResolver;
 use Reli\Inspector\Output\TraceFormatter\Templated\TemplatePathResolverInterface;
+use Reli\Inspector\Watch\VariableReader;
+use Reli\Inspector\Watch\VariableReaderInterface;
 use Reli\Lib\Amphp\ContextCreator;
 use Reli\Lib\Amphp\ContextCreatorInterface;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
@@ -77,6 +79,7 @@ return [
     ProcessSearcherInterface::class => autowire(ProcessSearcher::class),
     Config::class => fn () => AppDirectory::loadConfig(__DIR__ . '/config.php'),
     TemplatePathResolverInterface::class => autowire(TemplatePathResolver::class),
+    VariableReaderInterface::class => autowire(VariableReader::class),
     StateCollector::class => function (Container $container) {
         $collectors = [];
         $collectors[] = $container->make(ProcessStateCollector::class);

--- a/docs/design-trace-var-peek.md
+++ b/docs/design-trace-var-peek.md
@@ -281,12 +281,223 @@ Same for `VariableValueFormatter` once extracted.
   fixture process, assert the output contains the expected `# global::$x = ...`
   line in phpspy mode and a `SAMPLE_ANNOTATION` event in rbt mode.
 
+## Daemon mode
+
+`inspector:daemon` runs N workers in parallel, each of which owns its own
+trace loop against a single target PID. `--trace-var` must work there too —
+otherwise operators have to choose between multi-process coverage and
+per-sample context. This section covers how the same option plugs into the
+daemon without changing the rest of the daemon architecture.
+
+### Where variable reads happen: in each worker
+
+The worker process is the only party with `process_vm_readv` access to the
+target PHP process. All variable reads must therefore happen **inside
+`PhpReaderTraceLoop::run()`** (`src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php:45`),
+right after `readCallTrace()` returns — exactly the same insertion point as
+in the single-process `GetTraceCommand`.
+
+The controller never touches target memory on the worker's behalf. It only
+consumes the annotations that the worker has already produced.
+
+### Option propagation
+
+`SetSettingsMessage`
+(`src/Inspector/Daemon/Reader/Protocol/Message/SetSettingsMessage.php`)
+already carries `GetTraceSettings` from the controller to each worker at
+start-up. Since `--trace-var`, `--trace-var-every`, and
+`--trace-var-on-function` live on `GetTraceSettings` (per the single-process
+design above), they ride along for free. No new IPC message is required for
+configuration.
+
+The worker parses / holds the specs exactly once in
+`PhpReaderEntryPoint::run()`, then reuses them for every attach cycle.
+
+### Resolving the CG address per target
+
+`TargetProcessDescriptor`
+(`src/Inspector/Daemon/Dispatcher/TargetProcessDescriptor.php`) currently
+holds `eg_address`, `sg_address`, and `php_version` — but **not**
+`cg_address`. `static::` and `func_static::` specs need CG.
+
+`inspector:watch` already hit this problem and solved it by introducing
+`WatchTargetDescriptor` + `WatchDescriptorRetriever`
+(`src/Inspector/Watch/Daemon/Searcher/WatchTargetDescriptor.php`) — a
+parallel descriptor class with a `cg_address` field, populated at discovery
+time by the searcher. We have two options:
+
+1. **Reuse the watch descriptor** — share `WatchTargetDescriptor` /
+   `WatchDescriptorRetriever` between watch daemon and trace daemon. Rename
+   them to something neutral (e.g. `DaemonTargetDescriptorWithCg`) and let
+   both daemons consume them. Lowest code duplication; small refactor of
+   the watch daemon.
+2. **Add `?int $cg_address` to `TargetProcessDescriptor`** — optional field,
+   0/null when the trace command has no var-peek specs, populated only when
+   the trace daemon is launched with `--trace-var` that needs CG. Smallest
+   diff, no class hierarchy shuffling, at the cost of the base type
+   knowing about a feature it doesn't otherwise use.
+
+Recommend **option 2** for this PR. The field is cheap (one int), watch
+daemon continues to use its richer descriptor, and the trace daemon gets
+what it needs with no new class. If a third feature later wants CG on its
+descriptor, option 1 becomes worth the refactor.
+
+Either way, **CG resolution happens in the searcher** (once per newly
+discovered PID, cached), not in the reader worker, so the trace loop does
+not pay the lookup cost per sample.
+
+### Data flow per output format
+
+The daemon has three output modes (see `DaemonCommand::execute`,
+`src/Command/Inspector/DaemonCommand.php:90`). Each needs a slightly
+different plumbing for annotations:
+
+#### (a) Per-worker `rbt` (`-F rbt`) — simplest
+
+The worker writes directly to its own `worker_<pid>.rbt` file via
+`PhpReaderEntryPoint::writeBinaryTrace()`
+(`src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php:152`).
+We extend that call:
+
+```php
+$this->binary_writer->writeTrace(
+    CallTraceConverter::toParsed($call_trace),
+    $delta_us,
+    $annotations,   // new: already a string→string map
+);
+```
+
+`BinaryTraceWriter::writeTrace()` already accepts `?array $annotations`
+and handles the RLE break case. **Zero IPC changes** — the annotations
+never leave the worker. This is the cleanest path and the one I'd ship
+first.
+
+#### (b) Bundled `rbt-bundled` (`-F rbt-bundled`) — writer extension
+
+Workers send `TraceMessage` to the controller; the controller's
+`writeBundledTrace()`
+(`src/Command/Inspector/DaemonCommand.php:282`) writes `PID_SAMPLE` events
+via `BinaryTraceWriter::writePidTrace()`.
+
+Two changes:
+
+1. **`TraceMessage`**
+   (`src/Inspector/Daemon/Reader/Protocol/Message/TraceMessage.php`) —
+   add `public ?array $annotations = null;` (serializable over the
+   existing AMPHP IPC channel).
+2. **`BinaryTraceWriter::writePidTrace()`**
+   (`src/Converter/BinaryTrace/BinaryTraceWriter.php:193`) — accept
+   `?array $annotations = null` and emit `SAMPLE_ANNOTATION` right after
+   `writePidSample()`. The rbt spec explicitly allows `SAMPLE_ANNOTATION`
+   to follow `PID_SAMPLE` (see `docs/binary-trace-format.md`
+   §SAMPLE_ANNOTATION). `writePidSample()` does not participate in the
+   RLE / run-length path, so the annotation logic is a straight append —
+   no pending-run state to reason about.
+
+Controller-side call becomes:
+
+```php
+$writer->writePidTrace(
+    CallTraceConverter::toParsed($result->trace),
+    $result->pid,
+    $delta_us,
+    $result->annotations,
+);
+```
+
+#### (c) Template (phpspy text) mode — annotations ride on `TraceMessage`
+
+The worker sends `TraceMessage` up; the controller passes
+`$result->trace` into `$trace_output->output(...)`
+(`DaemonCommand::execute`, inside the worker-dispatch async loop around
+line 228). We extend the same call site:
+
+```php
+$trace_output->output($result->trace, $result->annotations);
+```
+
+Since `TraceOutput::output()` already takes an optional `$annotations`
+parameter per the single-process design above, no additional interface
+change is needed for daemon mode — just the `TraceMessage` field
+extension from (b).
+
+### Summary of changes specific to daemon mode
+
+On top of the single-process change list in the previous sections, daemon
+mode adds:
+
+- **`src/Inspector/Daemon/Dispatcher/TargetProcessDescriptor.php`** — add
+  `?int $cg_address = null` (option 2 above).
+- **`src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetriever.php`**
+  (or its daemon-searcher equivalent) — resolve CG when the worker pool
+  was started with trace-var specs that need it. Gate the extra lookup on
+  `GetTraceSettings::$needs_cg` so daemons without var-peek pay nothing.
+- **`src/Inspector/Daemon/Reader/Protocol/Message/TraceMessage.php`** — new
+  `?array $annotations` field.
+- **`src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php`** — accept
+  a `VariableReader` (new constructor arg) and, inside the loop body,
+  call it after `readCallTrace()` then attach the result to the yielded
+  `TraceMessage`. Respect `--trace-var-every` and
+  `--trace-var-on-function` exactly like the single-process command.
+- **`src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php`** — in
+  the per-worker rbt branch (line 104 area), pass
+  `$message->annotations` through to `writeBinaryTrace()`; extend that
+  helper to forward into `writeTrace()`.
+- **`src/Command/Inspector/DaemonCommand.php`** — in the worker-dispatch
+  async loop, pass `$result->annotations` into `writeBundledTrace()` or
+  `$trace_output->output()` depending on mode.
+- **`src/Converter/BinaryTrace/BinaryTraceWriter.php`** — extend
+  `writePidTrace()` signature and body to emit `SAMPLE_ANNOTATION`
+  when annotations are present.
+- **DI wiring** — `VariableReader` already exists as a shared service; it
+  needs to be added to the worker container so `PhpReaderTraceLoop` can
+  receive it.
+
+### Performance: worker-count multiplier
+
+The single-process analysis puts Tier-3 variable reads at ~2ms overhead per
+poll on a warm cache, dominated by `process_vm_readv`. In daemon mode this
+cost is paid **per attached worker**, not per concurrent target in aggregate
+(workers read in parallel). However:
+
+- Total wall-clock CPU used by the daemon grows roughly linearly with
+  `active_workers × vars_per_sample`. Operators running at 10ms sampling
+  with 8 workers and 5 variables should expect the daemon itself to consume
+  a measurable core fraction. `--trace-var-every` remains the primary
+  throttle.
+- `--trace-var-on-function` becomes disproportionately valuable in daemon
+  mode: only workers whose current target stack contains the gate function
+  pay the `process_vm_readv` cost. For frameworks where the interesting
+  frame is rare (e.g. "only when inside `PDO::execute`"), the total cost
+  across the worker pool can drop by 10×+.
+
+### Annotation reliability during attach/detach
+
+Worker attach/detach is a normal lifecycle event. `VariableReader`
+throwing on a stale frame (e.g. target just exited `local::fn()`) is
+already handled by the per-spec `try { ... } catch (\Throwable) {}` in
+`VariableReader::readVariables()`, so there is no new failure mode
+introduced by running in daemon workers. The annotation set simply
+shrinks for that sample and the trace is emitted normally.
+
+On hard-detach (target process gone), `PhpReaderTraceLoop::run()` already
+terminates the generator; no annotations are produced for the half-read
+sample. The worker then proceeds to the next attach cycle.
+
+### Not in scope for daemon mode (yet)
+
+- **Per-target specs.** Today a single `--trace-var` list applies to every
+  target in the daemon. A future `--trace-var-for=<regex>:<spec>` that
+  scopes specs to PIDs matching a regex (or a function signature) would
+  let operators read `$controller->requestId` on web workers while
+  reading `$job->id` on queue workers. Straightforward extension, deferred
+  to a follow-up PR so this one stays bounded.
+- **Dynamic re-config.** Changing the var-peek spec list at runtime (via a
+  signal or control socket) is nice-to-have, not required. Restarting the
+  daemon is fine for v1.
+
 ## Follow-ups / out of scope
 
-- **Daemon mode**: the same flag should eventually propagate from
-  `inspector:daemon` to its workers so bundled / per-worker rbt output can
-  carry annotations. This is mechanically similar but involves IPC message
-  changes and is deferred to a later PR.
 - **Numeric annotations in rbt**: the current spec stores annotations as
   string pairs. If we later want to store ints natively, that's a
   `SAMPLE_ANNOTATION` v2 event addition (backward compatible via unknown-

--- a/docs/design-trace-var-peek.md
+++ b/docs/design-trace-var-peek.md
@@ -504,6 +504,31 @@ sample. The worker then proceeds to the next attach cycle.
   event skip).
 - **Cross-sample diff encoding**: for noisy values that move RLE, an
   `ANNOTATION_DELTA` scheme (only emit changed keys) could be added later.
+- **Per-spec config file (`--trace-var-config=<path>`)**: once users want
+  distinct `every` / `on-function` gates / short display names / error
+  policy (skip vs. mark `<error>`) *per variable*, the `--trace-var` flag
+  shape starts to fight them — all attached flags become global. A YAML
+  (or TOML) file that lists each spec with its own attributes is the
+  natural escape hatch, e.g.:
+  ```yaml
+  vars:
+    - spec: global::$request->requestId
+      name: req
+      every: 1
+    - spec: local::App\Queue\Worker::run()$job->id
+      name: job_id
+      every: 5
+      on_function: App\Queue\Worker::run
+      on_error: skip
+  ```
+  Not needed for v1 — the flag shape is enough while the spec count is
+  small and attributes are uniform. Revisit when either condition breaks
+  (multiple specs needing different cadences, or users asking for stable
+  short names in the output). The current CLI options are designed to be
+  a clean subset of what this file would express, so the migration is
+  additive: introduce `--trace-var-config`, keep the flags as sugar for
+  "one spec with defaults", and have both paths build the same internal
+  `list<VariableSpec>` + attribute record.
 
 ## References
 

--- a/docs/design-trace-var-peek.md
+++ b/docs/design-trace-var-peek.md
@@ -1,0 +1,308 @@
+# Design Notes: Variable Peek Annotations for `inspector:trace`
+
+**Status:** Draft
+**Target command:** `inspector:trace`
+**Depends on:** existing `VariableReader` (watch/peek-var), `BinaryTraceWriter` `SAMPLE_ANNOTATION` support
+
+## Goal
+
+Attach PHP variable values to each trace sample so that users can correlate
+stacks with the runtime state of `$GLOBALS`, locals, class statics, or function
+statics. Reuse the existing `--var` / `--watch-var` expression syntax from
+`inspector:peek-var` and `inspector:watch`, so the user experience is
+consistent across the three commands.
+
+- **phpspy output**: emit `varpeek`-style comment lines in the sample block
+  (matching phpspy's `# key = value` convention, which the existing
+  `PhpSpyCompatibleParser` already ignores as comments).
+- **rbt output**: emit `SAMPLE_ANNOTATION` events (event type `0x0B`) that are
+  already part of the binary-trace format spec and writer.
+
+## Motivation
+
+Today, the `trace` loop captures only the call stack. To understand *why* a
+particular stack is hot, users have to either:
+
+1. Run `inspector:peek-var` separately, which gives point-in-time reads but
+   can't be joined back to individual samples.
+2. Use `inspector:watch --watch-var ...`, which is condition-based and doesn't
+   record every sample.
+
+Both lose the 1:1 correspondence between a stack and the value that caused it.
+By folding variable reads into the trace loop, each sample can carry a small
+amount of structured context — e.g. the current SQL query, request URI, or an
+application-level counter — right next to the stack that produced it.
+
+## Non-Goals
+
+- Not a replacement for full object graph dumps. Only scalar / array-count /
+  string values are serialized, exactly like `peek-var`.
+- Not a condition trigger. If the value doesn't match some predicate, the
+  sample is still emitted — this is pure decoration, not filtering.
+- Not changing how `peek-var` or `watch --watch-var` work. The new option is
+  additive on `trace`.
+
+## CLI Surface
+
+Add one repeatable option to `inspector:trace`:
+
+```
+--trace-var=<expression>        # repeatable
+```
+
+The expression grammar is **exactly** what `inspector:peek-var --var` accepts
+(parsed by `Reli\Inspector\Watch\VariableSpec::parse()`):
+
+| Scope | Syntax |
+|---|---|
+| Global | `global::$var` |
+| Local | `local::<fqn>()$var` (use `<main>` for top-level) |
+| Static property | `static::Class::$prop` |
+| Function static | `func_static::<fqn>()$var` |
+
+Nested access (`[key]`, `->prop`) is already supported by
+`VariableReader::parsePathExpression()` and flows through unchanged.
+
+### Rate limit / sampling options
+
+Variable reads are Tier-3 in the watch tier model (~10ms per poll for heavy
+configurations), so at a 10ms sampling interval the overhead is significant.
+Two escape hatches:
+
+```
+--trace-var-every=N             # Read vars only every N-th sample (default: 1)
+--trace-var-on-function=<fqn>   # Skip reads when <fqn> is not on the stack
+```
+
+`--trace-var-on-function` is a cheap gate: we already have the `CallTrace`,
+so scanning it for a function name costs ~µs and lets us avoid the ~10ms
+`process_vm_readv` round-trip on samples where the interesting frame isn't
+active. This is especially valuable for `local::` and `func_static::` specs.
+
+### Failure modes
+
+If `VariableReader::readVariables()` throws for a specific spec (target frame
+gone, indirect chain dangling, etc.), that spec silently drops from the
+annotation set for **that sample only** — matching how `peek-var --repeat`
+already tolerates per-poll failures. The trace sample is still emitted with
+whatever specs did resolve.
+
+## Data Flow
+
+```
+GetTraceCommand::execute
+  ├── GetTraceSettings parses --trace-var into list<VariableSpec>
+  ├── If specs non-empty, resolve CG address (needed for static/func_static)
+  ├── Construct VariableReader (already DI-wired for peek-var / watch)
+  │
+  └── Main loop (per sample):
+       ├── readCallTrace()                           (unchanged)
+       ├── if specs && (sample_index % N == 0) && on_function_gate_passes:
+       │     variable_reader->readVariables(...)    (reuses existing code)
+       │     → array<string, VariableValue>
+       │     → formatAnnotations()                  (new, small)
+       │     → array<string, string>
+       │ else:
+       │     $annotations = null
+       │
+       └── $trace_output->output($call_trace, $annotations)
+```
+
+Key observation: `VariableReader::readVariables()` is already keyed by
+`VariableSpec::$lookup_key` (e.g., `global::$counter`), so the shape returned
+matches what we want for annotations — we only need a small adapter that
+renders each `VariableValue` into a phpspy-safe string.
+
+## Output: phpspy text format
+
+### Line format
+
+phpspy's varpeek convention is `# <name> = <value>` as a comment line
+emitted inside the sample block (before the trailing blank separator).
+reli-prof's existing `PhpSpyCompatibleParser` already skips lines where the
+first token is `#` (see `PhpSpyCompatibleParser::parsePhpSpyCompatible()`,
+`src/Converter/PhpSpyCompatibleParser.php:47`), so this is safe for
+round-tripping through `converter:*` commands.
+
+Example sample block with two annotations:
+
+```
+0 App\Repo\UserRepository::find /app/src/Repo/UserRepository.php:42
+1 App\Service\UserService::lookup /app/src/Service/UserService.php:17
+2 <main> /app/public/index.php:9
+# global::$request_uri = "/users/1234"
+# local::App\Service\UserService::lookup()$user_id = 1234
+
+```
+
+The blank line still terminates the sample. Frames come first, annotations
+after — this way a reader that strips comments still gets a valid phpspy
+trace.
+
+### Value rendering
+
+The rendering rules aim to stay on one line, be unambiguous, and match
+`VariableValue` types directly:
+
+| Type | Rendered |
+|---|---|
+| `TYPE_LONG` | `(int) 42` |
+| `TYPE_DOUBLE` | `(float) 3.14` |
+| `TYPE_STRING` | `(string) "hello"` — JSON-escaped, truncated at 200 chars with `...` |
+| `TYPE_BOOL` | `(bool) true` / `(bool) false` |
+| `TYPE_ARRAY` | `(array) count=10` |
+| `TYPE_NULL` | `null` |
+| `TYPE_UNKNOWN` | `(unknown)` |
+| spec not resolved | the annotation line is **omitted** (not emitted as `<not found>`) |
+
+Strings are JSON-escaped (not just `addslashes`) so that embedded newlines,
+tabs, and non-ASCII bytes can't break the line-oriented format. The same
+200-char truncation as `PeekVarCommand::truncate()` is applied.
+
+> **Note on matching phpspy exactly:** upstream phpspy's varpeek (`-V`) writes
+> `# varname = value_repr`. We use the same `# key = value` shape; the key is
+> the full `VariableSpec::$lookup_key` (e.g. `global::$counter`) rather than a
+> short alias, because that's the stable identifier already used by peek-var
+> and watch. Tools that depend on a specific shorter form can strip the prefix.
+
+### Template changes
+
+`resources/templates/phpspy.php` currently iterates frames only. It will be
+extended to iterate a new `$annotations` variable supplied alongside
+`$call_trace`:
+
+```php
+<?php foreach ($call_trace->call_frames as $depth => $frame): ?>
+<?= $depth ?> <?= $frame->getFullyQualifiedFunctionName() ?> <?= $frame->file_name ?>:<?= $frame->getLineno(), "\n" ?>
+<?php endforeach ?>
+<?php foreach ($annotations ?? [] as $key => $value): ?>
+# <?= $key ?> = <?= $value, "\n" ?>
+<?php endforeach ?>
+<?= "\n" ?>
+```
+
+Same edit is applied to `phpspy_with_opcode.php`. Templates receiving a
+missing `$annotations` continue to work (the `?? []` makes it no-op).
+
+## Output: rbt binary format
+
+The binary trace format already defines `SAMPLE_ANNOTATION` (`0x0B`):
+
+```
+Payload:
+  [count: varint]
+  [key_string_id: varint] [value_string_id: varint]  × count
+```
+
+`BinaryTraceWriter::writeTrace()` already accepts
+`?array<string,string> $annotations` as its third argument and emits the
+event after the `SAMPLE` / `COMPACT_SAMPLE`. The annotation values are
+interned through the segment's `STRING_DEF` table, so repeated values
+(e.g. the same SQL query across many samples) cost only one pair of varints
+per sample after the first. See `docs/binary-trace-format.md` §SAMPLE_ANNOTATION
+for the full spec.
+
+### Impact on REPEAT_SAMPLE (RLE)
+
+The spec already states: *"The writer considers two consecutive samples
+identical only if both their `stack_id` and their annotations match. If the
+annotation changes, the run is broken."* This has direct consequences for
+`--trace-var`:
+
+- **Stable annotations** (e.g. `global::$config['app_name']`): RLE keeps
+  working perfectly, adds ~2 bytes per changed run.
+- **Noisy annotations** (e.g. a monotonically increasing counter): RLE
+  effectively breaks per sample. Output grows to roughly
+  `samples × (compact_sample + annotation)`. Users should be warned to pick
+  variables that are stable over the scales they care about, or to use
+  `--trace-var-every=N` to cut the read rate.
+
+This is documented in the command's help text and the new section of
+`trace-command.md` (TBD).
+
+## Code changes (file by file)
+
+### New / extended
+
+- `src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php`
+  — add `list<VariableSpec> $var_specs` and the throttle fields.
+- `src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php`
+  — register `--trace-var`, `--trace-var-every`, `--trace-var-on-function`;
+  parse each `--trace-var` via `VariableSpec::parse()`.
+- `src/Inspector/Watch/VariableValueFormatter.php` (new, small)
+  — pure function `format(VariableValue): string` producing the phpspy-safe
+  rendered form described above. Shared between the trace command and, if
+  desired, `PeekVarCommand` (dedup of the existing `formatValue()` method
+  there is a cleanup opportunity, not required by this feature).
+- `src/Inspector/Output/TraceOutput/TraceOutput.php`
+  — extend the interface signature:
+  `public function output(CallTrace $call_trace, ?array $annotations = null): void;`
+  The default-null keeps all existing call sites compiling.
+- `src/Inspector/Output/TraceOutput/FormattedTraceOutput.php`
+  — pass `$annotations` through to the formatter (formatter interface gets a
+  matching extension).
+- `src/Inspector/Output/TraceOutput/BinaryTraceOutput.php`
+  — forward `$annotations` into `BinaryTraceWriter::writeTrace(...)`
+  (the writer already supports this; we just plumb it).
+- `src/Inspector/Output/TraceFormatter/CallTraceFormatter.php`
+  — extend: `format(CallTrace $call_trace, ?array $annotations = null): string;`
+- `src/Inspector/Output/TraceFormatter/Templated/TemplatedCallTraceFormatter.php`
+  — pass `$annotations` into the template scope alongside `$call_trace`.
+- `resources/templates/phpspy.php`, `resources/templates/phpspy_with_opcode.php`
+  — add the annotation `foreach` loop (see above).
+- `src/Command/Inspector/GetTraceCommand.php`
+  — resolve CG when needed, construct `VariableReader`, call
+  `readVariables()` inside the loop, gate via `--trace-var-every` /
+  `--trace-var-on-function`, format with `VariableValueFormatter`, pass
+  through to `$trace_output->output()`.
+
+### DI wiring
+
+`VariableReader` is already registered (used by `PeekVarCommand` and
+`WatchCommand`), so `GetTraceCommand` just needs a new constructor argument.
+Same for `VariableValueFormatter` once extracted.
+
+## Tests
+
+- `tests/Inspector/Watch/VariableValueFormatterTest.php` — unit tests for
+  each `VariableValue::TYPE_*` branch, including string escaping /
+  truncation.
+- `tests/Inspector/Output/TraceFormatter/Templated/...` — snapshot test that
+  renders a `CallTrace` + `$annotations` through `phpspy.php` and compares
+  against a fixture.
+- `tests/Converter/PhpSpyCompatibleParserTest.php` — add a case where a
+  sample block contains both frames and `# k = v` lines, confirming the
+  parser still yields the expected `ParsedCallTrace` (comments skipped).
+- `tests/Converter/BinaryTrace/BinaryTraceRoundTripTest.php` — extend: write
+  a sample with annotations, read it back, assert
+  `BinaryTraceSample::$annotations` round-trips.
+- `tests/Command/Inspector/GetTraceCommandTest.php` (or closest existing)
+  — end-to-end: run `inspector:trace --trace-var='global::$x'` against a
+  fixture process, assert the output contains the expected `# global::$x = ...`
+  line in phpspy mode and a `SAMPLE_ANNOTATION` event in rbt mode.
+
+## Follow-ups / out of scope
+
+- **Daemon mode**: the same flag should eventually propagate from
+  `inspector:daemon` to its workers so bundled / per-worker rbt output can
+  carry annotations. This is mechanically similar but involves IPC message
+  changes and is deferred to a later PR.
+- **Numeric annotations in rbt**: the current spec stores annotations as
+  string pairs. If we later want to store ints natively, that's a
+  `SAMPLE_ANNOTATION` v2 event addition (backward compatible via unknown-
+  event skip).
+- **Cross-sample diff encoding**: for noisy values that move RLE, an
+  `ANNOTATION_DELTA` scheme (only emit changed keys) could be added later.
+
+## References
+
+- phpspy varpeek format — upstream `phpspy` emits `# key = value` comment
+  lines inside each sample block; reli-prof's parser already treats any
+  `#`-prefixed token as a comment (`src/Converter/PhpSpyCompatibleParser.php:47`).
+- `docs/binary-trace-format.md` §SAMPLE_ANNOTATION — authoritative definition
+  of event `0x0B`.
+- `docs/peek-var-command.md` — variable expression grammar.
+- `docs/watch-command.md#variable-value-watch-var` — the same grammar in the
+  watch context.
+- `docs/internals/php-variable-reading.md` — how `VariableReader` walks Zend
+  structures.

--- a/docs/trace-var-command.md
+++ b/docs/trace-var-command.md
@@ -1,0 +1,316 @@
+# inspector:trace --trace-var — Per-Sample Variable Peek in Traces
+
+`inspector:trace --trace-var` attaches PHP variable values to each trace
+sample as they are captured, so you can join "what the stack was doing" to
+"what the runtime state was" without running a separate tool. Values are
+read from the target process with the same techniques as
+[`inspector:peek-var`](peek-var-command.md) and
+[`inspector:watch --watch-var`](watch-command.md),
+then emitted next to each sample in the trace output.
+
+## Quick Start
+
+```bash
+# Tag every sample with a global's value
+reli inspector:trace -p <pid> --trace-var='global::$request_uri'
+
+# Multiple variables — each appears as its own annotation line
+reli inspector:trace -p <pid> \
+  --trace-var='global::$request_uri' \
+  --trace-var='local::App\Controller::handle()$user_id'
+
+# Only read every 10th sample to cut overhead at high sampling rates
+reli inspector:trace -p <pid> -s 10000000 \
+  --trace-var='global::$state' \
+  --trace-var-every=10
+
+# Only read when a specific frame is active — skips process_vm_readv entirely
+# when the target function isn't on the stack
+reli inspector:trace -p <pid> \
+  --trace-var='local::App\PDOProxy::execute()$query' \
+  --trace-var-on-function='App\PDOProxy::execute'
+
+# Binary (rbt) output — annotations ride on SAMPLE_ANNOTATION events
+reli inspector:trace -p <pid> -F rbt -o trace.rbt \
+  --trace-var='global::$counter'
+```
+
+## Requirements
+
+Same as other `inspector:*` commands:
+
+- PHP 8.1+ (for execution), targets PHP 7.0+
+- FFI extension
+- `CAP_SYS_PTRACE` capability (usually root)
+
+## Variable Specification
+
+`--trace-var` takes **exactly the same expression grammar** as
+`inspector:peek-var --var` — see the full reference in
+[docs/peek-var-command.md](peek-var-command.md#variable-specification). In
+short:
+
+| Scope | Syntax | What it reads |
+|-------|--------|---------------|
+| Global | `global::$var` | `$GLOBALS['var']` |
+| Local | `local::func()$var` | Local variable in a specific function frame |
+| Static property | `static::Class::$prop` | Class static property |
+| Function static | `func_static::func()$var` | Function's `static $var` |
+
+Nested array keys and object properties use the same path syntax:
+
+```bash
+--trace-var='global::$config[database][host]'
+--trace-var='global::$app->cache->size'
+--trace-var='global::$container->services[cache]->pool[active]'
+```
+
+For `local::` and `func_static::`, the function name is **required**; use
+`<main>` for the top-level script scope.
+
+## Output Formats
+
+### phpspy text (`-F template:phpspy`, default)
+
+Annotations appear as `# <spec> = <value>` comment lines **after** the frame
+list, before the blank-line separator:
+
+```
+0 App\Controller::handle /app/src/Controller.php:17
+1 App\Http\Router::dispatch /app/src/Router.php:42
+2 <main> /app/public/index.php:9
+# global::$request_uri = (string) "/users/1234"
+# local::App\Controller::handle()$user_id = (int) 1234
+
+0 App\Controller::handle /app/src/Controller.php:18
+1 App\Http\Router::dispatch /app/src/Router.php:42
+2 <main> /app/public/index.php:9
+# global::$request_uri = (string) "/users/1234"
+# local::App\Controller::handle()$user_id = (int) 1234
+
+```
+
+reli's own phpspy parser and every downstream tool that treats `#`-prefixed
+lines as comments will simply ignore these lines, so the output stays
+round-trip safe — you can pipe it into `reli converter:pprof`,
+`reli converter:speedscope`, or any phpspy-compatible consumer without
+breaking them.
+
+Value rendering is stable and single-line by construction — strings are
+JSON-escaped and truncated at 200 characters, so embedded newlines, tabs,
+and non-ASCII bytes can never break the line-oriented format:
+
+| Type | Rendered |
+|------|----------|
+| `int` | `(int) 42` |
+| `float` | `(float) 3.14` |
+| `string` | `(string) "hello\nworld"` (truncated at 200 chars with `...`) |
+| `bool` | `(bool) true` / `(bool) false` |
+| `array` | `(array) count=10` |
+| `null` | `null` |
+| unknown type | `(unknown)` |
+| spec not resolved | the annotation line is **omitted** for that sample |
+
+### phpspy with opcode (`-F template:phpspy_with_opcode`)
+
+Same shape as plain phpspy, with annotations after the frame list. The
+opcode column on frame lines is unaffected.
+
+### rbt binary (`-F rbt` / `-F rbt-bundled`)
+
+Annotations are emitted as `SAMPLE_ANNOTATION` (event type `0x0B`)
+directly following each sample event. Keys and values are interned via
+`STRING_DEF` per segment, so repeated values (e.g. the same SQL query
+across many samples) cost only one pair of varints per sample after the
+first. Full format details are in
+[docs/binary-trace-format.md](binary-trace-format.md#sample_annotation-0x0b).
+
+All downstream converters that already read `.rbt`
+(`reli converter:phpspy`, `reli converter:speedscope`,
+`reli converter:pprof`, `reli converter:folded`) preserve or discard
+annotations based on what the target format supports — the phpspy text
+converter re-emits them as `# key = value` lines, matching the live-capture
+output.
+
+#### RLE interaction
+
+In compact (no-timestamp) mode rbt uses `REPEAT_SAMPLE` to run-length-encode
+consecutive identical samples. The writer considers two samples identical
+only if **both** their stack and their annotations match. This has two
+practical consequences:
+
+- **Stable annotations** (e.g. `global::$config['app_name']`, session ID,
+  tenant ID): RLE keeps working perfectly; the annotation adds roughly 2
+  bytes per changed run.
+- **Noisy annotations** (e.g. a monotonically increasing counter,
+  microsecond timestamps): RLE effectively breaks per sample. Output grows
+  to roughly `samples × (compact_sample + annotation)`, which is still far
+  smaller than phpspy text but larger than annotation-free rbt. Prefer
+  values that are stable over the scales you care about, or use
+  `--trace-var-every` to cut the read rate.
+
+### JSON Lines (`-F template:json_lines`)
+
+The `json_lines` template is currently **unchanged** when `--trace-var` is
+set — its JSON shape is stable for `jq`-based consumers. Annotations in
+JSON Lines output are a planned follow-up via a dedicated template; for
+now, use phpspy text or rbt if you need per-sample annotations.
+
+## Native (C-level) Trace Support
+
+`--with-native-trace` is fully supported. The merged native+PHP output
+carries annotations end-to-end in both phpspy text and rbt formats:
+
+```bash
+reli inspector:trace -p <pid> --with-native-trace \
+  --trace-var='global::$request_uri'
+```
+
+```
+0 libphp.so::zend_execute+0x42 [native]:0
+1 App\Controller::handle /app/src/Controller.php:17
+2 <main> /app/public/index.php:9
+# global::$request_uri = (string) "/users/1234"
+
+```
+
+Variable reads always resolve against the **PHP** state of the sample
+(call frames, symbol table, CVs); the presence of native frames has no
+effect on which variables are visible. When a sample is native-only (via
+`--native-trace-anytime`, emitted during interpreter initialization or
+shutdown), no annotations are attached, because there are no PHP frames
+to inspect.
+
+## Rate Limiting
+
+Variable reads go through `process_vm_readv(2)` just like other
+`inspector:*` reads. At default sampling rates the overhead is modest,
+but at high sampling rates (10ms intervals × several variables) it adds
+up. Two flags let you throttle without losing trace resolution:
+
+### `--trace-var-every=<N>` (default: 1)
+
+Read variables only every **N-th** sample. The trace itself is captured
+at full rate; only the variable reads are throttled. Useful when the
+variable you're watching changes on a much slower timescale than the
+sampling interval:
+
+```bash
+# 10ms sampling, but only read $memory_usage every 100th sample (every 1s)
+reli inspector:trace -p <pid> -s 10000000 \
+  --trace-var='global::$memory_usage' \
+  --trace-var-every=100
+```
+
+### `--trace-var-on-function=<fqn>`
+
+Skip the variable read entirely when the named fully-qualified function
+is **not** on the call stack. This is a cheap in-process gate — it scans
+the already-captured PHP call trace in microseconds and only pays the
+`process_vm_readv` cost when the target frame is actually active:
+
+```bash
+# Only read $query when PDO::execute is on the stack
+reli inspector:trace -p <pid> \
+  --trace-var='local::App\PDOProxy::execute()$query' \
+  --trace-var-on-function='App\PDOProxy::execute'
+```
+
+This is the right knob when you're correlating a specific function's
+state with the stacks that reach it — you pay zero extra cost on samples
+that are elsewhere in the program.
+
+The two flags compose: `--trace-var-every=5 --trace-var-on-function=...`
+means "at most once every 5 samples **and** only when the gate passes".
+
+## Error Handling
+
+Variable reads can fail for harmless reasons — the target frame may have
+just returned, an object may have been freed mid-read, or the process may
+be in the middle of a memory allocation that briefly makes the structure
+inconsistent. `--trace-var` degrades gracefully:
+
+- A single spec that fails (target not found, indirect chain dangling,
+  etc.) is silently omitted from that sample's annotation set. Other
+  specs in the same sample are still emitted.
+- If the whole `readVariables` call throws (transient memory read
+  failure), that sample's annotation set is dropped entirely. The trace
+  **sample itself is still emitted** — you get a naked frame list, never
+  a gap in the trace.
+- Specs that resolve but have no value at the moment (e.g. a CV that
+  hasn't been assigned yet) produce no line for that sample.
+
+This is the same contract as `inspector:peek-var --repeat` and
+`inspector:watch --watch-var`: transient reader failures never interrupt
+the loop.
+
+## Daemon Mode
+
+`inspector:daemon` supports `--trace-var` in all three output modes:
+
+```bash
+# Per-worker rbt (annotations never leave the worker; zero IPC overhead)
+reli inspector:daemon -P 'php-fpm' -F rbt \
+  --trace-var='local::App\Svc::run()$req_id'
+
+# Bundled rbt (annotations ride on PID_SAMPLE + SAMPLE_ANNOTATION)
+reli inspector:daemon -P 'php-fpm' -F rbt-bundled \
+  --trace-var='global::$request_uri'
+
+# Template text (annotations flow over IPC to the controller)
+reli inspector:daemon -P 'php-fpm' -F template:phpspy \
+  --trace-var='global::$request_uri'
+```
+
+The same `--trace-var-every` / `--trace-var-on-function` knobs apply to
+every worker. The specs apply uniformly across all discovered targets —
+per-target specs are a planned future extension.
+
+### Performance considerations in daemon mode
+
+Variable reads are paid **per attached worker**, not once globally — the
+cost across the worker pool is roughly
+`active_workers × vars_per_sample × sample_rate`. At 8 workers sampling
+at 10ms with 5 variables each, the daemon uses a measurable but still
+small fraction of a CPU. Two mitigations worth knowing:
+
+- `--trace-var-on-function` is disproportionately valuable in daemon
+  mode: only the workers whose **current** stack contains the gate
+  function pay the `process_vm_readv` cost. For rare target frames
+  (e.g. "only when inside `PDO::execute`"), total daemon cost can drop
+  by 10× or more.
+- `--trace-var-every` is a uniform knob across all workers. Use it when
+  the variable you care about changes on a slower timescale than the
+  sampling interval.
+
+CG (compiler globals) resolution for `static::` and `func_static::`
+specs happens **in the searcher**, once per discovered PID, and is
+cached. So adding a static-scope spec doesn't make the hot reader path
+any more expensive than the equivalent local-scope spec.
+
+## All Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--trace-var=<expr>` | — | Variable to peek per sample (repeatable). Same grammar as `inspector:peek-var --var` |
+| `--trace-var-every=<N>` | `1` | Read variables only every N-th sample |
+| `--trace-var-on-function=<fqn>` | — | Skip reads when the given FQN is not on the stack |
+
+All existing `inspector:trace` / `inspector:daemon` options (sampling
+interval, output format, native traces, etc.) continue to work unchanged.
+Run `reli inspector:trace --help` for the complete list.
+
+## Relationship with `peek-var` and `watch --watch-var`
+
+| | `inspector:peek-var` | `inspector:watch --watch-var` | `inspector:trace --trace-var` |
+|---|---|---|---|
+| **Purpose** | Read current value | Trigger actions on condition | Attach values to every trace sample |
+| **Output** | Variable values | Trigger events + actions | Call traces with per-sample annotations |
+| **When values are read** | On demand (one-shot or repeat) | Every poll while monitoring | Once per trace sample (or every N-th) |
+| **Joins to stacks?** | No | No (separate trace captures) | **Yes**, 1:1 with each sample |
+| **Best for** | Quick checks, scripting | Production monitoring / alerting | Correlating runtime state with hot stacks |
+
+Use `--trace-var` when you want to answer *"which stacks are hot while
+`$request_uri` is `/api/heavy`?"* or *"what values of `$user_id` show up
+in the `PDO::execute` stack?"* — questions that need the stack and the
+value to be recorded together, sample by sample.

--- a/resources/templates/json_lines.php
+++ b/resources/templates/json_lines.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 /** @var CallTrace $call_trace */
+// $annotations is currently ignored in this template. Changing the JSON
+// shape mid-stream would break existing `jq`-based consumers; a future
+// template (e.g. json_lines_with_vars) can opt in when demand exists.
 ?>
 <?= json_encode($call_trace, JSON_UNESCAPED_UNICODE) ?>
 <?= "\n" ?>

--- a/resources/templates/phpspy.php
+++ b/resources/templates/phpspy.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 /** @var CallTrace $call_trace */
+/** @var array<string, string>|null $annotations */
 ?>
 <?php foreach ($call_trace->call_frames as $depth => $frame): ?>
 <?= $depth ?> <?= $frame->getFullyQualifiedFunctionName() ?> <?= $frame->file_name ?>:<?= $frame->getLineno(), "\n" ?>
+<?php endforeach ?>
+<?php foreach ($annotations ?? [] as $key => $value): ?>
+# <?= $key ?> = <?= $value, "\n" ?>
 <?php endforeach ?>
 <?= "\n" ?>

--- a/resources/templates/phpspy_with_opcode.php
+++ b/resources/templates/phpspy_with_opcode.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 /** @var CallTrace $call_trace */
-$depth_offset = 0;
+/** @var array<string, string>|null $annotations */
 ?>
+<?php $depth_offset = 0; ?>
 <?php if ($call_trace->call_frames[0]->getOpcodeName() !== ''): ?>
 <?= $depth_offset++ ?> <VM>::<?= $call_trace->call_frames[0]->getOpcodeName() ?> <VM>:-1<?= "\n" ?>
 <?php endif ?>
 <?php foreach ($call_trace->call_frames as $depth => $frame): ?>
 <?= $depth + $depth_offset ?> <?= $frame->getFullyQualifiedFunctionName() ?> <?= $frame->file_name ?>:<?= $frame->getLineno() ?><?php if ($frame->getOpcodeName() !== ''): ?>:<?= $frame->getOpcodeName() ?><?php endif ?><?= "\n" ?>
+<?php endforeach ?>
+<?php foreach ($annotations ?? [] as $key => $value): ?>
+# <?= $key ?> = <?= $value, "\n" ?>
 <?php endforeach ?>
 <?= "\n" ?>

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -119,6 +119,7 @@ final class DaemonCommand extends Command
             $target_php_settings,
             $my_pid,
             $no_cache,
+            $get_trace_settings->needsCompilerGlobals(),
         );
 
         // Pass resolved output dir to workers (not the raw user path)
@@ -216,16 +217,20 @@ final class DaemonCommand extends Command
                         $result = $reader->receiveTraceOrDetachWorker();
                         if ($result instanceof TraceMessage) {
                             if ($bundled_writer !== null && $result->pid !== null) {
-                                // Bundled mode: write PID_SAMPLE directly
+                                // Bundled mode: write PID_SAMPLE directly,
+                                // carrying any --trace-var annotations the
+                                // worker attached.
                                 $this->writeBundledTrace(
                                     $bundled_writer,
                                     $result->trace,
                                     $result->pid,
                                     $bundled_last_hrtime_ns,
+                                    $result->annotations,
                                 );
                             } elseif ($trace_output !== null) {
-                                // Template mode: use TraceOutput
-                                $trace_output->output($result->trace);
+                                // Template mode: use TraceOutput, passing
+                                // annotations through to the formatter.
+                                $trace_output->output($result->trace, $result->annotations);
                             }
                             // rbt per-worker mode: traces written by worker directly, nothing to do here
                         } else {
@@ -279,11 +284,15 @@ final class DaemonCommand extends Command
         }
     }
 
+    /**
+     * @param array<string, string>|null $annotations
+     */
     private function writeBundledTrace(
         BinaryTraceWriter $writer,
         CallTrace $call_trace,
         int $pid,
         ?int &$last_hrtime_ns,
+        ?array $annotations = null,
     ): void {
         $now_ns = hrtime(true);
         $delta_us = 0;
@@ -292,7 +301,12 @@ final class DaemonCommand extends Command
         }
         $last_hrtime_ns = $now_ns;
 
-        $writer->writePidTrace(CallTraceConverter::toParsed($call_trace), $pid, $delta_us);
+        $writer->writePidTrace(
+            CallTraceConverter::toParsed($call_trace),
+            $pid,
+            $delta_us,
+            $annotations,
+        );
 
         if ($writer->getSamplesSinceCheckpoint() >= 1000) {
             $writer->writeCheckpoint();

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -236,12 +236,26 @@ final class GetTraceCommand extends Command
                     if ($call_trace !== null || $native_trace_anytime) {
                         $native_trace = $native_collector->collect($process_specifier->pid);
                         if ($native_trace !== null) {
-                            // Merged native+php traces intentionally skip
-                            // --trace-var annotations for now; the merged
-                            // output path has no annotation slot yet.
                             $php_trace = $call_trace ?? new CallTrace();
                             $merged = $trace_merger->merge($native_trace, $php_trace);
-                            $merged_trace_output->outputMerged($merged);
+                            // --trace-var peek is evaluated against the
+                            // PHP frame list regardless of whether the
+                            // merged output carries native frames; the
+                            // on-function gate and variable reads depend
+                            // only on PHP state. When call_trace is null
+                            // (native-only sample via --native-trace-anytime),
+                            // no annotations are produced.
+                            $annotations = null;
+                            if ($call_trace !== null) {
+                                $annotations = $var_peek_collector?->collect(
+                                    $call_trace,
+                                    $process_specifier,
+                                    $target_php_settings,
+                                    $eg_address,
+                                    $cg_address,
+                                );
+                            }
+                            $merged_trace_output->outputMerged($merged, $annotations);
                         } elseif ($call_trace !== null) {
                             $annotations = $var_peek_collector?->collect(
                                 $call_trace,

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -28,6 +28,8 @@ use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConso
 use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettingsFromConsoleInput;
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
 use Reli\Inspector\TraceLoopProvider;
+use Reli\Inspector\Watch\TraceVarPeekCollector;
+use Reli\Inspector\Watch\VariableReaderInterface;
 use Reli\Lib\Dwarf\NativeTraceCollector;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
@@ -65,6 +67,7 @@ final class GetTraceCommand extends Command
         private TargetProcessResolver $target_process_resolver,
         private RetryingLoopProvider $retrying_loop_provider,
         private BinaryAnalysisCache $binary_analysis_cache,
+        private VariableReaderInterface $variable_reader,
         private ?NativeTraceCollector $native_trace_collector = null,
     ) {
         parent::__construct();
@@ -152,6 +155,27 @@ final class GetTraceCommand extends Command
             $target_php_settings
         );
 
+        // --trace-var: resolve CG up front (only if any spec needs it) and
+        // construct the per-sample peek collector. When no specs are
+        // configured the collector stays null and the loop takes the
+        // zero-overhead path.
+        $cg_address = 0;
+        $var_peek_collector = null;
+        if ($get_trace_settings->var_specs !== []) {
+            if ($get_trace_settings->needsCompilerGlobals()) {
+                $cg_address = $this->php_globals_finder->findCompilerGlobals(
+                    $process_specifier,
+                    $target_php_settings,
+                );
+            }
+            $var_peek_collector = new TraceVarPeekCollector(
+                $this->variable_reader,
+                $get_trace_settings->var_specs,
+                $get_trace_settings->var_every,
+                $get_trace_settings->var_on_function,
+            );
+        }
+
         // Set up merged trace output if native tracing is enabled
         $merged_trace_output = null;
         $trace_merger = null;
@@ -184,6 +208,7 @@ final class GetTraceCommand extends Command
                 $loop_settings,
                 $eg_address,
                 $sg_address,
+                $cg_address,
                 $trace_output,
                 $trace_cache,
                 $with_native,
@@ -191,6 +216,7 @@ final class GetTraceCommand extends Command
                 $merged_trace_output,
                 $trace_merger,
                 $native_trace_anytime,
+                $var_peek_collector,
             ): bool {
                 if ($loop_settings->stop_process and $this->process_stopper->stop($process_specifier->pid)) {
                     defer($_, fn () => $this->process_stopper->resume($process_specifier->pid));
@@ -210,15 +236,32 @@ final class GetTraceCommand extends Command
                     if ($call_trace !== null || $native_trace_anytime) {
                         $native_trace = $native_collector->collect($process_specifier->pid);
                         if ($native_trace !== null) {
+                            // Merged native+php traces intentionally skip
+                            // --trace-var annotations for now; the merged
+                            // output path has no annotation slot yet.
                             $php_trace = $call_trace ?? new CallTrace();
                             $merged = $trace_merger->merge($native_trace, $php_trace);
                             $merged_trace_output->outputMerged($merged);
                         } elseif ($call_trace !== null) {
-                            $trace_output->output($call_trace);
+                            $annotations = $var_peek_collector?->collect(
+                                $call_trace,
+                                $process_specifier,
+                                $target_php_settings,
+                                $eg_address,
+                                $cg_address,
+                            );
+                            $trace_output->output($call_trace, $annotations);
                         }
                     }
                 } elseif ($call_trace !== null) {
-                    $trace_output->output($call_trace);
+                    $annotations = $var_peek_collector?->collect(
+                        $call_trace,
+                        $process_specifier,
+                        $target_php_settings,
+                        $eg_address,
+                        $cg_address,
+                    );
+                    $trace_output->output($call_trace, $annotations);
                 }
                 return true;
             },

--- a/src/Converter/BinaryTrace/BinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/BinaryTraceWriter.php
@@ -102,11 +102,19 @@ final class BinaryTraceWriter
     /**
      * Write a trace sample, emitting STRING_DEF, FRAME_DEF and STACK_DEF events as needed.
      *
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata. When non-empty, a SAMPLE_ANNOTATION event is
+     *     emitted directly after the SAMPLE / COMPACT_SAMPLE; annotation
+     *     strings are interned via STRING_DEF, so repeated values cost
+     *     only one varint pair per sample after the first.
      * @return int The stack_id used for this sample
      */
-    public function writeTrace(ParsedCallTrace $trace, int $timestamp_delta_us = 0): int
-    {
-        return $this->writeAnnotatedTrace($trace, $timestamp_delta_us);
+    public function writeTrace(
+        ParsedCallTrace $trace,
+        int $timestamp_delta_us = 0,
+        ?array $annotations = null,
+    ): int {
+        return $this->writeAnnotatedTrace($trace, $timestamp_delta_us, $annotations);
     }
 
     /**

--- a/src/Converter/BinaryTrace/BinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/BinaryTraceWriter.php
@@ -196,12 +196,28 @@ final class BinaryTraceWriter
     /**
      * Write a trace as a PID_SAMPLE, emitting FRAME_DEF and STACK_DEF as needed.
      *
+     * When `$annotations` is non-empty, a SAMPLE_ANNOTATION event is emitted
+     * directly after the PID_SAMPLE (the rbt spec allows SAMPLE_ANNOTATION to
+     * follow PID_SAMPLE just like SAMPLE / COMPACT_SAMPLE). Annotation keys
+     * and values are interned via STRING_DEF. The PID_SAMPLE path does not
+     * participate in run-length encoding — interleaved per-sample PIDs break
+     * runs by construction — so the annotation append is straight-line with
+     * no pending-run bookkeeping.
+     *
+     * @param array<string, string>|null $annotations
      * @return int The stack_id used for this sample
      */
-    public function writePidTrace(ParsedCallTrace $trace, int $pid, int $timestamp_delta_us = 0): int
-    {
+    public function writePidTrace(
+        ParsedCallTrace $trace,
+        int $pid,
+        int $timestamp_delta_us = 0,
+        ?array $annotations = null,
+    ): int {
         $stack_id = $this->defineTrace($trace);
         $this->writePidSample($stack_id, $pid, $timestamp_delta_us);
+        if ($annotations !== null && $annotations !== []) {
+            $this->emitAnnotation($annotations);
+        }
         return $stack_id;
     }
 

--- a/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
+++ b/src/Converter/BinaryTrace/SegmentedBinaryTraceWriter.php
@@ -66,9 +66,16 @@ final class SegmentedBinaryTraceWriter
     /**
      * Write a trace sample with an absolute timestamp.
      * Handles segment rotation, definition re-emission, and timestamp deltas.
+     *
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata. Attached to the emitted SAMPLE via
+     *     SAMPLE_ANNOTATION; strings are interned in the current segment.
      */
-    public function writeTrace(ParsedCallTrace $trace, int $timestamp_us): void
-    {
+    public function writeTrace(
+        ParsedCallTrace $trace,
+        int $timestamp_us,
+        ?array $annotations = null,
+    ): void {
         if ($this->current_writer === null) {
             $this->startSegment($timestamp_us);
         }
@@ -86,7 +93,7 @@ final class SegmentedBinaryTraceWriter
 
         $this->trackTrace($trace);
         assert($this->current_writer !== null);
-        $this->current_writer->writeTrace($trace, $delta);
+        $this->current_writer->writeTrace($trace, $delta, $annotations);
 
         if ($this->current_writer->getSamplesSinceCheckpoint() >= $this->checkpoint_interval) {
             $this->current_writer->writeCheckpoint();

--- a/src/Inspector/Daemon/Dispatcher/TargetProcessDescriptor.php
+++ b/src/Inspector/Daemon/Dispatcher/TargetProcessDescriptor.php
@@ -17,12 +17,21 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
 
 final class TargetProcessDescriptor
 {
-    /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */
+    /**
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     * @param int $cg_address compiler-globals address, or 0 when not
+     *     resolved. Populated by the searcher only when the daemon was
+     *     launched with a feature that needs CG (e.g. `inspector:trace
+     *     --trace-var` specs that reference `static::` or `func_static::`
+     *     scopes). Consumers MUST treat 0 as "not available" and skip
+     *     CG-dependent operations.
+     */
     public function __construct(
         public int $pid,
         public int $eg_address,
         public int $sg_address,
         public string $php_version,
+        public int $cg_address = 0,
     ) {
     }
 

--- a/src/Inspector/Daemon/Reader/Protocol/Message/TraceMessage.php
+++ b/src/Inspector/Daemon/Reader/Protocol/Message/TraceMessage.php
@@ -17,9 +17,18 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
 final class TraceMessage
 {
+    /**
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata (e.g. `--trace-var` peek results). Populated
+     *     by the reader worker when the daemon is launched with any
+     *     annotation-producing feature; ignored otherwise. Serialises
+     *     over the existing AMPHP IPC channel without additional work
+     *     because arrays of strings are natively supported.
+     */
     public function __construct(
         public CallTrace $trace,
         public ?int $pid = null,
+        public ?array $annotations = null,
     ) {
     }
 }

--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
@@ -102,10 +102,14 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
                 Log::debug('start trace');
                 foreach ($loop_runner as $message) {
                     if ($use_binary_direct && $this->binary_writer !== null) {
-                        $this->writeBinaryTrace($message->trace);
+                        // Per-worker rbt mode: annotations never leave the
+                        // worker — they go straight into our own .rbt file.
+                        $this->writeBinaryTrace($message->trace, $message->annotations);
                     } else {
+                        // Bundled / template modes: forward annotations to
+                        // the controller via IPC for it to write out.
                         $this->protocol->sendTrace(
-                            new TraceMessage($message->trace, $pid)
+                            new TraceMessage($message->trace, $pid, $message->annotations)
                         );
                     }
                 }
@@ -149,7 +153,10 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
         $this->binary_stream = $stream;
     }
 
-    private function writeBinaryTrace(CallTrace $call_trace): void
+    /**
+     * @param array<string, string>|null $annotations
+     */
+    private function writeBinaryTrace(CallTrace $call_trace, ?array $annotations = null): void
     {
         assert($this->binary_writer !== null);
         $now_ns = hrtime(true);
@@ -159,7 +166,11 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
         }
         $this->last_hrtime_ns = $now_ns;
 
-        $this->binary_writer->writeTrace(CallTraceConverter::toParsed($call_trace), $delta_us);
+        $this->binary_writer->writeTrace(
+            CallTraceConverter::toParsed($call_trace),
+            $delta_us,
+            $annotations,
+        );
 
         if ($this->binary_writer->getSamplesSinceCheckpoint() >= 1000) {
             $this->binary_writer->writeCheckpoint();

--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderTraceLoop.php
@@ -17,9 +17,13 @@ use Generator;
 use Reli\Inspector\Daemon\Dispatcher\TargetProcessDescriptor;
 use Reli\Inspector\Daemon\Reader\Protocol\Message\TraceMessage;
 use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettings;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
+use Reli\Inspector\Watch\TraceVarPeekCollector;
+use Reli\Inspector\Watch\VariableReaderInterface;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
 use Reli\Lib\PhpProcessReader\CallTraceReader\TraceCache;
+use Reli\Lib\Process\ProcessSpecifier;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 
 use function is_null;
@@ -31,6 +35,7 @@ final class PhpReaderTraceLoop implements PhpReaderTraceLoopInterface
         private CallTraceReader $executor_globals_reader,
         private ReaderLoopProvider $reader_loop_provider,
         private ProcessStopper $process_stopper,
+        private VariableReaderInterface $variable_reader,
     ) {
     }
 
@@ -48,12 +53,40 @@ final class PhpReaderTraceLoop implements PhpReaderTraceLoopInterface
         GetTraceSettings $get_trace_settings
     ): Generator {
         $trace_cache = new TraceCache();
+
+        // Build a peek collector for this attach, reusing exactly the
+        // single-process logic. Null when no --trace-var specs are
+        // configured, so the hot path stays allocation-free.
+        $var_peek_collector = null;
+        if ($get_trace_settings->var_specs !== []) {
+            $var_peek_collector = new TraceVarPeekCollector(
+                $this->variable_reader,
+                $get_trace_settings->var_specs,
+                $get_trace_settings->var_every,
+                $get_trace_settings->var_on_function,
+            );
+        }
+
+        // The CG address rides along on the descriptor when the searcher
+        // was told this daemon needs it (see PhpSearcherController::sendTarget
+        // and ProcessDescriptorRetriever). static::/func_static:: specs
+        // will silently resolve to <not found> when cg_address is 0,
+        // matching inspector:peek-var's behaviour.
+        $cg_address = $target_process_descriptor->cg_address;
+        $process_specifier = new ProcessSpecifier($target_process_descriptor->pid);
+        /** @var TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> */
+        $target_php_settings = new TargetPhpSettings($target_process_descriptor->php_version);
+
         $loop = $this->reader_loop_provider->getMainLoop(
             function () use (
                 $get_trace_settings,
                 $target_process_descriptor,
                 $loop_settings,
                 $trace_cache,
+                $var_peek_collector,
+                $cg_address,
+                $process_specifier,
+                $target_php_settings,
             ): Generator {
                 if ($loop_settings->stop_process and $this->process_stopper->stop($target_process_descriptor->pid)) {
                     defer($_, fn () => $this->process_stopper->resume($target_process_descriptor->pid));
@@ -69,7 +102,14 @@ final class PhpReaderTraceLoop implements PhpReaderTraceLoopInterface
                 if (is_null($call_trace)) {
                     return;
                 }
-                yield new TraceMessage($call_trace);
+                $annotations = $var_peek_collector?->collect(
+                    $call_trace,
+                    $process_specifier,
+                    $target_php_settings,
+                    $target_process_descriptor->eg_address,
+                    $cg_address,
+                );
+                yield new TraceMessage($call_trace, null, $annotations);
             },
             $loop_settings
         );

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
@@ -53,12 +53,14 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
         TargetPhpSettings $target_php_settings,
         int $pid,
         bool $no_cache = false,
+        bool $needs_compiler_globals = false,
     ): void {
         $message = new TargetPhpSettingsMessage(
             $regex,
             $target_php_settings,
             $pid,
             $no_cache,
+            $needs_compiler_globals,
         );
         $this->auto_context_recovering->withAutoRecover(
             function (PhpSearcherControllerProtocolInterface $protocol) use ($message) {

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
@@ -26,6 +26,7 @@ interface PhpSearcherControllerInterface
         TargetPhpSettings $target_php_settings,
         int $pid,
         bool $no_cache = false,
+        bool $needs_compiler_globals = false,
     ): void;
 
     public function receivePidList(): UpdateTargetProcessMessage;

--- a/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
+++ b/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
@@ -21,12 +21,19 @@ final class TargetPhpSettingsMessage
     /**
      * @param non-empty-string $regex
      * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|'auto'> $target_php_settings
+     * @param bool $needs_compiler_globals ask the searcher to resolve the
+     *     CG address for each discovered PHP process. Set from the daemon
+     *     when its feature set (e.g. inspector:trace --trace-var with
+     *     static::/func_static:: scopes) requires CG. When false, the
+     *     searcher skips the extra lookup and TargetProcessDescriptor's
+     *     cg_address stays 0.
      */
     public function __construct(
         public string $regex,
         public TargetPhpSettings $target_php_settings,
         public int $parent_pid,
         public bool $no_cache = false,
+        public bool $needs_compiler_globals = false,
     ) {
     }
 }

--- a/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
+++ b/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
@@ -69,6 +69,7 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
                                     $pid,
                                     $target_php_settings_message->target_php_settings,
                                     $cache,
+                                    $target_php_settings_message->needs_compiler_globals,
                                 ),
                                 $searched_pids
                             ),

--- a/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetriever.php
+++ b/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetriever.php
@@ -30,11 +30,19 @@ class ProcessDescriptorRetriever
     ) {
     }
 
-    /** @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|'auto'> $target_php_settings */
+    /**
+     * @param TargetPhpSettings<value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS>|'auto'> $target_php_settings
+     * @param bool $needs_compiler_globals when true, resolve CG alongside
+     *     EG/SG so consumers like inspector:trace --trace-var can read
+     *     class static properties and function-static variables.
+     *     Resolution happens once per PID via the descriptor cache, so
+     *     the extra lookup is paid at most once per target.
+     */
     public function getProcessDescriptor(
         int $pid,
         TargetPhpSettings $target_php_settings,
         ProcessDescriptorCache $process_descriptor_cache,
+        bool $needs_compiler_globals = false,
     ): TargetProcessDescriptor {
         $cache = $process_descriptor_cache->get($pid);
         if (!is_null($cache)) {
@@ -57,6 +65,13 @@ class ProcessDescriptorRetriever
                 $process_specifier,
                 $target_php_settings_decided
             );
+            $cg_address = 0;
+            if ($needs_compiler_globals) {
+                $cg_address = $this->php_globals_finder->findCompilerGlobals(
+                    $process_specifier,
+                    $target_php_settings_decided,
+                );
+            }
         } catch (\Throwable $e) {
             Log::debug(
                 'error on analyzing php binary',
@@ -77,6 +92,7 @@ class ProcessDescriptorRetriever
             $eg_address,
             $sg_address,
             $target_php_settings_decided->php_version,
+            $cg_address,
         );
         $process_descriptor_cache->set($result);
         return $result;

--- a/src/Inspector/Output/TraceFormatter/CallTraceFormatter.php
+++ b/src/Inspector/Output/TraceFormatter/CallTraceFormatter.php
@@ -17,5 +17,12 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
 interface CallTraceFormatter
 {
-    public function format(CallTrace $call_trace): string;
+    /**
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata (e.g. peeked variable values). Text-oriented
+     *     formatters should emit these on lines that won't be mistaken for
+     *     stack frames; formatters that can't express annotations MUST
+     *     silently ignore the argument.
+     */
+    public function format(CallTrace $call_trace, ?array $annotations = null): string;
 }

--- a/src/Inspector/Output/TraceFormatter/Compat/CompatCallTraceFormatter.php
+++ b/src/Inspector/Output/TraceFormatter/Compat/CompatCallTraceFormatter.php
@@ -36,8 +36,12 @@ final class CompatCallTraceFormatter implements CallTraceFormatter
     }
 
     #[\Override]
-    public function format(CallTrace $call_trace): string
+    public function format(CallTrace $call_trace, ?array $annotations = null): string
     {
+        // The compat format has no way to express annotations without
+        // breaking consumers that expect a bare frame list, so they are
+        // intentionally ignored here. Callers that need per-sample
+        // annotations should use the phpspy template instead.
         $frames = [];
         foreach ($call_trace->call_frames as $call_frame) {
             $frames[] = $this->call_frame_formatter->format($call_frame);

--- a/src/Inspector/Output/TraceFormatter/MergedCallTraceFormatter.php
+++ b/src/Inspector/Output/TraceFormatter/MergedCallTraceFormatter.php
@@ -17,7 +17,14 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\MergedCallTrace;
 
 final class MergedCallTraceFormatter
 {
-    public function format(MergedCallTrace $trace): string
+    /**
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata, emitted as `# key = value` comment lines
+     *     after the frame list (same convention as the phpspy template).
+     *     reli's own PhpSpyCompatibleParser treats `#`-prefixed lines as
+     *     comments, so the merged output remains round-trip safe.
+     */
+    public function format(MergedCallTrace $trace, ?array $annotations = null): string
     {
         $output = '';
         $depth = 0;
@@ -36,6 +43,12 @@ final class MergedCallTraceFormatter
                 $output .= "{$depth} {$php->getFullyQualifiedFunctionName()} {$php->file_name}:{$php->getLineno()}\n";
             }
             $depth++;
+        }
+
+        if ($annotations !== null && $annotations !== []) {
+            foreach ($annotations as $key => $value) {
+                $output .= "# {$key} = {$value}\n";
+            }
         }
 
         $output .= "\n";

--- a/src/Inspector/Output/TraceFormatter/Templated/TemplatedCallTraceFormatter.php
+++ b/src/Inspector/Output/TraceFormatter/Templated/TemplatedCallTraceFormatter.php
@@ -25,7 +25,7 @@ use function ob_start;
 
 final class TemplatedCallTraceFormatter implements CallTraceFormatter
 {
-    /** @var ?Closure(CallTrace): string */
+    /** @var ?Closure(CallTrace, ?array<string, string>): string */
     private ?Closure $renderer = null;
 
     public function __construct(
@@ -35,12 +35,12 @@ final class TemplatedCallTraceFormatter implements CallTraceFormatter
     }
 
     #[\Override]
-    public function format(CallTrace $call_trace): string
+    public function format(CallTrace $call_trace, ?array $annotations = null): string
     {
-        return ($this->getRenderer())($call_trace);
+        return ($this->getRenderer())($call_trace, $annotations);
     }
 
-    /** @return Closure(CallTrace): string */
+    /** @return Closure(CallTrace, ?array<string, string>): string */
     private function getRenderer(): Closure
     {
         if ($this->renderer === null) {
@@ -55,10 +55,13 @@ final class TemplatedCallTraceFormatter implements CallTraceFormatter
                 $template_body = substr($template_content, $body_start + 2);
                 /**
                  * @psalm-suppress ForbiddenCode
-                 * @var Closure(CallTrace): string $renderer
+                 * @var Closure(CallTrace, ?array<string, string>): string $renderer
                  */
                 $renderer = eval(
-                    'return static function (\\' . CallTrace::class . ' $call_trace): string {'
+                    'return static function ('
+                    . '\\' . CallTrace::class . ' $call_trace, '
+                    . '?array $annotations = null'
+                    . '): string {'
                     . 'ob_start();'
                     . '?' . '>' . $template_body
                     . '<' . '?php return ob_get_clean();'
@@ -66,7 +69,10 @@ final class TemplatedCallTraceFormatter implements CallTraceFormatter
                 );
             } else {
                 // Template is pure PHP (no closing tag separator) — fall back to include
-                $renderer = static function (CallTrace $call_trace) use ($template_path): string {
+                $renderer = static function (
+                    CallTrace $call_trace,
+                    ?array $annotations = null,
+                ) use ($template_path): string {
                     ob_start();
                     /** @psalm-suppress UnresolvableInclude */
                     include $template_path;

--- a/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
@@ -39,9 +39,9 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     }
 
     #[\Override]
-    public function output(CallTrace $call_trace): void
+    public function output(CallTrace $call_trace, ?array $annotations = null): void
     {
-        $this->writeParsed(CallTraceConverter::toParsed($call_trace));
+        $this->writeParsed(CallTraceConverter::toParsed($call_trace), $annotations);
     }
 
     #[\Override]
@@ -80,7 +80,10 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
         }
     }
 
-    private function writeParsed(ParsedCallTrace $parsed): void
+    /**
+     * @param array<string, string>|null $annotations
+     */
+    private function writeParsed(ParsedCallTrace $parsed, ?array $annotations = null): void
     {
         if (!$this->header_written) {
             $this->writer->writeHeader();
@@ -94,7 +97,7 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
         }
         $this->last_hrtime_ns = $now_ns;
 
-        $this->writer->writeTrace($parsed, $delta_us);
+        $this->writer->writeTrace($parsed, $delta_us, $annotations);
 
         if ($this->writer->getSamplesSinceCheckpoint() >= $this->checkpoint_interval) {
             $this->writer->writeCheckpoint();

--- a/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
@@ -45,9 +45,9 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     }
 
     #[\Override]
-    public function outputMerged(MergedCallTrace $merged_trace): void
+    public function outputMerged(MergedCallTrace $merged_trace, ?array $annotations = null): void
     {
-        $this->writeParsed(CallTraceConverter::mergedToParsed($merged_trace));
+        $this->writeParsed(CallTraceConverter::mergedToParsed($merged_trace), $annotations);
     }
 
     /**

--- a/src/Inspector/Output/TraceOutput/FormattedMergedTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/FormattedMergedTraceOutput.php
@@ -26,10 +26,10 @@ final class FormattedMergedTraceOutput implements MergedTraceOutput
     }
 
     #[\Override]
-    public function outputMerged(MergedCallTrace $merged_trace): void
+    public function outputMerged(MergedCallTrace $merged_trace, ?array $annotations = null): void
     {
         $this->outputChannel->output(
-            $this->formatter->format($merged_trace)
+            $this->formatter->format($merged_trace, $annotations)
         );
     }
 }

--- a/src/Inspector/Output/TraceOutput/FormattedTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/FormattedTraceOutput.php
@@ -26,10 +26,10 @@ final class FormattedTraceOutput implements TraceOutput
     }
 
     #[\Override]
-    public function output(CallTrace $call_trace): void
+    public function output(CallTrace $call_trace, ?array $annotations = null): void
     {
         $this->output_channel->output(
-            $this->call_trace_formatter->format($call_trace)
+            $this->call_trace_formatter->format($call_trace, $annotations)
         );
     }
 }

--- a/src/Inspector/Output/TraceOutput/MergedTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/MergedTraceOutput.php
@@ -17,5 +17,11 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\MergedCallTrace;
 
 interface MergedTraceOutput
 {
-    public function outputMerged(MergedCallTrace $merged_trace): void;
+    /**
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata (e.g. --trace-var peek results). Same
+     *     semantics as TraceOutput::output(). Implementations that can't
+     *     express annotations MUST silently ignore this argument.
+     */
+    public function outputMerged(MergedCallTrace $merged_trace, ?array $annotations = null): void;
 }

--- a/src/Inspector/Output/TraceOutput/SegmentedBinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/SegmentedBinaryTraceOutput.php
@@ -27,7 +27,7 @@ final class SegmentedBinaryTraceOutput implements TraceOutput
     }
 
     #[\Override]
-    public function output(CallTrace $call_trace): void
+    public function output(CallTrace $call_trace, ?array $annotations = null): void
     {
         $now_ns = hrtime(true);
         if ($this->start_hrtime_ns === null) {
@@ -35,7 +35,11 @@ final class SegmentedBinaryTraceOutput implements TraceOutput
         }
 
         $timestamp_us = (int)(($now_ns - $this->start_hrtime_ns) / 1000);
-        $this->writer->writeTrace(CallTraceConverter::toParsed($call_trace), $timestamp_us);
+        $this->writer->writeTrace(
+            CallTraceConverter::toParsed($call_trace),
+            $timestamp_us,
+            $annotations,
+        );
     }
 
     public function finish(): void

--- a/src/Inspector/Output/TraceOutput/TraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/TraceOutput.php
@@ -17,5 +17,10 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
 interface TraceOutput
 {
-    public function output(CallTrace $call_trace): void;
+    /**
+     * @param array<string, string>|null $annotations optional per-sample
+     *     key/value metadata (e.g. peeked variable values). Implementations
+     *     that do not support annotations MUST silently ignore this argument.
+     */
+    public function output(CallTrace $call_trace, ?array $annotations = null): void;
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
@@ -13,18 +13,40 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Settings\GetTraceSettings;
 
+use Reli\Inspector\Watch\VariableSpec;
+
 final class GetTraceSettings
 {
     public const BULK_STACK_COPY_DEFAULT_MAX_SIZE = 65536;
 
     /**
      * @param int|null $bulk_stack_copy_max_size null = disabled, int = max bytes to prefetch
+     * @param list<VariableSpec> $var_specs list of variables to peek per sample (empty = disabled)
+     * @param int $var_every read variables only every N-th sample (1 = every sample)
+     * @param string|null $var_on_function skip variable reads when this FQN is not on the stack
      */
     public function __construct(
         public int $depth,
         public bool $with_native_trace = false,
         public bool $native_trace_anytime = false,
         public ?int $bulk_stack_copy_max_size = null,
+        public array $var_specs = [],
+        public int $var_every = 1,
+        public ?string $var_on_function = null,
     ) {
+    }
+
+    /**
+     * True if any var-peek spec targets a scope that requires the CG address
+     * (class static property or function static variable).
+     */
+    public function needsCompilerGlobals(): bool
+    {
+        foreach ($this->var_specs as $spec) {
+            if ($spec->scope === 'static' || $spec->scope === 'func_static') {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
@@ -19,10 +19,16 @@ final class GetTraceSettingsException extends InspectorSettingsException
 {
     public const DEPTH_IS_NOT_INTEGER = 1;
     public const BULK_STACK_COPY_IS_NOT_VALID_SIZE = 2;
+    public const TRACE_VAR_EXPRESSION_IS_INVALID = 3;
+    public const TRACE_VAR_EVERY_IS_NOT_POSITIVE_INTEGER = 4;
 
     protected const ERRORS = [
         self::DEPTH_IS_NOT_INTEGER => 'depth is not integer',
         self::BULK_STACK_COPY_IS_NOT_VALID_SIZE =>
             'bulk-stack-copy value must be an integer with optional K/M suffix (e.g. 65536, 64K, 1M)',
+        self::TRACE_VAR_EXPRESSION_IS_INVALID =>
+            'trace-var expression is invalid (see --var syntax for inspector:peek-var)',
+        self::TRACE_VAR_EVERY_IS_NOT_POSITIVE_INTEGER =>
+            'trace-var-every must be a positive integer (1 or greater)',
     ];
 }

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Settings\GetTraceSettings;
 
+use InvalidArgumentException;
 use PhpCast\NullableCast;
 use Reli\Inspector\Settings\InspectorSettingsException;
+use Reli\Inspector\Watch\VariableSpec;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -55,6 +57,28 @@ final class GetTraceSettingsFromConsoleInput
                 'bulk-copy VM stack per sample for consistency (default max: 64K). '
                 . 'Accepts optional max size in bytes (e.g. 65536, 16K, 256K)'
             )
+            ->addOption(
+                'trace-var',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'variable to peek per sample and attach as an annotation '
+                . '(same syntax as inspector:peek-var --var, e.g. '
+                . "global::\$counter, local::App\\Svc::run()\$id, "
+                . "static::App\\Cache::\$entries, func_static::App\\retry()\$n)"
+            )
+            ->addOption(
+                'trace-var-every',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'read --trace-var only every N-th sample (default: 1 = every sample)'
+            )
+            ->addOption(
+                'trace-var-on-function',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'skip --trace-var reads when this fully-qualified function is not on the stack '
+                . '(cheap gate that avoids process_vm_readv when the target frame is inactive)'
+            )
         ;
     }
 
@@ -86,6 +110,67 @@ final class GetTraceSettingsFromConsoleInput
     }
 
     /**
+     * @return list<VariableSpec>
+     * @throws GetTraceSettingsException
+     */
+    private function parseVarSpecs(InputInterface $input): array
+    {
+        /** @var mixed $raw */
+        $raw = $input->getOption('trace-var');
+        if (!is_array($raw)) {
+            return [];
+        }
+        $specs = [];
+        foreach ($raw as $expression) {
+            if (!is_string($expression) || $expression === '') {
+                continue;
+            }
+            try {
+                $specs[] = VariableSpec::parse($expression);
+            } catch (InvalidArgumentException) {
+                throw GetTraceSettingsException::create(
+                    GetTraceSettingsException::TRACE_VAR_EXPRESSION_IS_INVALID,
+                );
+            }
+        }
+        return $specs;
+    }
+
+    /**
+     * @throws GetTraceSettingsException
+     */
+    private function parseVarEvery(InputInterface $input): int
+    {
+        /** @var mixed $raw */
+        $raw = $input->getOption('trace-var-every');
+        if ($raw === null) {
+            return 1;
+        }
+        $value = NullableCast::toString($raw);
+        if ($value === null) {
+            return 1;
+        }
+        $parsed = filter_var($value, FILTER_VALIDATE_INT);
+        if ($parsed === false || $parsed < 1) {
+            throw GetTraceSettingsException::create(
+                GetTraceSettingsException::TRACE_VAR_EVERY_IS_NOT_POSITIVE_INTEGER,
+            );
+        }
+        return $parsed;
+    }
+
+    private function parseVarOnFunction(InputInterface $input): ?string
+    {
+        /** @var mixed $raw */
+        $raw = $input->getOption('trace-var-on-function');
+        $value = NullableCast::toString($raw);
+        if ($value === null || $value === '') {
+            return null;
+        }
+        return $value;
+    }
+
+    /**
      * @throws InspectorSettingsException
      */
     public function createSettings(InputInterface $input): GetTraceSettings
@@ -106,6 +191,18 @@ final class GetTraceSettingsFromConsoleInput
 
         $bulk_stack_copy_max_size = $this->parseBulkStackCopy($input);
 
-        return new GetTraceSettings($depth, $with_native_trace, $native_trace_anytime, $bulk_stack_copy_max_size);
+        $var_specs = $this->parseVarSpecs($input);
+        $var_every = $this->parseVarEvery($input);
+        $var_on_function = $this->parseVarOnFunction($input);
+
+        return new GetTraceSettings(
+            $depth,
+            $with_native_trace,
+            $native_trace_anytime,
+            $bulk_stack_copy_max_size,
+            $var_specs,
+            $var_every,
+            $var_on_function,
+        );
     }
 }

--- a/src/Inspector/Watch/Daemon/Searcher/WatchTargetDescriptor.php
+++ b/src/Inspector/Watch/Daemon/Searcher/WatchTargetDescriptor.php
@@ -38,6 +38,7 @@ final class WatchTargetDescriptor
             $this->eg_address,
             $this->sg_address,
             $this->php_version,
+            $this->cg_address,
         );
     }
 

--- a/src/Inspector/Watch/TraceVarPeekCollector.php
+++ b/src/Inspector/Watch/TraceVarPeekCollector.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
+use Reli\Lib\Process\ProcessSpecifier;
+use Throwable;
+
+/**
+ * Per-sample variable-peek collector for `inspector:trace --trace-var`.
+ *
+ * Holds the parsed spec list and per-sample throttle state (sample_index),
+ * so the trace loop only has to call `collect()` once per sample and get
+ * back an annotation map (or null) to pass into `TraceOutput::output()`.
+ *
+ * Construction is cheap; the collector is expected to live for the duration
+ * of a single trace command invocation. It is not thread-safe — each worker
+ * in daemon mode constructs its own.
+ */
+final class TraceVarPeekCollector
+{
+    private int $sample_index = 0;
+
+    /**
+     * @param list<VariableSpec> $var_specs non-empty; callers should not
+     *     construct a collector when there are no specs (use null instead).
+     * @param int $var_every read variables only every N-th sample (>= 1)
+     * @param string|null $var_on_function skip reads when this FQN is
+     *     absent from the current call stack; null disables the gate.
+     */
+    public function __construct(
+        private VariableReaderInterface $variable_reader,
+        private array $var_specs,
+        private int $var_every = 1,
+        private ?string $var_on_function = null,
+    ) {
+    }
+
+    /**
+     * Collect annotations for a single trace sample.
+     *
+     * Returns null when:
+     *   - this sample is skipped by --trace-var-every,
+     *   - the --trace-var-on-function gate fails (target frame absent),
+     *   - VariableReader::readVariables() throws (target gone, stale frame,
+     *     transient memory read failure — we degrade gracefully rather than
+     *     killing the loop), or
+     *   - every spec resolved to <not found> so there is nothing to attach.
+     *
+     * Otherwise returns a map keyed by the spec's lookup_key (e.g.
+     * "global::$counter") with pre-formatted string values ready to be
+     * embedded in phpspy comment lines or interned into rbt
+     * SAMPLE_ANNOTATION events.
+     *
+     * @param TargetPhpSettings<
+     *     value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>
+     * > $target_php_settings
+     * @return array<string, string>|null
+     */
+    public function collect(
+        CallTrace $call_trace,
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        int $eg_address,
+        int $cg_address,
+    ): ?array {
+        // Advance the cycle counter regardless of gate outcome so
+        // --trace-var-every behaves predictably even when --trace-var-on-function
+        // suppresses intermediate reads.
+        $current_index = ++$this->sample_index;
+
+        if ($current_index % $this->var_every !== 0) {
+            return null;
+        }
+
+        if (
+            $this->var_on_function !== null
+            && !$this->hasFunctionOnStack($call_trace, $this->var_on_function)
+        ) {
+            return null;
+        }
+
+        try {
+            $values = $this->variable_reader->readVariables(
+                $this->var_specs,
+                $process_specifier,
+                $target_php_settings,
+                $eg_address,
+                $cg_address,
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($values === []) {
+            return null;
+        }
+
+        $result = [];
+        foreach ($values as $lookup_key => $value) {
+            $result[$lookup_key] = VariableValueFormatter::format($value);
+        }
+        return $result;
+    }
+
+    private function hasFunctionOnStack(CallTrace $trace, string $target_fqn): bool
+    {
+        foreach ($trace->call_frames as $frame) {
+            if ($frame->getFullyQualifiedFunctionName() === $target_fqn) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -41,7 +41,7 @@ use Reli\Lib\Process\ProcessSpecifier;
  * - static:      class static properties (requires CG)
  * - func_static: function static variables
  */
-final class VariableReader
+final class VariableReader implements VariableReaderInterface
 {
     public function __construct(
         private MemoryReaderInterface $memory_reader,
@@ -54,6 +54,7 @@ final class VariableReader
      * @param TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $target_php_settings
      * @return array<string, VariableValue>
      */
+    #[\Override]
     public function readVariables(
         array $specs,
         ProcessSpecifier $process_specifier,

--- a/src/Inspector/Watch/VariableReaderInterface.php
+++ b/src/Inspector/Watch/VariableReaderInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\Process\ProcessSpecifier;
+
+/**
+ * Reads PHP variable values from a target process.
+ *
+ * Extracted from the concrete `VariableReader` so that collaborators
+ * (watch triggers, trace-var peek, etc.) can depend on a narrow,
+ * mock-friendly surface.
+ */
+interface VariableReaderInterface
+{
+    /**
+     * @param list<VariableSpec> $specs
+     * @param TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $target_php_settings
+     * @return array<string, VariableValue> keyed by `VariableSpec::$lookup_key`;
+     *     specs that could not be resolved are omitted rather than being
+     *     returned as a null or placeholder value.
+     */
+    public function readVariables(
+        array $specs,
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        int $eg_address,
+        int $cg_address = 0,
+    ): array;
+}

--- a/src/Inspector/Watch/VariableValueFormatter.php
+++ b/src/Inspector/Watch/VariableValueFormatter.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Renders a VariableValue into a single-line, line-safe string.
+ *
+ * Used by inspector:trace --trace-var to produce annotation values that are
+ * embedded in phpspy text output (as `# key = value` comment lines) and in
+ * rbt SAMPLE_ANNOTATION events. A single renderer keeps both formats in
+ * lockstep.
+ *
+ * Output shape:
+ *   TYPE_LONG    → "(int) 42"
+ *   TYPE_DOUBLE  → "(float) 3.14"
+ *   TYPE_STRING  → "(string) \"hello\"" (JSON-escaped, capped at max_length)
+ *   TYPE_BOOL    → "(bool) true" / "(bool) false"
+ *   TYPE_ARRAY   → "(array) count=10"
+ *   TYPE_NULL    → "null"
+ *   TYPE_UNKNOWN → "(unknown)"
+ *
+ * All outputs are guaranteed to contain no raw LF, CR, or unescaped control
+ * characters — the JSON encoding of the string branch handles UTF-8 and
+ * embedded newlines, and the other branches are ASCII-only by construction.
+ */
+final class VariableValueFormatter
+{
+    public const DEFAULT_MAX_STRING_LENGTH = 200;
+
+    public static function format(
+        VariableValue $value,
+        int $max_string_length = self::DEFAULT_MAX_STRING_LENGTH,
+    ): string {
+        return match ($value->type) {
+            VariableValue::TYPE_LONG => '(int) ' . (string)$value->scalar_value,
+            VariableValue::TYPE_DOUBLE => '(float) ' . self::formatDouble($value->scalar_value),
+            VariableValue::TYPE_STRING => '(string) ' . self::formatString(
+                (string)$value->scalar_value,
+                $max_string_length,
+            ),
+            VariableValue::TYPE_BOOL => '(bool) ' . ($value->scalar_value === true ? 'true' : 'false'),
+            VariableValue::TYPE_ARRAY => '(array) count=' . ($value->array_count ?? 0),
+            VariableValue::TYPE_NULL => 'null',
+            default => '(unknown)',
+        };
+    }
+
+    private static function formatDouble(mixed $scalar_value): string
+    {
+        if (!is_float($scalar_value) && !is_int($scalar_value)) {
+            return '0';
+        }
+        // (string) on a float uses precision ini setting; good enough for
+        // human-readable annotations. NaN/Inf map to "NAN" / "INF" which
+        // are line-safe and unambiguous.
+        return (string)$scalar_value;
+    }
+
+    private static function formatString(string $raw, int $max_length): string
+    {
+        if ($max_length > 0 && mb_strlen($raw) > $max_length) {
+            $raw = mb_substr($raw, 0, $max_length) . '...';
+        }
+        // JSON encoding guarantees: quotes around the value, backslash-
+        // escaped control chars (including LF/CR), and UTF-8 safety.
+        // JSON_UNESCAPED_UNICODE keeps non-ASCII readable rather than
+        // emitting \uXXXX sequences.
+        $encoded = json_encode($raw, JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            // Fall back to an opaque marker rather than dropping the line.
+            // json_encode can fail on invalid UTF-8 sequences; in that case
+            // we lose the string content but keep the annotation structure
+            // intact.
+            return '"<invalid-utf8>"';
+        }
+        return $encoded;
+    }
+}

--- a/tests/Converter/BinaryTrace/DaemonOutputTest.php
+++ b/tests/Converter/BinaryTrace/DaemonOutputTest.php
@@ -221,6 +221,62 @@ final class DaemonOutputTest extends BaseTestCase
     }
 
     /**
+     * Bundled mode with per-sample annotations round-trips through PID_SAMPLE
+     * + SAMPLE_ANNOTATION. This path doesn't use RLE (per-sample PIDs break
+     * runs) so each annotated sample emits its own annotation event.
+     */
+    public function testBundledModePidSampleWithAnnotations(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $traceA = new ParsedCallTrace(
+            new ParsedCallFrame('func_a', '/a.php', 1),
+        );
+        $traceB = new ParsedCallTrace(
+            new ParsedCallFrame('func_b', '/b.php', 2),
+        );
+
+        $writer = new BinaryTraceWriter($stream, 10000, has_timestamps: true);
+        $writer->writeHeader();
+        $writer->writePidTrace(
+            $traceA,
+            100,
+            0,
+            ['global::$counter' => '(int) 1'],
+        );
+        $writer->writePidTrace(
+            $traceB,
+            200,
+            10000,
+            ['global::$counter' => '(int) 2', 'global::$name' => '(string) "x"'],
+        );
+        // Null annotations — should emit no SAMPLE_ANNOTATION event.
+        $writer->writePidTrace($traceA, 100, 10000, null);
+        $writer->writeCheckpoint();
+        $writer->writeSegmentEnd();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(3, $results);
+        $this->assertSame(100, $results[0]->pid);
+        $this->assertSame(
+            ['global::$counter' => '(int) 1'],
+            $results[0]->annotations,
+        );
+        $this->assertSame(200, $results[1]->pid);
+        $this->assertSame(
+            ['global::$counter' => '(int) 2', 'global::$name' => '(string) "x"'],
+            $results[1]->annotations,
+        );
+        $this->assertSame(100, $results[2]->pid);
+        $this->assertNull($results[2]->annotations);
+    }
+
+    /**
      * Bundled mode clean shutdown: CHECKPOINT + SEGMENT_END at end.
      */
     public function testBundledModeCleanEnd(): void

--- a/tests/Inspector/Output/TraceFormatter/Templated/PhpSpyTemplateTest.php
+++ b/tests/Inspector/Output/TraceFormatter/Templated/PhpSpyTemplateTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\TraceFormatter\Templated;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
+
+/**
+ * Exercises the real `resources/templates/phpspy.php` and
+ * `phpspy_with_opcode.php` templates with and without annotations, so
+ * that changes to the templates (frame line shape, annotation line
+ * format, blank-line terminator) are caught here rather than in a
+ * live profiling run.
+ */
+class PhpSpyTemplateTest extends BaseTestCase
+{
+    private const TEMPLATE_DIR = __DIR__ . '/../../../../../resources/templates';
+
+    private function buildFormatter(string $template_name): TemplatedCallTraceFormatter
+    {
+        $resolver = Mockery::mock(TemplatePathResolverInterface::class);
+        $resolver
+            ->allows()
+            ->resolve($template_name)
+            ->andReturns(self::TEMPLATE_DIR . "/{$template_name}.php");
+        return new TemplatedCallTraceFormatter($resolver, $template_name);
+    }
+
+    private function buildTrace(): CallTrace
+    {
+        return new CallTrace(
+            new CallFrame('App\\Service', 'run', '/app/src/Service.php', null),
+            new CallFrame('', '<main>', '/app/public/index.php', null),
+        );
+    }
+
+    public function testPhpSpyWithoutAnnotationsIsUnchanged(): void
+    {
+        $formatter = $this->buildFormatter('phpspy');
+        $output = $formatter->format($this->buildTrace());
+
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyWithNullAnnotationsIsUnchanged(): void
+    {
+        $formatter = $this->buildFormatter('phpspy');
+        $output = $formatter->format($this->buildTrace(), null);
+
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyWithEmptyAnnotationsIsUnchanged(): void
+    {
+        $formatter = $this->buildFormatter('phpspy');
+        $output = $formatter->format($this->buildTrace(), []);
+
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyEmitsAnnotationsAfterFrames(): void
+    {
+        $formatter = $this->buildFormatter('phpspy');
+        $annotations = [
+            'global::$counter' => '(int) 42',
+            'local::App\\Service::run()$id' => '(string) "abc"',
+        ];
+        $output = $formatter->format($this->buildTrace(), $annotations);
+
+        // Annotations appear as `# key = value` comment lines after all
+        // frames, before the blank terminator.
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "# global::\$counter = (int) 42\n"
+            . "# local::App\\Service::run()\$id = (string) \"abc\"\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyAnnotationLinesAreParsedAsComments(): void
+    {
+        // Round-trip: the annotated output must still be parseable by
+        // reli-prof's own phpspy parser (which treats `#` lines as
+        // comments). This guards the CommentParser:47 contract.
+        $formatter = $this->buildFormatter('phpspy');
+        $annotations = ['global::$x' => '(int) 7'];
+        $text = $formatter->format($this->buildTrace(), $annotations);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $text);
+        rewind($stream);
+
+        $parser = new \Reli\Converter\PhpSpyCompatibleParser();
+        $traces = iterator_to_array($parser->parseFile($stream));
+
+        $this->assertCount(1, $traces);
+        $parsed = $traces[0];
+        $this->assertCount(2, $parsed->call_frames);
+        $this->assertSame('App\\Service::run', $parsed->call_frames[0]->function_name);
+        $this->assertSame('<main>', $parsed->call_frames[1]->function_name);
+    }
+
+    public function testPhpSpyWithOpcodeWithoutAnnotationsIsUnchanged(): void
+    {
+        $formatter = $this->buildFormatter('phpspy_with_opcode');
+        $output = $formatter->format($this->buildTrace());
+
+        // No opcodes on these frames, so output matches plain phpspy
+        // (depth_offset stays 0 because the innermost frame has no opcode).
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyWithOpcodeEmitsAnnotationsAfterFrames(): void
+    {
+        $formatter = $this->buildFormatter('phpspy_with_opcode');
+        $output = $formatter->format($this->buildTrace(), ['global::$a' => '(int) 1']);
+
+        $expected = "0 App\\Service::run /app/src/Service.php:-1\n"
+            . "1 <main> /app/public/index.php:-1\n"
+            . "# global::\$a = (int) 1\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPhpSpyAnnotationOrderIsPreserved(): void
+    {
+        // Operators expect deterministic ordering (same as --trace-var
+        // declaration order). Associative-array iteration in PHP is
+        // insertion-ordered, so this works for free — but the guarantee
+        // is important enough to pin down as a test.
+        $formatter = $this->buildFormatter('phpspy');
+        $annotations = [
+            'global::$c' => '(int) 1',
+            'global::$a' => '(int) 2',
+            'global::$b' => '(int) 3',
+        ];
+        $output = $formatter->format($this->buildTrace(), $annotations);
+        $c_pos = strpos($output, '$c');
+        $a_pos = strpos($output, '$a');
+        $b_pos = strpos($output, '$b');
+        $this->assertNotFalse($c_pos);
+        $this->assertNotFalse($a_pos);
+        $this->assertNotFalse($b_pos);
+        $this->assertLessThan($a_pos, $c_pos);
+        $this->assertLessThan($b_pos, $a_pos);
+    }
+}

--- a/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
+++ b/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
@@ -158,6 +158,64 @@ final class BinaryTraceOutputTest extends BaseTestCase
         $this->assertSame('App::run', $frames[1]->function_name);
     }
 
+    public function testOutputWithAnnotationsRoundTrips(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $trace = new CallTrace(
+            new CallFrame('App', 'run', '/app.php', null),
+        );
+        $output->output(
+            $trace,
+            [
+                'global::$counter' => '(int) 42',
+                'local::App::run()$id' => '(string) "abc"',
+            ],
+        );
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(
+            [
+                'global::$counter' => '(int) 42',
+                'local::App::run()$id' => '(string) "abc"',
+            ],
+            $results[0]->annotations,
+        );
+    }
+
+    public function testOutputWithNullAnnotationsEmitsNoAnnotationEvent(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $trace = new CallTrace(
+            new CallFrame('App', 'run', '/app.php', null),
+        );
+        $output->output($trace, null);
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]->annotations);
+    }
+
     public function testCheckpointInterval(): void
     {
         $stream = fopen('php://memory', 'r+');

--- a/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
+++ b/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
@@ -156,6 +156,53 @@ final class BinaryTraceOutputTest extends BaseTestCase
         $this->assertSame('zend_execute', $frames[0]->function_name);
         $this->assertFalse($frames[1]->isNative());
         $this->assertSame('App::run', $frames[1]->function_name);
+        $this->assertNull($results[0]->annotations);
+    }
+
+    public function testOutputMergedWithAnnotationsRoundTrips(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $merged = new MergedCallTrace(
+            MergedCallFrame::fromNative(
+                new NativeCallFrame('zend_execute', 'libphp.so', 0x42, 0x7f00),
+            ),
+            MergedCallFrame::fromPhp(
+                new CallFrame('App', 'run', '/app.php', null),
+            ),
+        );
+        $output->outputMerged(
+            $merged,
+            [
+                'global::$counter' => '(int) 42',
+                'local::App::run()$id' => '(string) "abc"',
+            ],
+        );
+        $output->finish();
+
+        rewind($stream);
+        $reader = new BinaryTraceReader();
+        $results = iterator_to_array($reader->read($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $results);
+        // Native + PHP frames both preserved.
+        $frames = $results[0]->trace->call_frames;
+        $this->assertCount(2, $frames);
+        $this->assertTrue($frames[0]->isNative());
+        $this->assertFalse($frames[1]->isNative());
+        // And the annotations round-trip.
+        $this->assertSame(
+            [
+                'global::$counter' => '(int) 42',
+                'local::App::run()$id' => '(string) "abc"',
+            ],
+            $results[0]->annotations,
+        );
     }
 
     public function testOutputWithAnnotationsRoundTrips(): void

--- a/tests/Inspector/Output/TraceOutput/TraceOutputFactoryTest.php
+++ b/tests/Inspector/Output/TraceOutput/TraceOutputFactoryTest.php
@@ -49,7 +49,7 @@ class TraceOutputFactoryTest extends BaseTestCase
             )
         ;
         $call_trace_formatter->expects()
-            ->format($test_trace)
+            ->format($test_trace, null)
             ->andReturns('formatted')
         ;
         $trace_output_factory = new TraceOutputFactory($trace_formatter_factory);
@@ -88,7 +88,7 @@ class TraceOutputFactoryTest extends BaseTestCase
             )
         ;
         $call_trace_formatter->expects()
-            ->format($test_trace)
+            ->format($test_trace, null)
             ->andReturns('formatted')
         ;
 

--- a/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
@@ -19,31 +19,58 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 {
+    /**
+     * Build an input mock with per-option overrides. Every test calls
+     * createSettings() which reads every option, so we need to answer all
+     * of them. Mockery's `allows()` has first-match-wins semantics, so
+     * overrides must be applied before defaults.
+     *
+     * @param array<string, mixed> $overrides option-name => return value
+     * @param bool $bulk_stack_copy_flag value for hasParameterOption(['--bulk-stack-copy'])
+     */
+    private function buildInput(
+        array $overrides = [],
+        bool $bulk_stack_copy_flag = false,
+    ): InputInterface {
+        $defaults = [
+            'depth' => null,
+            'with-native-trace' => false,
+            'native-trace-anytime' => false,
+            'bulk-stack-copy' => null,
+            'trace-var' => [],
+            'trace-var-every' => null,
+            'trace-var-on-function' => null,
+        ];
+        $merged = $overrides + $defaults;
+
+        $input = Mockery::mock(InputInterface::class);
+        foreach ($merged as $name => $value) {
+            $input->allows()->getOption($name)->andReturns($value);
+        }
+        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns($bulk_stack_copy_flag);
+        return $input;
+    }
+
     public function testFromConsoleInput(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(10);
-        $input->expects()->getOption('with-native-trace')->andReturns(false);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
+        $input = $this->buildInput(['depth' => 10]);
 
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
 
         $this->assertSame(10, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
         $this->assertNull($settings->bulk_stack_copy_max_size);
+        $this->assertSame([], $settings->var_specs);
+        $this->assertSame(1, $settings->var_every);
+        $this->assertNull($settings->var_on_function);
     }
 
     public function testFromConsoleInputDefault(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->expects()->getOption('with-native-trace')->andReturns(false);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
+        $input = $this->buildInput();
+
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertSame(PHP_INT_MAX, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
         $this->assertNull($settings->bulk_stack_copy_max_size);
@@ -51,25 +78,17 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
     public function testFromConsoleInputDepthNotInteger(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns('abc');
-        $input->allows()->getOption('with-native-trace')->andReturns(false);
-        $input->allows()->getOption('native-trace-anytime')->andReturns(false);
-        $input->allows()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
+        $input = $this->buildInput(['depth' => 'abc']);
         $this->expectException(GetTraceSettingsException::class);
         (new GetTraceSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputWithNativeTrace(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->expects()->getOption('with-native-trace')->andReturns(true);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
+        $input = $this->buildInput(['with-native-trace' => true]);
+
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertTrue($settings->with_native_trace);
         $this->assertFalse($settings->native_trace_anytime);
         $this->assertNull($settings->bulk_stack_copy_max_size);
@@ -77,13 +96,10 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
     public function testFromConsoleInputNativeTraceAnytime(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->expects()->getOption('with-native-trace')->andReturns(false);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(true);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(false);
+        $input = $this->buildInput(['native-trace-anytime' => true]);
+
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertTrue($settings->with_native_trace); // implied by anytime
         $this->assertTrue($settings->native_trace_anytime);
         $this->assertNull($settings->bulk_stack_copy_max_size);
@@ -91,35 +107,167 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
     public function testFromConsoleInputBulkStackCopyFlag(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->expects()->getOption('with-native-trace')->andReturns(false);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns(null);
-        $input->allows()->hasParameterOption(['--bulk-stack-copy'])->andReturns(true);
+        $input = $this->buildInput([], bulk_stack_copy_flag: true);
+
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputBulkStackCopyWithSize(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->expects()->getOption('with-native-trace')->andReturns(false);
-        $input->expects()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns('128K');
+        $input = $this->buildInput(['bulk-stack-copy' => '128K']);
+
         $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertSame(128 * 1024, $settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputBulkStackCopyInvalidSize(): void
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('depth')->andReturns(null);
-        $input->allows()->getOption('with-native-trace')->andReturns(false);
-        $input->allows()->getOption('native-trace-anytime')->andReturns(false);
-        $input->expects()->getOption('bulk-stack-copy')->andReturns('abc');
+        $input = $this->buildInput(['bulk-stack-copy' => 'abc']);
+
         $this->expectException(GetTraceSettingsException::class);
         (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputTraceVarSingle(): void
+    {
+        $input = $this->buildInput(['trace-var' => ['global::$counter']]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertCount(1, $settings->var_specs);
+        $this->assertSame('global', $settings->var_specs[0]->scope);
+        $this->assertSame('$counter', $settings->var_specs[0]->var_name);
+        $this->assertSame('global::$counter', $settings->var_specs[0]->lookup_key);
+    }
+
+    public function testFromConsoleInputTraceVarMultiple(): void
+    {
+        $input = $this->buildInput([
+            'trace-var' => [
+                'global::$a',
+                'static::App\\Cache::$entries',
+                'func_static::App\\retry()$n',
+            ],
+        ]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertCount(3, $settings->var_specs);
+        $this->assertSame('global', $settings->var_specs[0]->scope);
+        $this->assertSame('static', $settings->var_specs[1]->scope);
+        $this->assertSame('func_static', $settings->var_specs[2]->scope);
+    }
+
+    public function testFromConsoleInputTraceVarSkipsEmptyExpressions(): void
+    {
+        $input = $this->buildInput(['trace-var' => ['', 'global::$a']]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertCount(1, $settings->var_specs);
+    }
+
+    public function testFromConsoleInputTraceVarInvalidExpressionRaises(): void
+    {
+        $input = $this->buildInput(['trace-var' => ['nope']]);
+
+        $this->expectException(GetTraceSettingsException::class);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputTraceVarEveryDefault(): void
+    {
+        $input = $this->buildInput();
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame(1, $settings->var_every);
+    }
+
+    public function testFromConsoleInputTraceVarEveryExplicit(): void
+    {
+        $input = $this->buildInput(['trace-var-every' => '10']);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame(10, $settings->var_every);
+    }
+
+    public function testFromConsoleInputTraceVarEveryZeroRaises(): void
+    {
+        $input = $this->buildInput(['trace-var-every' => '0']);
+
+        $this->expectException(GetTraceSettingsException::class);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputTraceVarEveryNegativeRaises(): void
+    {
+        $input = $this->buildInput(['trace-var-every' => '-1']);
+
+        $this->expectException(GetTraceSettingsException::class);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputTraceVarEveryGarbageRaises(): void
+    {
+        $input = $this->buildInput(['trace-var-every' => 'abc']);
+
+        $this->expectException(GetTraceSettingsException::class);
+        (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+    }
+
+    public function testFromConsoleInputTraceVarOnFunction(): void
+    {
+        $input = $this->buildInput(['trace-var-on-function' => 'App\\Svc::run']);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame('App\\Svc::run', $settings->var_on_function);
+    }
+
+    public function testFromConsoleInputTraceVarOnFunctionEmptyTreatedAsNull(): void
+    {
+        $input = $this->buildInput(['trace-var-on-function' => '']);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertNull($settings->var_on_function);
+    }
+
+    public function testNeedsCompilerGlobalsFalseForGlobalOnly(): void
+    {
+        $input = $this->buildInput([
+            'trace-var' => ['global::$a', 'local::main()$b'],
+        ]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertFalse($settings->needsCompilerGlobals());
+    }
+
+    public function testNeedsCompilerGlobalsTrueForStatic(): void
+    {
+        $input = $this->buildInput([
+            'trace-var' => ['global::$a', 'static::App\\Cache::$entries'],
+        ]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertTrue($settings->needsCompilerGlobals());
+    }
+
+    public function testNeedsCompilerGlobalsTrueForFuncStatic(): void
+    {
+        $input = $this->buildInput([
+            'trace-var' => ['func_static::App\\retry()$n'],
+        ]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertTrue($settings->needsCompilerGlobals());
     }
 }

--- a/tests/Inspector/Watch/TraceVarPeekCollectorTest.php
+++ b/tests/Inspector/Watch/TraceVarPeekCollectorTest.php
@@ -1,0 +1,376 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use Mockery;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
+use Reli\Lib\Process\ProcessSpecifier;
+use RuntimeException;
+
+class TraceVarPeekCollectorTest extends BaseTestCase
+{
+    /**
+     * @return TargetPhpSettings<'v84'>
+     */
+    private function targetPhpSettings(): TargetPhpSettings
+    {
+        /** @var TargetPhpSettings<'v84'> */
+        return new TargetPhpSettings('v84');
+    }
+
+    private function processSpecifier(): ProcessSpecifier
+    {
+        return new ProcessSpecifier(1234);
+    }
+
+    private function trace(string $innermost_fqn = 'App\\Service::run'): CallTrace
+    {
+        // Split "A\B::c" into class + method to match CallFrame constructor shape.
+        $parts = explode('::', $innermost_fqn, 2);
+        if (count($parts) === 2) {
+            $frame = new CallFrame($parts[0], $parts[1], '/app.php', null);
+        } else {
+            $frame = new CallFrame('', $innermost_fqn, '/app.php', null);
+        }
+        return new CallTrace(
+            $frame,
+            new CallFrame('', '<main>', '/index.php', null),
+        );
+    }
+
+    public function testCollectReturnsFormattedAnnotations(): void
+    {
+        $spec = VariableSpec::parse('global::$counter');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader
+            ->expects()
+            ->readVariables(
+                $this->matchSpecList(['global::$counter']),
+                Mockery::type(ProcessSpecifier::class),
+                Mockery::type(TargetPhpSettings::class),
+                0x1000,
+                0,
+            )
+            ->andReturns([
+                'global::$counter' => new VariableValue(VariableValue::TYPE_LONG, 42, null),
+            ]);
+
+        $collector = new TraceVarPeekCollector($reader, [$spec]);
+        $result = $collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertSame(['global::$counter' => '(int) 42'], $result);
+    }
+
+    public function testCollectReturnsNullWhenReaderReturnsEmpty(): void
+    {
+        $spec = VariableSpec::parse('global::$missing');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->allows()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->andReturns([]);
+
+        $collector = new TraceVarPeekCollector($reader, [$spec]);
+        $result = $collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testCollectReturnsNullWhenReaderThrows(): void
+    {
+        $spec = VariableSpec::parse('global::$a');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->allows()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->andThrows(new RuntimeException('transient read failure'));
+
+        $collector = new TraceVarPeekCollector($reader, [$spec]);
+        $result = $collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testEveryTwoReadsOnOddIndexesOnly(): void
+    {
+        // With var_every=2, every other sample should be skipped. The
+        // sample_index advances on every call regardless of gate outcome,
+        // so the first call is index=1 (skipped), second is index=2 (read).
+        $spec = VariableSpec::parse('global::$counter');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->expects()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->twice()
+            ->andReturns([
+                'global::$counter' => new VariableValue(VariableValue::TYPE_LONG, 1, null),
+            ]);
+
+        $collector = new TraceVarPeekCollector($reader, [$spec], var_every: 2);
+
+        // Index 1 — skipped
+        $this->assertNull($collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // Index 2 — reads
+        $this->assertNotNull($collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // Index 3 — skipped
+        $this->assertNull($collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // Index 4 — reads
+        $this->assertNotNull($collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+    }
+
+    public function testOnFunctionGateAllowsReadWhenFrameIsOnStack(): void
+    {
+        $spec = VariableSpec::parse('local::App\\Service::run()$id');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->expects()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->once()
+            ->andReturns([
+                'local::App\\Service::run()$id' => new VariableValue(VariableValue::TYPE_LONG, 7, null),
+            ]);
+
+        $collector = new TraceVarPeekCollector(
+            $reader,
+            [$spec],
+            var_on_function: 'App\\Service::run',
+        );
+        $result = $collector->collect(
+            $this->trace('App\\Service::run'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertSame(['local::App\\Service::run()$id' => '(int) 7'], $result);
+    }
+
+    public function testOnFunctionGateSuppressesReadWhenFrameIsAbsent(): void
+    {
+        $spec = VariableSpec::parse('local::App\\Service::run()$id');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        // readVariables must NOT be called
+        $reader->shouldNotReceive('readVariables');
+
+        $collector = new TraceVarPeekCollector(
+            $reader,
+            [$spec],
+            var_on_function: 'App\\Service::run',
+        );
+        $result = $collector->collect(
+            $this->trace('Unrelated\\Frame::handle'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testOnFunctionGateAndEveryInteractCorrectly(): void
+    {
+        // var_every=2 + gate: sample 1 skipped (every), sample 2 gated-out
+        // (no target frame), sample 3 skipped (every), sample 4 would read
+        // but frame present — so one read across 4 calls.
+        $spec = VariableSpec::parse('local::App\\Service::run()$id');
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->expects()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->once()
+            ->andReturns([
+                'local::App\\Service::run()$id' => new VariableValue(VariableValue::TYPE_LONG, 1, null),
+            ]);
+
+        $collector = new TraceVarPeekCollector(
+            $reader,
+            [$spec],
+            var_every: 2,
+            var_on_function: 'App\\Service::run',
+        );
+
+        // 1 — skipped by every
+        $this->assertNull($collector->collect(
+            $this->trace('App\\Service::run'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // 2 — every passes but gate fails
+        $this->assertNull($collector->collect(
+            $this->trace('Other::thing'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // 3 — skipped by every
+        $this->assertNull($collector->collect(
+            $this->trace('App\\Service::run'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+        // 4 — every passes AND gate passes
+        $this->assertNotNull($collector->collect(
+            $this->trace('App\\Service::run'),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        ));
+    }
+
+    public function testCollectFormatsAllValueTypes(): void
+    {
+        $specs = [
+            VariableSpec::parse('global::$i'),
+            VariableSpec::parse('global::$s'),
+            VariableSpec::parse('global::$a'),
+            VariableSpec::parse('global::$b'),
+            VariableSpec::parse('global::$n'),
+        ];
+        $reader = Mockery::mock(VariableReaderInterface::class);
+        $reader->expects()->readVariables(
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+            Mockery::any(),
+        )
+            ->andReturns([
+                'global::$i' => new VariableValue(VariableValue::TYPE_LONG, 5, null),
+                'global::$s' => new VariableValue(VariableValue::TYPE_STRING, 'hi', null),
+                'global::$a' => new VariableValue(VariableValue::TYPE_ARRAY, null, 3),
+                'global::$b' => new VariableValue(VariableValue::TYPE_BOOL, true, null),
+                'global::$n' => new VariableValue(VariableValue::TYPE_NULL, null, null),
+            ]);
+
+        $collector = new TraceVarPeekCollector($reader, $specs);
+        $result = $collector->collect(
+            $this->trace(),
+            $this->processSpecifier(),
+            $this->targetPhpSettings(),
+            0x1000,
+            0,
+        );
+
+        $this->assertSame(
+            [
+                'global::$i' => '(int) 5',
+                'global::$s' => '(string) "hi"',
+                'global::$a' => '(array) count=3',
+                'global::$b' => '(bool) true',
+                'global::$n' => 'null',
+            ],
+            $result,
+        );
+    }
+
+    /**
+     * Mockery matcher that asserts the spec list argument matches the given
+     * list of lookup_key strings in order.
+     *
+     * @param list<string> $expected_keys
+     */
+    private function matchSpecList(array $expected_keys): object
+    {
+        return Mockery::on(function ($arg) use ($expected_keys): bool {
+            if (!is_array($arg)) {
+                return false;
+            }
+            if (count($arg) !== count($expected_keys)) {
+                return false;
+            }
+            foreach ($arg as $i => $spec) {
+                if (!$spec instanceof VariableSpec) {
+                    return false;
+                }
+                if ($spec->lookup_key !== $expected_keys[$i]) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+}

--- a/tests/Inspector/Watch/VariableValueFormatterTest.php
+++ b/tests/Inspector/Watch/VariableValueFormatterTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+use PHPUnit\Framework\TestCase;
+
+class VariableValueFormatterTest extends TestCase
+{
+    public function testLong(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_LONG, 42, null);
+        $this->assertSame('(int) 42', VariableValueFormatter::format($v));
+    }
+
+    public function testLongNegative(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_LONG, -1, null);
+        $this->assertSame('(int) -1', VariableValueFormatter::format($v));
+    }
+
+    public function testDouble(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_DOUBLE, 3.14, null);
+        $this->assertSame('(float) 3.14', VariableValueFormatter::format($v));
+    }
+
+    public function testDoubleInteger(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_DOUBLE, 1.0, null);
+        $this->assertSame('(float) 1', VariableValueFormatter::format($v));
+    }
+
+    public function testString(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, 'hello', null);
+        $this->assertSame('(string) "hello"', VariableValueFormatter::format($v));
+    }
+
+    public function testStringEmpty(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, '', null);
+        $this->assertSame('(string) ""', VariableValueFormatter::format($v));
+    }
+
+    public function testStringWithDoubleQuote(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, 'say "hi"', null);
+        $this->assertSame('(string) "say \\"hi\\""', VariableValueFormatter::format($v));
+    }
+
+    public function testStringWithBackslash(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, 'a\\b', null);
+        $this->assertSame('(string) "a\\\\b"', VariableValueFormatter::format($v));
+    }
+
+    public function testStringWithNewline(): void
+    {
+        // JSON encoding turns \n into a backslash-n escape so the output
+        // stays on a single line — critical for the phpspy comment format.
+        $v = new VariableValue(VariableValue::TYPE_STRING, "line1\nline2", null);
+        $formatted = VariableValueFormatter::format($v);
+        $this->assertSame('(string) "line1\\nline2"', $formatted);
+        $this->assertStringNotContainsString("\n", $formatted);
+    }
+
+    public function testStringWithTab(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, "a\tb", null);
+        $this->assertSame('(string) "a\\tb"', VariableValueFormatter::format($v));
+    }
+
+    public function testStringWithCarriageReturn(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, "a\rb", null);
+        $formatted = VariableValueFormatter::format($v);
+        $this->assertSame('(string) "a\\rb"', $formatted);
+        $this->assertStringNotContainsString("\r", $formatted);
+    }
+
+    public function testStringWithUnicode(): void
+    {
+        // JSON_UNESCAPED_UNICODE keeps non-ASCII readable.
+        $v = new VariableValue(VariableValue::TYPE_STRING, 'こんにちは', null);
+        $this->assertSame('(string) "こんにちは"', VariableValueFormatter::format($v));
+    }
+
+    public function testStringTruncatedAtDefaultLimit(): void
+    {
+        $long = str_repeat('x', 250);
+        $v = new VariableValue(VariableValue::TYPE_STRING, $long, null);
+        $formatted = VariableValueFormatter::format($v);
+        $expected_body = str_repeat('x', 200) . '...';
+        $this->assertSame('(string) "' . $expected_body . '"', $formatted);
+    }
+
+    public function testStringNotTruncatedAtBoundary(): void
+    {
+        $exact = str_repeat('x', 200);
+        $v = new VariableValue(VariableValue::TYPE_STRING, $exact, null);
+        $formatted = VariableValueFormatter::format($v);
+        $this->assertSame('(string) "' . $exact . '"', $formatted);
+    }
+
+    public function testStringTruncatedWithCustomLimit(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_STRING, 'abcdef', null);
+        $formatted = VariableValueFormatter::format($v, max_string_length: 3);
+        $this->assertSame('(string) "abc..."', $formatted);
+    }
+
+    public function testStringTruncationCountsUnicodeChars(): void
+    {
+        // 10 Japanese chars (multi-byte) must be truncated by character count,
+        // not by byte count — otherwise we'd cut in the middle of a codepoint.
+        $v = new VariableValue(VariableValue::TYPE_STRING, str_repeat('あ', 10), null);
+        $formatted = VariableValueFormatter::format($v, max_string_length: 3);
+        $this->assertSame('(string) "あああ..."', $formatted);
+    }
+
+    public function testStringInvalidUtf8FallsBack(): void
+    {
+        // Raw invalid UTF-8 byte; json_encode returns false in strict mode.
+        $v = new VariableValue(VariableValue::TYPE_STRING, "\xc3\x28", null);
+        $formatted = VariableValueFormatter::format($v);
+        $this->assertSame('(string) "<invalid-utf8>"', $formatted);
+    }
+
+    public function testBoolTrue(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_BOOL, true, null);
+        $this->assertSame('(bool) true', VariableValueFormatter::format($v));
+    }
+
+    public function testBoolFalse(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_BOOL, false, null);
+        $this->assertSame('(bool) false', VariableValueFormatter::format($v));
+    }
+
+    public function testArrayWithCount(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 10);
+        $this->assertSame('(array) count=10', VariableValueFormatter::format($v));
+    }
+
+    public function testArrayEmpty(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 0);
+        $this->assertSame('(array) count=0', VariableValueFormatter::format($v));
+    }
+
+    public function testArrayWithNullCountFallsBackToZero(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, null);
+        $this->assertSame('(array) count=0', VariableValueFormatter::format($v));
+    }
+
+    public function testNull(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_NULL, null, null);
+        $this->assertSame('null', VariableValueFormatter::format($v));
+    }
+
+    public function testUnknown(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_UNKNOWN, null, null);
+        $this->assertSame('(unknown)', VariableValueFormatter::format($v));
+    }
+}

--- a/tests/Lib/Dwarf/MergedCallTraceFormatterTest.php
+++ b/tests/Lib/Dwarf/MergedCallTraceFormatterTest.php
@@ -71,6 +71,72 @@ class MergedCallTraceFormatterTest extends BaseTestCase
         $this->assertStringContainsString('/app/test.php:', $lines[1]);
     }
 
+    public function testFormatWithAnnotationsEmitsCommentLinesAfterFrames(): void
+    {
+        $trace = new MergedCallTrace(
+            MergedCallFrame::fromNative(new NativeCallFrame('execute_ex', 'php8.4', 0, 0x2000)),
+            MergedCallFrame::fromPhp(new CallFrame('App\\Service', 'run', '/app/svc.php', null)),
+        );
+
+        $output = $this->formatter->format(
+            $trace,
+            [
+                'global::$counter' => '(int) 42',
+                'local::App\\Service::run()$id' => '(string) "abc"',
+            ],
+        );
+
+        $expected = "0 php8.4::execute_ex [native]:0\n"
+            . "1 App\\Service::run /app/svc.php:-1\n"
+            . "# global::\$counter = (int) 42\n"
+            . "# local::App\\Service::run()\$id = (string) \"abc\"\n"
+            . "\n";
+        $this->assertSame($expected, $output);
+    }
+
+    public function testFormatWithEmptyAnnotationsIsIdenticalToNullAnnotations(): void
+    {
+        $trace = new MergedCallTrace(
+            MergedCallFrame::fromPhp(new CallFrame('', 'main', '/index.php', null)),
+        );
+        $this->assertSame(
+            $this->formatter->format($trace),
+            $this->formatter->format($trace, []),
+        );
+        $this->assertSame(
+            $this->formatter->format($trace),
+            $this->formatter->format($trace, null),
+        );
+    }
+
+    public function testFormatAnnotationLinesRoundTripThroughPhpSpyParser(): void
+    {
+        // reli's own parser must treat the annotation lines as comments
+        // so merged-output streams remain re-parseable after annotations
+        // are added.
+        $trace = new MergedCallTrace(
+            MergedCallFrame::fromNative(new NativeCallFrame('execute_ex', 'php', 0, 0x1000)),
+            MergedCallFrame::fromPhp(new CallFrame('App', 'run', '/app.php', null)),
+        );
+        $text = $this->formatter->format($trace, ['global::$x' => '(int) 7']);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $text);
+        rewind($stream);
+
+        $parser = new \Reli\Converter\PhpSpyCompatibleParser();
+        $parsed = iterator_to_array($parser->parseFile($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $parsed);
+        $this->assertCount(2, $parsed[0]->call_frames);
+        // Frame 0 is the native frame; parser treats its display name as
+        // the function token.
+        $this->assertStringContainsString('execute_ex', $parsed[0]->call_frames[0]->function_name);
+        $this->assertSame('App::run', $parsed[0]->call_frames[1]->function_name);
+    }
+
     public function testPhpSpyCompatibility(): void
     {
         // Verify output can be parsed by PhpSpyCompatibleParser


### PR DESCRIPTION
## Summary

Adds a new `--trace-var` option to `inspector:trace` (and by extension `inspector:daemon`) that attaches PHP variable values to each trace sample, so you can join "what stack was running" to "what the runtime state was" without a separate tool or a log correlate. The expression grammar is the same one `inspector:peek-var` and `inspector:watch --watch-var` already use, and the output flows through every existing sink:

- **phpspy text**: `# key = value` comment lines after the frame list — re-parseable by reli's own phpspy parser and all `converter:*` tools, because `#`-prefixed lines are already treated as comments.
- **rbt binary**: `SAMPLE_ANNOTATION` (event type `0x0B`) events interned via `STRING_DEF`, supported by `SAMPLE` / `COMPACT_SAMPLE` / `PID_SAMPLE`.
- **Native+PHP merged output** (`--with-native-trace`): same treatment in both text and rbt.
- **Daemon mode**: all three output formats (`rbt`, `rbt-bundled`, `template:*`) carry annotations end-to-end.

The feature is purely additive — every existing invocation (no `--trace-var` specified) takes the zero-overhead path. When specs are present, overhead is controllable via `--trace-var-every` and `--trace-var-on-function`.

## Example

```bash
reli inspector:trace -p <pid> --with-native-trace \
  --trace-var='global::$request_uri' \
  --trace-var='local::App\Controller::handle()$user_id'
```

```
0 libphp.so::zend_execute+0x42 [native]:0
1 App\Controller::handle /app/src/Controller.php:17
2 <main> /app/public/index.php:9
# global::$request_uri = (string) "/users/1234"
# local::App\Controller::handle()$user_id = (int) 1234

```

## CLI surface

| Option | Default | Description |
|---|---|---|
| `--trace-var=<expr>` | — | Variable to peek per sample (repeatable). Exact same grammar as `inspector:peek-var --var`: `global::$var`, `local::func()$var`, `static::Class::$prop`, `func_static::func()$var`, with `[key]` / `->prop` path access. |
| `--trace-var-every=<N>` | `1` | Read variables only every N-th sample. The trace itself is captured at full rate; only the variable reads are throttled. |
| `--trace-var-on-function=<fqn>` | — | Skip the `process_vm_readv` read entirely when the named FQN is not on the call stack. Cheap in-process gate — scans the already-captured PHP trace in microseconds. |

## Implementation (step-by-step, one commit per step)

### Step 1 — `VariableValueFormatter` + settings plumbing
- New `VariableValueFormatter` (`src/Inspector/Watch/`): pure renderer from `VariableValue` to a single-line, line-safe string. Strings are `json_encode(..., JSON_UNESCAPED_UNICODE)` and mb-truncated at 200 chars, so embedded LF/CR/tabs/invalid UTF-8 can never break the line-oriented phpspy format or rbt string interning.
- `GetTraceSettings` grows `var_specs: list<VariableSpec>`, `var_every: int`, `var_on_function: ?string` and a `needsCompilerGlobals()` helper.
- `GetTraceSettingsFromConsoleInput` registers the three new options, parsing `--trace-var` via `VariableSpec::parse()` and validating `--trace-var-every` as a positive int. Two new exception codes on `GetTraceSettingsException` cover bad input.
- The existing settings-parser test used a fragile "allows first wins" mock pattern that blocked per-test overrides; refactored into a `buildInput()` helper, then added 17 new cases for the new fields and failure modes.
- Added `VariableValueFormatterTest` (24 cases: all types, escape sequences, unicode, truncation at character boundary, invalid-UTF-8 fallback).

### Step 2 — Annotations through `TraceOutput` / `CallTraceFormatter`
- `TraceOutput::output()` and `CallTraceFormatter::format()` get an optional `?array $annotations` parameter; implementations (`FormattedTraceOutput`, `BinaryTraceOutput`, `SegmentedBinaryTraceOutput`, `CompatCallTraceFormatter`, `TemplatedCallTraceFormatter`) forward it. `CompatCallTraceFormatter` intentionally ignores annotations (the compat format has nowhere to put them) and documents why.
- `TemplatedCallTraceFormatter`'s eval'd closure gains the new parameter so templates can read `$annotations`.
- `phpspy.php` and `phpspy_with_opcode.php` iterate `$annotations ?? []` after the frame list, emitting `# key = value` lines before the blank terminator. `json_lines.php` is intentionally left alone to keep its JSON shape stable for `jq` consumers.
- `BinaryTraceWriter::writeTrace()` was public but previously dropped annotations; now accepts and forwards to `writeAnnotatedTrace()` which already handled the RLE break case. `SegmentedBinaryTraceWriter::writeTrace()` threads them into the underlying writer.
- Fixed a pre-existing latent bug in `phpspy_with_opcode.php` surfaced by the new test: `$depth_offset = 0;` was in the stripped PHP-header section, so the eval'd renderer ran with an undefined variable (coerced to 0, but emitting a warning). Moved into the template body.
- New `PhpSpyTemplateTest` (8 cases): renders the real `resources/templates/phpspy.php` and `phpspy_with_opcode.php` with and without annotations, does a round-trip through `PhpSpyCompatibleParser` to prove annotation lines are still seen as comments, and pins down that declaration order is preserved. Extended `BinaryTraceOutputTest` with annotation round-trip + null-annotation cases.

### Step 3 — Wiring `VariableReader` into `GetTraceCommand`
- New `VariableReaderInterface` extracted from the `final` `VariableReader` so collaborators can depend on a mock-friendly surface. Production behaviour is unchanged; DI binds the interface to the concrete class in `config/di.php`.
- New `TraceVarPeekCollector`: holds the spec list and a per-sample cycle counter, applies `--trace-var-every`, walks the `CallTrace` to evaluate `--trace-var-on-function` (cheap gate, skips the `process_vm_readv` round-trip entirely when the target frame is absent), calls the reader, and formats the result through `VariableValueFormatter`. Throwables from the reader degrade gracefully to a null annotation map — the trace sample is still emitted.
- `GetTraceCommand` takes a `VariableReaderInterface` via DI and, when any `--trace-var` spec is present, resolves CG lazily (only when `needsCompilerGlobals()` is true), builds a collector, and threads its output through `TraceOutput::output()` on every sample.
- New `TraceVarPeekCollectorTest` (8 cases): formatted output, empty/throwing reader, `--trace-var-every` throttling, on-function gate pass/fail, every+gate interaction, and end-to-end formatting across all `VariableValue` branches.

### Step 4 — `BinaryTraceWriter::writePidTrace` annotations
Daemon bundled (`rbt-bundled`) mode uses `PID_SAMPLE` events, which the rbt spec already allows `SAMPLE_ANNOTATION` to follow. `writePidTrace` gains an optional `?array $annotations` and, when non-empty, emits the annotation event immediately after `writePidSample` via the shared `emitAnnotation` helper (string-interned). `PID_SAMPLE` doesn't participate in RLE (interleaved per-sample PIDs break runs by construction), so the annotation append is straight-line — no pending-run bookkeeping. New round-trip test in `DaemonOutputTest` covers single-key, multi-key, and null cases.

### Steps 5+6+7 — Daemon mode (all output paths + CG on descriptor)
Done as one commit because the three changes are mutually dependent:

- **Step 7: CG on descriptor.** `TargetProcessDescriptor` gains an optional `?int $cg_address = 0`. `TargetPhpSettingsMessage` grows a `needs_compiler_globals` flag that the daemon controller sets from `GetTraceSettings::needsCompilerGlobals()`; `PhpSearcherController::sendTarget` and the interface grow the matching parameter. `ProcessDescriptorRetriever` calls `findCompilerGlobals` only when asked, behind the existing per-PID descriptor cache — paid once per target. `WatchTargetDescriptor::toBaseDescriptor()` is updated to forward its own `cg_address` so future unification is additive.
- **Step 5: per-worker rbt.** `PhpReaderTraceLoop` takes a `VariableReaderInterface` via DI autowiring (same interface binding as step 3) and constructs its own `TraceVarPeekCollector` from the received `GetTraceSettings`. The loop body calls the collector after `readCallTrace()` and yields a `TraceMessage` carrying both trace and annotations. `PhpReaderEntryPoint::writeBinaryTrace` accepts `?array $annotations` and forwards to `BinaryTraceWriter::writeTrace`. In this mode annotations **never leave the worker** — they go straight into the worker's own `.rbt` file with zero IPC cost.
- **Step 6: `TraceMessage` extension + bundled / template modes.** `TraceMessage` gains a `?array $annotations = null` field (serializes over AMPHP IPC without special handling). `PhpReaderEntryPoint`'s IPC-send branch forwards `$message->annotations` into the new `TraceMessage` it sends to the controller. `DaemonCommand`'s worker-dispatch loop:
  - **bundled**: `writeBundledTrace` accepts annotations and forwards to `writePidTrace` (step 4).
  - **template**: `$trace_output->output($result->trace, $result->annotations)`.

Result: every daemon output path carries `--trace-var` annotations end-to-end. When no specs are configured, the collector stays null and the extra branches collapse to pointer checks — no measurable overhead for the legacy path.

### Native+PHP merged output
Drops the "merged output has no annotation slot" note from the initial design. `MergedTraceOutput::outputMerged()` gains `?array $annotations = null`; both implementations (`BinaryTraceOutput`, `FormattedMergedTraceOutput`) forward it. `MergedCallTraceFormatter::format()` accepts annotations and emits `# key = value` lines after the frame list (same convention as the phpspy template). `GetTraceCommand`'s merged branch now builds annotations for the PHP side of the sample and passes them into `outputMerged`; when `call_trace` is null (native-only sample via `--native-trace-anytime`), no annotations are synthesised because there are no PHP frames to inspect. 3 new cases in `MergedCallTraceFormatterTest` + 1 round-trip case in `BinaryTraceOutputTest`.

### User documentation
- New **`docs/trace-var-command.md`** (316 lines), mirroring the structure of `peek-var-command.md` / `watch-command.md`: quick start, requirements, variable spec grammar (cross-linked to peek-var), all output formats with sample output and value rendering table, native trace support, rate limiting guidance, error handling contract, daemon-mode behaviour across all three output modes, all options reference table, and a relationship rubric vs `peek-var` and `watch --watch-var`.
- **`README.md`**: new bullet in "What can I use this for?" and a new top-level section between "Peek Variable" and "Examples" that matches the template the other experimental sections use (short intro, quick-start examples, sample output, "see docs/..." tail).
- **`docs/design-trace-var-peek.md`** already covers the design rationale (motivation, non-goals, data flow, RLE implications, daemon plumbing, `--trace-var-config` YAML as a future escape hatch) and was written before any code — it's the design doc that drove the implementation order above.

## Design decisions worth calling out

- **`VariableReaderInterface` extraction** was motivated by test mockability (`VariableReader` is `final`), but the narrow surface is also documentation about what collaborators actually need.
- **Collector as a separate class** (not inlined in `GetTraceCommand`) so daemon workers can reuse it verbatim. `PhpReaderTraceLoop` constructs its own instance per attach cycle with the same config.
- **CG resolution in the searcher, cached per PID**: adding a `static::` or `func_static::` spec doesn't make the hot reader path any more expensive than the equivalent `local::` spec in daemon mode.
- **`writePidTrace` annotations don't touch RLE** because PID_SAMPLE doesn't participate in the run-length path; this kept the writer change surgical.
- **JSON Lines is intentionally untouched** — changing the JSON shape mid-stream would break `jq`-based consumers. A dedicated template can opt in when there's demand; noted in the doc.
- **Pre-existing `phpspy_with_opcode.php` bug** (undefined `$depth_offset` warning from eval'd renderer) was surfaced by the new test and fixed in-place since the scope was the same two templates.

## Verification

- **phpunit** (non-docker): 40+ new tests across `VariableValueFormatterTest`, `GetTraceSettingsFromConsoleInputTest`, `PhpSpyTemplateTest`, `TraceVarPeekCollectorTest`, `BinaryTraceOutputTest`, `DaemonOutputTest`, `MergedCallTraceFormatterTest`. All non-docker suites pass (failures in `tests/Inspector/**` are pre-existing `php:X.Y-cli` / `php:X.Y-zts` integration tests that require docker images not present in the sandbox; verified identical failure set on the unchanged base).
- **psalm** (`./vendor/bin/psalm.phar`): `No errors found!`
- **phpcs** (`PSR12` against `src/` and `tests/`): no violations
- **Manual smoke**: `reli inspector:trace --help` shows the three new options registered correctly; DI resolves `GetTraceCommand` and `PhpReaderTraceLoop` with the new `VariableReaderInterface` dependency.

## Documentation

- `docs/design-trace-var-peek.md` — design rationale and decision log (pre-implementation)
- `docs/trace-var-command.md` — user-facing reference (new)
- `README.md` — navigation entry + condensed intro section (new)

https://claude.ai/code/session_01FYUYc8iM9giJwS1DWKNFXv