### PR TITLE
Add path mapping support to trace exploration

### DIFF
--- a/src/Command/Rbt/ExploreCommand.php
+++ b/src/Command/Rbt/ExploreCommand.php
@@ -111,7 +111,9 @@ final class ExploreCommand extends Command
             $from = substr($entry, 0, $eq);
             $to = substr($entry, $eq + 1);
             if ($from === '') {
-                $output->writeln("<error>Invalid --path-map value \"{$entry}\": \"from\" part must not be empty.</error>");
+                $output->writeln(
+                    "<error>Invalid --path-map value \"{$entry}\": \"from\" part must not be empty.</error>"
+                );
                 return 1;
             }
             $path_map[$from] = $to;

--- a/src/Command/Rbt/ExploreCommand.php
+++ b/src/Command/Rbt/ExploreCommand.php
@@ -58,6 +58,17 @@ final class ExploreCommand extends Command
                 . ' Use this if the TUI seems to ignore keys to verify whether'
                 . ' bytes are reaching PHP at all',
             )
+            ->addOption(
+                'path-map',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'rewrite file paths in the trace for local navigation;'
+                . ' format is "from=to" where "from" is a prefix recorded in'
+                . ' the trace and "to" is the local replacement'
+                . ' (e.g. --path-map /var/www/html=/home/you/project'
+                . ' or --path-map /var/www/html=. for project-relative paths).'
+                . ' May be specified multiple times; longest prefix wins',
+            )
         ;
     }
 
@@ -88,8 +99,26 @@ final class ExploreCommand extends Command
             ? Keymap::fromJsonFile($keymap_path)
             : Keymap::default();
 
+        /** @var list<string> $path_map_raw */
+        $path_map_raw = $input->getOption('path-map');
+        $path_map = [];
+        foreach ($path_map_raw as $entry) {
+            $eq = strpos($entry, '=');
+            if ($eq === false) {
+                $output->writeln("<error>Invalid --path-map value \"{$entry}\": expected \"from=to\" format.</error>");
+                return 1;
+            }
+            $from = substr($entry, 0, $eq);
+            $to = substr($entry, $eq + 1);
+            if ($from === '') {
+                $output->writeln("<error>Invalid --path-map value \"{$entry}\": \"from\" part must not be empty.</error>");
+                return 1;
+            }
+            $path_map[$from] = $to;
+        }
+
         $output->writeln("<info>loading {$path} ...</info>");
-        $model = TraceModel::load($path);
+        $model = TraceModel::load($path, $path_map);
         $output->writeln(sprintf(
             '<info>loaded %s samples (%.1fs sampled wall, %d-us period)</info>',
             number_format($model->sampleCount()),

--- a/src/Rbt/Explore/TraceModel.php
+++ b/src/Rbt/Explore/TraceModel.php
@@ -45,8 +45,13 @@ final class TraceModel
 
     /**
      * Load a .rbt file (gzip-aware) into a fully realised model.
+     *
+     * @param array<string, string> $path_map source-prefix => local-prefix
+     *     mappings applied to every file path in the trace. Longer
+     *     prefixes are tried first so a specific mapping always wins
+     *     over a broader one (e.g. "/app/vendor" before "/app").
      */
-    public static function load(string $path): self
+    public static function load(string $path, array $path_map = []): self
     {
         $stream = @fopen($path, 'rb');
         if ($stream === false) {
@@ -76,7 +81,7 @@ final class TraceModel
                 $stack = [];
                 foreach ($sample->trace->call_frames as $frame) {
                     $function = $frame->function_name;
-                    $file = $frame->file_name;
+                    $file = $path_map !== [] ? self::mapPath($frame->file_name, $path_map) : $frame->file_name;
                     $line = $frame->lineno;
                     $with_line = $function . ' ' . $file . ':' . $line;
 
@@ -112,6 +117,25 @@ final class TraceModel
         } finally {
             fclose($stream);
         }
+    }
+
+    /**
+     * @param array<string, string> $path_map
+     */
+    private static function mapPath(string $path, array $path_map): string
+    {
+        $best_prefix = '';
+        $best_replacement = '';
+        foreach ($path_map as $from => $to) {
+            if (str_starts_with($path, $from) && strlen($from) > strlen($best_prefix)) {
+                $best_prefix = $from;
+                $best_replacement = $to;
+            }
+        }
+        if ($best_prefix === '') {
+            return $path;
+        }
+        return $best_replacement . substr($path, strlen($best_prefix));
     }
 
     public function sampleCount(): int

--- a/tests/Rbt/Explore/TraceModelTest.php
+++ b/tests/Rbt/Explore/TraceModelTest.php
@@ -102,6 +102,66 @@ class TraceModelTest extends BaseTestCase
         $this->assertEqualsWithDelta(0.030, $model->durationSeconds(), 1e-9);
     }
 
+    public function testLoadAppliesPathMap(): void
+    {
+        $this->writeRbt([
+            $this->trace(['foo /var/www/html/app/Foo.php:10', 'main /var/www/html/index.php:5']),
+            $this->trace(['bar /usr/share/php/Bar.php:20']),
+        ]);
+
+        $model = TraceModel::load($this->tmp, [
+            '/var/www/html' => '/home/user/project',
+            '/usr/share/php' => '/home/user/vendor',
+        ]);
+
+        $this->assertSame(2, $model->sampleCount());
+        $this->assertContains('foo /home/user/project/app/Foo.php:10', $model->frame_keys);
+        $this->assertContains('main /home/user/project/index.php:5', $model->frame_keys);
+        $this->assertContains('bar /home/user/vendor/Bar.php:20', $model->frame_keys);
+    }
+
+    public function testLoadPathMapLongestPrefixWins(): void
+    {
+        $this->writeRbt([
+            $this->trace(['foo /app/vendor/lib/Foo.php:1']),
+            $this->trace(['bar /app/src/Bar.php:2']),
+        ]);
+
+        $model = TraceModel::load($this->tmp, [
+            '/app' => '/local',
+            '/app/vendor' => '/local-vendor',
+        ]);
+
+        $this->assertContains('foo /local-vendor/lib/Foo.php:1', $model->frame_keys);
+        $this->assertContains('bar /local/src/Bar.php:2', $model->frame_keys);
+    }
+
+    public function testLoadPathMapToRelativePath(): void
+    {
+        $this->writeRbt([
+            $this->trace(['foo /var/www/html/app/Foo.php:10']),
+        ]);
+
+        $model = TraceModel::load($this->tmp, [
+            '/var/www/html' => '.',
+        ]);
+
+        $this->assertContains('foo ./app/Foo.php:10', $model->frame_keys);
+    }
+
+    public function testLoadPathMapNoMatchLeavesPathUnchanged(): void
+    {
+        $this->writeRbt([
+            $this->trace(['foo /other/path/Foo.php:1']),
+        ]);
+
+        $model = TraceModel::load($this->tmp, [
+            '/var/www/html' => '/home/user/project',
+        ]);
+
+        $this->assertContains('foo /other/path/Foo.php:1', $model->frame_keys);
+    }
+
     public function testLoadMissingFileThrows(): void
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
## Summary
Add support for remapping file paths in trace files during exploration, allowing users to translate absolute server paths to local development paths for easier navigation.

## Changes
- **TraceModel**: Added `$path_map` parameter to `load()` method with a new `mapPath()` helper that applies prefix-based path transformations. Longer prefixes are matched first to ensure specific mappings take precedence over broader ones.
- **ExploreCommand**: Added `--path-map` option that accepts multiple "from=to" format arguments. Includes validation to ensure the "from" part is non-empty and the format is correct.
- **Tests**: Added comprehensive test coverage for path mapping functionality:
  - Basic path mapping with multiple entries
  - Longest prefix matching behavior
  - Mapping to relative paths (e.g., ".")
  - Unmapped paths remain unchanged

## Implementation Details
- Path mapping uses a simple prefix-matching algorithm that iterates through all mappings to find the longest matching prefix
- Unmapped paths are returned unchanged
- The feature is opt-in via command-line option with sensible defaults (empty map = no transformation)
- Validation prevents invalid `--path-map` entries from being silently ignored

https://claude.ai/code/session_0152A6FJDKfCNJCUb1Zm11Zv