### PR TITLE
feat: add mouse support to rbt:explore TUI

### DIFF
--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -307,6 +307,19 @@ final class ExploreTui
         $buf .= $this->renderHeader($state, $cols);
 
         if ($state->mode === ExploreMode::Sandwich) {
+            // Clamp overview_selected early so renderMiniFlame (which
+            // runs before renderOverviewLines) sees a valid index.
+            // Without this, a negative overview_selected causes
+            // getCursorKeyId() to return null and the highlight falls
+            // back to focus_id, making it jump to a wrong position.
+            $ov_rows = $this->ensureOverview()['rows'];
+            if ($this->overview_selected < 0) {
+                $this->overview_selected = 0;
+            }
+            if ($ov_rows !== [] && $this->overview_selected >= count($ov_rows)) {
+                $this->overview_selected = count($ov_rows) - 1;
+            }
+
             if ($show_mini_flame) {
                 $buf .= $this->renderMiniFlame($cols) . "\n";
             }
@@ -459,6 +472,7 @@ final class ExploreTui
             }
             $pos = $end;
         }
+        /** @var list<int> $pixel_keys */
         $this->mini_flame_pixel_keys = $pixel_keys;
 
         // If the cursor row's natural position lies past the visible
@@ -3050,7 +3064,7 @@ final class ExploreTui
 
         // Left-click — detect double-click for focus/enter action.
         $now = microtime(true);
-        $is_double = ($now - $this->last_click_time) < (self::DOUBLE_CLICK_MS / 1000.0)
+        $is_double = ($now - $this->last_click_time) < ((float)self::DOUBLE_CLICK_MS / 1000.0)
             && $this->last_click_row === $mouse->row
             && $this->last_click_col === $mouse->col;
         $this->last_click_time = $now;
@@ -3163,7 +3177,7 @@ final class ExploreTui
         match ($pane) {
             ActivePane::Callers  => $this->callers_selected += $delta,
             ActivePane::Callees  => $this->callees_selected += $delta,
-            ActivePane::Overview, ActivePane::Focus => null,
+            default => null,
         };
     }
 

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -199,6 +199,16 @@ final class ExploreTui
      */
     private array $tree_folded = [];
 
+    /**
+     * Double-click detection state. Tracks the last left-click's
+     * timestamp and position so a second click within the threshold
+     * at the same cell can be promoted to a focus action.
+     */
+    private float $last_click_time = 0.0;
+    private int $last_click_row = -1;
+    private int $last_click_col = -1;
+    private const DOUBLE_CLICK_MS = 400;
+
     public function __construct(TraceModel $model, TerminalInterface $term, Keymap $keymap)
     {
         $this->model = $model;
@@ -2972,7 +2982,24 @@ final class ExploreTui
             return;
         }
 
-        // Left-click.
+        // Left-click — detect double-click for focus/enter action.
+        $now = microtime(true);
+        $is_double = ($now - $this->last_click_time) < (self::DOUBLE_CLICK_MS / 1000.0)
+            && $this->last_click_row === $mouse->row
+            && $this->last_click_col === $mouse->col;
+        $this->last_click_time = $now;
+        $this->last_click_row = $mouse->row;
+        $this->last_click_col = $mouse->col;
+
+        if ($is_double) {
+            // The first click already moved the selection / cursor to
+            // the right row, so Enter will act on it.
+            $this->dispatchEnter();
+            // Reset so a third rapid click doesn't trigger another enter.
+            $this->last_click_time = 0.0;
+            return;
+        }
+
         if ($hover_pane === ActivePane::Overview) {
             $this->dispatchMouseOverview($state, $body_row, $body_rows);
             return;

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -3147,7 +3147,7 @@ final class ExploreTui
         if ($state->focus_id === $key_id) {
             return; // already focused on this frame
         }
-        $label = Aggregator::labelFor($this->model, $key_id, true);
+        $label = Aggregator::labelFor($this->model, $key_id, $this->opts->no_line);
         $this->pushSandwichFocus($key_id, $label, $state->sandwich_view);
 
         // When panes or overview was active, switch to the Focus

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -209,6 +209,15 @@ final class ExploreTui
     private int $last_click_col = -1;
     private const DOUBLE_CLICK_MS = 400;
 
+    /**
+     * Cached mini-flame pixel → overview key_id mapping, populated
+     * during render so click handlers can look up which frame a
+     * column corresponds to without recomputing the allocation.
+     *
+     * @var list<int>  pixel_index → key_id (-1 = unallocated)
+     */
+    private array $mini_flame_pixel_keys = [];
+
     public function __construct(TraceModel $model, TerminalInterface $term, Keymap $keymap)
     {
         $this->model = $model;
@@ -353,6 +362,7 @@ final class ExploreTui
         $cache = $this->ensureOverview();
         $rows = $cache['rows'];
         if ($rows === [] || $width <= 0) {
+            $this->mini_flame_pixel_keys = [];
             return str_repeat(' ', max(0, $width));
         }
 
@@ -361,6 +371,7 @@ final class ExploreTui
             $total += $count;
         }
         if ($total === 0) {
+            $this->mini_flame_pixel_keys = [];
             return str_repeat(' ', $width);
         }
 
@@ -404,8 +415,11 @@ final class ExploreTui
 
         // Walk frames in order, allocating subpixels proportionally.
         // The break at $total_pixels truncates the long tail.
+        // Also builds a parallel pixel → key_id mapping for click handling.
         $pos = 0;
         $cursor_rendered_in_strip = false;
+        /** @var list<int> pixel_index → key_id (-1 = unallocated) */
+        $pixel_keys = array_fill(0, $total_pixels, -1);
         foreach ($rows as $i => [, $key_id, ]) {
             if ($pos >= $total_pixels) {
                 break;
@@ -419,12 +433,14 @@ final class ExploreTui
             for ($p = $pos; $p < $end; $p++) {
                 $pixel_frame[$p] = $i;
                 $pixel_focus[$p] = $is_highlight;
+                $pixel_keys[$p] = $key_id;
             }
             if ($is_highlight) {
                 $cursor_rendered_in_strip = true;
             }
             $pos = $end;
         }
+        $this->mini_flame_pixel_keys = $pixel_keys;
 
         // If the cursor row's natural position lies past the visible
         // strip (typical for callers/callees on aggregator functions
@@ -2963,6 +2979,12 @@ final class ExploreTui
         $body_rows = $rows - 6 - ($show_mini_flame ? 1 : 0);
         $body_start = 4 + ($show_mini_flame ? 1 : 0);
 
+        // Click on the mini-flame strip row (directly after the header).
+        if ($show_mini_flame && $screen_row === 4 && !$is_scroll) {
+            $this->dispatchMouseMiniFlame($screen_col, $cols);
+            return;
+        }
+
         if ($screen_row < $body_start || $screen_row >= $body_start + $body_rows) {
             return;
         }
@@ -3099,6 +3121,34 @@ final class ExploreTui
             ActivePane::Callees  => $this->callees_selected += $delta,
             ActivePane::Overview, ActivePane::Focus => null,
         };
+    }
+
+    /**
+     * Left-click in list mode body: row 0 is header, rows 1+ are data.
+     */
+    /**
+     * Left-click on the mini-flame strip: focus on the frame at that column.
+     */
+    private function dispatchMouseMiniFlame(int $screen_col, int $cols): void
+    {
+        if ($this->mini_flame_pixel_keys === []) {
+            return;
+        }
+        // The mini-flame spans the full terminal width. Each cell = 2 pixels.
+        $pixel = $screen_col * 2;
+        if ($pixel < 0 || $pixel >= count($this->mini_flame_pixel_keys)) {
+            return;
+        }
+        $key_id = $this->mini_flame_pixel_keys[$pixel];
+        if ($key_id < 0) {
+            return;
+        }
+        $state = $this->currentState();
+        if ($state->focus_id === $key_id) {
+            return; // already focused on this frame
+        }
+        $label = Aggregator::labelFor($this->model, $key_id, true);
+        $this->pushSandwichFocus($key_id, $label, $state->sandwich_view);
     }
 
     /**

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2985,7 +2985,7 @@ final class ExploreTui
             SandwichView::Panes => $this->dispatchMousePanes($state, $body_row, $body_rows),
             SandwichView::TreeCallees,
             SandwichView::TreeCallers => $this->dispatchMouseTree($body_row, $body_rows),
-            SandwichView::Flame => null,
+            SandwichView::Flame => $this->dispatchMouseFlame($body_row, $screen_col, $sidebar_width, $body_rows),
         };
     }
 
@@ -3160,6 +3160,51 @@ final class ExploreTui
         $total = count($this->ensureCallees()['rows']);
         if ($data_row < $total) {
             $this->callees_selected = $data_row;
+        }
+    }
+
+    /**
+     * Left-click in sandwich flame view: move cursor to the clicked bar.
+     */
+    private function dispatchMouseFlame(
+        int $body_row,
+        int $screen_col,
+        int $sidebar_width,
+        int $body_rows,
+    ): void {
+        $layout = $this->buildCurrentSandwichLayout();
+        if ($layout === null) {
+            return;
+        }
+        $total_visual = $layout['total_visual_rows'];
+        if ($body_row < 0 || $body_row >= $total_visual) {
+            return;
+        }
+        // Convert screen column to inner-body x coordinate.
+        // Sidebar + separator occupy the left portion of the screen.
+        $separator_width = $sidebar_width > 0 ? 1 : 0;
+        $inner_x = $screen_col - $sidebar_width - $separator_width;
+        if ($inner_x < 0) {
+            return;
+        }
+        $bars = $layout['visual_rows'][$body_row] ?? [];
+        if ($bars === []) {
+            // Allow clicking the focus row even though it has no bars.
+            if ($body_row === $layout['focus_visual_row']) {
+                $this->flame_cursor_visual_row = $body_row;
+                $this->flame_cursor_x = $inner_x;
+            }
+            return;
+        }
+        $hit = $this->findBarAtX($bars, $inner_x);
+        if ($hit === null) {
+            $hit = $this->findNearestBar($bars, $inner_x);
+        }
+        $this->flame_cursor_visual_row = $body_row;
+        if ($hit !== null) {
+            $this->flame_cursor_x = $hit['x'] + intdiv($hit['w'], 2);
+        } else {
+            $this->flame_cursor_x = $inner_x;
         }
     }
 

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -3149,6 +3149,22 @@ final class ExploreTui
         }
         $label = Aggregator::labelFor($this->model, $key_id, true);
         $this->pushSandwichFocus($key_id, $label, $state->sandwich_view);
+
+        // When panes or overview was active, switch to the Focus
+        // banner so the mini-flame highlight tracks the newly focused
+        // frame. getActiveCursorFrame() returns focus_id directly for
+        // ActivePane::Focus, which is exactly what we just clicked.
+        // Flame / tree views initialise their cursor onto the focus
+        // bar on the next render, so they highlight correctly already.
+        if (
+            $state->active_pane === ActivePane::Callers
+            || $state->active_pane === ActivePane::Callees
+            || $state->active_pane === ActivePane::Overview
+        ) {
+            $this->replaceTop(
+                $this->currentState()->withActivePane(ActivePane::Focus)
+            );
+        }
     }
 
     /**

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -3038,6 +3038,13 @@ final class ExploreTui
             $this->list_selected += $delta;
             return;
         }
+        // Activate the hovered pane so the scroll is visible. Without
+        // this, the overview's auto-center logic would overwrite the
+        // selection on the next render and the scroll would appear to
+        // have no effect.
+        if ($state->active_pane !== $pane && $pane !== ActivePane::Focus) {
+            $this->replaceTop($state->withActivePane($pane));
+        }
         match ($pane) {
             ActivePane::Callers  => $this->callers_selected += $delta,
             ActivePane::Callees  => $this->callees_selected += $delta,

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2918,7 +2918,7 @@ final class ExploreTui
      * Handle a parsed SGR mouse event.
      *
      * Supported interactions:
-     *   - Scroll wheel (up/down) in any view → equivalent to ↑/↓
+     *   - Scroll wheel: scroll the pane under the mouse pointer
      *   - Left-click on a body row → move selection to that row
      *   - Left-click on sidebar (overview) → activate + select row
      *   - Left-click on sandwich pane → activate that pane + select
@@ -2930,18 +2930,11 @@ final class ExploreTui
             return;
         }
 
-        // Scroll wheel: translate to ↑/↓ navigation.
-        if ($mouse->button === MouseEvent::SCROLL_UP) {
-            $this->dispatchUpDown(-3);
-            return;
-        }
-        if ($mouse->button === MouseEvent::SCROLL_DOWN) {
-            $this->dispatchUpDown(3);
-            return;
-        }
+        $is_scroll = $mouse->button === MouseEvent::SCROLL_UP
+            || $mouse->button === MouseEvent::SCROLL_DOWN;
 
-        // Only left-click for selection.
-        if ($mouse->button !== MouseEvent::BUTTON_LEFT) {
+        // For non-scroll events, only left-click is handled.
+        if (!$is_scroll && $mouse->button !== MouseEvent::BUTTON_LEFT) {
             return;
         }
 
@@ -2958,37 +2951,102 @@ final class ExploreTui
         $show_mini_flame = $state->mode === ExploreMode::Sandwich
             && $this->mini_flame_enabled;
         $body_rows = $rows - 6 - ($show_mini_flame ? 1 : 0);
-        $body_start = 4 + ($show_mini_flame ? 1 : 0); // header=4 + optional mini-flame
+        $body_start = 4 + ($show_mini_flame ? 1 : 0);
 
-        // Click outside the body area — ignore.
         if ($screen_row < $body_start || $screen_row >= $body_start + $body_rows) {
             return;
         }
 
         $body_row = $screen_row - $body_start;
 
-        // Check if click is in the sidebar region.
         $show_sidebar = $state->mode === ExploreMode::Sandwich
             && $this->shouldShowSidebar($cols);
         $sidebar_width = $show_sidebar ? $this->computeSidebarWidth($cols) : 0;
 
-        if ($show_sidebar && $screen_col < $sidebar_width) {
-            $this->dispatchMouseOverview($state, $body_row, $body_rows);
+        // Determine which pane the pointer is over and dispatch.
+        $hover_pane = $this->hitTestPane($state, $body_row, $body_rows, $screen_col, $sidebar_width);
+
+        if ($is_scroll) {
+            $delta = $mouse->button === MouseEvent::SCROLL_UP ? -3 : 3;
+            $this->dispatchMouseScroll($state, $hover_pane, $delta);
             return;
         }
 
-        // Click is in the main body.
+        // Left-click.
+        if ($hover_pane === ActivePane::Overview) {
+            $this->dispatchMouseOverview($state, $body_row, $body_rows);
+            return;
+        }
         if ($state->mode !== ExploreMode::Sandwich) {
             $this->dispatchMouseList($body_row);
             return;
         }
-
         match ($state->sandwich_view) {
             SandwichView::Panes => $this->dispatchMousePanes($state, $body_row, $body_rows),
             SandwichView::TreeCallees,
             SandwichView::TreeCallers => $this->dispatchMouseTree($body_row, $body_rows),
-            SandwichView::Flame => null, // flame bars don't map cleanly to row selection
+            SandwichView::Flame => null,
         };
+    }
+
+    /**
+     * Determine which logical pane the mouse pointer is hovering over.
+     *
+     * Returns an ActivePane value for sandwich mode or null for list mode
+     * (list mode has only one pane, so no disambiguation is needed).
+     */
+    private function hitTestPane(
+        ViewState $state,
+        int $body_row,
+        int $body_rows,
+        int $screen_col,
+        int $sidebar_width,
+    ): ?ActivePane {
+        if ($sidebar_width > 0 && $screen_col < $sidebar_width) {
+            return ActivePane::Overview;
+        }
+        if ($state->mode !== ExploreMode::Sandwich) {
+            return null; // list mode
+        }
+        if ($state->sandwich_view !== SandwichView::Panes) {
+            // Flame / tree views have a single main body; treat as
+            // whichever non-overview pane is active (callers/callees).
+            return $state->active_pane === ActivePane::Overview
+                ? ActivePane::Callees
+                : $state->active_pane;
+        }
+        // Panes view: callers top / focus banner / callees bottom.
+        $banner_rows = 3;
+        $available = max(0, $body_rows - $banner_rows);
+        $caller_body = (int)floor($available / 2);
+        if ($body_row < $caller_body) {
+            return ActivePane::Callers;
+        }
+        if ($body_row < $caller_body + $banner_rows) {
+            return ActivePane::Focus;
+        }
+        return ActivePane::Callees;
+    }
+
+    /**
+     * Scroll the pane that the mouse pointer is hovering over.
+     */
+    private function dispatchMouseScroll(ViewState $state, ?ActivePane $pane, int $delta): void
+    {
+        if ($pane === null) {
+            // List mode.
+            $this->list_selected += $delta;
+            return;
+        }
+        match ($pane) {
+            ActivePane::Callers  => $this->callers_selected += $delta,
+            ActivePane::Callees  => $this->callees_selected += $delta,
+            ActivePane::Overview => $this->overview_selected += $delta,
+            ActivePane::Focus    => null, // nothing to scroll
+        };
+        if ($pane === ActivePane::Overview && $this->overview_follow) {
+            $this->liveFollowOverviewFocus();
+        }
     }
 
     /**

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -3045,15 +3045,33 @@ final class ExploreTui
         if ($state->active_pane !== $pane && $pane !== ActivePane::Focus) {
             $this->replaceTop($state->withActivePane($pane));
         }
+        if ($pane === ActivePane::Overview) {
+            $this->overview_selected += $delta;
+            if ($this->overview_follow) {
+                $this->liveFollowOverviewFocus();
+            }
+            return;
+        }
+        // Tree and flame views have their own cursor state that is
+        // separate from the per-pane callers/callees selection.
+        if ($state->mode === ExploreMode::Sandwich) {
+            switch ($state->sandwich_view) {
+                case SandwichView::TreeCallees:
+                case SandwichView::TreeCallers:
+                    $this->tree_cursor_row += $delta;
+                    return;
+                case SandwichView::Flame:
+                    $this->moveFlameCursorRow($delta > 0 ? 1 : -1);
+                    return;
+                case SandwichView::Panes:
+                    break; // fall through to per-pane selection below
+            }
+        }
         match ($pane) {
             ActivePane::Callers  => $this->callers_selected += $delta,
             ActivePane::Callees  => $this->callees_selected += $delta,
-            ActivePane::Overview => $this->overview_selected += $delta,
-            ActivePane::Focus    => null, // nothing to scroll
+            ActivePane::Overview, ActivePane::Focus => null,
         };
-        if ($pane === ActivePane::Overview && $this->overview_follow) {
-            $this->liveFollowOverviewFocus();
-        }
     }
 
     /**

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -218,6 +218,25 @@ final class ExploreTui
      */
     private array $mini_flame_pixel_keys = [];
 
+    /**
+     * Mouse scroll delta: how many rows each scroll event moves.
+     * Adjustable via the [δN] indicator in the header (click to
+     * cycle presets, scroll to fine-tune).
+     */
+    private int $scroll_delta = 3;
+
+    /** @var list<int> preset values cycled through on click */
+    private const SCROLL_DELTA_PRESETS = [1, 2, 3, 5, 10];
+
+    /**
+     * Column range of the [δN] indicator on header line 2 (0-based,
+     * exclusive end). Set by renderHeader() so the mouse dispatcher
+     * knows where the widget is.
+     *
+     * @var array{int, int}
+     */
+    private array $scroll_delta_cols = [0, 0];
+
     public function __construct(TraceModel $model, TerminalInterface $term, Keymap $keymap)
     {
         $this->model = $model;
@@ -555,12 +574,25 @@ final class ExploreTui
             },
         };
         $line2 = sprintf('mode: %s   history: %d back', $mode_label, $hist);
-        $line3 = sprintf(
+        $line3_left = sprintf(
             'no-line: %s   match: %s   filter: %s',
             $this->opts->no_line ? 'on' : 'off',
             $this->opts->match_re ?? '(none)',
             $state->view_filter ?? '(none)',
         );
+        $delta_label = sprintf('[δ%d]', $this->scroll_delta);
+        $delta_len = mb_strlen($delta_label);
+        // Right-align the scroll-delta indicator on line 2 (row index 2).
+        $gap = $cols - mb_strlen($line3_left) - $delta_len;
+        if ($gap >= 2) {
+            $delta_col_start = $cols - $delta_len;
+            $line3 = $line3_left . str_repeat(' ', $gap) . $delta_label;
+        } else {
+            // Terminal too narrow — omit the indicator.
+            $delta_col_start = 0;
+            $line3 = $line3_left;
+        }
+        $this->scroll_delta_cols = [$delta_col_start, $delta_col_start + $delta_len];
 
         $out = $this->styleHeader(self::shorten($line1, $cols)) . "\n";
         $out .= self::shorten($line2, $cols) . "\n";
@@ -2979,6 +3011,16 @@ final class ExploreTui
         $body_rows = $rows - 6 - ($show_mini_flame ? 1 : 0);
         $body_start = 4 + ($show_mini_flame ? 1 : 0);
 
+        // [δN] indicator on header line 2 (screen row 2).
+        if (
+            $screen_row === 2
+            && $screen_col >= $this->scroll_delta_cols[0]
+            && $screen_col < $this->scroll_delta_cols[1]
+        ) {
+            $this->dispatchScrollDeltaWidget($is_scroll, $mouse);
+            return;
+        }
+
         // Click on the mini-flame strip row (directly after the header).
         if ($show_mini_flame && $screen_row === 4 && !$is_scroll) {
             $this->dispatchMouseMiniFlame($screen_col, $cols);
@@ -2999,7 +3041,7 @@ final class ExploreTui
         $hover_pane = $this->hitTestPane($state, $body_row, $body_rows, $screen_col, $sidebar_width);
 
         if ($is_scroll) {
-            $step = $mouse->shift ? 3 : 1;
+            $step = $this->scroll_delta;
             $delta = $mouse->button === MouseEvent::SCROLL_UP ? -$step : $step;
             $this->dispatchMouseScroll($state, $hover_pane, $delta);
             return;
@@ -3125,8 +3167,30 @@ final class ExploreTui
     }
 
     /**
-     * Left-click in list mode body: row 0 is header, rows 1+ are data.
+     * Handle click / scroll on the [δN] header widget.
+     * Click cycles through presets, scroll adjusts ±1 (clamped 1–20).
      */
+    private function dispatchScrollDeltaWidget(
+        bool $is_scroll,
+        MouseEvent $mouse,
+    ): void {
+        if ($is_scroll) {
+            $dir = $mouse->button === MouseEvent::SCROLL_UP ? -1 : 1;
+            $this->scroll_delta = max(1, min(20, $this->scroll_delta + $dir));
+        } else {
+            // Cycle through presets.
+            $idx = array_search($this->scroll_delta, self::SCROLL_DELTA_PRESETS, true);
+            if ($idx === false) {
+                // Current value is not a preset — snap to nearest.
+                $this->scroll_delta = self::SCROLL_DELTA_PRESETS[0];
+            } else {
+                $next = ($idx + 1) % count(self::SCROLL_DELTA_PRESETS);
+                $this->scroll_delta = self::SCROLL_DELTA_PRESETS[$next];
+            }
+        }
+        $this->status = "scroll delta: {$this->scroll_delta}";
+    }
+
     /**
      * Left-click on the mini-flame strip: focus on the frame at that column.
      */

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -3180,6 +3180,18 @@ final class ExploreTui
         if ($body_row < 0 || $body_row >= $total_visual) {
             return;
         }
+
+        // Clicking the flame body should hand navigation focus to
+        // the main body so that a subsequent Enter drills into the
+        // clicked bar rather than acting on the overview sidebar.
+        $state = $this->currentState();
+        if (
+            $state->active_pane === ActivePane::Overview
+            || $state->active_pane === ActivePane::Focus
+        ) {
+            $this->replaceTop($state->withActivePane(ActivePane::Callees));
+        }
+
         // Convert screen column to inner-body x coordinate.
         // Sidebar + separator occupy the left portion of the screen.
         $separator_width = $sidebar_width > 0 ? 1 : 0;
@@ -3216,6 +3228,15 @@ final class ExploreTui
         // Tree body has a 1-line header, then data rows.
         if ($body_row < 1) {
             return;
+        }
+        // Hand navigation focus to the main body so Enter acts on the
+        // tree cursor, not the overview sidebar.
+        $state = $this->currentState();
+        if (
+            $state->active_pane === ActivePane::Overview
+            || $state->active_pane === ActivePane::Focus
+        ) {
+            $this->replaceTop($state->withActivePane(ActivePane::Callees));
         }
         $this->tree_cursor_row = $body_row - 1 + $this->tree_top_row;
     }

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2999,7 +2999,8 @@ final class ExploreTui
         $hover_pane = $this->hitTestPane($state, $body_row, $body_rows, $screen_col, $sidebar_width);
 
         if ($is_scroll) {
-            $delta = $mouse->button === MouseEvent::SCROLL_UP ? -1 : 1;
+            $step = $mouse->shift ? 3 : 1;
+            $delta = $mouse->button === MouseEvent::SCROLL_UP ? -$step : $step;
             $this->dispatchMouseScroll($state, $hover_pane, $delta);
             return;
         }

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2999,7 +2999,7 @@ final class ExploreTui
         $hover_pane = $this->hitTestPane($state, $body_row, $body_rows, $screen_col, $sidebar_width);
 
         if ($is_scroll) {
-            $delta = $mouse->button === MouseEvent::SCROLL_UP ? -3 : 3;
+            $delta = $mouse->button === MouseEvent::SCROLL_UP ? -1 : 1;
             $this->dispatchMouseScroll($state, $hover_pane, $delta);
             return;
         }

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -223,7 +223,7 @@ final class ExploreTui
      * Adjustable via the [δN] indicator in the header (click to
      * cycle presets, scroll to fine-tune).
      */
-    private int $scroll_delta = 3;
+    private int $scroll_delta = 1;
 
     /** @var list<int> preset values cycled through on click */
     private const SCROLL_DELTA_PRESETS = [1, 2, 3, 5, 10];

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2685,6 +2685,12 @@ final class ExploreTui
             return;
         }
 
+        $mouse = MouseEvent::tryParse($key);
+        if ($mouse !== null) {
+            $this->dispatchMouse($mouse);
+            return;
+        }
+
         $action = $this->keymap->resolve($key);
         if ($action === null) {
             return;
@@ -2906,6 +2912,184 @@ final class ExploreTui
                 $this->status = 'overview: ' . ($this->sidebar_override ? 'on' : 'off');
                 return;
         }
+    }
+
+    /**
+     * Handle a parsed SGR mouse event.
+     *
+     * Supported interactions:
+     *   - Scroll wheel (up/down) in any view → equivalent to ↑/↓
+     *   - Left-click on a body row → move selection to that row
+     *   - Left-click on sidebar (overview) → activate + select row
+     *   - Left-click on sandwich pane → activate that pane + select
+     */
+    private function dispatchMouse(MouseEvent $mouse): void
+    {
+        // Only act on press events (ignore release / drag).
+        if (!$mouse->press) {
+            return;
+        }
+
+        // Scroll wheel: translate to ↑/↓ navigation.
+        if ($mouse->button === MouseEvent::SCROLL_UP) {
+            $this->dispatchUpDown(-3);
+            return;
+        }
+        if ($mouse->button === MouseEvent::SCROLL_DOWN) {
+            $this->dispatchUpDown(3);
+            return;
+        }
+
+        // Only left-click for selection.
+        if ($mouse->button !== MouseEvent::BUTTON_LEFT) {
+            return;
+        }
+
+        // Convert 1-based ANSI coords to 0-based screen row/col.
+        $screen_row = $mouse->row - 1;
+        $screen_col = $mouse->col - 1;
+
+        [$cols, $rows] = $this->term->size();
+        if ($cols < self::MIN_COLS || $rows < self::MIN_ROWS) {
+            return;
+        }
+
+        $state = $this->currentState();
+        $show_mini_flame = $state->mode === ExploreMode::Sandwich
+            && $this->mini_flame_enabled;
+        $body_rows = $rows - 6 - ($show_mini_flame ? 1 : 0);
+        $body_start = 4 + ($show_mini_flame ? 1 : 0); // header=4 + optional mini-flame
+
+        // Click outside the body area — ignore.
+        if ($screen_row < $body_start || $screen_row >= $body_start + $body_rows) {
+            return;
+        }
+
+        $body_row = $screen_row - $body_start;
+
+        // Check if click is in the sidebar region.
+        $show_sidebar = $state->mode === ExploreMode::Sandwich
+            && $this->shouldShowSidebar($cols);
+        $sidebar_width = $show_sidebar ? $this->computeSidebarWidth($cols) : 0;
+
+        if ($show_sidebar && $screen_col < $sidebar_width) {
+            $this->dispatchMouseOverview($state, $body_row, $body_rows);
+            return;
+        }
+
+        // Click is in the main body.
+        if ($state->mode !== ExploreMode::Sandwich) {
+            $this->dispatchMouseList($body_row);
+            return;
+        }
+
+        match ($state->sandwich_view) {
+            SandwichView::Panes => $this->dispatchMousePanes($state, $body_row, $body_rows),
+            SandwichView::TreeCallees,
+            SandwichView::TreeCallers => $this->dispatchMouseTree($body_row, $body_rows),
+            SandwichView::Flame => null, // flame bars don't map cleanly to row selection
+        };
+    }
+
+    /**
+     * Left-click in list mode body: row 0 is header, rows 1+ are data.
+     */
+    private function dispatchMouseList(int $body_row): void
+    {
+        if ($body_row < 1) {
+            return; // clicked on header
+        }
+        $data_row = $body_row - 1 + $this->list_top_row;
+        $total = count($this->ensureList()['rows']);
+        if ($data_row < $total) {
+            $this->list_selected = $data_row;
+        }
+    }
+
+    /**
+     * Left-click in the overview sidebar.
+     */
+    private function dispatchMouseOverview(ViewState $state, int $body_row, int $body_rows): void
+    {
+        if ($body_row < 1) {
+            return; // clicked on header
+        }
+        $visible = max(0, $body_rows - 1);
+        $data_row = $body_row - 1 + $this->overview_top_row;
+        $total = count($this->ensureOverview()['rows']);
+        if ($data_row >= $total) {
+            return;
+        }
+        // Activate the overview pane and move selection.
+        if ($state->active_pane !== ActivePane::Overview) {
+            $this->replaceTop($state->withActivePane(ActivePane::Overview));
+        }
+        $this->overview_selected = $data_row;
+        if ($this->overview_follow) {
+            $this->liveFollowOverviewFocus();
+        }
+    }
+
+    /**
+     * Left-click in sandwich panes view: determine which pane was
+     * clicked and set the selection within that pane.
+     */
+    private function dispatchMousePanes(ViewState $state, int $body_row, int $body_rows): void
+    {
+        $banner_rows = 3;
+        $available = max(0, $body_rows - $banner_rows);
+        $caller_body = (int)floor($available / 2);
+        $callee_body = $available - $caller_body;
+
+        // Callers pane: rows 0 to caller_body-1 (header + body)
+        if ($body_row < $caller_body) {
+            if ($body_row < 1) {
+                return; // header
+            }
+            if ($state->active_pane !== ActivePane::Callers) {
+                $this->replaceTop($state->withActivePane(ActivePane::Callers));
+            }
+            $data_row = $body_row - 1 + $this->callers_top_row;
+            $total = count($this->ensureCallers()['rows']);
+            if ($data_row < $total) {
+                $this->callers_selected = $data_row;
+            }
+            return;
+        }
+
+        // Focus banner: rows caller_body to caller_body+2
+        if ($body_row < $caller_body + $banner_rows) {
+            if ($state->active_pane !== ActivePane::Focus) {
+                $this->replaceTop($state->withActivePane(ActivePane::Focus));
+            }
+            return;
+        }
+
+        // Callees pane: rows caller_body+3 onwards (header + body)
+        $callee_local = $body_row - $caller_body - $banner_rows;
+        if ($callee_local < 1) {
+            return; // header
+        }
+        if ($state->active_pane !== ActivePane::Callees) {
+            $this->replaceTop($state->withActivePane(ActivePane::Callees));
+        }
+        $data_row = $callee_local - 1 + $this->callees_top_row;
+        $total = count($this->ensureCallees()['rows']);
+        if ($data_row < $total) {
+            $this->callees_selected = $data_row;
+        }
+    }
+
+    /**
+     * Left-click in sandwich tree view: set tree cursor to clicked row.
+     */
+    private function dispatchMouseTree(int $body_row, int $body_rows): void
+    {
+        // Tree body has a 1-line header, then data rows.
+        if ($body_row < 1) {
+            return;
+        }
+        $this->tree_cursor_row = $body_row - 1 + $this->tree_top_row;
     }
 
     private function dispatchPrompt(string $key): void

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -582,11 +582,12 @@ final class ExploreTui
         );
         $delta_label = sprintf('[δ%d]', $this->scroll_delta);
         $delta_len = mb_strlen($delta_label);
-        // Right-align the scroll-delta indicator on line 2 (row index 2).
-        $gap = $cols - mb_strlen($line3_left) - $delta_len;
-        if ($gap >= 2) {
-            $delta_col_start = $cols - $delta_len;
-            $line3 = $line3_left . str_repeat(' ', $gap) . $delta_label;
+        $left_len = mb_strlen($line3_left);
+        // Place the indicator right after the settings text so it
+        // stays near the left-side overview sidebar on wide terminals.
+        if ($left_len + 3 + $delta_len <= $cols) {
+            $delta_col_start = $left_len + 3;
+            $line3 = $line3_left . '   ' . $delta_label;
         } else {
             // Terminal too narrow — omit the indicator.
             $delta_col_start = 0;

--- a/src/Rbt/Explore/MouseEvent.php
+++ b/src/Rbt/Explore/MouseEvent.php
@@ -34,6 +34,7 @@ final class MouseEvent
         public readonly int $row,
         public readonly bool $press,
         public readonly bool $drag,
+        public readonly bool $shift = false,
     ) {
     }
 
@@ -53,9 +54,10 @@ final class MouseEvent
         $row = (int)$m[3];
         $press = $m[4] === 'M';
 
+        $shift = ($cb & 4) !== 0;
         $drag = ($cb & 32) !== 0;
-        $button = $cb & ~32;
+        $button = $cb & ~(4 | 8 | 16 | 32);
 
-        return new self($button, $col, $row, $press, $drag);
+        return new self($button, $col, $row, $press, $drag, $shift);
     }
 }

--- a/src/Rbt/Explore/MouseEvent.php
+++ b/src/Rbt/Explore/MouseEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Explore;
+
+/**
+ * Parsed SGR mouse event (mode 1006).
+ *
+ * SGR format: \e[<Cb;Cx;CyM  (press) or \e[<Cb;Cx;Cym (release)
+ * where Cb = button flags, Cx = 1-based column, Cy = 1-based row.
+ */
+final class MouseEvent
+{
+    public const BUTTON_LEFT = 0;
+    public const BUTTON_MIDDLE = 1;
+    public const BUTTON_RIGHT = 2;
+    public const BUTTON_NONE = 3;
+    public const SCROLL_UP = 64;
+    public const SCROLL_DOWN = 65;
+
+    public function __construct(
+        public readonly int $button,
+        public readonly int $col,
+        public readonly int $row,
+        public readonly bool $press,
+        public readonly bool $drag,
+    ) {
+    }
+
+    /**
+     * Try to parse a raw escape sequence as an SGR mouse event.
+     *
+     * Returns null if the sequence is not a valid SGR mouse event.
+     */
+    public static function tryParse(string $seq): ?self
+    {
+        // SGR: \e[<Cb;Cx;CyM or \e[<Cb;Cx;Cym
+        if (!preg_match('/^\e\[<(\d+);(\d+);(\d+)([Mm])$/', $seq, $m)) {
+            return null;
+        }
+        $cb = (int)$m[1];
+        $col = (int)$m[2];
+        $row = (int)$m[3];
+        $press = $m[4] === 'M';
+
+        $drag = ($cb & 32) !== 0;
+        $button = $cb & ~32;
+
+        return new self($button, $col, $row, $press, $drag);
+    }
+}

--- a/src/Rbt/Explore/Terminal.php
+++ b/src/Rbt/Explore/Terminal.php
@@ -99,8 +99,11 @@ final class Terminal implements TerminalInterface
         // that `time 1` would add to every single keystroke.
         $this->applyStty('-icanon -echo min 1 time 0');
 
-        // Alt screen on, hide cursor.
-        $this->write("\e[?1049h\e[?25l");
+        // Alt screen on, hide cursor, enable SGR mouse tracking.
+        // ?1000h = basic press/release tracking
+        // ?1002h = button-motion (drag) tracking
+        // ?1006h = SGR extended coordinates (no 223-column limit)
+        $this->write("\e[?1049h\e[?25l\e[?1000h\e[?1002h\e[?1006h");
 
         $this->entered = true;
     }
@@ -113,8 +116,8 @@ final class Terminal implements TerminalInterface
         }
         $this->entered = false;
 
-        // Show cursor, leave alt screen.
-        $this->write("\e[?25h\e[?1049l");
+        // Disable mouse tracking, show cursor, leave alt screen.
+        $this->write("\e[?1006l\e[?1002l\e[?1000l\e[?25h\e[?1049l");
 
         if ($this->stty_orig !== null) {
             $this->applyStty($this->stty_orig);
@@ -171,9 +174,11 @@ final class Terminal implements TerminalInterface
         // in libc's buffer by the time we get here; if they aren't, we
         // simply return the bytes we have and let the keymap try to
         // resolve a partial sequence (which it will refuse and ignore).
+        // SGR mouse events ("\e[<0;120;45M") can be up to ~18 bytes,
+        // so the drain budget must be generous.
         @stream_set_blocking($this->tty_in, false);
         $bytes = $first;
-        for ($i = 0; $i < 8; $i++) {
+        for ($i = 0; $i < 20; $i++) {
             $next = @fgetc($this->tty_in);
             if ($next === false || $next === '') {
                 break;

--- a/src/Rbt/Explore/Terminal.php
+++ b/src/Rbt/Explore/Terminal.php
@@ -97,7 +97,7 @@ final class Terminal implements TerminalInterface
         // inter-byte timer. We compose multi-byte sequences ourselves via
         // a non-blocking drain so we don't pay the 100 ms inter-byte delay
         // that `time 1` would add to every single keystroke.
-        $this->applyStty('-icanon -echo min 1 time 0');
+        $this->applyStty('-icanon -echo -ixon min 1 time 0');
 
         // Alt screen on, hide cursor, enable SGR mouse tracking.
         // ?1000h = basic press/release tracking

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1362,8 +1362,8 @@ class ExploreTuiStateTest extends BaseTestCase
         // Scroll inside body area (ANSI row 6 = body row 1).
         $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        // Scroll up moves by -3.
-        $this->assertSame(2, $this->get($tui, 'list_selected'));
+        // Scroll up moves by -1.
+        $this->assertSame(4, $this->get($tui, 'list_selected'));
     }
 
     public function testMouseScrollDownMovesListSelectionDown(): void
@@ -1372,7 +1372,7 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->set($tui, 'term', new FakeTerminal(120, 30));
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(3, $this->get($tui, 'list_selected'));
+        $this->assertSame(1, $this->get($tui, 'list_selected'));
     }
 
     public function testMouseScrollTargetsPaneUnderPointer(): void
@@ -1395,7 +1395,7 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->inv($tui, 'dispatchMouse', $mouse);
 
         // Callees selection should have moved, not callers.
-        $this->assertSame(3, $this->get($tui, 'callees_selected'));
+        $this->assertSame(1, $this->get($tui, 'callees_selected'));
         $this->assertSame(0, $this->get($tui, 'callers_selected'));
     }
 
@@ -1411,7 +1411,7 @@ class ExploreTuiStateTest extends BaseTestCase
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 5, 8, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
 
-        $this->assertSame(3, $this->get($tui, 'overview_selected'));
+        $this->assertSame(1, $this->get($tui, 'overview_selected'));
     }
 
     public function testMouseReleaseIsIgnored(): void

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1354,11 +1354,13 @@ class ExploreTuiStateTest extends BaseTestCase
     public function testMouseScrollUpMovesListSelectionUp(): void
     {
         $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
         // Start at row 5.
         $this->inv($tui, 'moveSelection', 5);
         $this->assertSame(5, $this->get($tui, 'list_selected'));
 
-        $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 10, true, false);
+        // Scroll inside body area (ANSI row 6 = body row 1).
+        $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
         // Scroll up moves by -3.
         $this->assertSame(2, $this->get($tui, 'list_selected'));
@@ -1367,9 +1369,49 @@ class ExploreTuiStateTest extends BaseTestCase
     public function testMouseScrollDownMovesListSelectionDown(): void
     {
         $tui = $this->makeTui();
-        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 10, true, false);
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
         $this->assertSame(3, $this->get($tui, 'list_selected'));
+    }
+
+    public function testMouseScrollTargetsPaneUnderPointer(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+
+        // Push into sandwich mode.
+        $this->inv($tui, 'focusSelected');
+        /** @var ViewState $state */
+        $state = $this->inv($tui, 'currentState');
+        $this->assertSame(ExploreMode::Sandwich, $state->mode);
+
+        // Active pane is Callers, but scroll over the callees region.
+        // body_start = 5 (4 header + 1 mini-flame), body_rows = 23
+        // banner=3, available=20, caller_body=10
+        // Callees body starts at body_row 13 → ANSI row = 5+13+1 = 19
+        // Use column past sidebar (sidebar_width=33, separator=1).
+        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 36, 19, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+
+        // Callees selection should have moved, not callers.
+        $this->assertSame(3, $this->get($tui, 'callees_selected'));
+        $this->assertSame(0, $this->get($tui, 'callers_selected'));
+    }
+
+    public function testMouseScrollOverSidebarScrollsOverview(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+
+        // Push into sandwich mode.
+        $this->inv($tui, 'focusSelected');
+
+        // Scroll in the sidebar area (col 5, inside sidebar_width=33).
+        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 5, 8, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+
+        $this->assertSame(3, $this->get($tui, 'overview_selected'));
     }
 
     public function testMouseReleaseIsIgnored(): void

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1362,8 +1362,8 @@ class ExploreTuiStateTest extends BaseTestCase
         // Scroll inside body area (ANSI row 6 = body row 1).
         $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        // Scroll up moves by -1.
-        $this->assertSame(4, $this->get($tui, 'list_selected'));
+        // Default scroll_delta is 3, so scroll up moves by -3.
+        $this->assertSame(2, $this->get($tui, 'list_selected'));
     }
 
     public function testMouseScrollDownMovesListSelectionDown(): void
@@ -1372,25 +1372,59 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->set($tui, 'term', new FakeTerminal(120, 30));
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(1, $this->get($tui, 'list_selected'));
+        $this->assertSame(3, $this->get($tui, 'list_selected'));
     }
 
-    public function testShiftScrollMovesThreeRows(): void
+    public function testScrollDeltaWidgetClickCyclesPresets(): void
     {
         $tui = $this->makeTui();
         $this->set($tui, 'term', new FakeTerminal(120, 30));
-        // Start at row 5.
-        $this->inv($tui, 'moveSelection', 5);
+        $this->assertSame(3, $this->get($tui, 'scroll_delta'));
 
-        // Shift+scroll down in body area.
-        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false, true);
+        // Render to populate scroll_delta_cols.
+        $this->inv($tui, 'render');
+        [$col_start, $col_end] = $this->get($tui, 'scroll_delta_cols');
+        // Click on the indicator — should cycle 3 → 5.
+        $mouse = new MouseEvent(
+            MouseEvent::BUTTON_LEFT,
+            $col_start + 1 + 1, // 0-based→1-based ANSI
+            3, // header row 2 → ANSI row 3
+            true,
+            false,
+        );
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(8, $this->get($tui, 'list_selected'));
+        $this->assertSame(5, $this->get($tui, 'scroll_delta'));
+    }
 
-        // Shift+scroll up.
-        $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false, true);
+    public function testScrollDeltaWidgetScrollAdjusts(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+        $this->inv($tui, 'render');
+        [$col_start, ] = $this->get($tui, 'scroll_delta_cols');
+        $ansi_col = $col_start + 1 + 1;
+
+        // Scroll up on the indicator → 3-1=2.
+        $mouse = new MouseEvent(
+            MouseEvent::SCROLL_UP,
+            $ansi_col,
+            3,
+            true,
+            false,
+        );
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(5, $this->get($tui, 'list_selected'));
+        $this->assertSame(2, $this->get($tui, 'scroll_delta'));
+
+        // Scroll down → 2+1=3.
+        $mouse = new MouseEvent(
+            MouseEvent::SCROLL_DOWN,
+            $ansi_col,
+            3,
+            true,
+            false,
+        );
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(3, $this->get($tui, 'scroll_delta'));
     }
 
     public function testMouseScrollTargetsPaneUnderPointer(): void
@@ -1412,8 +1446,8 @@ class ExploreTuiStateTest extends BaseTestCase
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 36, 19, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
 
-        // Callees selection should have moved, not callers.
-        $this->assertSame(1, $this->get($tui, 'callees_selected'));
+        // Default scroll_delta=3, so callees moves by 3.
+        $this->assertSame(3, $this->get($tui, 'callees_selected'));
         $this->assertSame(0, $this->get($tui, 'callers_selected'));
     }
 
@@ -1429,7 +1463,7 @@ class ExploreTuiStateTest extends BaseTestCase
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 5, 8, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
 
-        $this->assertSame(1, $this->get($tui, 'overview_selected'));
+        $this->assertSame(3, $this->get($tui, 'overview_selected'));
     }
 
     public function testMouseReleaseIsIgnored(): void

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1375,6 +1375,24 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->assertSame(1, $this->get($tui, 'list_selected'));
     }
 
+    public function testShiftScrollMovesThreeRows(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+        // Start at row 5.
+        $this->inv($tui, 'moveSelection', 5);
+
+        // Shift+scroll down in body area.
+        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false, true);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(8, $this->get($tui, 'list_selected'));
+
+        // Shift+scroll up.
+        $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false, true);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(5, $this->get($tui, 'list_selected'));
+    }
+
     public function testMouseScrollTargetsPaneUnderPointer(): void
     {
         $tui = $this->makeTui();

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1362,8 +1362,8 @@ class ExploreTuiStateTest extends BaseTestCase
         // Scroll inside body area (ANSI row 6 = body row 1).
         $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        // Default scroll_delta is 3, so scroll up moves by -3.
-        $this->assertSame(2, $this->get($tui, 'list_selected'));
+        // Default scroll_delta is 1, so scroll up moves by -1.
+        $this->assertSame(4, $this->get($tui, 'list_selected'));
     }
 
     public function testMouseScrollDownMovesListSelectionDown(): void
@@ -1372,19 +1372,19 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->set($tui, 'term', new FakeTerminal(120, 30));
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 6, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(3, $this->get($tui, 'list_selected'));
+        $this->assertSame(1, $this->get($tui, 'list_selected'));
     }
 
     public function testScrollDeltaWidgetClickCyclesPresets(): void
     {
         $tui = $this->makeTui();
         $this->set($tui, 'term', new FakeTerminal(120, 30));
-        $this->assertSame(3, $this->get($tui, 'scroll_delta'));
+        $this->assertSame(1, $this->get($tui, 'scroll_delta'));
 
         // Render to populate scroll_delta_cols.
         $this->inv($tui, 'render');
         [$col_start, $col_end] = $this->get($tui, 'scroll_delta_cols');
-        // Click on the indicator — should cycle 3 → 5.
+        // Click on the indicator — should cycle 1 → 2.
         $mouse = new MouseEvent(
             MouseEvent::BUTTON_LEFT,
             $col_start + 1 + 1, // 0-based→1-based ANSI
@@ -1393,7 +1393,7 @@ class ExploreTuiStateTest extends BaseTestCase
             false,
         );
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(5, $this->get($tui, 'scroll_delta'));
+        $this->assertSame(2, $this->get($tui, 'scroll_delta'));
     }
 
     public function testScrollDeltaWidgetScrollAdjusts(): void
@@ -1404,18 +1404,7 @@ class ExploreTuiStateTest extends BaseTestCase
         [$col_start, ] = $this->get($tui, 'scroll_delta_cols');
         $ansi_col = $col_start + 1 + 1;
 
-        // Scroll up on the indicator → 3-1=2.
-        $mouse = new MouseEvent(
-            MouseEvent::SCROLL_UP,
-            $ansi_col,
-            3,
-            true,
-            false,
-        );
-        $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(2, $this->get($tui, 'scroll_delta'));
-
-        // Scroll down → 2+1=3.
+        // Scroll down on the indicator → 1+1=2.
         $mouse = new MouseEvent(
             MouseEvent::SCROLL_DOWN,
             $ansi_col,
@@ -1424,7 +1413,18 @@ class ExploreTuiStateTest extends BaseTestCase
             false,
         );
         $this->inv($tui, 'dispatchMouse', $mouse);
-        $this->assertSame(3, $this->get($tui, 'scroll_delta'));
+        $this->assertSame(2, $this->get($tui, 'scroll_delta'));
+
+        // Scroll up → 2-1=1.
+        $mouse = new MouseEvent(
+            MouseEvent::SCROLL_UP,
+            $ansi_col,
+            3,
+            true,
+            false,
+        );
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(1, $this->get($tui, 'scroll_delta'));
     }
 
     public function testMouseScrollTargetsPaneUnderPointer(): void
@@ -1446,8 +1446,8 @@ class ExploreTuiStateTest extends BaseTestCase
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 36, 19, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
 
-        // Default scroll_delta=3, so callees moves by 3.
-        $this->assertSame(3, $this->get($tui, 'callees_selected'));
+        // Default scroll_delta=1, so callees moves by 1.
+        $this->assertSame(1, $this->get($tui, 'callees_selected'));
         $this->assertSame(0, $this->get($tui, 'callers_selected'));
     }
 
@@ -1463,7 +1463,7 @@ class ExploreTuiStateTest extends BaseTestCase
         $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 5, 8, true, false);
         $this->inv($tui, 'dispatchMouse', $mouse);
 
-        $this->assertSame(3, $this->get($tui, 'overview_selected'));
+        $this->assertSame(1, $this->get($tui, 'overview_selected'));
     }
 
     public function testMouseReleaseIsIgnored(): void

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -1348,4 +1348,103 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->assertStringContainsString('col', $tableHead);
         $this->assertNotSame('col', $tableHead);
     }
+
+    // ---------- mouse dispatch ----------
+
+    public function testMouseScrollUpMovesListSelectionUp(): void
+    {
+        $tui = $this->makeTui();
+        // Start at row 5.
+        $this->inv($tui, 'moveSelection', 5);
+        $this->assertSame(5, $this->get($tui, 'list_selected'));
+
+        $mouse = new MouseEvent(MouseEvent::SCROLL_UP, 10, 10, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        // Scroll up moves by -3.
+        $this->assertSame(2, $this->get($tui, 'list_selected'));
+    }
+
+    public function testMouseScrollDownMovesListSelectionDown(): void
+    {
+        $tui = $this->makeTui();
+        $mouse = new MouseEvent(MouseEvent::SCROLL_DOWN, 10, 10, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(3, $this->get($tui, 'list_selected'));
+    }
+
+    public function testMouseReleaseIsIgnored(): void
+    {
+        $tui = $this->makeTui();
+        $this->inv($tui, 'moveSelection', 2);
+        // Release event — should not change selection.
+        $mouse = new MouseEvent(MouseEvent::BUTTON_LEFT, 10, 10, false, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(2, $this->get($tui, 'list_selected'));
+    }
+
+    public function testMouseClickListBodySelectsRow(): void
+    {
+        $tui = $this->makeTui();
+        // Set up a fake terminal size for geometry calculation.
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+
+        // List mode: no mini-flame, body_start = 4 (header, 0-based).
+        // body row 0 = table header, body row 1+ = data rows.
+        // ANSI row for data row 0 = body_start + 1(header) + 0 + 1(to 1-based) = 6
+        $mouse = new MouseEvent(MouseEvent::BUTTON_LEFT, 10, 6, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(0, $this->get($tui, 'list_selected'));
+
+        // Model has 2 list rows (leaf_x, leaf_y). Click data row 1.
+        // ANSI row = 4 + 1 + 1 + 1 = 7
+        $mouse = new MouseEvent(MouseEvent::BUTTON_LEFT, 10, 7, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        $this->assertSame(1, $this->get($tui, 'list_selected'));
+    }
+
+    public function testMouseClickSandwichPanesSwitchesPaneAndSelectsRow(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+
+        // Push into sandwich mode by focusing on a frame.
+        $this->inv($tui, 'focusSelected');
+        /** @var ViewState $state */
+        $state = $this->inv($tui, 'currentState');
+        $this->assertSame(ExploreMode::Sandwich, $state->mode);
+        $this->assertSame(ActivePane::Callers, $state->active_pane);
+
+        // Sidebar width at 120 cols = int(120*0.28) = 33, separator = 1.
+        // Must click past col 34 (0-based) to land in the body, not sidebar.
+        // body_start = 4 + 1(mini-flame) = 5
+        // body_rows = 30 - 6 - 1 = 23
+        // banner = 3, available = 20, caller_body = 10
+        // Callees pane starts at body_row 13 (= 10 + 3).
+        // Callee data row 0: body_row 14
+        // ANSI row = body_start + body_row + 1 = 5 + 14 + 1 = 20
+        // ANSI col past sidebar: 36 (1-based, well past col 34)
+        $mouse = new MouseEvent(
+            MouseEvent::BUTTON_LEFT,
+            36,
+            20,
+            true,
+            false,
+        );
+        $this->inv($tui, 'dispatchMouse', $mouse);
+
+        /** @var ViewState $state */
+        $state = $this->inv($tui, 'currentState');
+        $this->assertSame(ActivePane::Callees, $state->active_pane);
+    }
+
+    public function testMouseRightClickIsIgnored(): void
+    {
+        $tui = $this->makeTui();
+        $this->set($tui, 'term', new FakeTerminal(120, 30));
+
+        $mouse = new MouseEvent(MouseEvent::BUTTON_RIGHT, 10, 6, true, false);
+        $this->inv($tui, 'dispatchMouse', $mouse);
+        // Selection should not have changed.
+        $this->assertSame(0, $this->get($tui, 'list_selected'));
+    }
 }

--- a/tests/Rbt/Explore/MouseEventTest.php
+++ b/tests/Rbt/Explore/MouseEventTest.php
@@ -89,6 +89,32 @@ class MouseEventTest extends BaseTestCase
         $this->assertNull(MouseEvent::tryParse("\e[5~"));
     }
 
+    public function testParseShiftModifier(): void
+    {
+        // Shift adds bit 2 (4) to Cb. Left click + shift = 0+4 = 4.
+        $event = MouseEvent::tryParse("\e[<4;10;5M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_LEFT, $event->button);
+        $this->assertTrue($event->shift);
+        $this->assertFalse($event->drag);
+    }
+
+    public function testShiftScrollUp(): void
+    {
+        // Scroll up (64) + shift (4) = 68.
+        $event = MouseEvent::tryParse("\e[<68;1;1M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::SCROLL_UP, $event->button);
+        $this->assertTrue($event->shift);
+    }
+
+    public function testNoShiftByDefault(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;10;5M");
+        $this->assertNotNull($event);
+        $this->assertFalse($event->shift);
+    }
+
     public function testReturnsNullForMalformed(): void
     {
         $this->assertNull(MouseEvent::tryParse("\e[<0;10M"));

--- a/tests/Rbt/Explore/MouseEventTest.php
+++ b/tests/Rbt/Explore/MouseEventTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Explore;
+
+use Reli\BaseTestCase;
+
+class MouseEventTest extends BaseTestCase
+{
+    public function testParseLeftPress(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;10;5M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_LEFT, $event->button);
+        $this->assertSame(10, $event->col);
+        $this->assertSame(5, $event->row);
+        $this->assertTrue($event->press);
+        $this->assertFalse($event->drag);
+    }
+
+    public function testParseLeftRelease(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;10;5m");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_LEFT, $event->button);
+        $this->assertFalse($event->press);
+    }
+
+    public function testParseScrollUp(): void
+    {
+        $event = MouseEvent::tryParse("\e[<64;1;1M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::SCROLL_UP, $event->button);
+        $this->assertTrue($event->press);
+    }
+
+    public function testParseScrollDown(): void
+    {
+        $event = MouseEvent::tryParse("\e[<65;1;1M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::SCROLL_DOWN, $event->button);
+    }
+
+    public function testParseDrag(): void
+    {
+        // button 0 + 32 (drag flag) = 32
+        $event = MouseEvent::tryParse("\e[<32;20;10M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_LEFT, $event->button);
+        $this->assertTrue($event->drag);
+    }
+
+    public function testParseLargeCoordinates(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;200;150M");
+        $this->assertNotNull($event);
+        $this->assertSame(200, $event->col);
+        $this->assertSame(150, $event->row);
+    }
+
+    public function testParseMiddleButton(): void
+    {
+        $event = MouseEvent::tryParse("\e[<1;5;5M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_MIDDLE, $event->button);
+    }
+
+    public function testParseRightButton(): void
+    {
+        $event = MouseEvent::tryParse("\e[<2;5;5M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_RIGHT, $event->button);
+    }
+
+    public function testReturnsNullForNonMouseSequence(): void
+    {
+        $this->assertNull(MouseEvent::tryParse("\e[A"));
+        $this->assertNull(MouseEvent::tryParse("a"));
+        $this->assertNull(MouseEvent::tryParse("\e[5~"));
+    }
+
+    public function testReturnsNullForMalformed(): void
+    {
+        $this->assertNull(MouseEvent::tryParse("\e[<0;10M"));
+        $this->assertNull(MouseEvent::tryParse("\e[<;10;5M"));
+    }
+}


### PR DESCRIPTION
## Summary

Add full mouse support to the `rbt:explore` TUI, making all views interactive with click, scroll, and double-click.

### Mouse interactions

- **Click to select**: Left-click selects rows in list mode, sandwich panes (callers/callees), overview sidebar, and flame graph bars
- **Scroll wheel**: Scrolls whichever pane the pointer is over (callers, callees, overview, tree, list) — no need to switch active pane first
- **Double-click to focus**: Double-click any row to drill down (equivalent to Enter)
- **Mini-flame click**: Click the Braille histogram strip to instantly focus on that frame
- **Scroll delta widget**: `[δN]` indicator in the header — click to cycle presets (1/2/3/5/10), scroll to fine-tune (range 1–20)

### Other improvements

- **Ctrl+S freeze fix**: Disable XON/XOFF flow control (`-ixon`) in raw mode so accidental Ctrl+S doesn't freeze the terminal
- **SGR modifier parsing**: Shift/Meta/Ctrl bits are now stripped from the button value so modified mouse events don't break button identification
- **Mini-flame highlight accuracy**: After clicking the mini-flame strip, the active pane switches to Focus so the highlight correctly tracks the newly focused frame
- **Overview clamp**: `overview_selected` is clamped before `renderMiniFlame()` so scrolling past the top of the overview no longer makes the highlight jump to the wrong position

### Technical details

- SGR mouse tracking modes `?1000h` (press/release), `?1002h` (button-motion/drag), `?1006h` (extended coordinates) enabled on terminal enter, disabled on leave
- New `MouseEvent` value object parses SGR escape sequences (`\e[<Cb;Cx;CyM/m`), extracts button, coordinates, press/release, drag, and shift flags
- Escape sequence drain budget increased from 8→20 bytes to accommodate SGR mouse sequences (up to ~18 bytes)
- Double-click detection via 400ms timestamp threshold at same cell position
- Mini-flame pixel→key_id cache built during render for O(1) click lookup

## Test plan

- [x] `MouseEvent::tryParse` — 13 test cases covering all button types, scroll, drag, shift, large coordinates, malformed/non-mouse sequences
- [x] `ExploreTuiStateTest` — mouse dispatch tests: scroll up/down, scroll targets hovered pane, scroll over sidebar, click list body, click sandwich panes, scroll delta widget click/scroll, right-click ignored, release ignored
- [x] phpcs clean
- [x] psalm clean (0 errors)
- [x] Manual testing: verify click selection, scroll, double-click focus, mini-flame click, delta widget in all views (list, panes, flame, tree)

https://claude.ai/code/session_0152A6FJDKfCNJCUb1Zm11Zv