### PR TITLE
Add memory scope support to variable reader and watch triggers

### DIFF
--- a/src/Command/Inspector/PeekVarCommand.php
+++ b/src/Command/Inspector/PeekVarCommand.php
@@ -60,7 +60,8 @@ final class PeekVarCommand extends Command
             'variable to read (e.g., global::$var,'
                 . ' local::func()$var,'
                 . ' static::Class::$prop,'
-                . ' func_static::func()$var)',
+                . ' func_static::func()$var,'
+                . ' memory::memory_get_usage)',
         );
         $this->addOption(
             'repeat',

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
@@ -64,7 +64,8 @@ final class GetTraceSettingsFromConsoleInput
                 'variable to peek per sample and attach as an annotation '
                 . '(same syntax as inspector:peek-var --var, e.g. '
                 . "global::\$counter, local::App\\Svc::run()\$id, "
-                . "static::App\\Cache::\$entries, func_static::App\\retry()\$n)"
+                . "static::App\\Cache::\$entries, func_static::App\\retry()\$n, "
+                . 'memory::memory_get_usage, memory::memory_get_peak_usage)'
             )
             ->addOption(
                 'trace-var-every',

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -70,7 +70,8 @@ final class WatchSettingsFromConsoleInput
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'trigger on variable value condition'
                     . ' (format: scope::name:op:value,'
-                    . ' e.g. global::cache:count_gt:10000)',
+                    . ' e.g. global::cache:count_gt:10000,'
+                    . ' memory::memory_get_usage:gt:104857600)',
             )
             // CPU trigger options
             ->addOption(

--- a/src/Inspector/Watch/HeapStats.php
+++ b/src/Inspector/Watch/HeapStats.php
@@ -20,6 +20,7 @@ final class HeapStats
         public readonly int $real_size,
         public readonly int $peak,
         public readonly int $limit,
+        public readonly int $real_peak = 0,
     ) {
     }
 

--- a/src/Inspector/Watch/HeapStatsReader.php
+++ b/src/Inspector/Watch/HeapStatsReader.php
@@ -83,6 +83,7 @@ final class HeapStatsReader
             real_size: $heap->real_size,
             peak: $heap->peak,
             limit: $heap->limit,
+            real_peak: $heap->real_peak,
         );
     }
 

--- a/src/Inspector/Watch/Trigger/VariableValueTrigger.php
+++ b/src/Inspector/Watch/Trigger/VariableValueTrigger.php
@@ -27,6 +27,8 @@ use Reli\Inspector\Watch\WatchContext;
  *   static::App\Cache::$size:gt:100000
  *   func_static::App\retry()$attempt:gt:10
  *   global::status:eq:error
+ *   memory::memory_get_usage:gt:104857600
+ *   memory::memory_get_peak_usage:gt:134217728
  */
 final class VariableValueTrigger implements TriggerInterface
 {
@@ -73,6 +75,22 @@ final class VariableValueTrigger implements TriggerInterface
                         . " '{$this->expression}'."
                         . ' global:: requires $ prefix'
                         . ' (e.g., global::$var:op:value)',
+                );
+            }
+        }
+        if ($this->scope === 'memory') {
+            $valid_names = [
+                'memory_get_usage',
+                'memory_get_peak_usage',
+                'memory_get_usage_real',
+                'memory_get_peak_usage_real',
+            ];
+            if (!in_array($this->var_name, $valid_names, true)) {
+                throw new \InvalidArgumentException(
+                    "Invalid watch-var expression:"
+                        . " '{$this->expression}'."
+                        . ' memory:: requires one of: '
+                        . implode(', ', $valid_names),
                 );
             }
         }

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -40,12 +40,14 @@ use Reli\Lib\Process\ProcessSpecifier;
  * - local:       current call frame CVs
  * - static:      class static properties (requires CG)
  * - func_static: function static variables
+ * - memory:      ZendMM heap stats (memory_get_usage, memory_get_peak_usage, etc.)
  */
 final class VariableReader implements VariableReaderInterface
 {
     public function __construct(
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
+        private ?HeapStatsReader $heap_stats_reader = null,
     ) {
     }
 
@@ -75,12 +77,40 @@ final class VariableReader implements VariableReaderInterface
             $php_version,
         );
 
-        $eg_pointer = new Pointer(
-            ZendExecutorGlobals::class,
-            $eg_address,
-            $zend_type_reader->sizeOf('zend_executor_globals'),
-        );
-        $eg = $dereferencer->deref($eg_pointer);
+        // Check if any spec needs EG (non-memory scopes)
+        $has_non_memory = false;
+        $has_memory = false;
+        foreach ($specs as $spec) {
+            if ($spec->scope === 'memory') {
+                $has_memory = true;
+            } else {
+                $has_non_memory = true;
+            }
+        }
+
+        $eg = null;
+        if ($has_non_memory) {
+            $eg_pointer = new Pointer(
+                ZendExecutorGlobals::class,
+                $eg_address,
+                $zend_type_reader->sizeOf('zend_executor_globals'),
+            );
+            $eg = $dereferencer->deref($eg_pointer);
+        }
+
+        // Read heap stats once if any memory spec is present
+        $heap_stats = null;
+        if ($has_memory && $this->heap_stats_reader !== null) {
+            try {
+                $heap_stats = $this->heap_stats_reader->read(
+                    $process_specifier,
+                    $target_php_settings,
+                    $eg_address,
+                );
+            } catch (\Throwable) {
+                // heap stats unavailable; memory specs will be skipped
+            }
+        }
 
         $results = [];
 
@@ -91,32 +121,36 @@ final class VariableReader implements VariableReaderInterface
 
             try {
                 $value = match ($scope) {
-                    'global' => $this->readGlobalVariable(
+                    'memory' => $this->readMemoryVariable(
+                        $name,
+                        $heap_stats,
+                    ),
+                    'global' => $eg !== null ? $this->readGlobalVariable(
                         $eg,
                         $dereferencer,
                         $zend_type_reader,
                         $name,
-                    ),
-                    'local' => $this->readLocalVariable(
+                    ) : null,
+                    'local' => $eg !== null ? $this->readLocalVariable(
                         $eg,
                         $dereferencer,
                         $zend_type_reader,
                         $name,
-                    ),
-                    'static' => $this->readStaticProperty(
+                    ) : null,
+                    'static' => $eg !== null ? $this->readStaticProperty(
                         $eg,
                         $dereferencer,
                         $zend_type_reader,
                         $name,
                         $cg_address,
-                    ),
-                    'func_static' => $this->readFuncStaticVariable(
+                    ) : null,
+                    'func_static' => $eg !== null ? $this->readFuncStaticVariable(
                         $eg,
                         $dereferencer,
                         $zend_type_reader,
                         $name,
                         $cg_address,
-                    ),
+                    ) : null,
                     default => null,
                 };
                 if ($value !== null) {
@@ -128,6 +162,39 @@ final class VariableReader implements VariableReaderInterface
         }
 
         return $results;
+    }
+
+    /**
+     * Read a memory metric from the Zend Memory Manager heap.
+     *
+     * Maps to PHP's memory_get_usage() / memory_get_peak_usage() equivalents:
+     *   memory_get_usage           → heap->size   (emalloc usage)
+     *   memory_get_peak_usage      → heap->peak   (peak emalloc usage)
+     *   memory_get_usage_real      → heap->real_size (OS-level allocation)
+     *   memory_get_peak_usage_real → heap->real_peak (peak OS-level allocation)
+     */
+    private function readMemoryVariable(
+        string $name,
+        ?HeapStats $heap_stats,
+    ): ?VariableValue {
+        if ($heap_stats === null) {
+            return null;
+        }
+        $bytes = match ($name) {
+            'memory_get_usage' => $heap_stats->size,
+            'memory_get_peak_usage' => $heap_stats->peak,
+            'memory_get_usage_real' => $heap_stats->real_size,
+            'memory_get_peak_usage_real' => $heap_stats->real_peak,
+            default => null,
+        };
+        if ($bytes === null) {
+            return null;
+        }
+        return new VariableValue(
+            VariableValue::TYPE_LONG,
+            $bytes,
+            null,
+        );
     }
 
     private function readGlobalVariable(

--- a/src/Inspector/Watch/VariableSpec.php
+++ b/src/Inspector/Watch/VariableSpec.php
@@ -22,6 +22,10 @@ namespace Reli\Inspector\Watch;
  *   local::App\Service::process()$retries
  *   static::App\Cache::$entries
  *   func_static::App\retry()$attempt
+ *   memory::memory_get_usage
+ *   memory::memory_get_peak_usage
+ *   memory::memory_get_usage_real
+ *   memory::memory_get_peak_usage_real
  */
 final class VariableSpec
 {
@@ -47,7 +51,8 @@ final class VariableSpec
                     . ' (e.g., global::$var,'
                     . ' local::func()$var,'
                     . ' static::Class::$prop,'
-                    . ' func_static::func()$var)'
+                    . ' func_static::func()$var,'
+                    . ' memory::memory_get_usage)'
             );
         }
         $scope = $parts[0];
@@ -92,6 +97,23 @@ final class VariableSpec
                 );
             }
         }
+        if ($scope === 'memory') {
+            $valid_names = [
+                'memory_get_usage',
+                'memory_get_peak_usage',
+                'memory_get_usage_real',
+                'memory_get_peak_usage_real',
+            ];
+            if (!in_array($name, $valid_names, true)) {
+                throw new \InvalidArgumentException(
+                    "Invalid variable expression:"
+                        . " '{$expression}'."
+                        . " memory:: requires one of: "
+                        . implode(', ', $valid_names),
+                );
+            }
+            return;
+        }
         $valid_scopes = ['global', 'local', 'static', 'func_static'];
         if (!in_array($scope, $valid_scopes, true)) {
             throw new \InvalidArgumentException(
@@ -99,7 +121,8 @@ final class VariableSpec
                     . " '{$expression}'."
                     . " Unknown scope '{$scope}'."
                     . ' Valid scopes: '
-                    . implode(', ', $valid_scopes),
+                    . implode(', ', $valid_scopes)
+                    . ', memory',
             );
         }
     }

--- a/tests/Inspector/Watch/Trigger/VariableValueTriggerTest.php
+++ b/tests/Inspector/Watch/Trigger/VariableValueTriggerTest.php
@@ -259,6 +259,66 @@ class VariableValueTriggerTest extends TestCase
         $this->assertTrue($trigger->requiresDeepInspection());
     }
 
+    public function testParseMemoryUsageExpression(): void
+    {
+        $parsed = VariableValueTrigger::parseExpression(
+            'memory::memory_get_usage:gt:104857600'
+        );
+        $this->assertSame('memory', $parsed['scope']);
+        $this->assertSame('memory_get_usage', $parsed['name']);
+        $this->assertSame('gt', $parsed['op']);
+        $this->assertSame('104857600', $parsed['value']);
+    }
+
+    public function testParseMemoryPeakUsageExpression(): void
+    {
+        $parsed = VariableValueTrigger::parseExpression(
+            'memory::memory_get_peak_usage:gte:134217728'
+        );
+        $this->assertSame('memory', $parsed['scope']);
+        $this->assertSame('memory_get_peak_usage', $parsed['name']);
+        $this->assertSame('gte', $parsed['op']);
+        $this->assertSame('134217728', $parsed['value']);
+    }
+
+    public function testMemoryUsageGtFires(): void
+    {
+        $trigger = new VariableValueTrigger(
+            'memory::memory_get_usage:gt:104857600'
+        );
+        $context = $this->makeContext([
+            'memory::memory_get_usage' => new VariableValue(
+                VariableValue::TYPE_LONG,
+                209715200,
+                null,
+            ),
+        ]);
+        $event = $trigger->evaluate($context);
+        $this->assertNotNull($event);
+        $this->assertSame('watch-var', $event->trigger_name);
+    }
+
+    public function testMemoryUsageGtDoesNotFire(): void
+    {
+        $trigger = new VariableValueTrigger(
+            'memory::memory_get_usage:gt:104857600'
+        );
+        $context = $this->makeContext([
+            'memory::memory_get_usage' => new VariableValue(
+                VariableValue::TYPE_LONG,
+                52428800,
+                null,
+            ),
+        ]);
+        $this->assertNull($trigger->evaluate($context));
+    }
+
+    public function testMemoryInvalidNameThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new VariableValueTrigger('memory::invalid_name:gt:0');
+    }
+
     /**
      * @param array<string, VariableValue> $vars
      */

--- a/tests/Inspector/Watch/VariableReaderIntegrationTest.php
+++ b/tests/Inspector/Watch/VariableReaderIntegrationTest.php
@@ -34,6 +34,7 @@ use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
 use Reli\Lib\Process\MemoryReader\MemoryReader;
@@ -1087,6 +1088,207 @@ class VariableReaderIntegrationTest extends BaseTestCase
         $key_items = 'static::PreloadedTarget::$items';
         $this->assertArrayHasKey($key_items, $results);
         $this->assertSame(4, $results[$key_items]->array_count);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testReadMemoryVariables(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script = <<<'CODE'
+            <?php
+            $data = str_repeat("x", 1024 * 1024); // ~1MB
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $chunk_finder = new PhpZendMemoryManagerChunkFinder(
+            $process_memory_map_creator,
+            $zend_type_reader_creator,
+        );
+        $heap_stats_reader = new HeapStatsReader(
+            $chunk_finder,
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+
+        $variable_reader = new VariableReader(
+            $memory_reader,
+            $zend_type_reader_creator,
+            $heap_stats_reader,
+        );
+
+        $specs = [
+            VariableSpec::parse('memory::memory_get_usage'),
+            VariableSpec::parse('memory::memory_get_peak_usage'),
+            VariableSpec::parse('memory::memory_get_usage_real'),
+            VariableSpec::parse('memory::memory_get_peak_usage_real'),
+        ];
+        $results = $variable_reader->readVariables(
+            $specs,
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+        );
+
+        // memory_get_usage — should be > 1MB after str_repeat
+        $key_usage = 'memory::memory_get_usage';
+        $this->assertArrayHasKey($key_usage, $results);
+        $this->assertSame(
+            VariableValue::TYPE_LONG,
+            $results[$key_usage]->type,
+        );
+        $this->assertGreaterThan(
+            1024 * 1024,
+            $results[$key_usage]->scalar_value,
+            'memory_get_usage should be > 1MB',
+        );
+
+        // memory_get_peak_usage — should be >= usage
+        $key_peak = 'memory::memory_get_peak_usage';
+        $this->assertArrayHasKey($key_peak, $results);
+        $this->assertSame(
+            VariableValue::TYPE_LONG,
+            $results[$key_peak]->type,
+        );
+        $this->assertGreaterThanOrEqual(
+            $results[$key_usage]->scalar_value,
+            $results[$key_peak]->scalar_value,
+            'peak should be >= current usage',
+        );
+
+        // memory_get_usage_real — OS-level allocation, should be > 0
+        $key_real = 'memory::memory_get_usage_real';
+        $this->assertArrayHasKey($key_real, $results);
+        $this->assertGreaterThan(
+            0,
+            $results[$key_real]->scalar_value,
+            'real_size should be > 0',
+        );
+
+        // memory_get_peak_usage_real — should be >= real_size
+        $key_real_peak = 'memory::memory_get_peak_usage_real';
+        $this->assertArrayHasKey($key_real_peak, $results);
+        $this->assertGreaterThanOrEqual(
+            $results[$key_real]->scalar_value,
+            $results[$key_real_peak]->scalar_value,
+            'real_peak should be >= real_size',
+        );
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testReadMemoryAndGlobalVariablesTogether(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script = <<<'CODE'
+            <?php
+            $GLOBALS['gcount'] = 42;
+            $data = str_repeat("x", 1024 * 1024);
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $process_memory_map_creator = ProcessMemoryMapCreator::create();
+        $chunk_finder = new PhpZendMemoryManagerChunkFinder(
+            $process_memory_map_creator,
+            $zend_type_reader_creator,
+        );
+        $heap_stats_reader = new HeapStatsReader(
+            $chunk_finder,
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+
+        $variable_reader = new VariableReader(
+            $memory_reader,
+            $zend_type_reader_creator,
+            $heap_stats_reader,
+        );
+
+        // Mix memory and global scopes in a single readVariables call
+        $specs = [
+            VariableSpec::parse('memory::memory_get_usage'),
+            VariableSpec::parse('global::$gcount'),
+            VariableSpec::parse('memory::memory_get_peak_usage'),
+        ];
+        $results = $variable_reader->readVariables(
+            $specs,
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+        );
+
+        // Both scopes should resolve
+        $this->assertArrayHasKey('memory::memory_get_usage', $results);
+        $this->assertGreaterThan(
+            0,
+            $results['memory::memory_get_usage']->scalar_value,
+        );
+
+        $this->assertArrayHasKey('global::$gcount', $results);
+        $this->assertSame(42, $results['global::$gcount']->scalar_value);
+
+        $this->assertArrayHasKey('memory::memory_get_peak_usage', $results);
+        $this->assertGreaterThan(
+            0,
+            $results['memory::memory_get_peak_usage']->scalar_value,
+        );
     }
 
     /**

--- a/tests/Inspector/Watch/VariableSpecTest.php
+++ b/tests/Inspector/Watch/VariableSpecTest.php
@@ -110,4 +110,39 @@ class VariableSpecTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         VariableSpec::parse('invalid::$var');
     }
+
+    public function testParseMemoryGetUsage(): void
+    {
+        $spec = VariableSpec::parse('memory::memory_get_usage');
+        $this->assertSame('memory', $spec->scope);
+        $this->assertSame('memory_get_usage', $spec->var_name);
+        $this->assertSame('memory::memory_get_usage', $spec->lookup_key);
+    }
+
+    public function testParseMemoryGetPeakUsage(): void
+    {
+        $spec = VariableSpec::parse('memory::memory_get_peak_usage');
+        $this->assertSame('memory', $spec->scope);
+        $this->assertSame('memory_get_peak_usage', $spec->var_name);
+    }
+
+    public function testParseMemoryGetUsageReal(): void
+    {
+        $spec = VariableSpec::parse('memory::memory_get_usage_real');
+        $this->assertSame('memory', $spec->scope);
+        $this->assertSame('memory_get_usage_real', $spec->var_name);
+    }
+
+    public function testParseMemoryGetPeakUsageReal(): void
+    {
+        $spec = VariableSpec::parse('memory::memory_get_peak_usage_real');
+        $this->assertSame('memory', $spec->scope);
+        $this->assertSame('memory_get_peak_usage_real', $spec->var_name);
+    }
+
+    public function testInvalidMemoryName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        VariableSpec::parse('memory::invalid_name');
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds support for reading PHP memory metrics (memory_get_usage, memory_get_peak_usage, memory_get_usage_real, memory_get_peak_usage_real) through the variable reader and watch trigger system. This allows users to monitor heap memory statistics from running PHP processes.

## Key Changes

- **New `memory` scope**: Added a new variable scope `memory::` that maps to Zend Memory Manager heap statistics
  - `memory::memory_get_usage` → heap->size (emalloc usage)
  - `memory::memory_get_peak_usage` → heap->peak (peak emalloc usage)
  - `memory::memory_get_usage_real` → heap->real_size (OS-level allocation)
  - `memory::memory_get_peak_usage_real` → heap->real_peak (peak OS-level allocation)

- **VariableReader enhancements**:
  - Added optional `HeapStatsReader` dependency to constructor
  - Implemented `readMemoryVariable()` method to extract memory metrics from heap stats
  - Optimized to only dereference executor globals when non-memory scopes are requested
  - Added error handling for unavailable heap stats

- **VariableSpec validation**: Added validation for memory scope variable names with clear error messages

- **VariableValueTrigger support**: Extended trigger expressions to support memory scope conditions (e.g., `memory::memory_get_usage:gt:104857600`)

- **HeapStats model**: Added `real_peak` field to track peak OS-level memory allocation

- **Integration tests**: Added comprehensive tests for reading memory variables independently and mixed with other scopes

- **Documentation**: Updated command help text and docstrings to include memory scope examples

## Implementation Details

- Memory metrics are read once per `readVariables()` call if any memory spec is present, avoiding redundant heap stat reads
- Graceful degradation: if heap stats are unavailable, memory specs are skipped rather than failing the entire operation
- Memory scope can be freely mixed with other scopes (global, local, static, func_static) in a single read operation
- All four memory metrics are validated at parse time to prevent invalid variable names

https://claude.ai/code/session_01Syb1k99ESBLtHMzGqx5aTH