### PR TITLE
Add memory scope to user-facing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ Options:
 # Monitor a PHP variable
 ./reli inspector:watch -p <pid> --watch-var='global::$cache:count_gt:10000'
 
+# Monitor memory usage via variable interface
+./reli inspector:watch -p <pid> --watch-var='memory::memory_get_usage:gt:104857600'
+
 # Grab 3 memory dumps and stop
 ./reli inspector:watch -p <pid> --memory-usage=128M --oneshot=3
 ```
@@ -411,7 +414,7 @@ See [docs/watch-command.md](docs/watch-command.md) for full documentation.
 ./reli inspector:peek-var -p <pid> --var='global::$counter' --format=json
 ```
 
-Supported scopes: `global::$var`, `local::func()$var`, `static::Class::$prop`, `func_static::func()$var`.
+Supported scopes: `global::$var`, `local::func()$var`, `static::Class::$prop`, `func_static::func()$var`, `memory::memory_get_usage`.
 
 See [docs/peek-var-command.md](docs/peek-var-command.md) for full documentation.
 
@@ -422,6 +425,9 @@ See [docs/peek-var-command.md](docs/peek-var-command.md) for full documentation.
 ```bash
 # Tag every sample with the current request URI
 ./reli inspector:trace -p <pid> --trace-var='global::$request_uri'
+
+# Track memory usage per sample
+./reli inspector:trace -p <pid> --trace-var='memory::memory_get_usage'
 
 # Multiple variables — each becomes its own annotation line
 ./reli inspector:trace -p <pid> \

--- a/docs/design-trace-var-peek.md
+++ b/docs/design-trace-var-peek.md
@@ -59,6 +59,7 @@ The expression grammar is **exactly** what `inspector:peek-var --var` accepts
 | Local | `local::<fqn>()$var` (use `<main>` for top-level) |
 | Static property | `static::Class::$prop` |
 | Function static | `func_static::<fqn>()$var` |
+| Memory | `memory::memory_get_usage` etc. |
 
 Nested access (`[key]`, `->prop`) is already supported by
 `VariableReader::parsePathExpression()` and flows through unchanged.

--- a/docs/design-watch-command.md
+++ b/docs/design-watch-command.md
@@ -22,6 +22,7 @@ Unified into `--watch-var` with `count_gt`/`count_lt`/`count_eq` operators (e.g.
 - `local::` and `func_static::` require function specification (`func()$var`)
 - Top-level script scope uses `<main>` (not `main`) to avoid collision with user-defined functions
 - Nested path access: `[key]` for arrays, `->prop` for objects
+- `memory::` scope added for ZendMM heap stats (`memory_get_usage`, `memory_get_peak_usage`, `memory_get_usage_real`, `memory_get_peak_usage_real`)
 
 ### `--oneshot` vs long-running daemon
 `--oneshot=<N>` exits after N triggers. For daemons restarted by supervisors, use restart-resilient mechanisms (`--max-dump-size`, `--max-triggers-per-hour`, `--cooldown`).

--- a/docs/internals/watch-command-architecture.md
+++ b/docs/internals/watch-command-architecture.md
@@ -144,6 +144,7 @@ Scopes:
   local::func()$var         specific frame only
   static::Class::$prop      class static property (needs CG)
   func_static::func()$var   function static variable
+  memory::memory_get_usage  ZendMM heap stats (via HeapStatsReader)
 ```
 
 ### Path Expressions

--- a/docs/peek-var-command.md
+++ b/docs/peek-var-command.md
@@ -16,6 +16,16 @@ reli inspector:peek-var -p <pid> \
   --var='global::$counter' \
   --var='global::$config[database][host]'
 
+# Read memory usage (equivalent to memory_get_usage())
+reli inspector:peek-var -p <pid> --var='memory::memory_get_usage'
+
+# Read all memory metrics at once
+reli inspector:peek-var -p <pid> \
+  --var='memory::memory_get_usage' \
+  --var='memory::memory_get_peak_usage' \
+  --var='memory::memory_get_usage_real' \
+  --var='memory::memory_get_peak_usage_real'
+
 # Repeat every 500ms (Ctrl+C to stop)
 reli inspector:peek-var -p <pid> --var='global::$cache' --repeat=500
 
@@ -43,9 +53,27 @@ Variable expressions use the format `scope::identifier`.
 | Local | `local::func()$var` | Local variable in a specific function frame |
 | Static property | `static::Class::$prop` | Class static property |
 | Function static | `func_static::func()$var` | Function's `static $var` |
+| Memory | `memory::memory_get_usage` | Zend MM heap stats (see below) |
 
 For `local::` and `func_static::`, the function name is **required**.
 Use `<main>` for the top-level script scope.
+
+### Memory Scope
+
+The `memory::` scope exposes Zend Memory Manager heap statistics, equivalent
+to PHP's `memory_get_usage()` / `memory_get_peak_usage()` functions. Values
+are returned as integers (bytes).
+
+| Name | PHP equivalent | Description |
+|------|---------------|-------------|
+| `memory::memory_get_usage` | `memory_get_usage()` | Current emalloc heap usage |
+| `memory::memory_get_peak_usage` | `memory_get_peak_usage()` | Peak emalloc heap usage |
+| `memory::memory_get_usage_real` | `memory_get_usage(true)` | Current OS-level allocation |
+| `memory::memory_get_peak_usage_real` | `memory_get_peak_usage(true)` | Peak OS-level allocation |
+
+The read is lightweight (~1ms, single `process_vm_readv` syscall) and does not
+require compiler globals (CG), so it works without the extra overhead of
+`static::` / `func_static::` scopes.
 
 ### Path Expressions
 
@@ -79,6 +107,10 @@ Nested array keys and object properties are supported:
 
 # Function static variable
 --var='func_static::App\retry()$attempts'
+
+# Memory metrics
+--var='memory::memory_get_usage'
+--var='memory::memory_get_peak_usage'
 ```
 
 ## Output Formats

--- a/docs/trace-var-command.md
+++ b/docs/trace-var-command.md
@@ -30,6 +30,11 @@ reli inspector:trace -p <pid> \
   --trace-var='local::App\PDOProxy::execute()$query' \
   --trace-var-on-function='App\PDOProxy::execute'
 
+# Track memory usage per sample
+reli inspector:trace -p <pid> \
+  --trace-var='memory::memory_get_usage' \
+  --trace-var='memory::memory_get_peak_usage'
+
 # Binary (rbt) output — annotations ride on SAMPLE_ANNOTATION events
 reli inspector:trace -p <pid> -F rbt -o trace.rbt \
   --trace-var='global::$counter'
@@ -56,6 +61,7 @@ short:
 | Local | `local::func()$var` | Local variable in a specific function frame |
 | Static property | `static::Class::$prop` | Class static property |
 | Function static | `func_static::func()$var` | Function's `static $var` |
+| Memory | `memory::memory_get_usage` | Zend MM heap stats |
 
 Nested array keys and object properties use the same path syntax:
 
@@ -64,6 +70,11 @@ Nested array keys and object properties use the same path syntax:
 --trace-var='global::$app->cache->size'
 --trace-var='global::$container->services[cache]->pool[active]'
 ```
+
+The `memory::` scope exposes `memory_get_usage()` / `memory_get_peak_usage()`
+equivalents. Available names: `memory_get_usage`, `memory_get_peak_usage`,
+`memory_get_usage_real`, `memory_get_peak_usage_real`. See
+[docs/peek-var-command.md](peek-var-command.md#memory-scope) for details.
 
 For `local::` and `func_static::`, the function name is **required**; use
 `<main>` for the top-level script scope.

--- a/docs/watch-command.md
+++ b/docs/watch-command.md
@@ -105,8 +105,11 @@ Fires when a PHP variable meets a condition. Multiple `--watch-var` flags can be
 | Local | `local::func()$var` | Local variable in a specific function frame |
 | Static property | `static::Class::$prop` | Class static property |
 | Function static | `func_static::func()$var` | Function's `static $var` |
+| Memory | `memory::memory_get_usage` | Zend MM heap stats |
 
 For `local::` and `func_static::`, the function name is **required**. Use `<main>` for the top-level script scope.
+
+The `memory::` scope exposes `memory_get_usage()` / `memory_get_peak_usage()` equivalents as integers (bytes). Available names: `memory_get_usage`, `memory_get_peak_usage`, `memory_get_usage_real`, `memory_get_peak_usage_real`. See [docs/peek-var-command.md](peek-var-command.md#memory-scope) for details.
 
 #### Operators
 
@@ -150,6 +153,12 @@ Variable names support path expressions for nested array keys and object propert
 
 # Top-level script variable
 --watch-var='local::<main>()$counter:gt:1000'
+
+# Memory usage exceeds 100MB
+--watch-var='memory::memory_get_usage:gt:104857600'
+
+# Peak memory exceeds 256MB
+--watch-var='memory::memory_get_peak_usage:gt:268435456'
 ```
 
 ### CPU Usage (`--cpu-usage=<percent>`)


### PR DESCRIPTION
## Summary

- Add `memory` scope documentation to all user-facing docs: README, peek-var, trace-var, watch-command, and design docs
- Documents the four memory metrics (`memory_get_usage`, `memory_get_peak_usage`, `memory_get_usage_real`, `memory_get_peak_usage_real`) added in PR #604
- Adds quick-start examples and scope reference tables across all relevant documentation files

## Changed files

- `README.md`: Added memory scope to scope list and examples
- `docs/peek-var-command.md`: Added "Memory Scope" section with full reference table
- `docs/trace-var-command.md`: Added memory scope to scope table and examples
- `docs/watch-command.md`: Added memory scope to scope table and `--watch-var` examples
- `docs/design-trace-var-peek.md`: Added memory to CLI surface scope table
- `docs/design-watch-command.md`: Added memory scope to syntax evolution notes
- `docs/internals/watch-command-architecture.md`: Added memory to scope list

## Test plan

- [x] Documentation only — no code changes
- [ ] Verify rendered markdown displays correctly

https://claude.ai/code/session_01Syb1k99ESBLtHMzGqx5aTH