### PR TITLE
Require PHP 8.5

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: dom, mbstring
           coverage: none
           tools: cs2pr

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: ffi, dom, mbstring
           coverage: pcov
 
@@ -400,7 +400,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: ffi, dom, mbstring
           coverage: pcov
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: dom, mbstring
           coverage: none
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Reli
-![Minimum PHP version: 8.1.0](https://img.shields.io/badge/php-8.1.0%2B-blue.svg)
+![Minimum PHP version: 8.5.0](https://img.shields.io/badge/php-8.5.0%2B-blue.svg)
 [![Packagist](https://img.shields.io/packagist/v/reliforp/reli-prof.svg)](https://packagist.org/packages/reliforp/reli-prof)
 [![Github Actions](https://github.com/reliforp/reli-prof/workflows/build/badge.svg)](https://github.com/reliforp/reli-prof/actions)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/reliforp/reli-prof/badges/quality-score.png?b=0.11.x)](https://scrutinizer-ci.com/g/reliforp/reli-prof/?branch=0.11.x)
@@ -80,14 +80,15 @@ Much of what can be done with phpspy will be done with reli in the future.
 ## Requirements
 ### Supported PHP versions
 #### Execution
-- PHP 8.1+ (NTS / ZTS)
+- PHP 8.5+ (NTS / ZTS)
 - 64bit Linux x86_64
 - 64bit Linux AArch64 (experimental)
 - FFI extension must be enabled.
 - PCNTL extension must be enabled.
 
-#### Development
-- PHP 8.3+ is required to run the test suite (PHPUnit 12 requirement). The runtime target (Execution) is still PHP 8.1+.
+> The recommended way to run reli-prof is via the provided Docker image,
+> which ships a compatible PHP build with FFI enabled. Bare-metal installs
+> on older PHP versions are not supported.
 
 #### Target
 - PHP 7.0+ (NTS / ZTS)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": "^8.1",
+    "php": "^8.5",
     "ext-ffi": "*",
     "ext-filter": "*",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a39dc99eeb61a7d0dfb43256241af2f",
+    "content-hash": "7ee7104b9b1f008f4d48d543839697d6",
     "packages": [
         {
             "name": "amphp/amp",
@@ -89,16 +89,16 @@
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93"
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/daa00f2efdbd71565bf64ffefa89e37542addf93",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
                 "shasum": ""
             },
             "require": {
@@ -152,7 +152,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v2.1.1"
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
             },
             "funding": [
                 {
@@ -160,7 +160,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-17T04:49:38+00:00"
+            "time": "2025-03-16T17:10:27+00:00"
         },
         {
             "name": "amphp/cache",
@@ -229,16 +229,16 @@
         },
         {
             "name": "amphp/dns",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/dns.git",
-                "reference": "166c43737cef1b77782c648a9d9ed11ee0c9859f"
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/dns/zipball/166c43737cef1b77782c648a9d9ed11ee0c9859f",
-                "reference": "166c43737cef1b77782c648a9d9ed11ee0c9859f",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
                 "shasum": ""
             },
             "require": {
@@ -306,7 +306,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/dns/issues",
-                "source": "https://github.com/amphp/dns/tree/v2.3.0"
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -314,7 +314,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-21T01:15:34+00:00"
+            "time": "2025-01-19T15:43:40+00:00"
         },
         {
             "name": "amphp/parallel",
@@ -464,16 +464,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.1",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "66c095673aa5b6e689e63b52d19e577459129ab3"
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/66c095673aa5b6e689e63b52d19e577459129ab3",
-                "reference": "66c095673aa5b6e689e63b52d19e577459129ab3",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
                 "shasum": ""
             },
             "require": {
@@ -519,7 +519,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.1"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
             },
             "funding": [
                 {
@@ -527,7 +527,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-04T00:56:47+00:00"
+            "time": "2025-03-16T16:33:53+00:00"
         },
         {
             "name": "amphp/process",
@@ -599,24 +599,27 @@
         },
         {
             "name": "amphp/serialization",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -651,22 +654,28 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
             },
-            "time": "2020-03-25T21:39:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
         },
         {
             "name": "amphp/socket",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
                 "shasum": ""
             },
             "require": {
@@ -675,17 +684,17 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
                 "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "amphp/process": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -729,7 +738,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -737,7 +746,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-21T14:33:03+00:00"
+            "time": "2026-04-19T15:09:56+00:00"
         },
         {
             "name": "amphp/sync",
@@ -980,31 +989,32 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v1.3.3",
+            "version": "v2.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "3dbf8a8e914634c48d389c1234552666b3d43754"
+                "reference": "a6abb4e54f6fcd3138120b9ad497f0bd146f9919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/3dbf8a8e914634c48d389c1234552666b3d43754",
-                "reference": "3dbf8a8e914634c48d389c1234552666b3d43754",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/a6abb4e54f6fcd3138120b9ad497f0bd146f9919",
+                "reference": "a6abb4e54f6fcd3138120b9ad497f0bd146f9919",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3|^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "nesbot/carbon": "^2.61",
-                "pestphp/pest": "^1.21.3",
-                "phpstan/phpstan": "^1.8.2",
-                "symfony/var-dumper": "^5.4.11"
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "nesbot/carbon": "^2.67|^3.0",
+                "pestphp/pest": "^2.36|^3.0|^4.0",
+                "phpstan/phpstan": "^2.0",
+                "symfony/var-dumper": "^6.2.0|^7.0.0|^8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -1036,37 +1046,42 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2023-11-08T14:08:06+00:00"
+            "time": "2026-04-14T13:33:34+00:00"
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1094,6 +1109,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -1106,9 +1122,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -1118,7 +1136,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1126,26 +1144,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -1153,6 +1170,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1177,7 +1195,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -1202,7 +1220,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1210,7 +1228,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1317,16 +1335,16 @@
         },
         {
             "name": "php-di/invoker",
-            "version": "2.3.4",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-DI/Invoker.git",
-                "reference": "33234b32dafa8eb69202f950a1fc92055ed76a86"
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/33234b32dafa8eb69202f950a1fc92055ed76a86",
-                "reference": "33234b32dafa8eb69202f950a1fc92055ed76a86",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/3c1ddfdef181431fbc4be83378f6d036d59e81e1",
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1",
                 "shasum": ""
             },
             "require": {
@@ -1336,7 +1354,7 @@
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "mnapoli/hard-mode": "~0.3.0",
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.0 || ^10 || ^11 || ^12"
             },
             "type": "library",
             "autoload": {
@@ -1360,7 +1378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-DI/Invoker/issues",
-                "source": "https://github.com/PHP-DI/Invoker/tree/2.3.4"
+                "source": "https://github.com/PHP-DI/Invoker/tree/2.3.7"
             },
             "funding": [
                 {
@@ -1368,7 +1386,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-08T09:24:21+00:00"
+            "time": "2025-08-30T10:22:22+00:00"
         },
         {
             "name": "php-di/php-di",
@@ -1656,16 +1674,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.6",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254"
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/25de49af7223ba039f64da4ae9a28ec2d10d0254",
-                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
                 "shasum": ""
             },
             "require": {
@@ -1722,9 +1740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.6"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
-            "time": "2023-11-30T05:34:44+00:00"
+            "time": "2025-08-27T21:33:23+00:00"
         },
         {
             "name": "sj-i/php-cast",
@@ -2997,20 +3015,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -3018,8 +3036,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -3042,9 +3060,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -5148,34 +5166,33 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b"
+                "reference": "c7369cc1da250fcbfe0c5a9d109e419661549c39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2d19dde43fa2ff720b9a40763ace7226594f503b",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b",
+                "url": "https://api.github.com/repos/symfony/config/zipball/c7369cc1da250fcbfe0c5a9d109e419661549c39",
+                "reference": "c7369cc1da250fcbfe0c5a9d109e419661549c39",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^7.1|^8.0",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/finder": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5203,7 +5220,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.8"
+                "source": "https://github.com/symfony/config/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5223,29 +5240,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5"
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/58b9790d12f9670b7f53a1c1738febd3108970a5",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
+                "symfony/process": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5273,7 +5290,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.8"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5293,7 +5310,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/process",
@@ -5362,20 +5379,20 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
-                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -5404,7 +5421,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5424,7 +5441,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -5559,7 +5576,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "^8.5",
         "ext-ffi": "*",
         "ext-filter": "*",
         "ext-json": "*",

--- a/src/Converter/Speedscope/Settings/SpeedscopeConverterSettingsException.php
+++ b/src/Converter/Speedscope/Settings/SpeedscopeConverterSettingsException.php
@@ -19,7 +19,7 @@ final class SpeedscopeConverterSettingsException extends InspectorSettingsExcept
 {
     public const UNSUPPORTED_UTF8_ERROR_HANDLING = 1;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::UNSUPPORTED_UTF8_ERROR_HANDLING => 'unsupported utf8 error handling type is specified',
     ];
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -100,7 +100,7 @@ class GraphSubstrate
     /** @var array<int, list<int>> canonical_parent => [canonical_child, ...] for SCC */
     protected array $scc_adjacency = [];
 
-    private const FFI_CSR_THRESHOLD = 2_000_000;
+    private const int FFI_CSR_THRESHOLD = 2_000_000;
 
     /** @psalm-suppress UnsafeInstantiation */
     public static function loadFromDb(\PDO $db, int $run_id): static

--- a/src/Inspector/Settings/DaemonSettings/DaemonSettingsException.php
+++ b/src/Inspector/Settings/DaemonSettings/DaemonSettingsException.php
@@ -21,7 +21,7 @@ final class DaemonSettingsException extends InspectorSettingsException
     public const TARGET_REGEX_IS_NOT_STRING = 2;
     public const TARGET_REGEX_IS_NOT_SPECIFIED = 3;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::THREADS_IS_NOT_INTEGER => 'threads is not integer',
         self::TARGET_REGEX_IS_NOT_STRING => 'target-regex is not string',
         self::TARGET_REGEX_IS_NOT_SPECIFIED => 'target-regex is not specified',

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsException.php
@@ -22,7 +22,7 @@ final class GetTraceSettingsException extends InspectorSettingsException
     public const TRACE_VAR_EXPRESSION_IS_INVALID = 3;
     public const TRACE_VAR_EVERY_IS_NOT_POSITIVE_INTEGER = 4;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::DEPTH_IS_NOT_INTEGER => 'depth is not integer',
         self::BULK_STACK_COPY_IS_NOT_VALID_SIZE =>
             'bulk-stack-copy value must be an integer with optional K/M suffix (e.g. 65536, 64K, 1M)',

--- a/src/Inspector/Settings/InspectorSettingsException.php
+++ b/src/Inspector/Settings/InspectorSettingsException.php
@@ -19,10 +19,10 @@ use Throwable;
 /** @psalm-consistent-constructor */
 abstract class InspectorSettingsException extends \Exception
 {
-    public const ERROR_NONE = 0;
+    public const int ERROR_NONE = 0;
 
     /** @var array<int, string> */
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::ERROR_NONE => '',
     ];
 

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsException.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsException.php
@@ -20,7 +20,7 @@ final class MemoryProfilerSettingsException extends InspectorSettingsException
     public const MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER = 1;
     public const MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER = 2;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::MEMORY_LIMIT_ERROR_MAX_DEPTH_IS_NOT_POSITIVE_INTEGER
             => 'memory_limit_error_max_depth is not positive integer',
         self::MEMORY_LIMIT_ERROR_LINE_IS_NOT_INTEGER

--- a/src/Inspector/Settings/OutputSettings/OutputSettingsException.php
+++ b/src/Inspector/Settings/OutputSettings/OutputSettingsException.php
@@ -20,7 +20,7 @@ final class OutputSettingsException extends InspectorSettingsException
     public const OUTPUT_IS_NOT_STRING = 1;
     public const TEMPLATE_NOT_SPECIFIED = 2;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::OUTPUT_IS_NOT_STRING => 'output must be a string',
         self::TEMPLATE_NOT_SPECIFIED => 'template is not specified',
     ];

--- a/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
+++ b/src/Inspector/Settings/PhpSpySettings/PhpSpySettingsException.php
@@ -21,7 +21,7 @@ final class PhpSpySettingsException extends InspectorSettingsException
     public const BUFFER_SIZE_IS_NOT_INTEGER = 2;
     public const RATE_HZ_IS_NOT_INTEGER = 3;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::SLEEP_NS_IS_NOT_INTEGER => 'sleep-ns is not integer',
         self::BUFFER_SIZE_IS_NOT_INTEGER => 'buffer-size is not integer',
         self::RATE_HZ_IS_NOT_INTEGER => 'rate-hz is not integer',

--- a/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsException.php
+++ b/src/Inspector/Settings/TargetPhpSettings/TargetPhpSettingsException.php
@@ -24,7 +24,7 @@ final class TargetPhpSettingsException extends InspectorSettingsException
     public const LIBPTHREAD_PATH_IS_NOT_STRING = 7;
     public const TARGET_PHP_VERSION_INVALID = 8;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::PHP_REGEX_IS_NOT_STRING => 'php-regex must be a string',
         self::LIBPTHREAD_REGEX_IS_NOT_STRING => 'libpthread-regex must be a string',
         self::ZTS_GLOBALS_REGEX_IS_NOT_STRING => 'zts-globals-regex must be a string',

--- a/src/Inspector/Settings/TargetProcessSettings/TargetProcessSettingsException.php
+++ b/src/Inspector/Settings/TargetProcessSettings/TargetProcessSettingsException.php
@@ -20,7 +20,7 @@ final class TargetProcessSettingsException extends InspectorSettingsException
     public const TARGET_NOT_SPECIFIED = 1;
     public const PID_IS_NOT_INTEGER = 2;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::TARGET_NOT_SPECIFIED => 'either pid or command must be specified',
         self::PID_IS_NOT_INTEGER => 'pid is not integer',
     ];

--- a/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsException.php
+++ b/src/Inspector/Settings/TraceLoopSettings/TraceLoopSettingsException.php
@@ -21,7 +21,7 @@ final class TraceLoopSettingsException extends InspectorSettingsException
     public const MAX_RETRY_IS_NOT_INTEGER = 2;
     public const STOP_PROCESS_IS_NOT_BOOLEAN = 3;
 
-    protected const ERRORS = [
+    protected const array ERRORS = [
         self::SLEEP_NS_IS_NOT_INTEGER => 'sleep-ns is not integer',
         self::MAX_RETRY_IS_NOT_INTEGER => 'max-retries is not integer',
         self::STOP_PROCESS_IS_NOT_BOOLEAN => 'stop-process is not boolean',

--- a/src/Lib/Elf/Process/BinaryAnalysisCache.php
+++ b/src/Lib/Elf/Process/BinaryAnalysisCache.php
@@ -81,6 +81,7 @@ final class BinaryAnalysisCache
             return null;
         }
         try {
+            /** @psalm-suppress UndefinedFunction */
             $data = igbinary_unserialize($content);
         } catch (\Throwable) {
             return null;
@@ -113,7 +114,10 @@ final class BinaryAnalysisCache
         return $data;
     }
 
-    /** @param array<array-key, mixed> $data */
+    /**
+     * @param array<array-key, mixed> $data
+     * @psalm-suppress UndefinedFunction,MixedAssignment,MixedArgument
+     */
     private function saveIgbinary(BinaryFingerprint $fingerprint, string $namespace, array $data): void
     {
         $path = $this->getBasePath($fingerprint, $namespace) . '.igbinary';

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
@@ -15,10 +15,10 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV70 extends VersionAwareConstants
 {
-    public const ZEND_ACC_CLOSURE = 0x100000;
-    public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
+    public const int ZEND_ACC_CLOSURE = 0x100000;
+    public const int ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 
-    public const ZEND_CALL_CODE = (1 << 24);
+    public const int ZEND_CALL_CODE = (1 << 24);
 
-    public const ZEND_CALL_TOP = (1 << 25);
+    public const int ZEND_CALL_TOP = (1 << 25);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
@@ -15,6 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV71 extends VersionAwareConstants
 {
-    public const ZEND_ACC_CLOSURE = 0x100000;
-    public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
+    public const int ZEND_ACC_CLOSURE = 0x100000;
+    public const int ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
@@ -15,6 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV72 extends VersionAwareConstants
 {
-    public const ZEND_ACC_CLOSURE = 0x100000;
-    public const ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
+    public const int ZEND_ACC_CLOSURE = 0x100000;
+    public const int ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
@@ -15,6 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV73 extends VersionAwareConstants
 {
-    public const ZEND_ACC_CLOSURE = (1 << 20);
-    public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 30);
+    public const int ZEND_ACC_CLOSURE = (1 << 20);
+    public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 30);
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
@@ -15,6 +15,6 @@ namespace Reli\Lib\PhpInternals\Constants;
 
 final class PhpInternalsConstantsV74 extends VersionAwareConstants
 {
-    public const ZEND_ACC_CLOSURE = (1 << 20);
-    public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
+    public const int ZEND_ACC_CLOSURE = (1 << 20);
+    public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 }

--- a/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
+++ b/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
@@ -17,14 +17,19 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
 
 abstract class VersionAwareConstants
 {
+    /** @var int */
     public const int ZEND_ACC_CLOSURE = (1 << 22);
 
+    /** @var int */
     public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 
+    /** @var int */
     public const int ZEND_CALL_CODE = (1 << 16);
 
+    /** @var int */
     public const int ZEND_CALL_TOP = (1 << 17);
 
+    /** @var int */
     public const int ZEND_CALL_GENERATOR = (1 << 24);
 
     /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */

--- a/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
+++ b/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
@@ -17,20 +17,15 @@ use Reli\Lib\PhpInternals\ZendTypeReader;
 
 abstract class VersionAwareConstants
 {
-    /** @var int */
-    public const ZEND_ACC_CLOSURE = (1 << 22);
+    public const int ZEND_ACC_CLOSURE = (1 << 22);
 
-    /** @var int */
-    public const ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
+    public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
 
-    /** @var int */
-    public const ZEND_CALL_CODE = (1 << 16);
+    public const int ZEND_CALL_CODE = (1 << 16);
 
-    /** @var int */
-    public const ZEND_CALL_TOP = (1 << 17);
+    public const int ZEND_CALL_TOP = (1 << 17);
 
-    /** @var int */
-    public const ZEND_CALL_GENERATOR = (1 << 24);
+    public const int ZEND_CALL_GENERATOR = (1 << 24);
 
     /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */
     public static function getConstantsOfVersion(string $php_version): self

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -45,7 +45,7 @@ use Reli\Lib\Process\Pointer\Pointer;
 /** @psalm-consistent-constructor */
 class ZendArray implements CDataDereferencable
 {
-    public const BUCKET_SIZE_IN_BYTES = 32;
+    public const int BUCKET_SIZE_IN_BYTES = 32;
 
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendRefcountedH $gc;


### PR DESCRIPTION
## Summary

- Bump `"php"` constraint from `^8.1` to `^8.5` in composer.json
- Regenerate composer.lock under the new constraint
- CI host PHP (phpunit/phpcs/psalm) 8.3 → 8.5
- Add typed class constants (PHP 8.3+ syntax) where psalm's `MissingClassConstType` fires on target 8.5 — requires subclasses of typed consts to carry the same declaration
- `@psalm-suppress UndefinedFunction` on `igbinary_*` calls (optional ext, already guarded at runtime by `extension_loaded`)
- README: update badge + requirement text, note Docker is the recommended install route

## Why

Reli-prof's realistic distribution is the bundled Docker image (Dockerfile already ships PHP 8.5 after #370), so keeping composer.json at `^8.1` only protected a bare-metal install path that is rare and awkward (FFI setup overhead). Aligning the constraint:

- unblocks major dependency upgrades that require PHP 8.2+/8.3+
- lets us drop fallback code paths for older PHPs in follow-up work
- simplifies psalm's inferred target

## Follow-up

After this lands, the Renovate `symfony/console v8` PR (#373) can be closed — the project is staying on `symfony/console 6.4.x` LTS, which works fine on PHP 8.5 (confirmed on #370 CI).

## Test plan

- [x] local phpunit (unit suite, 2891 tests, 0 errors)
- [x] local psalm (0 errors)
- [x] local phpcs (clean)
- [x] CI phpunit target-version matrix (integration tests)
- [x] CI phpcs / psalm / FrankenPHP / Alpine