### PR TITLE
Upgrade symfony/console to v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-filter": "*",
     "ext-json": "*",
     "ext-pcntl": "*",
-    "symfony/console": "6.4.36",
+    "symfony/console": "^8.0",
     "php-di/php-di": "7.1.1",
     "amphp/parallel": "2.3.3",
     "amphp/amp": "3.1.1",
@@ -39,7 +39,7 @@
     "jetbrains/phpstorm-stubs": "2025.3",
     "php-coveralls/php-coveralls": "2.9.1",
     "psalm/phar": "^6.0",
-    "brianium/paratest": "^7.4.5"
+    "brianium/paratest": "^7.20"
   },
   "autoload": {
     "files": ["src/Lib/Defer/defer.php"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ee7104b9b1f008f4d48d543839697d6",
+    "content-hash": "dd6f26274cc83df87d59ffb668c89cd4",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1793,47 +1793,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.36",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5"
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b66d385dc58f69652e56f78a4184615e3f2b7f7",
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1867,7 +1859,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.36"
+                "source": "https://github.com/symfony/console/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -1887,7 +1879,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-27T15:30:51+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2380,35 +2372,34 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2447,7 +2438,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -2467,7 +2458,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2535,16 +2526,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v7.14.2",
+            "version": "v7.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "de06de1ae1203b11976c6ca01d6a9081c8b33d45"
+                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/de06de1ae1203b11976c6ca01d6a9081c8b33d45",
-                "reference": "de06de1ae1203b11976c6ca01d6a9081c8b33d45",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
+                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
                 "shasum": ""
             },
             "require": {
@@ -2555,24 +2546,24 @@
                 "fidry/cpu-core-counter": "^1.3.0",
                 "jean85/pretty-package-versions": "^2.1.1",
                 "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^12.4.0",
-                "phpunit/php-file-iterator": "^6",
-                "phpunit/php-timer": "^8",
-                "phpunit/phpunit": "^12.4.1",
-                "sebastian/environment": "^8.0.3",
-                "symfony/console": "^6.4.20 || ^7.3.4",
-                "symfony/process": "^6.4.20 || ^7.3.4"
+                "phpunit/php-code-coverage": "^12.5.3 || ^13.0.1",
+                "phpunit/php-file-iterator": "^6.0.1 || ^7",
+                "phpunit/php-timer": "^8 || ^9",
+                "phpunit/phpunit": "^12.5.14 || ^13.0.5",
+                "sebastian/environment": "^8.0.3 || ^9",
+                "symfony/console": "^7.4.7 || ^8.0.7",
+                "symfony/process": "^7.4.5 || ^8.0.5"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^14.0.0",
                 "ext-pcntl": "*",
                 "ext-pcov": "*",
                 "ext-posix": "*",
-                "phpstan/phpstan": "^2.1.31",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.7",
-                "phpstan/phpstan-strict-rules": "^2.0.7",
-                "symfony/filesystem": "^6.4.13 || ^7.3.2"
+                "phpstan/phpstan": "^2.1.44",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "symfony/filesystem": "^7.4.6 || ^8.0.6"
             },
             "bin": [
                 "bin/paratest",
@@ -2612,7 +2603,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.14.2"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.20.0"
             },
             "funding": [
                 {
@@ -2624,7 +2615,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2025-10-24T07:20:53+00:00"
+            "time": "2026-03-29T15:46:14+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -5314,20 +5305,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -5355,7 +5346,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5375,7 +5366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/reli
+++ b/reli
@@ -50,7 +50,7 @@ $command_enumerator = new CommandEnumerator(new GlobIterator(__DIR__. '/src/Comm
 foreach ($command_enumerator as $command_class) {
     /** @var Command $command */
     $command = $container->make($command_class);
-    $application->add($command);
+    $application->addCommand($command);
 }
 
 $application->run();

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -80,7 +80,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
 
         $command = $this->createCommand();
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -149,7 +149,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
 
         $command = $this->createCommand();
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -190,7 +190,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
 
         $command = $this->createCommand();
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -212,7 +212,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
     {
         $command = $this->createCommand();
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -230,7 +230,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
     {
         $command = $this->createCommand();
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([

--- a/tests/Command/Inspector/WatchCommandIntegrationTest.php
+++ b/tests/Command/Inspector/WatchCommandIntegrationTest.php
@@ -96,7 +96,7 @@ class WatchCommandIntegrationTest extends BaseTestCase
         /** @var WatchCommand $command */
         $command = $container->get(WatchCommand::class);
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -162,7 +162,7 @@ class WatchCommandIntegrationTest extends BaseTestCase
         /** @var WatchCommand $command */
         $command = $container->get(WatchCommand::class);
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         $tester->execute([
@@ -253,7 +253,7 @@ class WatchCommandIntegrationTest extends BaseTestCase
         /** @var WatchCommand $command */
         $command = $container->get(WatchCommand::class);
         $app = new Application();
-        $app->add($command);
+        $app->addCommand($command);
 
         $tester = new CommandTester($command);
         // No triggers specified — should fail before PID resolution


### PR DESCRIPTION
## Summary

- `symfony/console` 6.4.36 → ^8.0
- `brianium/paratest` 7.14.2 → ^7.20 (first paratest version supporting both symfony/console v8 and phpunit 12)
- Replace `Application::add()` → `Application::addCommand()` in `reli` bootstrap (the only API removal that hit us)

## Why

PHP 8.5 is now the minimum (#614), so symfony/console v8's PHP 8.2+ requirement no longer conflicts. Closes Renovate #373 in practice — we can go directly to v8 rather than pinning to 6.4 LTS.

## Surface review

The symfony/console API surface used by reli is narrow (Command, InputInterface/InputOption/InputArgument, OutputInterface, BufferedOutput, Application, Question, QuestionHelper, CommandTester). All of those remained source-compatible v6 → v8 except the single removed method above.

## Test plan

- [x] local phpunit unit suite (2891 tests, 0 errors)
- [x] local psalm (0 errors)
- [x] local phpcs (clean)
- [x] `php reli list` sanity
- [ ] CI full matrix