### PR TITLE
Silence PHP 8.5 test deprecations and warnings

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -555,6 +555,14 @@ jobs:
           mkdir -p build/logs
           docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
 
+      - name: Upload test trace log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reli-test-trace-${{ matrix.targets }}-arm64
+          path: /tmp/reli-test/reli-test-trace.log
+          if-no-files-found: ignore
+
       - name: Fix coverage paths from Docker container
         run: sed -i 's|/app/|${{ github.workspace }}/|g' build/logs/clover.xml
 

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -47,7 +47,7 @@ final class MemoryDumpInspectCommand extends Command
         /** @var string $dump_file */
         $dump_file = $input->getArgument('dump-file');
 
-        $fp = fopen($dump_file, 'rb');
+        $fp = @fopen($dump_file, 'rb');
         if ($fp === false) {
             throw new \RuntimeException("failed to open file: {$dump_file}");
         }

--- a/src/Inspector/Settings/InspectorSettingsException.php
+++ b/src/Inspector/Settings/InspectorSettingsException.php
@@ -31,7 +31,7 @@ abstract class InspectorSettingsException extends \Exception
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Inspector/Watch/DiskUsageTracker.php
+++ b/src/Inspector/Watch/DiskUsageTracker.php
@@ -45,7 +45,7 @@ final class DiskUsageTracker
 
     public function recordFile(string $path): void
     {
-        $size = filesize($path);
+        $size = @filesize($path);
         if ($size !== false) {
             $this->total_bytes += $size;
         }

--- a/src/Lib/PhpInternals/Types/Zend/ZendArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendArray.php
@@ -128,7 +128,7 @@ class ZendArray implements CDataDereferencable
     public function findByKey(
         Dereferencer $dereferencer,
         string $key,
-        int $hash = null
+        ?int $hash = null
     ): ?Bucket {
         if ($this->arData === null) {
             return null;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
@@ -94,11 +94,16 @@ final class FfiIntSet
 
     private function hash(int $key): int
     {
-        // Mix bits for better distribution of sequential addresses
-        $key = (($key >> 16) ^ $key) * 0x45d9f3b;
-        $key = (($key >> 16) ^ $key) * 0x45d9f3b;
+        // Fold the high 32 bits into the low word so that the
+        // multiplications below stay within 64-bit int range.
+        // Without this PHP would silently promote the product to a
+        // float when the key has bits above 2^31 (any real pointer),
+        // which emits an E_WARNING on PHP 8.4+.
+        $key = (($key >> 32) ^ $key) & 0xFFFFFFFF;
+        $key = ((($key >> 16) ^ $key) * 0x45d9f3b) & 0xFFFFFFFF;
+        $key = ((($key >> 16) ^ $key) * 0x45d9f3b) & 0xFFFFFFFF;
         $key = ($key >> 16) ^ $key;
-        return $key & 0x7FFFFFFFFFFFFFFF; // ensure positive
+        return $key & 0x7FFFFFFF;
     }
 
     private function allocate(int $capacity): void

--- a/tests/Converter/BinaryTrace/BinaryTraceRoundTripTest.php
+++ b/tests/Converter/BinaryTrace/BinaryTraceRoundTripTest.php
@@ -175,7 +175,7 @@ final class BinaryTraceRoundTripTest extends BaseTestCase
         $writer->flushPendingRun();
         $pos_after_one_sample = ftell($stream);
 
-        $sample_only_size = $pos_after_second - $pos_after_first;
+        $sample_only_size = $pos_after_one_sample - $pos_after_defs;
         $this->assertLessThanOrEqual(5, $sample_only_size, 'Repeated sample should be 2-5 bytes');
 
         fclose($stream);

--- a/tests/Inspector/Daemon/Dispatcher/DispatchTableTest.php
+++ b/tests/Inspector/Daemon/Dispatcher/DispatchTableTest.php
@@ -45,15 +45,13 @@ class DispatchTableTest extends BaseTestCase
         $worker_pool->expects()->getFreeWorker()->andReturns($worker2);
         $worker_pool->expects()->getFreeWorker()->andReturns($worker3);
         $worker_pool->expects()->getFreeWorker()->andReturns(null);
-        $gen = $dispatch_table->updateTargets(
+        $dispatch_table->updateTargets(
             new TargetProcessList(
                 new TargetProcessDescriptor(1, 0, 0, ZendTypeReader::V80),
                 new TargetProcessDescriptor(2, 0, 0, ZendTypeReader::V80),
                 new TargetProcessDescriptor(3, 0, 0, ZendTypeReader::V80),
             )
         );
-        foreach ($gen as $item) {
-        }
         $attached_first = $attached;
         sort($attached);
         $this->assertSame([1, 2, 3], $attached);

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/DiskBackedStringDictTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/DiskBackedStringDictTest.php
@@ -184,11 +184,9 @@ class DiskBackedStringDictTest extends TestCase
     private function seekBackingFile(int $offset): void
     {
         $diskPos = new \ReflectionProperty(DiskBackedStringDict::class, 'diskPos');
-        $diskPos->setAccessible(true);
         $diskPos->setValue($this->dict, $offset);
 
         $diskFh = new \ReflectionProperty(DiskBackedStringDict::class, 'diskFh');
-        $diskFh->setAccessible(true);
         $fh = $diskFh->getValue($this->dict);
         fseek($fh, $offset);
     }

--- a/tests/Inspector/Watch/Daemon/Worker/IntermittentMemoryReader.php
+++ b/tests/Inspector/Watch/Daemon/Worker/IntermittentMemoryReader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Watch\Daemon\Worker;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use FFI\CData;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -36,7 +37,7 @@ final class IntermittentMemoryReader implements MemoryReaderInterface
             throw new MemoryReaderException('simulated intermittent failure');
         }
         // Return a zeroed buffer
-        $buf = FFI::new("uint8_t[$size]");
+        $buf = FFIHelper::new("uint8_t[$size]");
         assert($buf instanceof CData);
         return $buf;
     }

--- a/tests/Lib/ByteStream/ByteReaderDisableWriteAccessTraitTest.php
+++ b/tests/Lib/ByteStream/ByteReaderDisableWriteAccessTraitTest.php
@@ -25,14 +25,14 @@ class ByteReaderDisableWriteAccessTraitTest extends BaseTestCase
         $instance = new class implements ArrayAccess {
             use ByteReaderDisableWriteAccessTrait;
 
-            public function offsetGet($offset)
+            public function offsetGet($offset): mixed
             {
                 return 0xDEADBEAF;
             }
 
-            public function offsetExists($offset)
+            public function offsetExists($offset): bool
             {
-                false;
+                return false;
             }
         };
         $instance[0] = 1;
@@ -44,14 +44,14 @@ class ByteReaderDisableWriteAccessTraitTest extends BaseTestCase
         $instance = new class implements ArrayAccess {
             use ByteReaderDisableWriteAccessTrait;
 
-            public function offsetGet($offset)
+            public function offsetGet($offset): mixed
             {
                 return 0xDEADBEAF;
             }
 
-            public function offsetExists($offset)
+            public function offsetExists($offset): bool
             {
-                false;
+                return false;
             }
         };
         unset($instance[0]);

--- a/tests/Lib/ByteStream/CDataByteReaderTest.php
+++ b/tests/Lib/ByteStream/CDataByteReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\ByteStream;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use Reli\BaseTestCase;
 
 class CDataByteReaderTest extends BaseTestCase
@@ -21,7 +22,7 @@ class CDataByteReaderTest extends BaseTestCase
     public function testRead()
     {
         /** @var \FFI\CArray<int> $cdata_array */
-        $cdata_array = FFI::new('unsigned char[3]');
+        $cdata_array = FFIHelper::new('unsigned char[3]');
         $cdata_array[0] = 1;
         $cdata_array[1] = 2;
         $cdata_array[2] = 3;
@@ -34,7 +35,7 @@ class CDataByteReaderTest extends BaseTestCase
     public function testWrite()
     {
         /** @var \FFI\CArray<int> $cdata_array */
-        $cdata_array = FFI::new('unsigned char[3]');
+        $cdata_array = FFIHelper::new('unsigned char[3]');
         $reader = new CDataByteReader($cdata_array);
         $this->expectException(\LogicException::class);
         $reader[0] = 0;
@@ -43,7 +44,7 @@ class CDataByteReaderTest extends BaseTestCase
     public function testOffsetExists()
     {
         /** @var \FFI\CArray<int> $cdata_array */
-        $cdata_array = FFI::new('unsigned char[3]');
+        $cdata_array = FFIHelper::new('unsigned char[3]');
         $cdata_array[0] = 1;
         $reader = new CDataByteReader($cdata_array);
         $this->assertTrue(isset($reader[0]));
@@ -53,7 +54,7 @@ class CDataByteReaderTest extends BaseTestCase
     public function testCreateSliceAsString()
     {
         /** @var \FFI\CArray<int> $cdata_array */
-        $cdata_array = FFI::new('unsigned char[4]');
+        $cdata_array = FFIHelper::new('unsigned char[4]');
         $cdata_array[0] = ord('a');
         $cdata_array[1] = ord('b');
         $cdata_array[2] = ord('c');

--- a/tests/Lib/ByteStream/ProcessMemoryByteReaderTest.php
+++ b/tests/Lib/ByteStream/ProcessMemoryByteReaderTest.php
@@ -16,6 +16,7 @@ namespace Reli\Lib\ByteStream;
 use Reli\BaseTestCase;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\FFI\FFIHelper;
 
 class ProcessMemoryByteReaderTest extends BaseTestCase
 {
@@ -35,7 +36,7 @@ class ProcessMemoryByteReaderTest extends BaseTestCase
 
     public function testOffsetGet()
     {
-        $buffer = \FFI::new('unsigned char[8192]');
+        $buffer = FFIHelper::new('unsigned char[8192]');
         $buffer[0] = 0xde;
         $buffer[1] = 0xad;
         $buffer[2] = 0xbe;
@@ -71,7 +72,7 @@ class ProcessMemoryByteReaderTest extends BaseTestCase
 
     public function testOffsetGetFirstPageNotAlignedToBufferSize()
     {
-        $buffer = \FFI::new('unsigned char[8192]');
+        $buffer = FFIHelper::new('unsigned char[8192]');
         $buffer[0] = 0xde;
         $buffer[1] = 0xad;
         $buffer[2] = 0xbe;
@@ -95,7 +96,7 @@ class ProcessMemoryByteReaderTest extends BaseTestCase
 
     public function testCreateSliceAsString()
     {
-        $buffer = \FFI::new('unsigned char[8192]');
+        $buffer = FFIHelper::new('unsigned char[8192]');
         $buffer[0] = 0xde;
         $buffer[1] = 0xad;
         $buffer[2] = 0xbe;

--- a/tests/Lib/Dwarf/DwarfExpressionTest.php
+++ b/tests/Lib/Dwarf/DwarfExpressionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Dwarf;
 
 use Reli\BaseTestCase;
+use Reli\Lib\FFI\FFIHelper;
 
 class DwarfExpressionTest extends BaseTestCase
 {
@@ -356,7 +357,7 @@ class DwarfExpressionTest extends BaseTestCase
             \Reli\Lib\Process\MemoryReader\MemoryReaderInterface::class
         );
         // DW_OP_constu(0x2000) DW_OP_deref → read 8 bytes from 0x2000
-        $eight_bytes = \FFI::new('unsigned char[8]');
+        $eight_bytes = FFIHelper::new('unsigned char[8]');
         // Little-endian 0x42
         $eight_bytes[0] = 0x42;
         for ($i = 1; $i < 8; $i++) {
@@ -387,7 +388,7 @@ class DwarfExpressionTest extends BaseTestCase
         $memory_reader = \Mockery::mock(
             \Reli\Lib\Process\MemoryReader\MemoryReaderInterface::class
         );
-        $four_bytes = \FFI::new('unsigned char[4]');
+        $four_bytes = FFIHelper::new('unsigned char[4]');
         $four_bytes[0] = 0x78;
         $four_bytes[1] = 0x56;
         $four_bytes[2] = 0x34;

--- a/tests/Lib/Dwarf/JitCodeReaderTest.php
+++ b/tests/Lib/Dwarf/JitCodeReaderTest.php
@@ -16,6 +16,7 @@ namespace Reli\Lib\Dwarf;
 use Mockery;
 use Reli\BaseTestCase;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\FFI\FFIHelper;
 
 class JitCodeReaderTest extends BaseTestCase
 {
@@ -34,7 +35,7 @@ class JitCodeReaderTest extends BaseTestCase
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         // Simulate: jit_descriptor.first_entry = 0 (no JIT code registered)
-        $zero_bytes = \FFI::new('unsigned char[8]');
+        $zero_bytes = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $zero_bytes[$i] = 0;
         }
@@ -53,7 +54,7 @@ class JitCodeReaderTest extends BaseTestCase
     public function testFindFdeEmptyReturnsNull(): void
     {
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
-        $zero = \FFI::new('unsigned char[8]');
+        $zero = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $zero[$i] = 0;
         }
@@ -70,7 +71,7 @@ class JitCodeReaderTest extends BaseTestCase
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
 
         // First read gets first_entry pointer (non-zero)
-        $ptr_bytes = \FFI::new('unsigned char[8]');
+        $ptr_bytes = FFIHelper::new('unsigned char[8]');
         $ptr_bytes[0] = 0x00;
         $ptr_bytes[1] = 0x10;
         for ($i = 2; $i < 8; $i++) {
@@ -106,7 +107,7 @@ class JitCodeReaderTest extends BaseTestCase
         $zero = $this->makePointerBytes(0);
 
         // Non-ELF data (not starting with 0x7f ELF)
-        $garbage = \FFI::new('unsigned char[64]');
+        $garbage = FFIHelper::new('unsigned char[64]');
         for ($i = 0; $i < 64; $i++) {
             $garbage[$i] = 0xAA;
         }
@@ -151,7 +152,7 @@ class JitCodeReaderTest extends BaseTestCase
      */
     private function makePointerBytes(int $value): \FFI\CData
     {
-        $bytes = \FFI::new('unsigned char[8]');
+        $bytes = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $bytes[$i] = ($value >> ($i * 8)) & 0xff;
         }

--- a/tests/Lib/Dwarf/NativeStackUnwinderTest.php
+++ b/tests/Lib/Dwarf/NativeStackUnwinderTest.php
@@ -19,6 +19,7 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\FFI\FFIHelper;
 
 class NativeStackUnwinderTest extends BaseTestCase
 {
@@ -229,7 +230,7 @@ class NativeStackUnwinderTest extends BaseTestCase
 
         // The unwinder will try to read return address from CFA
         // Mock: return 0 (will stop unwinding)
-        $zero_bytes = \FFI::new('unsigned char[8]');
+        $zero_bytes = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $zero_bytes[$i] = 0;
         }
@@ -271,7 +272,7 @@ class NativeStackUnwinderTest extends BaseTestCase
         }
 
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
-        $zero_bytes = \FFI::new('unsigned char[8]');
+        $zero_bytes = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $zero_bytes[$i] = 0;
         }
@@ -325,7 +326,7 @@ class NativeStackUnwinderTest extends BaseTestCase
 
         // Simulate frame pointer chain:
         // [rbp] = saved_rbp, [rbp+8] = return_address
-        $saved_rbp_bytes = \FFI::new('unsigned char[8]');
+        $saved_rbp_bytes = FFIHelper::new('unsigned char[8]');
         // saved_rbp = 0x7fff0100 (higher than current rbp)
         $saved_rbp_bytes[0] = 0x00;
         $saved_rbp_bytes[1] = 0x01;
@@ -335,7 +336,7 @@ class NativeStackUnwinderTest extends BaseTestCase
             $saved_rbp_bytes[$i] = 0;
         }
 
-        $ret_addr_bytes = \FFI::new('unsigned char[8]');
+        $ret_addr_bytes = FFIHelper::new('unsigned char[8]');
         // return address = 0x400100
         $ret_addr_bytes[0] = 0x00;
         $ret_addr_bytes[1] = 0x01;
@@ -344,7 +345,7 @@ class NativeStackUnwinderTest extends BaseTestCase
             $ret_addr_bytes[$i] = 0;
         }
 
-        $zero_bytes = \FFI::new('unsigned char[8]');
+        $zero_bytes = FFIHelper::new('unsigned char[8]');
         for ($i = 0; $i < 8; $i++) {
             $zero_bytes[$i] = 0;
         }

--- a/tests/Lib/Elf/Process/BinaryFingerprintCreatorTest.php
+++ b/tests/Lib/Elf/Process/BinaryFingerprintCreatorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Elf\Process;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use Mockery;
 use Reli\BaseTestCase;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMapInterface;
@@ -35,7 +36,7 @@ class BinaryFingerprintCreatorTest extends BaseTestCase
     private function createCdata(string $bytes): FFI\CData
     {
         $len = strlen($bytes);
-        $cdata = FFI::new("unsigned char[{$len}]");
+        $cdata = FFIHelper::new("unsigned char[{$len}]");
         for ($i = 0; $i < $len; $i++) {
             $cdata[$i] = ord($bytes[$i]);
         }

--- a/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
+++ b/tests/Lib/Elf/Process/ProcessModuleSymbolReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Elf\Process;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use Mockery;
 use Reli\BaseTestCase;
 use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
@@ -64,7 +65,7 @@ class ProcessModuleSymbolReaderTest extends BaseTestCase
             ->getBaseAddress()
             ->andReturns(new UInt64(0, 0))
         ;
-        $return = FFI::new('unsigned char[8]');
+        $return = FFIHelper::new('unsigned char[8]');
         $memory_reader = Mockery::mock(MemoryReaderInterface::class);
         $memory_reader->expects()->read(1, 0x10001000, 8)->andReturns($return);
 

--- a/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
+++ b/tests/Lib/Elf/Tls/LibThreadDbTlsFinderTest.php
@@ -21,16 +21,17 @@ use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\System\Architecture;
+use Reli\Lib\FFI\FFIHelper;
 
 class LibThreadDbTlsFinderTest extends BaseTestCase
 {
     public function testFindTls()
     {
         $symbol_reader = Mockery::mock(ProcessSymbolReaderInterface::class);
-        $_thread_db_pthread_dtvp = \FFI::new('unsigned char[12]');
-        $_thread_db_dtv_dtv = \FFI::new('unsigned char[12]');
-        $_thread_db_dtv_t_pointer_val = \FFI::new('unsigned char[12]');
-        $_thread_db_link_map_l_tls_modid = \FFI::new('unsigned char[12]');
+        $_thread_db_pthread_dtvp = FFIHelper::new('unsigned char[12]');
+        $_thread_db_dtv_dtv = FFIHelper::new('unsigned char[12]');
+        $_thread_db_dtv_t_pointer_val = FFIHelper::new('unsigned char[12]');
+        $_thread_db_link_map_l_tls_modid = FFIHelper::new('unsigned char[12]');
         \FFI::memset($_thread_db_pthread_dtvp, 0, 12);
         \FFI::memset($_thread_db_dtv_dtv, 0, 12);
         \FFI::memset($_thread_db_dtv_t_pointer_val, 0, 12);
@@ -49,13 +50,13 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
         $thread_pointer_retriever = Mockery::mock(ThreadPointerRetrieverInterface::class);
         $thread_pointer_retriever->expects()->getThreadPointer(1)->andReturns(0x10000);
 
-        $dtv_address = \FFI::new('unsigned char[8]');
+        $dtv_address = FFIHelper::new('unsigned char[8]');
         \FFI::memset($dtv_address, 0, 8);
         $dtv_address[2] = 2;
-        $tls_block_address = \FFI::new('unsigned char[8]');
+        $tls_block_address = FFIHelper::new('unsigned char[8]');
         \FFI::memset($tls_block_address, 0, 8);
         $tls_block_address[2] = 3;
-        $module_id = \FFI::new('unsigned char[4]');
+        $module_id = FFIHelper::new('unsigned char[4]');
         \FFI::memset($module_id, 0, 4);
         $module_id[0] = 1;
 
@@ -137,9 +138,9 @@ class LibThreadDbTlsFinderTest extends BaseTestCase
      */
     public static function casesDebugSymbolsFoundOrNot(): array
     {
-        $_thread_db_pthread_dtvp = \FFI::new('unsigned char[12]');
-        $_thread_db_dtv_dtv = \FFI::new('unsigned char[12]');
-        $_thread_db_dtv_t_pointer_val = \FFI::new('unsigned char[12]');
+        $_thread_db_pthread_dtvp = FFIHelper::new('unsigned char[12]');
+        $_thread_db_dtv_dtv = FFIHelper::new('unsigned char[12]');
+        $_thread_db_dtv_t_pointer_val = FFIHelper::new('unsigned char[12]');
         \FFI::memset($_thread_db_pthread_dtvp, 0, 12);
         \FFI::memset($_thread_db_dtv_dtv, 0, 12);
         \FFI::memset($_thread_db_dtv_t_pointer_val, 0, 12);

--- a/tests/Lib/PhpInternals/Types/Zend/ZendStringTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendStringTest.php
@@ -17,12 +17,13 @@ use Reli\BaseTestCase;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\PhpInternals\Types\C\RawString;
 use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\FFI\FFIHelper;
 
 class ZendStringTest extends BaseTestCase
 {
     public function testValues(): void
     {
-        $string_addr = \FFI::addr($buf = \FFI::new('char[16]'));
+        $string_addr = \FFI::addr($buf = FFIHelper::new('char[16]'));
         $zend_string = new ZendString(
             new CastedCData(
                 new class () {
@@ -43,14 +44,14 @@ class ZendStringTest extends BaseTestCase
         $this->assertSame(123, $zend_string->h);
         $this->assertSame(234, $zend_string->len);
         $this->assertSame(
-            \FFI::cast('long', $string_addr)->cdata,
+            FFIHelper::cast('long', $string_addr)->cdata,
             $zend_string->val->address
         );
     }
 
     public function testGetValuePointer(): void
     {
-        $string_addr = \FFI::addr($buf = \FFI::new('char[16]'));
+        $string_addr = \FFI::addr($buf = FFIHelper::new('char[16]'));
         $zend_string = new ZendString(
             new CastedCData(
                 new class () {

--- a/tests/Lib/PhpInternals/ZendTypeReaderTest.php
+++ b/tests/Lib/PhpInternals/ZendTypeReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpInternals;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use Reli\BaseTestCase;
 
 class ZendTypeReaderTest extends BaseTestCase
@@ -22,7 +23,7 @@ class ZendTypeReaderTest extends BaseTestCase
     {
         $reader = new ZendTypeReader(ZendTypeReader::V74);
         $string_size = $reader->sizeOf('zend_string');
-        $data = FFI::new("char[{$string_size}]");
+        $data = FFIHelper::new("char[{$string_size}]");
         FFI::memset($data, 0, $string_size);
         /** @var CastedCData<FFI\PhpInternals\zend_string> $string */
         $string = $reader->readAs('zend_string', $data);

--- a/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
+++ b/tests/Lib/PhpProcessReader/PhpGlobalsFinderTest.php
@@ -32,6 +32,9 @@ use Reli\Lib\Process\ProcessSpecifier;
 
 class PhpGlobalsFinderTest extends BaseTestCase
 {
+    /** @var resource|false */
+    private $child;
+
     public function testFindModuleRegistry()
     {
         $memory_reader = new MemoryReader();

--- a/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpVersionDetectorTest.php
@@ -32,6 +32,9 @@ use Reli\Lib\Process\ProcessSpecifier;
 
 class PhpVersionDetectorTest extends BaseTestCase
 {
+    /** @var resource|false */
+    private $child;
+
     public function testDetectVersion()
     {
         $memory_reader = new MemoryReader();

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Process\MemoryReader;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -189,8 +190,10 @@ class BufferedMemoryReaderTest extends TestCase
         FFI::memcpy($region1, 'AAAABBBB', 8);
         FFI::memcpy($region2, 'CCCCDDDD', 8);
 
-        $addr1 = FFI::cast('long', FFI::addr($region1))->cdata;
-        $addr2 = FFI::cast('long', FFI::addr($region2))->cdata;
+        $region1_ptr = FFI::addr($region1);
+        $region2_ptr = FFI::addr($region2);
+        $addr1 = FFIHelper::cast('long', $region1_ptr)->cdata;
+        $addr2 = FFIHelper::cast('long', $region2_ptr)->cdata;
 
         // Scatter-gather: read both regions in one syscall
         $buffered->prefetchScatterGather($pid, [
@@ -230,7 +233,8 @@ class BufferedMemoryReaderTest extends TestCase
         $region = $ffi->new('unsigned char[4]');
         assert($region !== null);
         FFI::memcpy($region, 'NEW!', 4);
-        $addr = FFI::cast('long', FFI::addr($region))->cdata;
+        $region_ptr = FFI::addr($region);
+        $addr = FFIHelper::cast('long', $region_ptr)->cdata;
 
         $buffered->prefetchScatterGather($pid, [
             ['address' => $addr, 'size' => 4],

--- a/tests/Lib/Process/MemoryReader/MockMemoryReader.php
+++ b/tests/Lib/Process/MemoryReader/MockMemoryReader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Process\MemoryReader;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 
 /**
  * @internal test helper
@@ -35,7 +36,7 @@ class MockMemoryReader implements MemoryReaderInterface
         $this->readCount++;
         $key = $remote_address . ':' . $size;
         $bytes = $this->data[$key] ?? str_repeat("\0", $size);
-        $buf = FFI::new("char[$size]");
+        $buf = FFIHelper::new("char[$size]");
         assert($buf !== null);
         FFI::memcpy($buf, $bytes, $size);
         /** @var \FFI\CArray<int> */

--- a/tests/Lib/Process/MemoryReader/RecordingMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/RecordingMemoryReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Process\MemoryReader;
 
 use FFI;
+use Reli\Lib\FFI\FFIHelper;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -35,7 +36,7 @@ class RecordingMemoryReaderTest extends TestCase
             {
                 $key = $remote_address . ':' . $size;
                 $bytes = $this->data[$key] ?? str_repeat("\0", $size);
-                $buf = FFI::new("char[$size]");
+                $buf = FFIHelper::new("char[$size]");
                 assert($buf !== null);
                 FFI::memcpy($buf, $bytes, $size);
                 /** @var \FFI\CArray<int> */


### PR DESCRIPTION
## Summary

Clean up the test suite's tail on PHP 8.5. Before: `Tests: 2891, Warnings: 24, Deprecations: 50, Notices: 3`. After: `Tests: 2891, 0 Warnings, 0 Deprecations, 0 Notices`.

## Deprecations

- `FFI::new()` / `FFI::cast()` static calls → route through the existing `FFIHelper` (already used in src/).
- Dynamic-property creation on `PhpGlobalsFinderTest::$child` / `PhpVersionDetectorTest::$child`: declare the property.
- `Throwable $previous = null` → `?Throwable $previous = null` (InspectorSettingsException).
- `int $hash = null` → `?int $hash = null` (ZendArray::findByKey).
- `ReflectionProperty::setAccessible(true)`: drop — no-op since PHP 8.1, deprecated in PHP 8.5.
- ArrayAccess anonymous classes: add `offsetGet(): mixed` / `offsetExists(): bool`.

## Warnings

- `FfiIntSet::hash()`: pre-fold into the low 32 bits so the multiplications stay in PHP's int range and don't silently promote to float (the float→int cast was the source of 19/24 warnings).
- `DiskUsageTracker::recordFile()` / `MemoryDumpInspectCommand::execute()`: `@`-suppress `filesize()`/`fopen()` — both already branch on `false` and the E_WARNING only surfaced on intentional error paths.
- `BinaryTraceRoundTripTest`: fix stale `$pos_after_first/$pos_after_second` var names → `$pos_after_defs/$pos_after_one_sample`.
- `DispatchTableTest`: drop dead `foreach ($gen as $item)` over `void` return.

## Notices

- `BufferedMemoryReaderTest`: hoist `FFI::addr($region)` into a variable before passing to `FFIHelper::cast()` (by-ref parameter).

## Test plan

- [x] local phpunit unit suite: 2891 tests, 0 failures except pre-existing `TraceeExecutorTest::testExecute` (local ptrace permission, CI not affected)
- [x] local psalm 0 errors
- [x] local phpcs clean
- [ ] CI full matrix