### PR TITLE
Add post-mortem core dump analysis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Reli is a sampling profiler (or a VM state inspector) written in PHP. It can rea
 - [Variable inspection](docs/peek-var-command.md): read PHP variable values from a running process without modifying it
 - [Per-sample variable peek in traces](docs/trace-var-command.md): attach PHP variable values (request URI, user id, SQL query, ...) to each trace sample so you can join runtime state to hot stacks
 - [Sidecar daemon](docs/sidecar.md): run a daemon that accepts on-demand memory dump requests from PHP processes via Unix socket — no FFI needed in the application, ideal for memory_limit crash analysis and CI regression detection
+- [Post-mortem analysis from a core dump](docs/coredump.md): run the same memory analyzer against an ELF core file (from `gcore`, `systemd-coredump`, kernel `core_pattern`, ...) when the process has already died or when live attachment isn't possible
 
 ## How it works
 It's implemented by using following techniques:
@@ -387,7 +388,7 @@ Options:
 
 ```
 
-## [Experimental] Watch: Condition-Based Process Monitoring
+## Watch: Condition-Based Process Monitoring
 
 `inspector:watch` monitors PHP processes and triggers profiling actions when configurable conditions are met. It only takes action when triggers fire, making it suitable for low-overhead production monitoring.
 
@@ -419,7 +420,7 @@ Rate limiting: `--cooldown` (with exponential backoff), `--max-triggers-per-hour
 
 See [docs/watch-command.md](docs/watch-command.md) for full documentation.
 
-## [Experimental] Peek Variable: One-Shot Variable Inspection
+## Peek Variable: One-Shot Variable Inspection
 
 `inspector:peek-var` reads PHP variable values from a running process — no triggers or actions, just the current value.
 
@@ -438,7 +439,7 @@ Supported scopes: `global::$var`, `local::func()$var`, `static::Class::$prop`, `
 
 See [docs/peek-var-command.md](docs/peek-var-command.md) for full documentation.
 
-## [Experimental] Trace Var Peek: Per-Sample Variable Inspection in Traces
+## Trace Var Peek: Per-Sample Variable Inspection in Traces
 
 `inspector:trace --trace-var` attaches PHP variable values to every trace sample, so you can correlate runtime state (request URI, user id, SQL query, ...) with the hot stacks that produced it — no separate tool, no log join.
 

--- a/docs/coredump.md
+++ b/docs/coredump.md
@@ -1,0 +1,166 @@
+# Core dump inspection (`inspector:coredump`)
+
+`inspector:coredump` runs the same memory analysis as `inspector:memory`
+against an **ELF core file** instead of a live process. It's the
+post-mortem counterpart to the online analyzer, and a useful fallback
+when live dumping cannot be used.
+
+## When to use
+
+- **The process has already died**: you have a core file (from the
+  kernel `core_pattern`, `systemd-coredump`, Docker runtime dump,
+  cloud platform artifact, CI sidecar, etc.) but no live PID to attach
+  to.
+- **Live dump fails**: if `inspector:memory` / `inspector:memory:dump`
+  cannot attach (ptrace denied, sandboxed container, unusual glibc /
+  musl layout, ZTS TLS scan failing on an exotic target), taking a
+  core dump with a tool you already have (`gcore`, `kill -SIGSEGV`,
+  kernel-level dump) and feeding it to `inspector:coredump` is a
+  reliable workaround — it reads ELF notes and memory pages out of
+  the core file instead of going through `/proc/<pid>/mem`.
+- **Reproducing an incident from an archived dump**: core files are
+  portable. A dump taken in production can be analyzed later on a
+  dev machine, as long as the matching PHP binary and shared libraries
+  can be provided (see `--dependency-root`).
+
+For live analysis of a still-running process, use
+[`inspector:memory`](memory-profiler.md) or
+[`inspector:memory:dump`](memory-dump.md). For reuse of an analyzer
+output across tools, use the SQLite pipeline described in
+[memory-report.md](memory-report.md) and [rmem-explore-and-serve.md](rmem-explore-and-serve.md).
+
+## Quick start
+
+```bash
+# Take a non-destructive core dump of a live process
+$ sudo gcore -o /tmp/myapp 12345
+# → /tmp/myapp.12345
+
+# Run the memory analyzer against the core file
+$ php ./reli inspector:coredump /tmp/myapp.12345 --pid 12345 \
+    -f sqlite3 -o snapshot.db
+
+# Feed the output into the normal analysis pipeline
+$ php ./reli inspector:memory:report snapshot.db
+$ php ./reli inspector:rmem:explore snapshot.db
+```
+
+The output of `inspector:coredump` uses the same
+[`MemoryProfilerSettings`](../src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php)
+as `inspector:memory`, so every output format (`json`, `sqlite3`,
+`binary`, `mysql`, `postgresql`, `report`, `report-json`) and every
+downstream tool (`memory:report`, `memory:compare`, `rmem:explore`,
+`rmem:serve`) works the same way.
+
+## Arguments and options
+
+### Required
+
+| Argument / option | Description |
+|---|---|
+| `<core-file>` | Path to the ELF core file to read. |
+| `--pid, -p` | The PID the target process had **at the time of the dump**. This is used to resolve the binary / shared-library layout that matches the core. |
+
+### Core-file specific
+
+| Option | Description |
+|---|---|
+| `--dependency-root, -r` | Path prefix applied to every binary / shared-library path referenced by the core. Use this when the dump was taken inside a container or chroot and the PHP binary / libs are not at the same absolute path on the analysis host. For example, `-r /proc/<pid>/root` when the target container is still alive on the same host, or `-r /var/lib/docker/.../merged` / a locally extracted image root. |
+| `--memory-limit` | Set the analyzer's own `memory_limit` (e.g. `2G`). Core files can be large; the analyzer holds data structures proportional to the live heap. |
+| `--no-cache` | Disable the binary analysis cache (`~/.cache/reli/binary-analysis/`). Useful if you are analyzing a dump whose binary differs from one the cache already knows about. |
+
+### Target PHP options (same as other inspector commands)
+
+`--php-version`, `--php-regex`, `--libpthread-regex`,
+`--zts-globals-regex`, `--php-path`, `--libpthread-path` behave the
+same way as in `inspector:trace` / `inspector:memory`. Auto-detection
+usually works; override only if the binary layout inside the core
+differs from what reli can infer.
+
+### Output options (same as `inspector:memory`)
+
+`--output-format` / `-f`, `--output` / `-o`, `--pretty-print`,
+`--db-host`, `--db-port`, `--db-name`, `--db-user`, `--db-password`,
+`--memory-limit-error-file`, `--memory-limit-error-line`,
+`--memory-limit-error-max-depth` — see
+[memory-profiler.md](memory-profiler.md) for full semantics.
+
+## Taking a core dump
+
+Any tool that produces a standard ELF core will work. A few common
+options:
+
+- **`gcore` (from gdb)** — non-destructive, the target keeps running:
+
+  ```bash
+  sudo gcore -o /tmp/myapp <pid>
+  ```
+
+- **Signal-based** — for a crash-repro workflow:
+
+  ```bash
+  kill -SIGSEGV <pid>        # process dies, kernel writes a core
+  ```
+
+  Make sure `ulimit -c` and `/proc/sys/kernel/core_pattern` are set
+  so that the core actually lands somewhere you can read.
+
+- **`systemd-coredump`** — on systems that route cores to the journal:
+
+  ```bash
+  coredumpctl dump <pid-or-unit> --output=/tmp/core
+  ```
+
+- **Containerized / production artifact** — many orchestrators capture
+  a core on OOM-kill or segfault automatically; consult your platform.
+
+### Include enough memory in the dump
+
+The analyzer needs to read back PHP heap chunks, the VM stack, and
+several read-only segments of the binary for symbol resolution. The
+kernel's per-process `coredump_filter` controls which VMAs end up in
+the core. For live captures via `gcore`, set it to `0x7f` to include
+private + shared + file-backed + ELF-header pages before dumping:
+
+```bash
+echo 0x7f | sudo tee /proc/<pid>/coredump_filter
+sudo gcore -o /tmp/myapp <pid>
+```
+
+See `man 5 core` for the full bitmask.
+
+## Limitations
+
+- **NTS targets only** today. For ZTS PHP 8.2+, `_tsrm_ls_cache` is
+  not in `.dynsym` on stripped binaries and is resolved via a
+  brute-force TLS scan on the live process. That scan cannot always
+  be reproduced against a core file, so ZTS post-mortem analysis is
+  currently best-effort. (See
+  `tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php`
+  for the current skip condition.)
+- **Dependencies must be available**: the analyzer resolves symbols
+  from the PHP binary and linked shared objects. If the analysis host
+  doesn't have the same files at the paths the core references, use
+  `--dependency-root` to point at a directory that does (e.g. a
+  locally extracted container root filesystem).
+- **Core must contain the relevant memory pages**. A dump taken with
+  a restrictive `coredump_filter` may be missing pages the analyzer
+  needs; it will report an error or produce a partial result.
+- **Status**: still marked `[experimental]`; output schema and CLI
+  are stable in practice but may evolve alongside the rest of the
+  memory pipeline.
+
+## See also
+
+- [`inspector:memory`](memory-profiler.md) — the live-process
+  equivalent. Output format and downstream pipeline are shared.
+- [`inspector:memory:dump`](memory-dump.md) — reli's own compact
+  `.relimem` dump format for offline analysis; prefer it over
+  `gcore + inspector:coredump` when the target is still alive and
+  reli can attach.
+- [`inspector:memory:report`](memory-report.md) — generate an
+  automated analysis report from the output.
+- [`inspector:rmem:explore`](rmem-explore-and-serve.md) — interactive
+  TUI over the SQLite output.
+- [`gcore` comparison](internals/memory-dump-vs-gcore.md) — internals
+  note on trade-offs between reli's native dump and ELF core files.

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -119,7 +119,7 @@ And the output is like below. The target process is [psalm](https://github.com/v
             "cached_chunks_size": 0,
             "heap_memory_analyzed_percentage": 98.36809784842008,
             "php_version": "v82",
-            "analyzer": "reli 0.9.0"
+            "analyzer": "reli 0.12.0"
         }
     ],
     "location_types_summary": {


### PR DESCRIPTION
## Summary
This PR adds support for analyzing ELF core dumps via a new `inspector:coredump` command, enabling post-mortem memory analysis when live process attachment is not possible.

## Key Changes

- **New command**: `inspector:coredump` performs the same memory analysis as `inspector:memory` but against ELF core files instead of live processes
- **Comprehensive documentation**: Added `docs/coredump.md` with:
  - Use cases (dead processes, live dump failures, archived dumps)
  - Quick start guide with `gcore` example
  - Full argument/option reference
  - Core dump capture methods and best practices
  - Known limitations (NTS-only, dependency availability, memory page requirements)
  - Cross-references to related tools
- **README updates**:
  - Added core dump analysis to feature list
  - Removed `[Experimental]` tag from `inspector:watch` and `inspector:peek-var` (now stable)
  - Updated version reference in memory profiler example (0.9.0 → 0.12.0)

## Implementation Details

The new command reuses existing `MemoryProfilerSettings` infrastructure, ensuring all output formats (`json`, `sqlite3`, `binary`, `mysql`, `postgresql`, `report`, `report-json`) and downstream tools (`memory:report`, `memory:compare`, `rmem:explore`, `rmem:serve`) work identically to the live analyzer.

Core-file-specific options include:
- `--pid` (required): PID at time of dump for binary/library layout resolution
- `--dependency-root`: Path prefix for binaries/libraries when dump was taken in container/chroot
- `--memory-limit`: Analyzer's own memory limit for large core files
- `--no-cache`: Disable binary analysis cache when analyzing different binaries

The implementation reads ELF notes and memory pages directly from the core file, providing a reliable fallback when ptrace-based live attachment fails.

https://claude.ai/code/session_01BhkpxioC3Kw1gmg2DZGgDe