### PR TITLE
Drop [experimental] from memory analysis commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,11 +343,11 @@ Options:
   -o, --output=OUTPUT                          output file path (default: stdout)
 ```
 
-## [Experimental] Dump the memory usage of the target process
+## Dump the memory usage of the target process
 ```bash
 ./reli inspector:memory --help
 Description:
-  [experimental] get memory usage from an outer process
+  get memory usage from an outer process
 
 Usage:
   inspector:memory [options] [--] [<cmd> [<args>...]]
@@ -706,9 +706,6 @@ See [docs/binary-trace-format.md](docs/binary-trace-format.md) for the full spec
 
 > [!CAUTION]
 > **Don't upload the output of this command to the internet, because it can contain sensitive information of the target script!!!**
-
-> [!WARNING]  
-> This feature is in an experimental stage and may be less stable than others. The contents of the output may change in the near future.
 
 ```bash
 $ sudo php ./reli i:memory -p 2183131 >2183131.memory_dump.json

--- a/docs/coredump.md
+++ b/docs/coredump.md
@@ -146,9 +146,6 @@ See `man 5 core` for the full bitmask.
 - **Core must contain the relevant memory pages**. A dump taken with
   a restrictive `coredump_filter` may be missing pages the analyzer
   needs; it will report an error or produce a partial result.
-- **Status**: still marked `[experimental]`; output schema and CLI
-  are stable in practice but may evolve alongside the rest of the
-  memory pipeline.
 
 ## See also
 

--- a/docs/memory-profiler.md
+++ b/docs/memory-profiler.md
@@ -49,7 +49,7 @@ docker run -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=h
 ```bash
 ./reli inspector:memory --help
 Description:
-  [experimental] get memory usage from an outer process
+  get memory usage from an outer process
 
 Usage:
   inspector:memory [options] [--] [<cmd> [<args>...]]
@@ -83,9 +83,6 @@ Options:
 # Usage
 > [!CAUTION]
 > **Don't upload the output of this command to the internet, because it can contain sensitive information of the target script!!!**
-
-> [!WARNING]  
-> This feature is in an experimental stage and may be less stable than others. The contents of the output may change in the near future.
 
 This tool can be used like this.
 

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -49,7 +49,7 @@ final class CoreDumpCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:coredump')
-            ->setDescription('[experimental] get memory usage from an outer process')
+            ->setDescription('get memory usage from a core dump file')
         ;
         $this->memory_profiler_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -38,7 +38,7 @@ final class MemoryAnalyzeCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:memory:analyze')
-            ->setDescription('[experimental] analyze a memory dump file created by inspector:memory:dump')
+            ->setDescription('analyze a memory dump file created by inspector:memory:dump')
         ;
         $this->memory_profiler_settings_from_console_input->setOptions($this);
         $this->addArgument(

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -54,7 +54,7 @@ final class MemoryCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:memory')
-            ->setDescription('[experimental] get memory usage from an outer process')
+            ->setDescription('get memory usage from an outer process')
         ;
         $this->memory_profiler_settings_from_console_input->setOptions($this);
         $this->target_process_settings_from_console_input->setOptions($this);

--- a/src/Command/Inspector/MemoryCompareCommand.php
+++ b/src/Command/Inspector/MemoryCompareCommand.php
@@ -35,7 +35,7 @@ final class MemoryCompareCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:memory:compare')
-            ->setDescription('[experimental] compare two memory snapshot SQLite databases')
+            ->setDescription('compare two memory snapshot SQLite databases')
         ;
         $this->addArgument(
             'baseline',

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -26,7 +26,7 @@ final class MemoryDbOptimizeCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:optimize-memory-db')
-            ->setDescription('[experimental] materialize node_paths in a memory analysis SQLite database')
+            ->setDescription('materialize node_paths in a memory analysis SQLite database')
             ->addArgument(
                 'db-path',
                 InputArgument::REQUIRED,

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -51,7 +51,7 @@ final class MemoryDumpCommand extends Command
     {
         $this->setName('inspector:memory:dump')
             ->setDescription(
-                '[experimental] dump memory pool from a PHP process'
+                'dump memory pool from a PHP process'
                     . ' for offline analysis'
             )
         ;

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -32,7 +32,7 @@ final class MemoryDumpInspectCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:memory:dump:inspect')
-            ->setDescription('[experimental] inspect a memory dump file header, memory map, and regions')
+            ->setDescription('inspect a memory dump file header, memory map, and regions')
         ;
         $this->addArgument(
             'dump-file',

--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -32,7 +32,7 @@ final class MemoryReportCommand extends Command
     public function configure(): void
     {
         $this->setName('inspector:memory:report')
-            ->setDescription('[experimental] generate analysis report from a memory snapshot SQLite database')
+            ->setDescription('generate analysis report from a memory snapshot SQLite database')
         ;
         $this->addArgument(
             'db-file',


### PR DESCRIPTION
## Summary

- The memory pipeline (`inspector:memory`, `memory:dump`, `memory:analyze`, `memory:report`, `memory:compare`, `memory:dump:inspect`, `optimize-memory-db`, `coredump`) has been used enough in practice that the `[experimental]` hedge no longer reflects reality. Removed it from every `setDescription()` and from the matching README / `docs/memory-profiler.md` headings, embedded `--help` blocks, and the "may be less stable than others" WARNING banner.
- AArch64 platform notes stay marked experimental — that part is still accurate.
- Bonus cleanup: `inspector:coredump`'s description was a copy-paste of `inspector:memory`'s (`get memory usage from an outer process`). It actually reads a core dump file, so corrected to `get memory usage from a core dump file`.

## Test plan

- [x] `./reli list` and `./reli inspector:memory --help` no longer show `[experimental]` in descriptions
- [x] `./reli inspector:coredump --help` shows the corrected wording
- [x] Existing test suites still pass (no tests asserted the `[experimental]` string; verified via grep)
- [x] README "Dump the memory usage of the target process" section renders without the WARNING banner but keeps the CAUTION about sensitive data

https://claude.ai/code/session_01BhkpxioC3Kw1gmg2DZGgDe