### PR TITLE
docs: add task-oriented docs index, slim README Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Reli is a sampling profiler (or a VM state inspector) written in PHP. It can read information about running PHP script from outside of the process. It's a stand alone CLI tool, so target programs don't need any modifications. The former name of this tool was sj-i/php-profiler. 
 
+Looking for a specific task? Jump to the [documentation index](docs/README.md) — it maps "I want to X" to the right command and doc.
+
 ## What can I use this for?
 - Detecting and visualizing bottlenecks in PHP scripts
   - It provides not only at the function level of profiling but also at line level or opcode level resolution, and even native C-level stack traces from the interpreter itself
@@ -129,264 +131,83 @@ composer install
 ```
 
 ## Usage
+
+For a task-oriented map of every command, see [docs/README.md](docs/README.md).
+Every subsection below shows a canonical invocation plus the most commonly used flags.
+Run `./reli <command> --help` for the complete option list — the CLI help is the source of truth.
+
 ### Get call traces
+Sample a running process, or spawn one and sample it:
+
 ```bash
-./reli inspector:trace --help
-Description:
-  periodically get call trace from an outer process or thread
+# Attach to a running process
+sudo php ./reli inspector:trace -p <pid>
 
-Usage:
-  inspector:trace [options] [--] [<cmd> [<args>...]]
+# Spawn and trace a new process
+./reli inspector:trace -- php script.php
 
-Arguments:
-  cmd                                        command to execute as a target: either pid (via -p/--pid) or cmd must be specified
-  args                                       command line arguments for cmd
-
-Options:
-  -p, --pid=PID                                process id
-  -O, --child-stdout=CHILD-STDOUT              write child process stdout to the specified path
-  -E, --child-stderr=CHILD-STDERR              write child process stderr to the specified path
-  -d, --depth[=DEPTH]                          max depth
-      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
-      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
-  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
-  -t, --template[=TEMPLATE]                    template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
-  -o, --output=OUTPUT                          path to write output from this tool (default: stdout)
-      --no-cache                               disable the binary analysis cache
-  -h, --help                                   Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                  Do not output any message
-  -V, --version                                Display this application version
-      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                         Do not ask any interactive question
-  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+# Capture to compact binary format (recommended for later analysis)
+sudo php ./reli inspector:trace -p <pid> -F rbt -o trace.rbt
 ```
+
+Key options: `-d/--depth`, `-s/--sleep-ns`, `-S/--stop-process`, `-t/--template=phpspy|phpspy_with_opcode|json_lines`, `-F/--output-format=rbt|rbt-bundled`, `-o/--output`, `--with-native-trace`, `--trace-var`.
 
 ### Daemon mode
+Concurrently trace every process whose command line matches a regex (e.g. an FPM pool):
+
 ```bash
-./reli inspector:daemon --help
-Description:
-  concurrently get call traces from processes whose command-lines match a given regex
-
-Usage:
-  inspector:daemon [options]
-
-Options:
-  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
-  -T, --threads[=THREADS]                      number of workers (default: 8)
-  -d, --depth[=DEPTH]                          max depth
-      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
-      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
-  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
-  -t, --template[=TEMPLATE]                    template name (phpspy|phpspy_with_opcode|json_lines) (default: phpspy)
-  -o, --output=OUTPUT                          path to write output from this tool (default: stdout)
-      --no-cache                               disable the binary analysis cache
-  -h, --help                                   Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                  Do not output any message
-  -V, --version                                Display this application version
-      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                         Do not ask any interactive question
-  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+sudo php ./reli inspector:daemon -P "^php-fpm" -F rbt -o /path/to/output_dir/
 ```
+
+Key options: `-P/--target-regex` (required), `-T/--threads`, `-d/--depth`, `-s/--sleep-ns`, `-F/--output-format`, `-o/--output`, `--with-native-trace`, `--trace-var`.
 
 ### top-like mode
+Real-time aggregated view across matching processes, in the spirit of UNIX `top`:
+
 ```bash
-./reli inspector:top --help
-Description:
-  show an aggregated view of traces in real time in a form similar to the UNIX top command.
-
-Usage:
-  inspector:top [options]
-
-Options:
-  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
-  -T, --threads[=THREADS]                      number of workers (default: 8)
-  -d, --depth[=DEPTH]                          max depth
-      --with-native-trace                      collect native (C-level) stack traces alongside PHP traces
-      --native-trace-anytime                   collect native traces even when PHP trace is unavailable (e.g. during init, shutdown)
-  -s, --sleep-ns[=SLEEP-NS]                    nanoseconds between traces (default: 1000 * 1000 * 10)
-  -r, --max-retries[=MAX-RETRIES]              max retries on contiguous errors of read (default: 10)
-  -S, --stop-process[=STOP-PROCESS]            stop the target process while reading its trace (default: off)
-      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                               disable the binary analysis cache
-  -h, --help                                   Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                  Do not output any message
-  -V, --version                                Display this application version
-      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                         Do not ask any interactive question
-  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+sudo php ./reli inspector:top -P "^php-fpm"
 ```
 
+Key options: `-P/--target-regex` (required), `-T/--threads`, `-d/--depth`, `-s/--sleep-ns`, `--with-native-trace`.
+
 ### Get the address of EG
+Useful for feeding phpspy manually, or for advanced integrations:
+
 ```bash
-./reli inspector:eg --help
-Description:
-  get EG address from an outer process or thread
-
-Usage:
-  inspector:eg_address [options] [--] [<cmd> [<args>...]]
-
-Arguments:
-  cmd                                        command to execute as a target: either pid (via -p/--pid) or cmd must be specified
-  args                                       command line arguments for cmd
-
-Options:
-  -p, --pid=PID                                process id
-  -O, --child-stdout=CHILD-STDOUT              write child process stdout to the specified path
-  -E, --child-stderr=CHILD-STDERR              write child process stderr to the specified path
-      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                               disable the binary analysis cache
-  -h, --help                                   Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                  Do not output any message
-  -V, --version                                Display this application version
-      --ansi|--no-ansi                         Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                         Do not ask any interactive question
-  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+$ sudo php ./reli inspector:eg -p <pid>
+0x555ae7825d80
 ```
 
 ### Hybrid phpspy mode
-Reli can use [phpspy](https://github.com/adsr/phpspy) as the tracing backend while handling EG address resolution (including ZTS). This combines phpspy's fast C-based tracing with reli's ZTS support.
+Reli can use [phpspy](https://github.com/adsr/phpspy) as the fast C-based tracing backend while letting reli resolve the EG address (including for ZTS targets, which phpspy alone cannot handle).
 
-#### Install phpspy
 ```bash
-./reli phpspy:install --help
-Description:
-  install or check phpspy binary
+# Install phpspy (builds from source, installs to ~/.reli/bin/phpspy by default)
+./reli phpspy:install
 
-Usage:
-  phpspy:install [options]
+# Single-process tracing
+sudo php ./reli phpspy:trace -p <pid>
 
-Options:
-      --check                      only check if phpspy is installed, do not install
-      --install-path=INSTALL-PATH  install location (default: ~/.reli/bin/phpspy)
-      --phpspy-path=PHPSPY-PATH    path to an existing phpspy binary to check
-  -h, --help                       Display help for the given command. When no command is given display help for the list command
+# Multi-process daemon
+sudo php ./reli phpspy:daemon -P "^php-fpm"
 ```
 
-#### Single process tracing with phpspy
-```bash
-./reli phpspy:trace --help
-Description:
-  get call traces using phpspy as the tracer backend (reli resolves EG address for ZTS support, then delegates tracing to phpspy)
-
-Usage:
-  phpspy:trace [options] [--] [<cmd> [<args>...]]
-
-Arguments:
-  cmd                                          command to execute as a target: either pid (via -p/--pid) or cmd must be specified
-  args                                         command line arguments for cmd
-
-Options:
-  -p, --pid=PID                                process id
-  -O, --child-stdout=CHILD-STDOUT              write child process stdout to the specified path
-  -E, --child-stderr=CHILD-STDERR              write child process stderr to the specified path
-  -d, --depth[=DEPTH]                          max depth
-      --php-regex[=PHP-REGEX]                  regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]    regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]  regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]              php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                    path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]      path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --phpspy-path=PHPSPY-PATH                path to the phpspy binary
-  -s, --sleep-ns[=SLEEP-NS]                    phpspy sleep between samples in nanoseconds (default: 10101010)
-  -b, --buffer-size[=BUFFER-SIZE]              phpspy buffer size (default: 4096)
-  -H, --rate-hz[=RATE-HZ]                      phpspy sampling rate in Hz (default: 99)
-      --phpspy-args=PHPSPY-ARGS                extra arguments to pass to phpspy
-      --no-cache                               disable the binary analysis cache
-  -o, --output=OUTPUT                          output file path (default: stdout)
-```
-
-#### Multi-process daemon mode with phpspy
-```bash
-./reli phpspy:daemon --help
-Description:
-  concurrently get call traces from multiple processes using phpspy as the tracer backend (reli resolves EG addresses for ZTS support, then delegates tracing to phpspy)
-
-Usage:
-  phpspy:daemon [options]
-
-Options:
-  -P, --target-regex=TARGET-REGEX              regex to find target processes which have matching command-line (required)
-  -T, --threads[=THREADS]                      number of workers (default: 8)
-  -d, --depth[=DEPTH]                          max depth
-      --phpspy-path=PHPSPY-PATH                path to the phpspy binary
-  -s, --sleep-ns[=SLEEP-NS]                    phpspy sleep between samples in nanoseconds (default: 10101010)
-  -b, --buffer-size[=BUFFER-SIZE]              phpspy buffer size (default: 4096)
-  -H, --rate-hz[=RATE-HZ]                      phpspy sampling rate in Hz (default: 99)
-      --phpspy-args=PHPSPY-ARGS                extra arguments to pass to phpspy
-      --no-cache                               disable the binary analysis cache
-  -o, --output=OUTPUT                          output file path (default: stdout)
-```
+Key `phpspy:trace` / `phpspy:daemon` options: `-s/--sleep-ns`, `-b/--buffer-size`, `-H/--rate-hz`, `--phpspy-args` (passthrough to phpspy), `--phpspy-path`, `-o/--output`.
 
 ## Dump the memory usage of the target process
+Run the memory analyser against a live PHP process. The output feeds the rest of the memory pipeline (`memory:report`, `rmem:explore`, `memory:compare`).
+
 ```bash
-./reli inspector:memory --help
-Description:
-  get memory usage from an outer process
+# Save to SQLite (recommended for large heaps; feeds rmem:explore and memory:report)
+sudo php ./reli inspector:memory -p <pid> -f sqlite3 -o snapshot.db
 
-Usage:
-  inspector:memory [options] [--] [<cmd> [<args>...]]
-
-Arguments:
-  cmd                                                                command to execute as a target: either pid (via -p/--pid) or cmd must be specified
-  args                                                               command line arguments for cmd
-
-Options:
-      --stop-process|--no-stop-process                               stop the process while inspecting (default: on)
-      --pretty-print|--no-pretty-print                               pretty print the result (default: off)
-  -f, --output-format=OUTPUT-FORMAT                                  output format (json, sqlite3, mysql, postgresql) [default: "json"]
-  -o, --output=OUTPUT                                                output file path (required for sqlite3 format)
-      --db-host=DB-HOST                                              database host (for mysql/postgresql) [default: "127.0.0.1"]
-      --db-port=DB-PORT                                              database port (for mysql/postgresql)
-      --db-name=DB-NAME                                              database name (for mysql/postgresql)
-      --db-user=DB-USER                                              database user (for mysql/postgresql)
-      --db-password=DB-PASSWORD                                      database password (for mysql/postgresql)
-      --memory-usage-error-file=MEMORY-LIMIT-ERROR-FILE              file path where memory_limit is exceeded
-      --memory-usage-error-line=MEMORY-LIMIT-ERROR-LINE              line number where memory_limit is exceeded
-      --memory-usage-error-max-depth[=MEMORY-LIMIT-ERROR-MAX-DEPTH]  max attempts to trace back the VM stack on memory_limit error [default: 512]
-  -p, --pid=PID                                                      process id
-  -O, --child-stdout=CHILD-STDOUT                                    write child process stdout to the specified path
-  -E, --child-stderr=CHILD-STDERR                                    write child process stderr to the specified path
-      --php-regex[=PHP-REGEX]                                        regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]                          regex to find the libpthread.so loaded in the target process
-      --zts-globals-regex[=ZTS-GLOBALS-REGEX]                        regex to find the binary containing globals symbols for ZTS loaded in the target process
-      --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                                          path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]                            path to the libpthread.so (only needed in tracing chrooted ZTS target)
-      --no-cache                                                     disable the binary analysis cache
-  -h, --help                                                         Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                                        Do not output any message
-  -V, --version                                                      Display this application version
-      --ansi|--no-ansi                                               Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                                               Do not ask any interactive question
-  -v|vv|vvv, --verbose                                               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
+# Original JSON + jq workflow
+sudo php ./reli inspector:memory -p <pid> -f json >snapshot.json
 ```
+
+Key options: `-f/--output-format=json|sqlite3|binary|mysql|postgresql|report|report-json`, `-o/--output`, `--stop-process/--no-stop-process`, `--pretty-print`, `--db-host`/`--db-port`/`--db-name`/`--db-user`/`--db-password`, `--memory-usage-error-file`/`--memory-usage-error-line`.
+
+See [docs/memory-profiler.md](docs/memory-profiler.md) for the full memory pipeline, [docs/memory-dump.md](docs/memory-dump.md) for the offline `inspector:memory:dump` flow, and [docs/coredump.md](docs/coredump.md) for post-mortem analysis from a core file.
 
 ## Watch: Condition-Based Process Monitoring
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,36 +36,27 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
 
-## Produce a memory graph
+## Capture memory graphs
 
-reli reads a running PHP process's memory and reconstructs it as a **memory graph** — values (objects, arrays, strings, call frames...) as nodes, references between them as edges. The graph is stored as SQLite (the default; every analyser below reads this), JSON (for `jq`-based ad-hoc inspection), or an inline findings report.
-
-The pipeline has two stages:
-
-1. **Dump** — copy the target's raw memory. Fast; the target is only stopped for as long as the copy takes.
-2. **Build** — walk those bytes as PHP internals to reconstruct the graph. When done against a live target, the target stays stopped for the whole walk.
-
-`inspector:memory:dump` does pure dump (writes a portable `.relimem` file). `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` do the build — they run the same heap walk against three memory sources (a live process, a `.relimem` file, or an ELF core file).
-
-**In production, dump now and build later.** `inspector:memory:dump` finishes in a fraction of the time a full `inspector:memory` run would, so the target stays responsive. `inspector:memory` fuses both stages into one command at the cost of a longer stop — convenient for ad-hoc local inspection or small heaps.
+A memory graph is reli's PHP heap reconstruction — values (objects, arrays, strings, call frames) as nodes, references as edges. Analysing a live process stops the target until the heap walk finishes; dumping the raw memory does not. **In production, dump now and analyse later.**
 
 | I want to... | Use | More |
 |---|---|---|
-| Dump now (short stop), build the graph offline **(recommended)** | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
-| Build from a live process in one step (longer stop) | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
-| Build from a core file (crashed / post-mortem) | `inspector:coredump` | [coredump.md](coredump.md) |
+| Dump now (short stop), analyse offline **(recommended)** | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| One-shot live capture (longer stop, one command) | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
+| From a core file (crashed / post-mortem) | `inspector:coredump` | [coredump.md](coredump.md) |
 
-Tip: pass `-f json` to any build command for `jq`-friendly output, or `-f report` to go straight to a prioritised findings report.
+Tip: pass `-f json` or `-f report` to any of the above for alternative output.
 
-## Analyse a memory graph
+## Analyse memory graphs
 
 | I want to... | Use | More |
 |---|---|---|
 | Browse interactively in a TUI **(recommended)** | `inspector:rmem:explore snap.db` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
 | Get a prioritised findings report | `inspector:memory:report snap.db` (or capture with `-f report`) | [memory-report.md](memory-report.md) |
-| Compare two snapshots (regression / leak tracking) | `inspector:memory:compare before.db after.db` | [memory-report.md](memory-report.md) |
-| Query a snapshot's SQL directly | `inspector:rmem:serve` or open the SQLite file | [rmem-explore-and-serve.md](rmem-explore-and-serve.md), [memory-profiler-database.md](memory-profiler-database.md) |
-| Let an AI assistant explore a snapshot | `inspector:rmem:mcp` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
+| Compare two graphs (regression / leak tracking) | `inspector:memory:compare before.db after.db` | [memory-report.md](memory-report.md) |
+| Query a graph's SQL directly | `inspector:rmem:serve` or open the SQLite file | [rmem-explore-and-serve.md](rmem-explore-and-serve.md), [memory-profiler-database.md](memory-profiler-database.md) |
+| Let an AI assistant explore a graph | `inspector:rmem:mcp` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
 
 ## Monitor production
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,84 @@
+# Reli documentation
+
+A task-oriented index. Start here if you know what you want to do but
+don't know which command (or which doc) to reach for. Everything in
+this file links out to a dedicated doc or a section of the top-level
+[README](../README.md).
+
+## Getting started
+
+- Install and first run — [README § Installation](../README.md#installation)
+- How it works (architecture overview) — [README § How it works](../README.md#how-it-works)
+- Supported PHP versions and platforms — [README § Requirements](../README.md#requirements)
+
+## Profile CPU
+
+| I want to... | Use | More |
+|---|---|---|
+| Attach to a running process | `inspector:trace -p <pid>` | [README § Get call traces](../README.md#get-call-traces) |
+| Capture to a compact binary file for later analysis **(recommended)** | `inspector:trace -p <pid> -F rbt -o trace.rbt` | [binary-trace-format.md](binary-trace-format.md) |
+| Trace many processes at once (e.g. a php-fpm pool) | `inspector:daemon -P <regex>` | [README § Daemon mode](../README.md#daemon-mode) |
+| Live `top`-style aggregation | `inspector:top -P <regex>` | [README § top-like mode](../README.md#top-like-mode) |
+| Include C-level frames | add `--with-native-trace` | [README § Collect native stack traces](../README.md#collect-native-c-level-stack-traces) |
+| See the executing opcode at each sample | add `--template=phpspy_with_opcode` | [README § opcodes](../README.md#show-currently-executing-opcodes-at-traces) |
+| Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
+| Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
+
+## Analyse CPU traces
+
+| I want to... | Use | More |
+|---|---|---|
+| Browse interactively in the terminal **(recommended)** | `rbt:explore trace.rbt` | [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) |
+| One-shot text report (hot frames, callers/callees, live tail) | `rbt:analyze trace.rbt` | [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) |
+| Convert to speedscope / pprof / flamegraph / callgrind / folded | `converter:<format>` | [binary-trace-format.md](binary-trace-format.md) |
+| Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
+| Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
+
+## Profile memory / find leaks
+
+| I want to... | Use | More |
+|---|---|---|
+| Live snapshot → interactive explorer **(recommended)** | `inspector:memory -f sqlite3 -o snap.db` then `inspector:rmem:explore snap.db` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
+| Prioritised findings report | `inspector:memory:report snap.db` (or `inspector:memory -f report`) | [memory-report.md](memory-report.md) |
+| Capture once, analyse later / on another machine | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Compare two snapshots (regression / leak tracking) | `inspector:memory:compare before.db after.db` | [memory-report.md](memory-report.md) |
+| Analyse a crashed process from its core file | `inspector:coredump` | [coredump.md](coredump.md) |
+| Query a snapshot's SQL directly | `inspector:rmem:serve` or open the SQLite file | [rmem-explore-and-serve.md](rmem-explore-and-serve.md), [memory-profiler-database.md](memory-profiler-database.md) |
+| Let an AI assistant explore a snapshot | `inspector:rmem:mcp` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
+| Use the original JSON + `jq` workflow | `inspector:memory -f json` | [memory-profiler.md](memory-profiler.md) |
+
+## Monitor production
+
+| I want to... | Use | More |
+|---|---|---|
+| Trigger an action when memory / a function / a variable condition matches | `inspector:watch` | [watch-command.md](watch-command.md) |
+| Accept on-demand memory dumps from the app over a Unix socket | `inspector:sidecar` | [sidecar.md](sidecar.md) |
+
+## Inspect runtime variables
+
+| I want to... | Use | More |
+|---|---|---|
+| Read a variable once (or poll it) | `inspector:peek-var` | [peek-var-command.md](peek-var-command.md) |
+| Attach a variable to every sample in a trace | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
+
+## Advanced / tooling
+
+| I want to... | Use | More |
+|---|---|---|
+| Just get the EG address (e.g. to feed phpspy manually) | `inspector:eg -p <pid>` | [README § Get the address of EG](../README.md#get-the-address-of-eg) |
+| Install phpspy | `phpspy:install` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
+| Clear or bypass the binary analysis cache | `cache:clear`, `--no-cache` | [README § Binary analysis cache](../README.md#binary-analysis-cache) |
+
+## Platform notes
+
+- Alpine / musl libc — [internals/alpine-investigation.md](internals/alpine-investigation.md)
+- AArch64 (ARM64, experimental) — [internals/aarch64-support.md](internals/aarch64-support.md)
+
+## Internals / design notes
+
+[internals/](internals/) collects architecture notes, design docs, and
+post-mortem investigations — FFI CData lifetime, trace consistency,
+memory analysis performance, rmem serve design, watch command
+architecture, and others. Read these when you want to understand
+*why* reli is shaped the way it is, or when hacking on the
+internals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Tip: pass `-f json` or `-f report` to any of the above for alternative output.
 | Query a graph's SQL directly | `inspector:rmem:serve` or open the SQLite file | [rmem-explore-and-serve.md](rmem-explore-and-serve.md), [memory-profiler-database.md](memory-profiler-database.md) |
 | Let an AI assistant explore a graph | `inspector:rmem:mcp` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
 
-## Monitor production
+## Monitor VMs
 
 | I want to... | Use | More |
 |---|---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,14 +38,17 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 
 ## Produce memory snapshots
 
-A snapshot is the analysable form of a PHP heap (SQLite by default, optionally JSON or an inline findings report). Production has two stages: **capture** raw memory, then **build** the heap graph from it. `inspector:memory:dump` is pure capture — it writes a portable `.relimem` file without analysing. `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` all do the build; they do the same heap walk and differ only in where memory is read from — a live process, a `.relimem` dump, or an ELF core file.
+A snapshot is the analysable form of a PHP heap — SQLite by default, optionally JSON or an inline findings report. Production has two stages: **capture** raw memory, then **build** the heap graph from it. `inspector:memory:dump` is pure capture — a quick raw-memory copy that writes a portable `.relimem` file. `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` all do the build; they run the same heap walk against three heap sources (a live process, a `.relimem` dump, or an ELF core file).
+
+Because the build stops the target for as long as the heap walk takes, **dump now and build later is the kindest choice in production** — `inspector:memory:dump` finishes in a fraction of the time a full analysis would. `inspector:memory` fuses both stages into one command at the cost of a longer stop; use it for ad-hoc local inspection or small heaps.
 
 | I want to... | Use | More |
 |---|---|---|
-| Capture + build from a live process (one step) **(recommended)** | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
-| Capture now (portable `.relimem`), build later | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Capture now (short stop), build the snapshot later **(recommended)** | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Capture + build in one step (longer stop, one command) | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
 | Build from a core file (crashed / post-mortem) | `inspector:coredump` | [coredump.md](coredump.md) |
-| JSON output for `jq`-based ad-hoc inspection | `inspector:memory -p <pid> -f json` | [memory-profiler.md](memory-profiler.md) |
+
+Tip: pass `-f json` to any build command for `jq`-friendly output, or `-f report` to go straight to a prioritised findings report.
 
 ## Analyse memory snapshots
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,21 +36,28 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
 
-## Produce memory snapshots
+## Produce a memory graph
 
-A snapshot is the analysable form of a PHP heap — SQLite by default, optionally JSON or an inline findings report. Production has two stages: **capture** raw memory, then **build** the heap graph from it. `inspector:memory:dump` is pure capture — a quick raw-memory copy that writes a portable `.relimem` file. `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` all do the build; they run the same heap walk against three heap sources (a live process, a `.relimem` dump, or an ELF core file).
+reli reads a running PHP process's memory and reconstructs it as a **memory graph** — values (objects, arrays, strings, call frames...) as nodes, references between them as edges. The graph is stored as SQLite (the default; every analyser below reads this), JSON (for `jq`-based ad-hoc inspection), or an inline findings report.
 
-Because the build stops the target for as long as the heap walk takes, **dump now and build later is the kindest choice in production** — `inspector:memory:dump` finishes in a fraction of the time a full analysis would. `inspector:memory` fuses both stages into one command at the cost of a longer stop; use it for ad-hoc local inspection or small heaps.
+The pipeline has two stages:
+
+1. **Dump** — copy the target's raw memory. Fast; the target is only stopped for as long as the copy takes.
+2. **Build** — walk those bytes as PHP internals to reconstruct the graph. When done against a live target, the target stays stopped for the whole walk.
+
+`inspector:memory:dump` does pure dump (writes a portable `.relimem` file). `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` do the build — they run the same heap walk against three memory sources (a live process, a `.relimem` file, or an ELF core file).
+
+**In production, dump now and build later.** `inspector:memory:dump` finishes in a fraction of the time a full `inspector:memory` run would, so the target stays responsive. `inspector:memory` fuses both stages into one command at the cost of a longer stop — convenient for ad-hoc local inspection or small heaps.
 
 | I want to... | Use | More |
 |---|---|---|
-| Capture now (short stop), build the snapshot later **(recommended)** | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
-| Capture + build in one step (longer stop, one command) | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
+| Dump now (short stop), build the graph offline **(recommended)** | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Build from a live process in one step (longer stop) | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
 | Build from a core file (crashed / post-mortem) | `inspector:coredump` | [coredump.md](coredump.md) |
 
 Tip: pass `-f json` to any build command for `jq`-friendly output, or `-f report` to go straight to a prioritised findings report.
 
-## Analyse memory snapshots
+## Analyse a memory graph
 
 | I want to... | Use | More |
 |---|---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
 
-## Capture memory graphs
+## Capture memory graphs (where memory is used)
 
 A memory graph is reli's PHP heap reconstruction — values (objects, arrays, strings, call frames) as nodes, references as edges. Analysing a live process stops the target until the heap walk finishes; dumping the raw memory does not. **In production, dump now and analyse later.**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,14 +36,16 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
 
-## Capture memory snapshots
+## Produce memory snapshots
+
+A snapshot is the analysable form of a PHP heap (SQLite by default, optionally JSON or an inline findings report). Production has two stages: **capture** raw memory, then **build** the heap graph from it. `inspector:memory:dump` is pure capture — it writes a portable `.relimem` file without analysing. `inspector:memory`, `inspector:memory:analyze`, and `inspector:coredump` all do the build; they do the same heap walk and differ only in where memory is read from — a live process, a `.relimem` dump, or an ELF core file.
 
 | I want to... | Use | More |
 |---|---|---|
-| Snapshot a live process to SQLite **(recommended)** | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
-| Capture once, analyse later / on another machine | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
-| Capture from a crashed process (core file) | `inspector:coredump` | [coredump.md](coredump.md) |
-| Capture as JSON (for `jq`-based ad-hoc inspection) | `inspector:memory -p <pid> -f json` | [memory-profiler.md](memory-profiler.md) |
+| Capture + build from a live process (one step) **(recommended)** | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
+| Capture now (portable `.relimem`), build later | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Build from a core file (crashed / post-mortem) | `inspector:coredump` | [coredump.md](coredump.md) |
+| JSON output for `jq`-based ad-hoc inspection | `inspector:memory -p <pid> -f json` | [memory-profiler.md](memory-profiler.md) |
 
 ## Analyse memory snapshots
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,9 @@ this file links out to a dedicated doc or a section of the top-level
 - How it works (architecture overview) — [README § How it works](../README.md#how-it-works)
 - Supported PHP versions and platforms — [README § Requirements](../README.md#requirements)
 
-## Profile CPU
+## Capture call traces
+
+Reli samples the call stack on a timer, so each trace reflects what the VM is doing over wall-clock time — including I/O, lock waits, and sleeps, not just on-CPU work.
 
 | I want to... | Use | More |
 |---|---|---|
@@ -24,7 +26,7 @@ this file links out to a dedicated doc or a section of the top-level
 | Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
 | Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
 
-## Analyse CPU traces
+## Analyse call traces
 
 | I want to... | Use | More |
 |---|---|---|
@@ -34,18 +36,24 @@ this file links out to a dedicated doc or a section of the top-level
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |
 
-## Profile memory / find leaks
+## Capture memory snapshots
 
 | I want to... | Use | More |
 |---|---|---|
-| Live snapshot → interactive explorer **(recommended)** | `inspector:memory -f sqlite3 -o snap.db` then `inspector:rmem:explore snap.db` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
-| Prioritised findings report | `inspector:memory:report snap.db` (or `inspector:memory -f report`) | [memory-report.md](memory-report.md) |
+| Snapshot a live process to SQLite **(recommended)** | `inspector:memory -p <pid> -f sqlite3 -o snap.db` | [memory-profiler.md](memory-profiler.md) |
 | Capture once, analyse later / on another machine | `inspector:memory:dump` → `inspector:memory:analyze` | [memory-dump.md](memory-dump.md) |
+| Capture from a crashed process (core file) | `inspector:coredump` | [coredump.md](coredump.md) |
+| Capture as JSON (for `jq`-based ad-hoc inspection) | `inspector:memory -p <pid> -f json` | [memory-profiler.md](memory-profiler.md) |
+
+## Analyse memory snapshots
+
+| I want to... | Use | More |
+|---|---|---|
+| Browse interactively in a TUI **(recommended)** | `inspector:rmem:explore snap.db` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
+| Get a prioritised findings report | `inspector:memory:report snap.db` (or capture with `-f report`) | [memory-report.md](memory-report.md) |
 | Compare two snapshots (regression / leak tracking) | `inspector:memory:compare before.db after.db` | [memory-report.md](memory-report.md) |
-| Analyse a crashed process from its core file | `inspector:coredump` | [coredump.md](coredump.md) |
 | Query a snapshot's SQL directly | `inspector:rmem:serve` or open the SQLite file | [rmem-explore-and-serve.md](rmem-explore-and-serve.md), [memory-profiler-database.md](memory-profiler-database.md) |
 | Let an AI assistant explore a snapshot | `inspector:rmem:mcp` | [rmem-explore-and-serve.md](rmem-explore-and-serve.md) |
-| Use the original JSON + `jq` workflow | `inspector:memory -f json` | [memory-profiler.md](memory-profiler.md) |
 
 ## Monitor production
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,9 @@ this file links out to a dedicated doc or a section of the top-level
 - How it works (architecture overview) — [README § How it works](../README.md#how-it-works)
 - Supported PHP versions and platforms — [README § Requirements](../README.md#requirements)
 
-## Capture call traces
+## Capture call traces (where time is spent)
 
-Reli samples the call stack on a timer, so each trace reflects what the VM is doing over wall-clock time — including I/O, lock waits, and sleeps, not just on-CPU work.
+Reli samples the call stack on a timer, so each trace reflects what the VM is doing over wall-clock time — including I/O, lock waits, and sleeps, not just on-CPU work. Aggregated across many samples, this shows where your code spends its time.
 
 | I want to... | Use | More |
 |---|---|---|
@@ -26,7 +26,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
 | Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
 
-## Analyse call traces
+## Analyse call traces (where time is spent)
 
 | I want to... | Use | More |
 |---|---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Trace many processes at once (e.g. a php-fpm pool) | `inspector:daemon -P <regex>` | [README § Daemon mode](../README.md#daemon-mode) |
 | Live `top`-style aggregation | `inspector:top -P <regex>` | [README § top-like mode](../README.md#top-like-mode) |
 | Include C-level frames | add `--with-native-trace` | [README § Collect native stack traces](../README.md#collect-native-c-level-stack-traces) |
-| See the executing opcode at each sample | add `--template=phpspy_with_opcode` | [README § opcodes](../README.md#show-currently-executing-opcodes-at-traces) |
+| See the opcode in phpspy text output (`.rbt` records it unconditionally) | `--template=phpspy_with_opcode` | [README § opcodes](../README.md#show-currently-executing-opcodes-at-traces) |
 | Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
 | Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
 
@@ -32,6 +32,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 |---|---|---|
 | Browse interactively in the terminal **(recommended)** | `rbt:explore trace.rbt` | [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) |
 | One-shot text report (hot frames, callers/callees, live tail) | `rbt:analyze trace.rbt` | [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) |
+| Show the opcode at each frame | `rbt:analyze --with-opcode`, or press `c` in `rbt:explore` | [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) |
 | Convert to speedscope / pprof / flamegraph / callgrind / folded | `converter:<format>` | [binary-trace-format.md](binary-trace-format.md) |
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [binary-trace-format.md](binary-trace-format.md) |
 | Recover a corrupted or truncated `.rbt` file | `rbt:recover` | [binary-trace-format.md](binary-trace-format.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
 | Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [trace-var-command.md](trace-var-command.md) |
 
-## Analyse call traces (where time is spent)
+## Analyse call traces
 
 | I want to... | Use | More |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Add `docs/README.md` as a task-oriented documentation index — "I want to X, which command and which doc?" tables covering CPU capture/analysis, memory profiling, production monitoring, variable inspection, and tooling, plus pointers to platform notes and internals. Linked from the top of the README so it's the first thing a new reader sees after the pitch.
- Slim the README's "Usage" section: eight consecutive `--help` dumps (258 lines) for `inspector:trace`, `inspector:daemon`, `inspector:top`, `inspector:eg_address`, `phpspy:install`, `phpspy:trace`, `phpspy:daemon`, and `inspector:memory` are replaced with:
  - one or two canonical invocations per command
  - a "Key options" line listing the flags people actually reach for
  - a pointer to `./reli <cmd> --help` as the source of truth
- Cross-link the memory section to the existing per-feature docs (`memory-profiler.md`, `memory-dump.md`, `coredump.md`) so readers can find the full pipeline from the README.

The `--help` dumps had already drifted from the real CLI (e.g. the trace dump didn't mention `-F/--output-format`, which has existed for a while); removing them makes the README easier to maintain because there's nothing to re-copy every time options change.

Net: README shrinks by ~180 lines (−235 / +56), while gaining a better entry point.

## Test plan

- [x] Render `docs/README.md` on GitHub — check all relative links resolve (per-doc, internals/, README § anchors)
- [ ] Render README.md — check the new "Usage" subsections still read as a self-contained quick reference
- [x] `./reli <cmd> --help` still prints accurate details for every command mentioned (the new text defers to `--help`, so accuracy is maintained automatically)
- [x] `docs/README.md` command names match `setName()` in src/ (spot-checked `inspector:sidecar`, `inspector:rmem:*`, `rbt:*`, `converter:*`, `phpspy:*`, `cache:clear`)

https://claude.ai/code/session_01BhkpxioC3Kw1gmg2DZGgDe