### PR TITLE
docs: reshape the README first screen (4-bullet capabilities, move background sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,93 +363,16 @@ You can pass extra phpspy flags via `--phpspy-args`:
 $ sudo php ./reli phpspy:trace -p <pid> --phpspy-args="-c -1"
 ```
 
-### Show currently executing opcodes at traces
-If a user wants to profile a really CPU-bound application, then he or she wouldn't only want to know what line is slow, but what opcode is.
-
-- **When capturing to `.rbt`**, the opcode is always recorded. Reveal it during analysis with `./reli rbt:analyze --with-opcode trace.rbt`, or press `c` inside `rbt:explore` to toggle the opcode column.
-- **For phpspy text output**, add `--template=phpspy_with_opcode` to `inspector:trace` or `inspector:daemon`:
-
-```bash
-$ sudo php ./reli i:trace --template=phpspy_with_opcode -p <pid of the target process or thread>
-```
-
-The output would be like the following.
-
-```
-0 <VM>::ZEND_ASSIGN <VM>:-1
-1 Mandelbrot::iterate /home/sji/work/test/mandelbrot.php:33:ZEND_ASSIGN
-2 Mandelbrot::__construct /home/sji/work/test/mandelbrot.php:12:ZEND_DO_FCALL
-3 <main> /home/sji/work/test/mandelbrot.php:45:ZEND_DO_FCALL
-
-0 <VM>::ZEND_ASSIGN <VM>:-1
-1 Mandelbrot::iterate /home/sji/work/test/mandelbrot.php:30:ZEND_ASSIGN
-2 Mandelbrot::__construct /home/sji/work/test/mandelbrot.php:12:ZEND_DO_FCALL
-3 <main> /home/sji/work/test/mandelbrot.php:45:ZEND_DO_FCALL
-```
-
-The currently executing opcode becomes the first frame of the callstack.
-So visualizations of the trace like flamegraph can show the usage of opcodes.
-
-For informational purposes, executing opcodes are also added to each end of the call frames. Except for the first frame, opcodes for function calls such as ZEND_DO_FCALL should appear there.
-
-If JIT is enabled at the target process, this information may be slightly inaccurate. To see JIT-compiled function names in traces, use `--with-native-trace` and set `opcache.jit_debug=0x10` on the target process.
-
 ### Use in a docker container and target a process on host
 ```bash
 $ docker pull reliforp/reli-prof
 $ docker run -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof i:trace -p <pid of the target process or thread>
 ```
 
-### Collect native (C-level) stack traces
-```bash
-$ sudo php ./reli i:trace --with-native-trace -p <pid>
-0 libc.so.6::clock_nanosleep+0x5a [native]:0
-1 libc.so.6::__nanosleep+0x17 [native]:0
-2 libc.so.6::usleep+0x4c [native]:0
-3 php8.4::zif_usleep+0x42 [native]:0
-4 usleep <internal>:-1
-5 <main> /app/test.php:15
-6 php8.4::execute_ex+0x4dfa [native]:0
-7 php8.4::zend_execute+0x141 [native]:0
-8 php8.4::zend_execute_script+0x56 [native]:0
-9 php8.4::php_execute_script_ex+0x278 [native]:0
-10 libc.so.6::__libc_start_main+0x8b [native]:0
-11 php8.4::_start+0x25 [native]:0
-```
+### Advanced capture: opcodes, native traces, JIT
+`inspector:trace` / `inspector:daemon` can also attach the executing Zend VM opcode, C-level native stack frames (`--with-native-trace`, with optional `--native-trace-anytime`), and JIT-compiled function names to every sample. These combine with any output format and with `--trace-var`.
 
-Native frames are labeled with `[native]:0` and show `module::symbol+offset`. PHP frames are placed on the callee side of `execute_ex`, reflecting that all PHP execution happens inside the VM's opcode dispatcher.
-
-`--with-native-trace` works with every output format. Capture to `.rbt` and drop into `rbt:explore` for interactive analysis of merged native+PHP traces, or convert to a flamegraph:
-```bash
-$ sudo php ./reli i:trace --with-native-trace -p <pid> -F rbt -o trace.rbt
-$ ./reli rbt:explore trace.rbt
-# ...or:
-$ ./reli converter:flamegraph <trace.rbt >flame_native.svg
-```
-
-Symbol resolution specifics:
-
-- **Stripped binaries** are supported — reli uses exported symbols from `.dynsym`.
-- **Separate debug symbol packages** (`-dbgsym` / `-debuginfo`) are loaded when available for full symbol coverage.
-- **JIT-compiled function names** resolve via `/tmp/perf-<pid>.map` when the target process has `opcache.jit_debug=0x10` (see the JIT-compiled code subsection below).
-
-### Collect native traces during interpreter initialization / shutdown
-```bash
-$ sudo php ./reli i:trace --native-trace-anytime -p <pid>
-```
-When `--native-trace-anytime` is used, native C-level traces are collected even when no PHP code is executing (e.g. during module initialization or shutdown). This is useful for investigating interpreter startup performance or extension loading behavior.
-
-### JIT-compiled code in native traces
-When the target PHP process has JIT enabled with `opcache.jit_debug=0x10`, JIT-compiled function names are resolved via `/tmp/perf-<pid>.map`:
-```bash
-$ php -d opcache.jit_debug=0x10 script.php &
-$ sudo php ./reli i:trace --with-native-trace -p $!
-0 [jit]::TRACE-2$fibonacci$4+0x141 [native]:0
-1 php8.4::zend_execute+0x141 [native]:0
-2 <main> /app/test.php:14
-```
-
-For DWARF-based unwinding through JIT frames, use `opcache.jit_debug=0x100` (GDB JIT interface).
+See [docs/tracing/advanced-capture.md](docs/tracing/advanced-capture.md) for the full walkthrough — opcode reveal in `.rbt` vs. phpspy text, DWARF unwinding, the `opcache.jit_debug` settings, Alpine/musl caveat.
 
 ### Convert traces to other formats
 `converter:*` reads both `.rbt` and phpspy text (auto-detected) and writes flamegraph SVG, speedscope, pprof, callgrind, folded stacks, or `.rbt`:
@@ -543,21 +466,18 @@ $ php ./reli inspector:memory:compare snapshot.db --run-id-baseline 1 --run-id-t
 The comparison report shows summary deltas, type breakdown deltas, per-class memory changes (added/removed/changed), and findings diff (new/resolved/changed issues). Use `--threshold 5` to filter changes smaller than 5%. See [docs/memory/memory-report.md](docs/memory/memory-report.md) for details.
 
 ## Binary analysis cache
-Reli caches the results of expensive binary analysis operations (ELF symbol resolution, TLS brute force offsets, PHP version detection, etc.) to disk. This dramatically speeds up repeated profiling of the same PHP binary -- for example, ZTS target initialization drops from ~8 seconds to ~5 milliseconds on warm cache.
 
-Cache files are stored under `~/.cache/reli/binary-analysis/` (following the XDG Base Directory specification), keyed by binary fingerprint (device ID + inode + ELF header content). In container environments, Docker's overlayfs can assign the same device ID and inode to different binaries across different images (e.g. `php:8.3` and `php:8.3-zts`), so the ELF header content is included to ensure different binaries always produce different cache keys.
+reli caches expensive binary-analysis results (ELF symbol resolution, ZTS TLS offsets, PHP version detection, …) under `~/.cache/reli/binary-analysis/`. This turns a ~8-second cold start for a ZTS target into ~5 ms on subsequent runs against the same binary.
 
-### Clear the cache
 ```bash
+# Clear the cache
 ./reli cache:clear
+
+# Bypass the cache for a single run
+./reli inspector:trace --no-cache -p <pid>
 ```
 
-### Disable the cache
-All inspector commands accept `--no-cache` to bypass the cache for a single run:
-```bash
-./reli inspector:trace --no-cache -p <pid>
-./reli inspector:daemon --no-cache -P "^php-fpm"
-```
+For what exactly is cached, how keys are computed, and the Docker-overlayfs edge case that shaped the keying scheme, see [docs/internals/binary-analysis-cache.md](docs/internals/binary-analysis-cache.md).
 
 ## Troubleshooting
 ### I get an error message "php module not found" and can't get a trace!

--- a/README.md
+++ b/README.md
@@ -11,74 +11,13 @@ Reli is a sampling profiler (or a VM state inspector) written in PHP. It can rea
 New here? [docs/getting-started.md](docs/getting-started.md) walks from install to your first trace. Looking for a specific task? The [documentation index](docs/README.md) maps "I want to X" to the right command and doc.
 
 ## What can I use this for?
-- Detecting and visualizing bottlenecks in PHP scripts
-  - It provides not only at the function level of profiling but also at line level or opcode level resolution, and even native C-level stack traces from the interpreter itself
-- Profiling without accumulated overhead even when a lot of fast functions called as this is a sampling profiler (see the links below, tideways, xhprof, and the profiler of xdebug, many profilers have this overhead)
-  - [Profiling Overhead and PHP 7](https://tideways.com/profiler/blog/profiling-overhead-and-php-7)
-  - [nikic/sample_prof](https://github.com/nikic/sample_prof)
-- Investigating the cause of a bug or performance failure
-  - Even if a PHP script is in an unexplained unresponsive state, you can use this to find out what it is doing internally.
-- [Finding memory bottlenecks or memory leaks](https://github.com/reliforp/reli-prof/blob/0.12.x/docs/memory/memory-profiler.md)
-- [Automatic memory analysis report](docs/memory/memory-report.md): generate prioritized findings from a memory snapshot — dominant classes, cycles, choke points, blame allocation, and more
-- [Interactive memory exploration](docs/memory/rmem-explore-and-serve.md): browse `.rmem` memory snapshots with `rmem:explore` (TUI with sandwich view, class/type rankings, cycle visualization, global search), run `rmem:serve` as a persistent query server, or connect AI assistants via `rmem:mcp` (MCP protocol)
-- [Analyzing `.rbt` traces in the terminal](docs/tracing/rbt-analyze-and-explore.md): pipe a binary trace into `rbt:analyze` for one-shot text reports (hot frames, callers/callees of a regex, live tail), or open `rbt:explore` for an interactive sandwich/flame/tree TUI
-- [Condition-based monitoring](docs/monitoring/watch-command.md): automatically trigger memory dumps, trace captures, or alerts when memory thresholds, function calls, or variable conditions are met
-- [Variable inspection](docs/inspection/peek-var-command.md): read PHP variable values from a running process without modifying it
-- [Per-sample variable peek in traces](docs/inspection/trace-var-command.md): attach PHP variable values (request URI, user id, SQL query, ...) to each trace sample so you can join runtime state to hot stacks
-- [Sidecar daemon](docs/monitoring/sidecar.md): run a daemon that accepts on-demand memory dump requests from PHP processes via Unix socket — no FFI needed in the application, ideal for memory_limit crash analysis and CI regression detection
-- [Post-mortem analysis from a core dump](docs/memory/coredump.md): run the same memory analyzer against an ELF core file (from `gcore`, `systemd-coredump`, kernel `core_pattern`, ...) when the process has already died or when live attachment isn't possible
 
-## How it works
-It's implemented by using following techniques:
+- **Where time is spent** — sampling profiler for PHP call stacks, with optional C-level frames and per-opcode detail. Capture to the compact `.rbt` binary format, browse in the `rbt:explore` TUI, or convert to speedscope / pprof / flamegraph / callgrind / folded.
+- **Where memory is used** — reconstruct the target's PHP heap into a queryable graph (`.rmem`). Open it interactively with `rmem:explore`, get a prioritised findings report with `memory:report`, or compare two snapshots with `memory:compare` to track regressions.
+- **What values flow through** — read PHP variable values from a running process without modifying it (`inspector:peek-var`), or attach variable values to every trace sample (`inspector:trace --trace-var`) so you can join runtime state to hot stacks.
+- **When something goes wrong** — trigger captures on runtime conditions. `inspector:watch` takes a memory dump or trace when memory thresholds, function calls, or variable conditions are met. `inspector:sidecar` accepts on-demand dump requests from the app over a Unix socket — ideal for `memory_limit` crash analysis.
 
-- Parsing ELF binary of the interpreter
-- Reading memory map from /proc/\<pid\>/maps
-- Reading memory of outer process by using ptrace(2) and process_vm_readv(2) via FFI
-- Analyzing internal data structure in the PHP VM (aka Zend Engine)
-
-If you have a bit of extra CPU resource, the overhead of this software would be negligible.
-
-## Alpine / musl libc support
-Reli works on Alpine Linux (musl libc). Sampling profiler, memory dump, memory analysis, and memory report all work on both regular and ZTS builds. Native C-level stack traces are not supported on musl due to its minimal `.eh_frame` (only 4 FDE entries vs glibc's ~3,700). See [Alpine internals](docs/internals/alpine-investigation.md) for technical details.
-
-## Native (C-level) stack trace support
-Reli can collect native C-level stack traces from the PHP interpreter alongside PHP traces. This lets you see what C functions the interpreter is executing inside each PHP function call, which is useful for diagnosing performance issues in PHP internals, extensions, or the interpreter itself.
-
-- Works with stripped binaries (uses exported symbols from `.dynsym`)
-- Loads separate debug symbol packages (`-dbgsym` / `-debuginfo`) for full symbol coverage
-- Resolves JIT-compiled function names when the target process has `opcache.jit_debug` enabled
-
-## Differences to phpspy, when to use reli
-Reli is heavily inspired by [adsr/phpspy](https://github.com/adsr/phpspy).
-
-The main difference between the two is that reli is written in almost pure PHP while phpspy is written in C.
-In profiling, there are cases you want to customize how and what information to get.
-If customizability for PHP developers matters, you can use this software at the cost of performance. (Although, we hope the cost is not too big.)
-
-Additionally, reli can find VM state from ZTS interpreters. For example, in the daemon mode, traces of threads started via [ext-parallel](https://github.com/krakjoe/parallel) are automatically retrieved. Currently this cannot be done with phpspy only.
-Reli also provides functionality to only get the address of EG from targets, so you can use actual profiling with phpspy if you want, even when the target is ZTS.
-
-Furthermore, reli provides a **hybrid phpspy mode** (`phpspy:trace`, `phpspy:daemon`) that combines reli's ZTS-aware EG resolution with phpspy's fast C-based tracing. Reli resolves the EG address (including for ZTS targets where phpspy alone cannot), then launches phpspy as the actual tracer with the resolved address. This gives you phpspy's speed with reli's ZTS support. See [Hybrid phpspy mode](#hybrid-phpspy-mode) for details.
-
-Other features of reli that phpspy does not currently have include:
-
-- Output more accurate line numbers
-- Customize output format with PHP templates
-- Get running opcodes of the PHP-VM
-- Automatic retrieval of the target PHP version from stripped PHP binaries
-- Output traces in speedscope, pprof, folded stacks, callgrind, or [compact binary (`.rbt`)](docs/tracing/binary-trace-format.md) format
-- Deeply analyzing memory usage of the target process
-- Collecting native (C-level) stack traces alongside PHP traces via DWARF `.eh_frame` unwinding
-- Resolving JIT-compiled function names via perf map and GDB JIT interface
-
-There is no particular reason why these features cannot be implemented on the phpspy side, so it may be possible to do them on phpspy in the future.
-
-On the other hand, there are a few things that phpspy can do but reli cannot yet.
-
-- Run more faster with lower overhead.
-- etc.
-
-Much of what can be done with phpspy will be done with reli in the future.
+For the full catalogue of tasks and commands, see the [documentation index](docs/README.md).
 
 ## Requirements
 ### Supported PHP versions
@@ -104,8 +43,10 @@ Much of what can be done with phpspy will be done with reli in the future.
 
 On targeting ZTS, reli finds EG from the TLS. Stripped binaries are supported (TLS segments are scanned via brute force). On glibc 2.34+, where libpthread is merged into libc, reli automatically falls back to libc.so, so no extra options are needed in most cases.
 
-### AArch64 (ARM64) support
-AArch64 Linux support is experimental. It enables profiling on ARM-based servers (e.g., AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets are supported. See [docs/internals/aarch64-support.md](docs/internals/aarch64-support.md) for technical details.
+### Platform notes
+
+- **AArch64 (ARM64)** — experimental. Enables profiling on ARM-based servers (AWS Graviton) and Apple Silicon Macs running Linux VMs or Docker containers. Both NTS and ZTS targets supported. See [docs/internals/aarch64-support.md](docs/internals/aarch64-support.md).
+- **Alpine / musl libc** — sampling profiler and the memory pipeline (dump / analyse / report) all work on both NTS and ZTS. Native C-level stack traces are not supported on musl due to its minimal `.eh_frame` (~4 FDE entries vs glibc's ~3,700). See [docs/internals/alpine-investigation.md](docs/internals/alpine-investigation.md).
 
 ## Installation
 ### From Docker
@@ -486,6 +427,12 @@ $ ./reli rbt:explore trace.rbt
 $ ./reli converter:flamegraph <trace.rbt >flame_native.svg
 ```
 
+Symbol resolution specifics:
+
+- **Stripped binaries** are supported — reli uses exported symbols from `.dynsym`.
+- **Separate debug symbol packages** (`-dbgsym` / `-debuginfo`) are loaded when available for full symbol coverage.
+- **JIT-compiled function names** resolve via `/tmp/perf-<pid>.map` when the target process has `opcache.jit_debug=0x10` (see the JIT-compiled code subsection below).
+
 ### Collect native traces during interpreter initialization / shutdown
 ```bash
 $ sudo php ./reli i:trace --native-trace-anytime -p <pid>
@@ -621,6 +568,40 @@ The `-S` option will give you better results. Using this option stops the execut
 
 ### I can't get traces on Amazon Linux 2.
 First, try `cat /proc/<pid>/maps` to check the memory map of the target PHP process. If the first module does not indicate the location of the PHP binary and looks like an anonymous region, try to specify `--php-regex="^$"` as an option.
+
+## How it works
+
+Under the hood, reli:
+
+- Parses the ELF binary of the PHP interpreter.
+- Reads the target's memory map from `/proc/<pid>/maps`.
+- Reads memory of the outer process through `ptrace(2)` and `process_vm_readv(2)` via FFI.
+- Analyses the internal data structures of the PHP VM (aka Zend Engine).
+
+If you have a bit of extra CPU resource to spare on the profiling host, the overhead of this software is negligible.
+
+## Differences to phpspy, when to use reli
+
+Reli started out heavily inspired by [adsr/phpspy](https://github.com/adsr/phpspy); several things have since diverged.
+
+The main structural difference is that reli is written in almost pure PHP while phpspy is written in C. If you want to customise *what* and *how* information is captured, doing it in PHP is easier — at some performance cost. (Though we aim to keep that cost modest.)
+
+Reli can also find VM state from ZTS interpreters: daemon-mode traces of threads started via [ext-parallel](https://github.com/krakjoe/parallel) are captured automatically, which phpspy alone cannot do. `inspector:eg` exposes just the EG address so that you can feed it to phpspy manually for ZTS targets, and the [hybrid phpspy mode](#hybrid-phpspy-mode) (`phpspy:trace` / `phpspy:daemon`) combines reli's ZTS-aware EG resolution with phpspy's fast C-based tracing.
+
+Other capabilities reli currently has that phpspy doesn't:
+
+- More accurate line numbers.
+- Output format customisation via PHP templates.
+- Running-opcode output for each sample.
+- Automatic PHP-version detection from stripped binaries.
+- Compact binary trace format (`.rbt`) plus speedscope / pprof / folded / callgrind / flamegraph converters (see [docs/tracing/binary-trace-format.md](docs/tracing/binary-trace-format.md)).
+- Deep memory-graph analysis of the target process.
+- Merged native (C-level) stack traces via DWARF `.eh_frame` unwinding.
+- JIT-compiled function-name resolution via perf map / GDB JIT interface.
+
+Nothing above is technically unreachable from phpspy — these may land there one day.
+
+On the other hand, phpspy still wins on raw sampling throughput and overhead. Much of what phpspy uniquely does will be covered by reli eventually.
 
 ## Goals
 We would like to achieve the following 5 goals through this project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,9 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | Capture to a compact binary file for later analysis **(recommended)** | `inspector:trace -p <pid> -F rbt -o trace.rbt` | [tracing/binary-trace-format.md](tracing/binary-trace-format.md) |
 | Trace many processes at once (e.g. a php-fpm pool) | `inspector:daemon -P <regex>` | [README § Daemon mode](../README.md#daemon-mode) |
 | Live `top`-style aggregation | `inspector:top -P <regex>` | [README § top-like mode](../README.md#top-like-mode) |
-| Include C-level frames | add `--with-native-trace` | [README § Collect native stack traces](../README.md#collect-native-c-level-stack-traces) |
-| See the opcode in phpspy text output (`.rbt` records it unconditionally) | `--template=phpspy_with_opcode` | [README § opcodes](../README.md#show-currently-executing-opcodes-at-traces) |
+| Include C-level frames | add `--with-native-trace` | [tracing/advanced-capture.md](tracing/advanced-capture.md) |
+| See the opcode in phpspy text output (`.rbt` records it unconditionally) | `--template=phpspy_with_opcode` | [tracing/advanced-capture.md](tracing/advanced-capture.md) |
+| Resolve JIT-compiled function names in native traces | `opcache.jit_debug=0x10` + `--with-native-trace` | [tracing/advanced-capture.md](tracing/advanced-capture.md) |
 | Use phpspy as the fast C backend, with reli-driven ZTS support | `phpspy:trace`, `phpspy:daemon` | [README § Hybrid phpspy mode](../README.md#hybrid-phpspy-mode) |
 | Attach a PHP variable to every sample | `inspector:trace --trace-var=…` | [inspection/trace-var-command.md](inspection/trace-var-command.md) |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,17 +8,29 @@ to the [documentation index](README.md) or the [README](../README.md).
 
 reli is a sampling profiler (and VM state inspector) that reads a
 running PHP process from the outside — no extension to load, no code
-changes to the target. Two broad capabilities:
+changes to the target. Four broad capabilities:
 
-- **Where time is spent**: periodic call-stack samples, optionally
-  with C-level frames and executing-opcode detail. Output to a
-  compact binary format (`.rbt`) or phpspy-compatible text.
-- **Where memory is used**: reconstruct the PHP heap into a queryable
-  graph. The default (and fastest) on-disk format is `.rmem` — every
-  analyser reads it natively. Browse it interactively with
+- **Where time is spent** — periodic call-stack samples, optionally
+  with C-level frames and executing-opcode detail. Output to the
+  compact `.rbt` binary format (or phpspy-compatible text) and
+  browse with `rbt:explore` / `rbt:analyze`.
+- **Where memory is used** — reconstruct the PHP heap into a
+  queryable graph. `.rmem` is the fastest on-disk format and is what
+  every analyser reads natively: browse interactively with
   `rmem:explore`, get a prioritised report with `memory:report`, or
-  compare two snapshots to track regressions. SQLite and JSON outputs
-  are also supported for interop.
+  compare two snapshots with `memory:compare`. SQLite and JSON
+  outputs are also supported for interop.
+- **What values flow through** — read PHP variable values from a
+  running process with `inspector:peek-var`, or attach variable
+  values to every trace sample with `inspector:trace --trace-var`
+  so that runtime state sits next to the hot stacks that produced
+  it.
+- **When something goes wrong** — react to runtime conditions.
+  `inspector:watch` triggers a memory dump / trace when memory
+  thresholds, function calls, or variable conditions are met.
+  `inspector:sidecar` accepts on-demand dump requests from the
+  application over a Unix socket — ideal for `memory_limit` crash
+  analysis.
 
 For the full catalogue of tasks-and-commands, see the
 [documentation index](README.md).

--- a/docs/internals/binary-analysis-cache.md
+++ b/docs/internals/binary-analysis-cache.md
@@ -1,0 +1,81 @@
+# Binary analysis cache
+
+reli caches expensive binary-analysis results to disk so that
+repeated profiling of the same PHP binary is fast. This note covers
+*what* gets cached, *where*, *how cache keys are computed*, and the
+Docker-overlayfs edge case that shaped the current keying scheme.
+For the user-facing one-liner (clear / bypass), see
+[README § Binary analysis cache](../../README.md#binary-analysis-cache).
+
+## What is cached
+
+The first time reli attaches to a PHP interpreter binary, it
+performs several one-shot analyses that are deterministic functions
+of that binary:
+
+- **ELF symbol resolution** — locating symbols in `.dynsym` /
+  `.symtab` / `.debug_*` sections.
+- **TLS brute-force offsets** — for ZTS targets, finding
+  `_tsrm_ls_cache` / engine globals in the TLS block when the
+  symbol has been stripped.
+- **PHP version detection** — deriving the target's PHP version
+  (e.g. `v84`) from binary contents.
+- Other per-binary resolution results used by the process readers.
+
+All of these depend only on the binary's bytes, so caching them and
+keying by a stable binary fingerprint is safe.
+
+## Performance impact
+
+The win is largest for ZTS targets, where the TLS brute-force scan
+dominates initialisation:
+
+| Target | Cold (first run) | Warm (cached) |
+|---|---|---|
+| Typical ZTS binary | ~8 s | ~5 ms |
+| Typical NTS binary | fast anyway | slightly faster |
+
+For short-lived processes (CI, one-shot scripts) the warm path
+matters; for long-running daemons the cost is amortised either way.
+
+## Where the cache lives
+
+Cache files sit under `~/.cache/reli/binary-analysis/`, following
+the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+(i.e. `$XDG_CACHE_HOME/reli/binary-analysis/` when `XDG_CACHE_HOME`
+is set).
+
+The directory is not shared between users or between containers
+unless you explicitly bind-mount it.
+
+## Cache key: `(device_id, inode, ELF-header-bytes)`
+
+A naive cache key using only the filesystem's `(device, inode)` pair
+is correct for most bare-metal setups but **breaks on Docker's
+overlayfs**: multiple images can have different binaries with the
+same `(device, inode)` pair (e.g. `php:8.3` vs `php:8.3-zts`), so a
+cache entry keyed only by `(device, inode)` could be served against
+the wrong binary.
+
+To make the key uniquely identify the binary even across overlayfs
+images, reli includes the **leading bytes of the ELF header** in
+the key. Since two different PHP builds differ in their ELF header
+content (at least in e_type/e_entry/section count or later fields),
+any meaningful binary change produces a different cache entry.
+
+This means:
+
+- Same binary, different mount → shared cache entry ✓
+- Different binary, same `(device, inode)` → separate cache entries ✓
+- Binary modified in place → new key → cold path, not a stale hit ✓
+
+## User controls
+
+- **Clear the cache**: `./reli cache:clear`. Safe at any time —
+  worst case is one cold run per newly-seen binary.
+- **Bypass for a single run**: pass `--no-cache` to any inspector
+  command, e.g. `./reli inspector:trace --no-cache -p <pid>`.
+- **Disable entirely**: there is no global kill switch. If you
+  always want cold runs (CI isolation, debugging cache logic, etc.)
+  add `--no-cache` in the wrapper, or run `cache:clear` in your
+  pre-run hook.

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -1,0 +1,146 @@
+# Advanced capture: opcodes, native traces, JIT
+
+Beyond the default call stacks, `inspector:trace` / `inspector:daemon`
+can attach three extra layers of detail to each sample:
+
+- **Executing opcode** — which Zend VM instruction was running
+- **Native (C-level) stack** — merged PHP + interpreter frames
+- **JIT-compiled function names** — resolve opcache-JIT frames to
+  symbolic names
+
+All three work with every output format (`.rbt`, `template:phpspy*`,
+`json_lines`) and on top of `inspector:daemon` the same way.
+
+## Executing opcode
+
+Useful when you want to know not only which line is slow but which
+**Zend VM opcode** is being dispatched. Different output paths expose
+it differently:
+
+- **Capturing to `.rbt`**: the opcode is recorded on every PHP frame
+  unconditionally — no flag needed at capture time. Reveal it during
+  analysis with `./reli rbt:analyze --with-opcode trace.rbt`, or
+  press `c` inside `rbt:explore` to toggle the opcode column.
+- **phpspy text output**: opt in at capture time with
+  `--template=phpspy_with_opcode`:
+
+  ```bash
+  $ sudo php ./reli i:trace --template=phpspy_with_opcode -p <pid>
+  0 <VM>::ZEND_ASSIGN <VM>:-1
+  1 Mandelbrot::iterate /home/sji/work/test/mandelbrot.php:33:ZEND_ASSIGN
+  2 Mandelbrot::__construct /home/sji/work/test/mandelbrot.php:12:ZEND_DO_FCALL
+  3 <main> /home/sji/work/test/mandelbrot.php:45:ZEND_DO_FCALL
+  ```
+
+  The currently executing opcode becomes the first frame of the
+  callstack, so visualisations like flamegraph show opcode usage
+  directly.
+
+  For informational purposes, the executing opcode is also appended
+  to the end of each call frame line (second position onward).
+  Expect function-call opcodes like `ZEND_DO_FCALL` there.
+
+If JIT is enabled on the target, line / opcode information may be
+slightly inaccurate. For JIT-compiled function names specifically,
+combine `--with-native-trace` with `opcache.jit_debug=0x10` (see
+below).
+
+## Native (C-level) stack traces
+
+Add `--with-native-trace` to capture interpreter C frames alongside
+the PHP stack. Useful for diagnosing time spent inside the engine,
+extensions, or libc.
+
+```bash
+$ sudo php ./reli i:trace --with-native-trace -p <pid>
+0 libc.so.6::clock_nanosleep+0x5a [native]:0
+1 libc.so.6::__nanosleep+0x17 [native]:0
+2 libc.so.6::usleep+0x4c [native]:0
+3 php8.4::zif_usleep+0x42 [native]:0
+4 usleep <internal>:-1
+5 <main> /app/test.php:15
+6 php8.4::execute_ex+0x4dfa [native]:0
+7 php8.4::zend_execute+0x141 [native]:0
+8 php8.4::zend_execute_script+0x56 [native]:0
+9 php8.4::php_execute_script_ex+0x278 [native]:0
+10 libc.so.6::__libc_start_main+0x8b [native]:0
+11 php8.4::_start+0x25 [native]:0
+```
+
+Native frames are labeled with `[native]:0` and show
+`module::symbol+offset`. PHP frames are placed on the callee side of
+`execute_ex`, reflecting that all PHP execution happens inside the
+VM's opcode dispatcher.
+
+Capture to `.rbt` and analyse interactively:
+
+```bash
+$ sudo php ./reli i:trace --with-native-trace -p <pid> -F rbt -o trace.rbt
+$ ./reli rbt:explore trace.rbt
+# ...or convert to a flamegraph:
+$ ./reli converter:flamegraph <trace.rbt >flame_native.svg
+```
+
+### Symbol resolution specifics
+
+- **Stripped binaries** are supported — reli uses exported symbols
+  from `.dynsym`.
+- **Separate debug symbol packages** (`-dbgsym` / `-debuginfo`) are
+  loaded when available for full symbol coverage.
+- **JIT-compiled function names** resolve via `/tmp/perf-<pid>.map`
+  when the target has `opcache.jit_debug=0x10` (see the JIT section
+  below).
+
+### Native traces during interpreter init / shutdown
+
+By default, reli only collects native frames at samples where a PHP
+frame is also being sampled. Use `--native-trace-anytime` to collect
+native traces even when no PHP code is executing — e.g. during module
+initialisation or interpreter shutdown:
+
+```bash
+$ sudo php ./reli i:trace --native-trace-anytime -p <pid>
+```
+
+Useful for investigating startup performance or extension loading
+behaviour.
+
+### Alpine / musl libc
+
+Native C-level stack traces are **not supported on musl libc** due
+to its minimal `.eh_frame` unwinding metadata (only ~4 FDE entries
+versus glibc's ~3,700). The sampling profiler and memory pipeline
+still work on Alpine; only `--with-native-trace` / `--native-trace-anytime`
+are affected. See [../internals/alpine-investigation.md](../internals/alpine-investigation.md)
+for the full investigation.
+
+## JIT-compiled code in native traces
+
+When the target PHP process has opcache JIT enabled with
+`opcache.jit_debug=0x10`, JIT-compiled function names are resolved
+through `/tmp/perf-<pid>.map`:
+
+```bash
+$ php -d opcache.jit_debug=0x10 script.php &
+$ sudo php ./reli i:trace --with-native-trace -p $!
+0 [jit]::TRACE-2$fibonacci$4+0x141 [native]:0
+1 php8.4::zend_execute+0x141 [native]:0
+2 <main> /app/test.php:14
+```
+
+For DWARF-based unwinding *through* JIT frames (i.e. correct stack
+reconstruction when a JIT trampoline calls back into the engine),
+set `opcache.jit_debug=0x100` instead — this enables the GDB JIT
+interface.
+
+## See also
+
+- [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md) — TUI /
+  analyser for the captured traces (including the `--with-opcode`
+  flag and the `c` toggle).
+- [binary-trace-format.md](binary-trace-format.md) — `.rbt` format
+  specification, including how opcode / native / annotation data is
+  encoded.
+- [../inspection/trace-var-command.md](../inspection/trace-var-command.md)
+  — a different kind of per-sample annotation (runtime variable
+  values).


### PR DESCRIPTION
## Summary

The first two screens on GitHub were spending their budget on four background sections (How it works / Alpine / Native / Differences to phpspy) plus an 11-item feature bullet list — before a reader could reach Installation or see a single command. Pulled the ordering back to what a new arrival actually wants.

### New first screen

1. Pitch + pointers to `docs/getting-started.md` and the `docs/README.md` index.
2. **`## What can I use this for?`** — four bullets that match the Getting-Started / docs/README.md framing:
   - **Where time is spent** (call traces)
   - **Where memory is used** (memory graph)
   - **What values flow through** (peek-var / trace-var)
   - **When something goes wrong** (watch / sidecar)
   
   Per-feature doc enumeration moved out; the docs index already carries it. Long-form task map lives there.
3. **`## Requirements`** + **`## Installation`** stay near the top.

Install is now at line 51 (was 110) and the first real command Example starts far earlier.

### Background sections consolidated or moved down

- **`## Alpine / musl libc support`** and **`## AArch64 (ARM64) support`** merge into a single **`### Platform notes`** sub-section under `## Requirements`.
- **`## Native (C-level) stack trace support`** removed as a standalone feature pitch. The three useful facts (stripped binaries via `.dynsym`, `-dbgsym`/`-debuginfo`, JIT function names via perf map) are preserved as a "Symbol resolution specifics" list at the end of the Examples "Collect native (C-level) stack traces" block.
- **`## How it works`** and **`## Differences to phpspy, when to use reli`** moved to the back of the file (after Troubleshooting, before Goals). The phpspy section keeps every claim but is tightened — reli has diverged from phpspy enough that a 30-line comparison doesn't belong in first-screen real estate.

### Getting-Started kept in sync

`docs/getting-started.md`'s "What reli gives you" list is expanded from two bullets to the same four so the framing is consistent across both entry points.

## Test plan

- [ ] Render README on GitHub — first screen shows pitch, `What can I use this for?` four bullets, start of Requirements, without the old background sections intervening
- [ ] Every relative doc link in the new intro resolves (`docs/getting-started.md`, `docs/README.md`)
- [ ] `### Platform notes` renders with AArch64 + Alpine bullets and the right internals links
- [ ] `## Differences to phpspy, when to use reli` still reads end-to-end near the bottom
- [ ] `## How it works` near the bottom has the ELF / `/proc/<pid>/maps` / ptrace+process_vm_readv / Zend Engine bullets intact
- [ ] Examples § "Collect native (C-level) stack traces" ends with the stripped-binary / `-dbgsym` / JIT note list

https://claude.ai/code/session_01BhkpxioC3Kw1gmg2DZGgDe