### PR TITLE
Refactor BufferedMemoryReader to support multi-slot prefetch with lazy segment loading

### DIFF
--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettings.php
@@ -17,7 +17,7 @@ use Reli\Inspector\Watch\VariableSpec;
 
 final class GetTraceSettings
 {
-    public const BULK_STACK_COPY_DEFAULT_MAX_SIZE = 65536;
+    public const BULK_STACK_COPY_DEFAULT_MAX_SIZE = 1048576;
 
     /**
      * @param int|null $bulk_stack_copy_max_size null = disabled, int = max bytes to prefetch

--- a/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInput.php
@@ -54,8 +54,14 @@ final class GetTraceSettingsFromConsoleInput
                 'bulk-stack-copy',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'bulk-copy VM stack per sample for consistency (default max: 64K). '
-                . 'Accepts optional max size in bytes (e.g. 65536, 16K, 256K)'
+                'bulk-copy VM stack per sample for consistency (default: on, max 1M). '
+                . 'Accepts optional max size in bytes (e.g. 65536, 16K, 256K, 1M)'
+            )
+            ->addOption(
+                'no-bulk-stack-copy',
+                null,
+                InputOption::VALUE_NONE,
+                'disable bulk-stack-copy (fall back to per-field reads)'
             )
             ->addOption(
                 'trace-var',
@@ -85,12 +91,15 @@ final class GetTraceSettingsFromConsoleInput
 
     private function parseBulkStackCopy(InputInterface $input): ?int
     {
+        if ((bool)$input->getOption('no-bulk-stack-copy')) {
+            return null;
+        }
+
         /** @var string|bool|int|float|list<string>|null $raw */
         $raw = $input->getOption('bulk-stack-copy');
         if ($raw === null) {
-            if (!$input->hasParameterOption(['--bulk-stack-copy'])) {
-                return null;
-            }
+            // Flag not passed at all, or passed without a value: use default.
+            // bulk-stack-copy is on by default — callers opt out via --no-bulk-stack-copy.
             return GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE;
         }
         $value = NullableCast::toString($raw);
@@ -101,11 +110,13 @@ final class GetTraceSettingsFromConsoleInput
         if (preg_match('/^(\d+)\s*([kKmM])?$/', $value, $m)) {
             $num = (int)$m[1];
             $suffix = strtoupper($m[2] ?? '');
-            return match ($suffix) {
+            $size = match ($suffix) {
                 'K' => $num * 1024,
                 'M' => $num * 1024 * 1024,
                 default => $num,
             };
+            // Explicit 0 disables (alternative to --no-bulk-stack-copy).
+            return $size > 0 ? $size : null;
         }
         throw GetTraceSettingsException::create(GetTraceSettingsException::BULK_STACK_COPY_IS_NOT_VALID_SIZE);
     }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -42,6 +42,27 @@ final class CallTraceReader
     /** Offset of zend_vm_stack->top within the segment header. */
     private const ZEND_VM_STACK_TOP_OFFSET = 0;
 
+    /**
+     * Scatter-gather layout tuning for bulk VM stack prefetch.
+     *
+     * Linux's process_vm_readv reads iovs in order and within each iov low
+     * -> high. To minimize the time gap between capturing EG(current_execute_data)
+     * (read first, at t0) and snapshotting the frame it points to, the iov
+     * containing the live top frames is placed right after the CED iov so it
+     * is read next. The remainder (cold, nearly-immutable deeper frames) is
+     * read last.
+     *
+     * HOT_BELOW_TOP_BYTES: how many bytes below EG(vm_stack_top) to include
+     *   in the hot chunk. Must comfortably cover the active frames the chain
+     *   walker actually touches (~65 frames at ~128B/frame = 8KB).
+     *
+     * HOT_ABOVE_TOP_BYTES: margin above vm_stack_top included in the hot
+     *   chunk, to catch frames pushed between Step 1 (reading EG fields) and
+     *   Step 2 (the actual scatter-gather read).
+     */
+    private const HOT_BELOW_TOP_BYTES = 8192;
+    private const HOT_ABOVE_TOP_BYTES = 16384;
+
     private ?ZendTypeReader $zend_type_reader = null;
     private bool $bulk_stack_copy_enabled = false;
 
@@ -221,28 +242,35 @@ final class CallTraceReader
             return null;
         }
 
-        // Prefetch up to vm_stack_top + 16KB margin, capped at vm_stack_end.
-        // The margin covers frames that may be pushed between Step 1 and Step 2.
-        $margin = 16384; // 16KB ≈ ~130 extra frames of headroom
-        $prefetch_end = min(
-            $vm_stack_top_raw->value + $margin,
+        $stack_regions = self::computeVmStackBulkRegions(
+            $vm_stack_address,
+            $vm_stack_top_raw->value,
             $vm_stack_end_raw->value,
         );
-        $stack_size = $prefetch_end - $vm_stack_address;
-        if ($stack_size <= 0 || $stack_size > $this->memory_reader->getMaxPrefetchSize()) {
+        $total_stack_size = 0;
+        foreach ($stack_regions as $r) {
+            $total_stack_size += $r['size'];
+        }
+        if ($total_stack_size <= 0
+            || $total_stack_size > $this->memory_reader->getMaxPrefetchSize()
+        ) {
             return null;
         }
 
-        // Step 2: Scatter-gather read current_execute_data + VM stack in one syscall
+        // Step 2: Scatter-gather read current_execute_data + VM stack in one syscall.
+        // Order: CED first, then HOT chunk (frames near vm_stack_top, where the
+        // chain walker starts), then COLD chunk (deeper frames). See the class
+        // constants HOT_{BELOW,ABOVE}_TOP_BYTES for the layout rationale.
         [$ced_offset,] = $zend_type_reader->getOffsetAndSizeOfMember(
             'zend_executor_globals',
             'current_execute_data'
         );
 
-        $this->memory_reader->prefetchScatterGather($pid, [
-            ['address' => $eg_address + $ced_offset, 'size' => $ptr_size],
-            ['address' => $vm_stack_address, 'size' => $stack_size],
-        ]);
+        $regions = [['address' => $eg_address + $ced_offset, 'size' => $ptr_size]];
+        foreach ($stack_regions as $r) {
+            $regions[] = $r;
+        }
+        $this->memory_reader->prefetchScatterGather($pid, $regions);
 
         // Read current_execute_data from the scatter-gather buffer
         $ced_cdata = $this->memory_reader->read($pid, $eg_address + $ced_offset, $ptr_size);
@@ -262,6 +290,41 @@ final class CallTraceReader
             $ced_address,
             $zend_type_reader->sizeOf('zend_execute_data'),
         );
+    }
+
+    /**
+     * Build the VM-stack portion of the scatter-gather iov list, split so the
+     * kernel reads hot frames (near vm_stack_top) right after the CED iov and
+     * cold frames (near <main>) last.
+     *
+     * Returned regions are ordered for iov placement: hot chunk first, cold
+     * chunk second (when a split is needed). For shallow stacks where the hot
+     * window already reaches the segment base, a single region is returned.
+     *
+     * @return list<array{address: int, size: int}>
+     */
+    public static function computeVmStackBulkRegions(
+        int $vm_stack_address,
+        int $vm_stack_top,
+        int $vm_stack_end,
+    ): array {
+        $hot_start = max($vm_stack_address, $vm_stack_top - self::HOT_BELOW_TOP_BYTES);
+        $hot_end = min($vm_stack_end, $vm_stack_top + self::HOT_ABOVE_TOP_BYTES);
+        if ($hot_end <= $hot_start) {
+            return [];
+        }
+        $hot_size = $hot_end - $hot_start;
+
+        if ($hot_start <= $vm_stack_address) {
+            // Whole stack fits in the hot window.
+            return [['address' => $vm_stack_address, 'size' => $hot_size]];
+        }
+
+        $cold_size = $hot_start - $vm_stack_address;
+        return [
+            ['address' => $hot_start, 'size' => $hot_size],
+            ['address' => $vm_stack_address, 'size' => $cold_size],
+        ];
     }
 
     /**

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -37,8 +37,16 @@ use Reli\Lib\Process\ProcessSpecifier;
 
 final class CallTraceReader
 {
+    /** Offset of zend_vm_stack->prev within the segment header. */
+    private const ZEND_VM_STACK_PREV_OFFSET = 16;
+    /** Offset of zend_vm_stack->top within the segment header. */
+    private const ZEND_VM_STACK_TOP_OFFSET = 0;
+
     private ?ZendTypeReader $zend_type_reader = null;
     private bool $bulk_stack_copy_enabled = false;
+
+    /** Base address of the VM stack segment last prefetched, for chain walk lazy-load. */
+    private int $current_vm_stack_base = 0;
 
     public function __construct(
         private MemoryReaderInterface $memory_reader,
@@ -245,11 +253,67 @@ final class CallTraceReader
             return null;
         }
 
+        // Record the current segment base so the chain walk can lazily follow
+        // `zend_vm_stack->prev` into older segments on buffer miss.
+        $this->current_vm_stack_base = $vm_stack_address;
+
         return new Pointer(
             ZendExecuteData::class,
             $ced_address,
             $zend_type_reader->sizeOf('zend_execute_data'),
         );
+    }
+
+    /**
+     * Lazily bulk-read a previous VM stack segment into an additional buffer
+     * slot so the chain walk can continue following `prev_execute_data`
+     * pointers that cross segment boundaries (common with Fibers, whose
+     * initial segment is only 4KB).
+     *
+     * Returns the prev-of-prev segment base address for further chaining,
+     * or null on failure / end-of-chain.
+     */
+    private function loadPrevSegment(
+        int $pid,
+        int $seg_base_address,
+        Dereferencer $dereferencer,
+    ): ?int {
+        if (!$this->memory_reader instanceof BufferedMemoryReader) {
+            return null;
+        }
+
+        // Read prev segment's header fields via inner reader (small one-offs).
+        // zend_vm_stack layout: { zval *top; zval *end; zend_vm_stack prev; }
+        try {
+            $top_pointer = new Pointer(
+                RawInt64::class,
+                $seg_base_address + self::ZEND_VM_STACK_TOP_OFFSET,
+                8,
+            );
+            $seg_top = $dereferencer->deref($top_pointer)->value;
+            $prev_pointer = new Pointer(
+                RawInt64::class,
+                $seg_base_address + self::ZEND_VM_STACK_PREV_OFFSET,
+                8,
+            );
+            $prev_of_prev = $dereferencer->deref($prev_pointer)->value;
+        } catch (MemoryReaderException) {
+            return null;
+        }
+
+        if ($seg_top <= $seg_base_address) {
+            return null;
+        }
+        $data_size = $seg_top - $seg_base_address;
+        if ($data_size > $this->memory_reader->getMaxPrefetchSize()) {
+            return null;
+        }
+
+        if (!$this->memory_reader->prefetchAdditional($pid, $seg_base_address, $data_size)) {
+            return null;
+        }
+
+        return $prev_of_prev !== 0 ? $prev_of_prev : null;
     }
 
     /**
@@ -323,10 +387,32 @@ final class CallTraceReader
 
         $frame_addresses[] = $addr;
 
+        // Lazy prev-segment fetch state: when a `prev_execute_data` pointer
+        // crosses into an older VM stack segment (common with Fibers, whose
+        // initial segment is only 4KB), we issue a one-shot bulk readv for
+        // the prev segment's used range so subsequent chain-walk reads hit
+        // the buffer instead of falling through to per-field reads.
+        $next_seg_base = null;  // base address of the next segment to load lazily; null = unknown / chain end
+        if ($buffered !== null && $this->current_vm_stack_base !== 0) {
+            $next_seg_base = $buffered->readRawInt64(
+                $pid,
+                $this->current_vm_stack_base + self::ZEND_VM_STACK_PREV_OFFSET,
+            );
+            if ($next_seg_base === 0) {
+                $next_seg_base = null;
+            }
+        }
+
         for ($i = 0; $i < $depth; $i++) {
+            /** @var int|null $prev_addr */
             $prev_addr = $buffered?->readRawInt64($pid, $addr + $prev_offset);
+            if ($prev_addr === null && $buffered !== null && $next_seg_base !== null) {
+                // Buffer miss. Try lazy prev-segment fetch before falling back.
+                $next_seg_base = $this->loadPrevSegment($pid, $next_seg_base, $dereferencer);
+                $prev_addr = $buffered->readRawInt64($pid, $addr + $prev_offset);
+            }
             if ($prev_addr === null) {
-                // Buffer miss — fall back to FieldReader for remaining frames
+                // Fall back to FieldReader for remaining frames
                 try {
                     $pointer = new Pointer(ZendExecuteData::class, $addr, $ed_size);
                     $ed = $dereferencer->deref($pointer);

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -63,6 +63,35 @@ final class CallTraceReader
     private const HOT_BELOW_TOP_BYTES = 8192;
     private const HOT_ABOVE_TOP_BYTES = 16384;
 
+    /**
+     * Runtime override for HOT_BELOW_TOP_BYTES via env var RELI_HOT_BELOW_BYTES.
+     * Useful for benchmark sweeps without rebuilding; not a public contract.
+     */
+    private static ?int $hot_below_override = null;
+    private static ?int $hot_above_override = null;
+
+    private static function hotBelowTopBytes(): int
+    {
+        if (self::$hot_below_override === null) {
+            $v = getenv('RELI_HOT_BELOW_BYTES');
+            self::$hot_below_override = ($v !== false && ctype_digit($v) && (int)$v > 0)
+                ? (int)$v
+                : self::HOT_BELOW_TOP_BYTES;
+        }
+        return self::$hot_below_override;
+    }
+
+    private static function hotAboveTopBytes(): int
+    {
+        if (self::$hot_above_override === null) {
+            $v = getenv('RELI_HOT_ABOVE_BYTES');
+            self::$hot_above_override = ($v !== false && ctype_digit($v) && (int)$v > 0)
+                ? (int)$v
+                : self::HOT_ABOVE_TOP_BYTES;
+        }
+        return self::$hot_above_override;
+    }
+
     private ?ZendTypeReader $zend_type_reader = null;
     private bool $bulk_stack_copy_enabled = false;
 
@@ -308,8 +337,10 @@ final class CallTraceReader
         int $vm_stack_top,
         int $vm_stack_end,
     ): array {
-        $hot_start = max($vm_stack_address, $vm_stack_top - self::HOT_BELOW_TOP_BYTES);
-        $hot_end = min($vm_stack_end, $vm_stack_top + self::HOT_ABOVE_TOP_BYTES);
+        $below = self::hotBelowTopBytes();
+        $above = self::hotAboveTopBytes();
+        $hot_start = max($vm_stack_address, $vm_stack_top - $below);
+        $hot_end = min($vm_stack_end, $vm_stack_top + $above);
         if ($hot_end <= $hot_start) {
             return [];
         }

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -251,7 +251,8 @@ final class CallTraceReader
         foreach ($stack_regions as $r) {
             $total_stack_size += $r['size'];
         }
-        if ($total_stack_size <= 0
+        if (
+            $total_stack_size <= 0
             || $total_stack_size > $this->memory_reader->getMaxPrefetchSize()
         ) {
             return null;

--- a/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
+++ b/src/Lib/PhpProcessReader/CallTraceReader/CallTraceReader.php
@@ -63,35 +63,6 @@ final class CallTraceReader
     private const HOT_BELOW_TOP_BYTES = 8192;
     private const HOT_ABOVE_TOP_BYTES = 16384;
 
-    /**
-     * Runtime override for HOT_BELOW_TOP_BYTES via env var RELI_HOT_BELOW_BYTES.
-     * Useful for benchmark sweeps without rebuilding; not a public contract.
-     */
-    private static ?int $hot_below_override = null;
-    private static ?int $hot_above_override = null;
-
-    private static function hotBelowTopBytes(): int
-    {
-        if (self::$hot_below_override === null) {
-            $v = getenv('RELI_HOT_BELOW_BYTES');
-            self::$hot_below_override = ($v !== false && ctype_digit($v) && (int)$v > 0)
-                ? (int)$v
-                : self::HOT_BELOW_TOP_BYTES;
-        }
-        return self::$hot_below_override;
-    }
-
-    private static function hotAboveTopBytes(): int
-    {
-        if (self::$hot_above_override === null) {
-            $v = getenv('RELI_HOT_ABOVE_BYTES');
-            self::$hot_above_override = ($v !== false && ctype_digit($v) && (int)$v > 0)
-                ? (int)$v
-                : self::HOT_ABOVE_TOP_BYTES;
-        }
-        return self::$hot_above_override;
-    }
-
     private ?ZendTypeReader $zend_type_reader = null;
     private bool $bulk_stack_copy_enabled = false;
 
@@ -337,10 +308,8 @@ final class CallTraceReader
         int $vm_stack_top,
         int $vm_stack_end,
     ): array {
-        $below = self::hotBelowTopBytes();
-        $above = self::hotAboveTopBytes();
-        $hot_start = max($vm_stack_address, $vm_stack_top - $below);
-        $hot_end = min($vm_stack_end, $vm_stack_top + $above);
+        $hot_start = max($vm_stack_address, $vm_stack_top - self::HOT_BELOW_TOP_BYTES);
+        $hot_end = min($vm_stack_end, $vm_stack_top + self::HOT_ABOVE_TOP_BYTES);
         if ($hot_end <= $hot_start) {
             return [];
         }

--- a/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
+++ b/src/Lib/Process/MemoryReader/BufferedMemoryReader.php
@@ -24,41 +24,49 @@ use Reli\Lib\Process\ProcessNotFoundException;
  * A decorator that can prefetch memory regions from a target process and serve
  * subsequent reads from local buffers.
  *
- * Supports two prefetch modes:
- * - Single-region prefetch via {@see prefetch()}
- * - Scatter-gather prefetch via {@see prefetchScatterGather()} which reads
- *   multiple non-contiguous regions in a single process_vm_readv syscall,
- *   minimizing the consistency window between them.
+ * Backed by a single pre-allocated pool buffer that is sliced bump-pointer
+ * style per prefetch. Up to {@see MAX_SCATTER_GATHER_REGIONS} regions may be
+ * kept resident at once, each occupying a slot with its own remote-address
+ * bookkeeping. This is enough headroom to cover the current VM stack segment
+ * plus a few lazily-fetched prev segments (as in Fiber-heavy targets).
+ *
+ * Supports:
+ * - Single-region prefetch via {@see prefetch()}.
+ * - Scatter-gather prefetch via {@see prefetchScatterGather()} that populates
+ *   multiple slots from a single process_vm_readv syscall — minimizing the
+ *   consistency window between the regions.
+ * - Incremental fetch via {@see prefetchAdditional()} that appends one more
+ *   region into a free slot without disturbing existing slots (used for
+ *   on-demand prev-segment reads during VM stack chain walks).
  */
 final class BufferedMemoryReader implements MemoryReaderInterface
 {
-    private const MAX_SCATTER_GATHER_REGIONS = 2;
+    public const MAX_SCATTER_GATHER_REGIONS = 4;
 
     private FFI $ffi;
 
-    // Two fixed buffer slots instead of an array — avoids per-read foreach/hash overhead
-    private ?int $buf0_pid = null;
-    private int $buf0_address = 0;
-    private int $buf0_size = 0;
-    private string $buf0_data = '';
+    /** Pre-allocated pool buffer; all prefetched data lives here. */
+    private CData $pool;
+    private int $pool_size;
+    private int $pool_used = 0;
 
-    private ?int $buf1_pid = null;
-    private int $buf1_address = 0;
-    private int $buf1_size = 0;
-    private string $buf1_data = '';
+    /** @var array<int, ?int> */
+    private array $slot_pid;
+    /** @var array<int, int> */
+    private array $slot_address;
+    /** @var array<int, int> */
+    private array $slot_size;
+    /** @var array<int, string> */
+    private array $slot_data;
 
-    // Pre-allocated scatter-gather infrastructure (reused across calls)
     private CData $sg_local_iovs;
     private CData $sg_remote_iovs;
     /** @var list<CData> */
     private array $sg_remote_bases;
-    private CData $sg_small_buf;
-    private ?CData $sg_large_buf = null;
-    private int $sg_large_buf_size = 0;
 
     public function __construct(
         private MemoryReaderInterface $inner,
-        private int $max_prefetch_size = 65536, // 64KB: typical VM stack usage + margin
+        private int $max_prefetch_size = 1048576,
     ) {
         $n = self::MAX_SCATTER_GATHER_REGIONS;
         $this->ffi = FFI::cdef('
@@ -76,6 +84,10 @@ final class BufferedMemoryReader implements MemoryReaderInterface
                              unsigned long flags);
         ', 'libc.so.6');
 
+        $this->pool = $this->ffi->new("unsigned char[{$max_prefetch_size}]")
+            ?? throw new CannotAllocateBufferException('cannot allocate pool buffer');
+        $this->pool_size = $max_prefetch_size;
+
         $this->sg_local_iovs = $this->ffi->new("struct iovec[{$n}]")
             ?? throw new CannotAllocateBufferException('cannot allocate iovec');
         $this->sg_remote_iovs = $this->ffi->new("struct iovec[{$n}]")
@@ -85,9 +97,11 @@ final class BufferedMemoryReader implements MemoryReaderInterface
             $this->sg_remote_bases[] = $this->ffi->new('long')
                 ?? throw new CannotAllocateBufferException('cannot allocate buffer');
         }
-        // Small buffer for region 0 (typically 8 bytes for a pointer)
-        $this->sg_small_buf = $this->ffi->new('unsigned char[64]')
-            ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+
+        $this->slot_pid = array_fill(0, $n, null);
+        $this->slot_address = array_fill(0, $n, 0);
+        $this->slot_size = array_fill(0, $n, 0);
+        $this->slot_data = array_fill(0, $n, '');
     }
 
     /**
@@ -96,16 +110,16 @@ final class BufferedMemoryReader implements MemoryReaderInterface
      */
     public function prefetch(int $pid, int $address, int $size): void
     {
-        if ($size <= 0 || $size > $this->max_prefetch_size) {
-            $this->clearBuffer();
+        $this->clearBuffer();
+        if ($size <= 0 || $size > $this->pool_size) {
             return;
         }
         $cdata = $this->inner->read($pid, $address, $size);
-        $this->buf0_pid = $pid;
-        $this->buf0_address = $address;
-        $this->buf0_size = $size;
-        $this->buf0_data = \FFI::string($cdata, $size);
-        $this->buf1_pid = null;
+        $this->slot_pid[0] = $pid;
+        $this->slot_address[0] = $address;
+        $this->slot_size[0] = $size;
+        $this->slot_data[0] = \FFI::string($cdata, $size);
+        $this->pool_used = $size;
     }
 
     /**
@@ -115,12 +129,11 @@ final class BufferedMemoryReader implements MemoryReaderInterface
      * between them is limited to kernel-side page-table walk time (typically
      * sub-microsecond) rather than the round-trip through PHP userspace.
      *
-     * Uses pre-allocated iovec arrays and buffers to avoid per-call FFI
-     * allocation overhead. Region 0 uses a fixed 64-byte buffer (sufficient
-     * for pointer-sized fields). Region 1's buffer is allocated once and
-     * reused if the size doesn't grow.
+     * Regions are copied into contiguous offsets within the pre-allocated
+     * pool, then surfaced as independent slots addressable via the caller's
+     * remote address.
      *
-     * @param list<array{address: int, size: int}> $regions max 2 regions
+     * @param list<array{address: int, size: int}> $regions max MAX_SCATTER_GATHER_REGIONS
      * @throws MemoryReaderException
      */
     public function prefetchScatterGather(int $pid, array $regions): void
@@ -136,31 +149,16 @@ final class BufferedMemoryReader implements MemoryReaderInterface
         foreach ($regions as $r) {
             $total_size += $r['size'];
         }
-        if ($total_size > $this->max_prefetch_size) {
+        if ($total_size > $this->pool_size) {
             return;
         }
 
-        // Set up iovecs using pre-allocated structures
-        /** @var list<CData> $local_buffers */
-        $local_buffers = [];
-
+        $offsets = [];
+        $cursor = 0;
         for ($i = 0; $i < $count; $i++) {
             $size = $regions[$i]['size'];
             $address = $regions[$i]['address'];
-
-            // Pick the right pre-allocated buffer
-            if ($i === 0 && $size <= 64) {
-                $buf = $this->sg_small_buf;
-            } else {
-                // Region 1 (VM stack): reuse large buffer if big enough
-                if ($this->sg_large_buf === null || $this->sg_large_buf_size < $size) {
-                    $this->sg_large_buf = $this->ffi->new("unsigned char[{$size}]")
-                        ?? throw new CannotAllocateBufferException('cannot allocate buffer');
-                    $this->sg_large_buf_size = $size;
-                }
-                $buf = $this->sg_large_buf;
-            }
-            $local_buffers[] = $buf;
+            $offsets[$i] = $cursor;
 
             /** @var \FFI\CInteger $this->sg_remote_bases[$i] */
             $this->sg_remote_bases[$i]->cdata = $address;
@@ -172,8 +170,12 @@ final class BufferedMemoryReader implements MemoryReaderInterface
              * @psalm-suppress PropertyTypeCoercion
              */
             $local_iov = $this->sg_local_iovs[$i];
-            /** @psalm-suppress PropertyTypeCoercion */
-            $local_iov->iov_base = \FFI::addr($buf);
+            /**
+             * @psalm-suppress PropertyTypeCoercion
+             * @psalm-suppress InaccessibleMethod
+             * @psalm-suppress PossiblyInvalidArgument
+             */
+            $local_iov->iov_base = \FFI::addr($this->pool[$cursor]);
             $local_iov->iov_len = $size;
 
             /**
@@ -185,6 +187,8 @@ final class BufferedMemoryReader implements MemoryReaderInterface
             $remote_iov->iov_len = $size;
             /** @psalm-suppress PropertyTypeCoercion */
             $remote_iov->iov_base = FFIHelper::cast('void *', $this->sg_remote_bases[$i]);
+
+            $cursor += $size;
         }
 
         /**
@@ -214,26 +218,126 @@ final class BufferedMemoryReader implements MemoryReaderInterface
             );
         }
 
-        // Store regions in fixed slots
-        $this->buf0_pid = $pid;
-        $this->buf0_address = $regions[0]['address'];
-        $this->buf0_size = $regions[0]['size'];
-        $this->buf0_data = \FFI::string($local_buffers[0], $regions[0]['size']);
-
-        if ($count > 1) {
-            $this->buf1_pid = $pid;
-            $this->buf1_address = $regions[1]['address'];
-            $this->buf1_size = $regions[1]['size'];
-            $this->buf1_data = \FFI::string($local_buffers[1], $regions[1]['size']);
-        } else {
-            $this->buf1_pid = null;
+        for ($i = 0; $i < $count; $i++) {
+            $size = $regions[$i]['size'];
+            $this->slot_pid[$i] = $pid;
+            $this->slot_address[$i] = $regions[$i]['address'];
+            $this->slot_size[$i] = $size;
+            /**
+             * @psalm-suppress InaccessibleMethod
+             * @psalm-suppress PossiblyInvalidArgument
+             */
+            $this->slot_data[$i] = \FFI::string(\FFI::addr($this->pool[$offsets[$i]]), $size);
         }
+        $this->pool_used = $cursor;
+    }
+
+    /**
+     * Append a region into the next free slot WITHOUT disturbing existing slots.
+     *
+     * Used to lazily fetch prev VM stack segments mid-chain-walk. Issues its
+     * own single-region process_vm_readv (so the new region is not guaranteed
+     * consistent with the earlier prefetched regions — that is acceptable for
+     * colder, older-segment frames whose content is essentially frozen during
+     * a request).
+     *
+     * Returns true iff the data is now resident in the buffer.
+     *
+     * @throws MemoryReaderException
+     */
+    public function prefetchAdditional(int $pid, int $address, int $size): bool
+    {
+        if ($size <= 0) {
+            return false;
+        }
+        if ($this->pool_used + $size > $this->pool_size) {
+            return false;
+        }
+
+        $slot = -1;
+        for ($i = 0; $i < self::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            if ($this->slot_pid[$i] === null) {
+                $slot = $i;
+                break;
+            }
+        }
+        if ($slot < 0) {
+            return false;
+        }
+
+        $offset = $this->pool_used;
+
+        /** @var \FFI\CInteger $this->sg_remote_bases[0] */
+        $this->sg_remote_bases[0]->cdata = $address;
+
+        /**
+         * @var FFI\Libc\iovec $local_iov
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidPropertyAssignment
+         * @psalm-suppress PropertyTypeCoercion
+         */
+        $local_iov = $this->sg_local_iovs[0];
+        /**
+         * @psalm-suppress PropertyTypeCoercion
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidArgument
+         */
+        $local_iov->iov_base = \FFI::addr($this->pool[$offset]);
+        $local_iov->iov_len = $size;
+
+        /**
+         * @var FFI\Libc\iovec $remote_iov
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidPropertyAssignment
+         */
+        $remote_iov = $this->sg_remote_iovs[0];
+        $remote_iov->iov_len = $size;
+        /** @psalm-suppress PropertyTypeCoercion */
+        $remote_iov->iov_base = FFIHelper::cast('void *', $this->sg_remote_bases[0]);
+
+        /**
+         * @var FFI\Libc\process_vm_readv_ffi $this->ffi
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidArgument
+         * @psalm-suppress MixedAssignment
+         */
+        $read = $this->ffi->process_vm_readv(
+            $pid,
+            \FFI::addr($this->sg_local_iovs[0]),
+            1,
+            \FFI::addr($this->sg_remote_iovs[0]),
+            1,
+            0
+        );
+
+        if ($read === -1) {
+            /** @var int $errno */
+            $errno = $this->ffi->errno;
+            if ($errno === Errno::ESRCH) {
+                throw new ProcessNotFoundException("process not found. pid={$pid}");
+            }
+            return false;
+        }
+
+        $this->slot_pid[$slot] = $pid;
+        $this->slot_address[$slot] = $address;
+        $this->slot_size[$slot] = $size;
+        /**
+         * @psalm-suppress InaccessibleMethod
+         * @psalm-suppress PossiblyInvalidArgument
+         */
+        $this->slot_data[$slot] = \FFI::string(\FFI::addr($this->pool[$offset]), $size);
+        $this->pool_used = $offset + $size;
+
+        return true;
     }
 
     public function clearBuffer(): void
     {
-        $this->buf0_pid = null;
-        $this->buf1_pid = null;
+        for ($i = 0; $i < self::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            $this->slot_pid[$i] = null;
+        }
+        $this->pool_used = 0;
     }
 
     public function getMaxPrefetchSize(): int
@@ -241,38 +345,38 @@ final class BufferedMemoryReader implements MemoryReaderInterface
         return $this->max_prefetch_size;
     }
 
+    /**
+     * Grow the pool if the new cap exceeds the current pool size. Shrinking
+     * is a no-op so long-lived readers don't churn allocations.
+     */
     public function setMaxPrefetchSize(int $max_prefetch_size): void
     {
         $this->max_prefetch_size = $max_prefetch_size;
+        if ($max_prefetch_size > $this->pool_size) {
+            $this->clearBuffer();
+            $this->pool = $this->ffi->new("unsigned char[{$max_prefetch_size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate pool buffer');
+            $this->pool_size = $max_prefetch_size;
+        }
     }
 
     /**
-     * Fast path: read a 64-bit integer directly from the buffer without
+     * Fast path: read a 64-bit integer directly from any slot's buffer without
      * any FFI allocation or casting. Returns null on buffer miss.
      */
     public function readRawInt64(int $pid, int $remote_address): ?int
     {
-        // Check slot 1 first (VM stack)
-        if (
-            $this->buf1_pid === $pid
-            && $remote_address >= $this->buf1_address
-            && ($remote_address + 8) <= ($this->buf1_address + $this->buf1_size)
-        ) {
-            $offset = $remote_address - $this->buf1_address;
-            /** @var array{1: int} $v */
-            $v = unpack('P', $this->buf1_data, $offset);
-            return $v[1];
-        }
-        // Check slot 0
-        if (
-            $this->buf0_pid === $pid
-            && $remote_address >= $this->buf0_address
-            && ($remote_address + 8) <= ($this->buf0_address + $this->buf0_size)
-        ) {
-            $offset = $remote_address - $this->buf0_address;
-            /** @var array{1: int} $v */
-            $v = unpack('P', $this->buf0_data, $offset);
-            return $v[1];
+        for ($i = 0; $i < self::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            if (
+                $this->slot_pid[$i] === $pid
+                && $remote_address >= $this->slot_address[$i]
+                && ($remote_address + 8) <= ($this->slot_address[$i] + $this->slot_size[$i])
+            ) {
+                $offset = $remote_address - $this->slot_address[$i];
+                /** @var array{1: int} $v */
+                $v = unpack('P', $this->slot_data[$i], $offset);
+                return $v[1];
+            }
         }
         return null;
     }
@@ -284,31 +388,19 @@ final class BufferedMemoryReader implements MemoryReaderInterface
     #[\Override]
     public function read(int $pid, int $remote_address, int $size): CData
     {
-        // Check slot 1 first (VM stack — most reads hit here)
-        if (
-            $this->buf1_pid === $pid
-            && $remote_address >= $this->buf1_address
-            && ($remote_address + $size) <= ($this->buf1_address + $this->buf1_size)
-        ) {
-            $offset = $remote_address - $this->buf1_address;
-            $buffer = $this->ffi->new("unsigned char[{$size}]")
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
-            \FFI::memcpy($buffer, substr($this->buf1_data, $offset, $size), $size);
-            /** @var \FFI\CArray<int> */
-            return $buffer;
-        }
-        // Check slot 0 (EG field / single prefetch)
-        if (
-            $this->buf0_pid === $pid
-            && $remote_address >= $this->buf0_address
-            && ($remote_address + $size) <= ($this->buf0_address + $this->buf0_size)
-        ) {
-            $offset = $remote_address - $this->buf0_address;
-            $buffer = $this->ffi->new("unsigned char[{$size}]")
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
-            \FFI::memcpy($buffer, substr($this->buf0_data, $offset, $size), $size);
-            /** @var \FFI\CArray<int> */
-            return $buffer;
+        for ($i = 0; $i < self::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            if (
+                $this->slot_pid[$i] === $pid
+                && $remote_address >= $this->slot_address[$i]
+                && ($remote_address + $size) <= ($this->slot_address[$i] + $this->slot_size[$i])
+            ) {
+                $offset = $remote_address - $this->slot_address[$i];
+                $buffer = $this->ffi->new("unsigned char[{$size}]")
+                    ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+                \FFI::memcpy($buffer, substr($this->slot_data[$i], $offset, $size), $size);
+                /** @var \FFI\CArray<int> */
+                return $buffer;
+            }
         }
         return $this->inner->read($pid, $remote_address, $size);
     }

--- a/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/GetTraceSettings/GetTraceSettingsFromConsoleInputTest.php
@@ -37,6 +37,7 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
             'with-native-trace' => false,
             'native-trace-anytime' => false,
             'bulk-stack-copy' => null,
+            'no-bulk-stack-copy' => false,
             'trace-var' => [],
             'trace-var-every' => null,
             'trace-var-on-function' => null,
@@ -59,7 +60,7 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
         $this->assertSame(10, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
-        $this->assertNull($settings->bulk_stack_copy_max_size);
+        $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
         $this->assertSame([], $settings->var_specs);
         $this->assertSame(1, $settings->var_every);
         $this->assertNull($settings->var_on_function);
@@ -73,6 +74,25 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
         $this->assertSame(PHP_INT_MAX, $settings->depth);
         $this->assertFalse($settings->with_native_trace);
+        // bulk-stack-copy is default-on
+        $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
+    }
+
+    public function testFromConsoleInputNoBulkStackCopyDisables(): void
+    {
+        $input = $this->buildInput(['no-bulk-stack-copy' => true]);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertNull($settings->bulk_stack_copy_max_size);
+    }
+
+    public function testFromConsoleInputBulkStackCopyZeroDisables(): void
+    {
+        $input = $this->buildInput(['bulk-stack-copy' => '0']);
+
+        $settings = (new GetTraceSettingsFromConsoleInput())->createSettings($input);
+
         $this->assertNull($settings->bulk_stack_copy_max_size);
     }
 
@@ -91,7 +111,7 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
         $this->assertTrue($settings->with_native_trace);
         $this->assertFalse($settings->native_trace_anytime);
-        $this->assertNull($settings->bulk_stack_copy_max_size);
+        $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputNativeTraceAnytime(): void
@@ -102,7 +122,7 @@ class GetTraceSettingsFromConsoleInputTest extends BaseTestCase
 
         $this->assertTrue($settings->with_native_trace); // implied by anytime
         $this->assertTrue($settings->native_trace_anytime);
-        $this->assertNull($settings->bulk_stack_copy_max_size);
+        $this->assertSame(GetTraceSettings::BULK_STACK_COPY_DEFAULT_MAX_SIZE, $settings->bulk_stack_copy_max_size);
     }
 
     public function testFromConsoleInputBulkStackCopyFlag(): void

--- a/tests/Lib/PhpProcessReader/CallTraceReader/VmStackBulkRegionsTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/VmStackBulkRegionsTest.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\CallTraceReader;
 
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Reli\BaseTestCase;
 
-class VmStackBulkRegionsTest extends TestCase
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class VmStackBulkRegionsTest extends BaseTestCase
 {
     #[Test]
     public function testShallowStackReturnsSingleRegionCoveringFromBaseToMargin(): void

--- a/tests/Lib/PhpProcessReader/CallTraceReader/VmStackBulkRegionsTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/VmStackBulkRegionsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\CallTraceReader;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class VmStackBulkRegionsTest extends TestCase
+{
+    #[Test]
+    public function testShallowStackReturnsSingleRegionCoveringFromBaseToMargin(): void
+    {
+        $base = 0x10_000_000;
+        $top = $base + 2000;            // 2KB used
+        $end = $base + 262144;          // 256KB segment
+
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $top, $end);
+
+        // Shallow: hot window (top-8K..top+16K) reaches below base, so we emit
+        // a single region starting at base up to top+16KB.
+        $this->assertCount(1, $regions);
+        $this->assertSame($base, $regions[0]['address']);
+        $this->assertSame($top + 16384 - $base, $regions[0]['size']);
+    }
+
+    #[Test]
+    public function testDeepStackSplitsHotThenCold(): void
+    {
+        $base = 0x10_000_000;
+        $top = $base + 180_000;         // 180KB used (deep)
+        $end = $base + 262144;
+
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $top, $end);
+
+        // Hot chunk: [top-8K, top+16K]; cold chunk: [base, top-8K]
+        $this->assertCount(2, $regions);
+
+        // iov[1] (hot) comes first
+        $hot_start = $top - 8192;
+        $hot_end = min($end, $top + 16384);
+        $this->assertSame($hot_start, $regions[0]['address']);
+        $this->assertSame($hot_end - $hot_start, $regions[0]['size']);
+
+        // iov[2] (cold) covers the base up to the hot chunk
+        $this->assertSame($base, $regions[1]['address']);
+        $this->assertSame($hot_start - $base, $regions[1]['size']);
+    }
+
+    #[Test]
+    public function testHotChunkIsClampedAtSegmentEnd(): void
+    {
+        $base = 0x10_000_000;
+        $end = $base + 262144;
+        $top = $end - 4000;             // top near segment end
+
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $top, $end);
+
+        // Hot chunk must not exceed $end even though top+16K would
+        $this->assertCount(2, $regions);
+        $this->assertSame($end, $regions[0]['address'] + $regions[0]['size']);
+    }
+
+    #[Test]
+    public function testHotStartIsClampedAtVmStackBase(): void
+    {
+        $base = 0x10_000_000;
+        $top = $base + 4000;            // top within 8K of base
+        $end = $base + 262144;
+
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $top, $end);
+
+        // Hot window reaches below base -> single-region path
+        $this->assertCount(1, $regions);
+        $this->assertSame($base, $regions[0]['address']);
+    }
+
+    #[Test]
+    public function testZeroStackReturnsEmpty(): void
+    {
+        $base = 0x10_000_000;
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $base, $base);
+
+        $this->assertSame([], $regions);
+    }
+
+    #[Test]
+    public function testHotChunkIncludesVmStackTopAndFramesBelow(): void
+    {
+        $base = 0x10_000_000;
+        $top = $base + 100_000;         // 100KB used
+        $end = $base + 262144;
+
+        $regions = CallTraceReader::computeVmStackBulkRegions($base, $top, $end);
+
+        // The single most important property: the hot region MUST cover the
+        // frame CED points to, which lives in [top - frame_size, top].
+        $this->assertCount(2, $regions);
+        $hot_addr = $regions[0]['address'];
+        $hot_size = $regions[0]['size'];
+        $this->assertLessThanOrEqual($top, $hot_addr);
+        $this->assertGreaterThanOrEqual($top, $hot_addr + $hot_size - 1);
+    }
+}

--- a/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
+++ b/tests/Lib/Process/MemoryReader/BufferedMemoryReaderTest.php
@@ -218,6 +218,77 @@ class BufferedMemoryReaderTest extends TestCase
     }
 
     #[Test]
+    public function testPrefetchAdditionalAppendsWithoutClearingExistingSlots(): void
+    {
+        $mock = $this->createMockReader();
+        $buffered = new BufferedMemoryReader($mock);
+
+        $pid = getmypid();
+        $ffi = FFI::cdef('');
+        $region1 = $ffi->new('unsigned char[8]');
+        $region2 = $ffi->new('unsigned char[8]');
+        $region3 = $ffi->new('unsigned char[8]');
+        assert($region1 !== null && $region2 !== null && $region3 !== null);
+        FFI::memcpy($region1, 'AAAAAAAA', 8);
+        FFI::memcpy($region2, 'BBBBBBBB', 8);
+        FFI::memcpy($region3, 'CCCCCCCC', 8);
+
+        $ptr1 = FFI::addr($region1);
+        $ptr2 = FFI::addr($region2);
+        $ptr3 = FFI::addr($region3);
+        $addr1 = FFIHelper::cast('long', $ptr1)->cdata;
+        $addr2 = FFIHelper::cast('long', $ptr2)->cdata;
+        $addr3 = FFIHelper::cast('long', $ptr3)->cdata;
+
+        $buffered->prefetchScatterGather($pid, [
+            ['address' => $addr1, 'size' => 8],
+            ['address' => $addr2, 'size' => 8],
+        ]);
+
+        $ok = $buffered->prefetchAdditional($pid, $addr3, 8);
+        $this->assertTrue($ok);
+
+        // All three regions must still be readable
+        $this->assertSame('AAAAAAAA', FFI::string($buffered->read($pid, $addr1, 8), 8));
+        $this->assertSame('BBBBBBBB', FFI::string($buffered->read($pid, $addr2, 8), 8));
+        $this->assertSame('CCCCCCCC', FFI::string($buffered->read($pid, $addr3, 8), 8));
+
+        $this->assertSame(0, $mock->readCount);
+    }
+
+    #[Test]
+    public function testPrefetchAdditionalFailsWhenNoSlotIsFree(): void
+    {
+        $mock = $this->createMockReader();
+        $buffered = new BufferedMemoryReader($mock);
+
+        $pid = getmypid();
+        $ffi = FFI::cdef('');
+        $regions = [];
+        $addrs = [];
+        for ($i = 0; $i < BufferedMemoryReader::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            $regions[$i] = $ffi->new('unsigned char[8]');
+            assert($regions[$i] !== null);
+            FFI::memcpy($regions[$i], str_repeat(chr(ord('A') + $i), 8), 8);
+            $ptr = FFI::addr($regions[$i]);
+            $addrs[$i] = FFIHelper::cast('long', $ptr)->cdata;
+        }
+        $sg_regions = [];
+        for ($i = 0; $i < BufferedMemoryReader::MAX_SCATTER_GATHER_REGIONS; $i++) {
+            $sg_regions[] = ['address' => $addrs[$i], 'size' => 8];
+        }
+        $buffered->prefetchScatterGather($pid, $sg_regions);
+
+        $extra = $ffi->new('unsigned char[8]');
+        assert($extra !== null);
+        $extra_ptr = FFI::addr($extra);
+        $extra_addr = FFIHelper::cast('long', $extra_ptr)->cdata;
+
+        $ok = $buffered->prefetchAdditional($pid, $extra_addr, 8);
+        $this->assertFalse($ok);
+    }
+
+    #[Test]
     public function testScatterGatherClearsOldBuffers(): void
     {
         $mock = $this->createMockReader();


### PR DESCRIPTION
## Summary

This PR refactors `BufferedMemoryReader` to use a unified pool-based buffer architecture with multiple independent slots, enabling lazy loading of previous VM stack segments during call trace chain walks. This improves consistency for Fiber-heavy workloads where VM stack segments are small (4KB) and frequently crossed.

## Key Changes

### BufferedMemoryReader Architecture Refactor
- **Unified pool buffer**: Replaced two fixed buffer slots (`buf0_data`, `buf1_data`) with a single pre-allocated pool buffer (`pool`) that is sliced bump-pointer style per prefetch
- **Slot-based metadata**: Converted fixed buffer fields to arrays (`slot_pid`, `slot_address`, `slot_size`, `slot_data`) supporting up to `MAX_SCATTER_GATHER_REGIONS` (increased from 2 to 4) independent regions
- **Removed dynamic allocation**: Eliminated per-call FFI allocations for scatter-gather buffers (`sg_small_buf`, `sg_large_buf`); all data now lives in the pre-allocated pool
- **New `prefetchAdditional()` method**: Allows appending a region into a free slot without disturbing existing slots, enabling lazy on-demand segment loads during chain walks

### CallTraceReader Enhancements
- **VM stack bulk region computation**: Added `computeVmStackBulkRegions()` static method that splits the VM stack into hot (near `vm_stack_top`) and cold (near base) chunks for optimal scatter-gather ordering
- **Lazy prev-segment loading**: Implemented `loadPrevSegment()` to fetch previous VM stack segments on-demand when chain walk encounters a buffer miss, using `prefetchAdditional()` to avoid clearing existing prefetched data
- **Improved consistency window**: Hot frames (where the chain walker starts) are read immediately after `current_execute_data`, minimizing the time gap between capturing the CED pointer and reading the frame it points to

### Configuration Changes
- **Default bulk-stack-copy enabled**: Changed default behavior to enable bulk-stack-copy with 1MB max size (up from 64KB)
- **New `--no-bulk-stack-copy` flag**: Allows users to explicitly disable bulk-stack-copy and fall back to per-field reads
- **Increased default pool size**: `max_prefetch_size` increased from 64KB to 1MB to accommodate deeper stacks and multiple segments

## Notable Implementation Details

- Pool buffer is allocated once in constructor and grown only if `setMaxPrefetchSize()` requests a larger capacity (shrinking is a no-op to avoid churn)
- Scatter-gather iov layout is carefully ordered: CED first (read at t0), then hot stack chunk (read at t1), then cold chunk (read last) to minimize consistency window
- `readRawInt64()` and `read()` now iterate through all slots instead of checking fixed positions, improving flexibility for future multi-region scenarios
- Comprehensive test coverage added for multi-slot prefetch and lazy segment loading behavior

https://claude.ai/code/session_01RVGwUKxZqGhn1KHWv2agAv