### PR TITLE
Add ZendMM chunk cache and fragmentation analysis passes

### DIFF
--- a/docs/internals/memory-report-architecture.md
+++ b/docs/internals/memory-report-architecture.md
@@ -47,7 +47,9 @@ MemoryReportCommand::execute()
         │     ├── OverviewPass($summary)
         │     ├── TypeBreakdownPass($location_types)
         │     ├── ClassRankingPass($class_objects)
-        │     └── CompanionDetectionPass($class_objects)
+        │     ├── CompanionDetectionPass($class_objects)
+        │     ├── ChunkCacheHeuristicPass($summary)
+        │     └── ChunkFragmentationPass($summary)
         ├── Phase 2: SQL passes (or --no-full-analysis < 500K nodes)
         │     ├── CallStackPass($db)
         │     ├── DynamicPropertiesPass($db)
@@ -162,10 +164,12 @@ Zero additional memory.
 
 | Pass | Source | Emits |
 |---|---|---|
-| OverviewPass | summary table | `overview`, `coverage_gap` |
+| OverviewPass | summary table | `overview`, `coverage_gap`, `near_memory_limit` |
 | TypeBreakdownPass | location_types_summary | `dominant_type` |
 | ClassRankingPass | class_objects_summary | `dominant_class` |
 | CompanionDetectionPass | class_objects_summary | `companion_cluster` |
+| ChunkCacheHeuristicPass | summary table | `zendmm_chunk_heuristic_state`, `zendmm_cache_expansion_imminent`, `zendmm_cache_bloat` |
+| ChunkFragmentationPass | summary table | `zendmm_chunk_fragmentation_state`, `zendmm_chunks_pinned_by_fragmentation`, `zendmm_heap_fragmentation_high` |
 
 ### Phase 2: SQL-Based
 
@@ -245,6 +249,8 @@ src/Inspector/Output/MemoryOutput/Report/
 │   ├── TypeBreakdownPass.php
 │   ├── ClassRankingPass.php
 │   ├── CompanionDetectionPass.php
+│   ├── ChunkCacheHeuristicPass.php   # ZendMM cache bloat / heuristic
+│   ├── ChunkFragmentationPass.php    # Fragmentation-pinned chunks
 │   ├── CallStackPass.php
 │   ├── DynamicPropertiesPass.php
 │   ├── PropertyScalingPass.php     # SQL or graph (retained)

--- a/docs/memory/memory-profiler-database.md
+++ b/docs/memory/memory-profiler-database.md
@@ -97,6 +97,28 @@ Key-value pairs containing metadata about the analysis snapshot.
 SELECT * FROM summary WHERE run_id = 1;
 ```
 
+Well-known keys produced for every run:
+
+| Key | Meaning |
+|---|---|
+| `php_version` | PHP version of the target process (e.g. `v84`) |
+| `memory_get_usage` | Userland `memory_get_usage()` — `zend_mm_heap->size` |
+| `memory_get_real_usage` | Userland `memory_get_usage(true)` — `zend_mm_heap->real_size` |
+| `memory_get_peak_usage` | `zend_mm_heap->peak` |
+| `memory_limit` | `zend_mm_heap->limit` |
+| `zend_mm_heap_total` / `zend_mm_heap_usage` | Analyzed heap totals per region |
+| `vm_stack_total` / `compiler_arena_total` | Region totals from RegionAnalyzer |
+| `heap_memory_analyzed_percentage` | Fraction of `memory_get_usage` covered by walked locations |
+| `rss` | Process RSS at capture time (when available) |
+| `cached_chunks_size` | `cached_chunks_count * 2 MiB` — bytes held in the chunk cache |
+| `chunks_count` | `zend_mm_heap->chunks_count` — in-use chunks |
+| `peak_chunks_count` | `zend_mm_heap->peak_chunks_count` |
+| `cached_chunks_count` | `zend_mm_heap->cached_chunks_count` |
+| `last_chunks_delete_boundary` | Chunk count at the last delete event — heuristic input |
+| `last_chunks_delete_count` | Consecutive deletes at that boundary — bumps `cached_chunks_max` on reaching 4 |
+| `chunks_total_free_bytes` | Sum of `free_pages * 4 KiB` across walked chunks (scattered free space) |
+| `chunks_mostly_empty_count` | Walked chunks that are ≥90% free — fragmentation-pinned candidates |
+
 #### `location_types_summary`
 Aggregated memory usage by location type, computed via `GROUP BY` from `context_node_locations`.
 

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -125,6 +125,13 @@ And the output is like below. The target process is [psalm](https://github.com/v
             "memory_get_usage": 129053816,
             "memory_get_real_usage": 153092096,
             "cached_chunks_size": 0,
+            "chunks_count": 73,
+            "peak_chunks_count": 73,
+            "cached_chunks_count": 0,
+            "last_chunks_delete_boundary": 0,
+            "last_chunks_delete_count": 0,
+            "chunks_total_free_bytes": 552960,
+            "chunks_mostly_empty_count": 0,
             "heap_memory_analyzed_percentage": 98.36809784842008,
             "php_version": "v82",
             "analyzer": "reli 0.12.0"
@@ -513,6 +520,20 @@ This section contains the summary of the memory usage of the target process. The
 #### cached_chunks_size
 - This is the total size of the chunks that are cached by ZendMM and not used at the time of the analysis
 - ZendMM may not immediately return unused chunks to the OS but use them for another allocation later, and this field represents their total size.
+
+#### chunks_count / peak_chunks_count / cached_chunks_count
+- Raw chunk counters from `zend_mm_heap`
+- `chunks_count` is the number of chunks currently in the in-use list, `peak_chunks_count` is the maximum observed during the request, and `cached_chunks_count` is the number of freed chunks ZendMM is still holding in its cache
+- `cached_chunks_size` === `cached_chunks_count * 2MB`
+
+#### last_chunks_delete_boundary / last_chunks_delete_count
+- State of the chunk-delete heuristic that decides when to grow `cached_chunks_max` (the ceiling on how many chunks ZendMM keeps cached instead of returning to the OS)
+- `last_chunks_delete_boundary` is the chunk count at which the most recent delete was observed; `last_chunks_delete_count` is how many consecutive deletes have happened at that boundary. Reaching 4 bumps `cached_chunks_max` up, so cached chunks stay resident for longer. Surfaced so memory analysis can tell "cache-bloated by heuristic" apart from "fragmentation-pinned".
+
+#### chunks_total_free_bytes / chunks_mostly_empty_count
+- Aggregates computed during the in-use chunk walk
+- `chunks_total_free_bytes` is the sum of `free_pages * 4KB` across all walked chunks — the total amount of free-page space scattered across the heap
+- `chunks_mostly_empty_count` is the number of in-use chunks that are ≥90% free, typically the "one long-lived allocation pins 2MB" pattern. Unlike `cached_chunks_count`, these cannot be released by `gc_mem_caches()` because they are still in the in-use list.
 
 #### zend_mm_chunk_total / zend_mm_chunk_usage
 - The total size of the normal chunks allocated by ZendMM and its analyzed usage

--- a/docs/memory/memory-report.md
+++ b/docs/memory/memory-report.md
@@ -252,6 +252,9 @@ All class names use fully qualified names (FQCN). Paths use PHP syntax: `<main>:
 | `large_array` | Large arrays (retained size when available) | "15.30 MB retained (table: 160.00 KB), 10,000 elements" |
 | `large_string` | Large strings with owner path | "205.88 KB — <main>:67::$messages[0]->structure->raw" |
 | `sparse_array` | Arrays with low slot utilization | "256.00 KB table, 5/16,384 slots (0.03%)" |
+| `zendmm_cache_bloat` | ZendMM caches more chunks than it's currently using | "holding 8 cached chunks (16.00 MB) vs 2 in-use" |
+| `zendmm_chunks_pinned_by_fragmentation` | ≥4 in-use chunks ≥90% empty but can't be returned to OS | "5 in-use chunks ≥90% empty but cannot be returned to the OS" |
+| `zendmm_heap_fragmentation_high` | Scattered free-page space exceeds analyzed heap usage | "10.00 MB free inside in-use chunks vs 3.00 MB analyzed" |
 
 ### Low Severity
 
@@ -275,12 +278,42 @@ All class names use fully qualified names (FQCN). Paths use PHP syntax: `<main>:
 | `root_blame` | Memory attributed to each root branch |
 | `retained_exact` | No cycles — retained size is exact |
 | `retained_approximate` | Cycles exist — retained size is approximate |
+| `zendmm_chunk_heuristic_state` | Current ZendMM chunk counters and chunk-delete heuristic state |
+| `zendmm_chunk_fragmentation_state` | Scattered free-page bytes and "mostly empty" chunk count |
 
 ### Warning
 
 | Kind | Description |
 |---|---|
 | `coverage_gap` | Less than 95% of heap analyzed — unaccounted memory |
+| `near_memory_limit` | Peak usage ≥80% (warning) or ≥95% (high) of `memory_limit` |
+| `zendmm_cache_expansion_imminent` | `last_chunks_delete_count` near the threshold — `cached_chunks_max` is about to grow |
+| `zendmm_chunks_pinned_by_fragmentation` | 1-3 in-use chunks ≥90% empty but pinned (Medium from 4 chunks) |
+
+### ZendMM Chunk Findings
+
+`zendmm_*` findings surface the two distinct ways a PHP process can hold on to
+memory without the userland heap (`memory_get_usage()`) reflecting it:
+
+- **Cache bloat** (`zendmm_cache_bloat`, `zendmm_cache_expansion_imminent`).
+  ZendMM keeps a cache of freed 2 MB chunks to avoid thrashing the OS
+  allocator, and grows `cached_chunks_max` when `last_chunks_delete_count`
+  reaches 4 at the same boundary. Long-lived CLI / worker processes that cycle
+  through bursty workloads can accumulate cached chunks that stay resident
+  until shutdown. Mitigation: call `gc_mem_caches()` between jobs.
+- **Fragmentation pin-up** (`zendmm_chunks_pinned_by_fragmentation`,
+  `zendmm_heap_fragmentation_high`). A chunk is only returned to the OS when
+  every page inside it is free, so one long-lived allocation (interned string,
+  persistent class entry, surviving HashTable bucket) can hold an otherwise
+  empty 2 MB hostage. `gc_mem_caches()` does **not** help here because these
+  chunks are still in the in-use list. Mitigation: recycle long-lived workers
+  after heavy transient allocations.
+
+The `zendmm_chunk_heuristic_state` and `zendmm_chunk_fragmentation_state` info
+findings always report the raw counters (`chunks_count`, `peak_chunks_count`,
+`cached_chunks_count`, `last_chunks_delete_boundary/count`,
+`chunks_total_free_bytes`, `chunks_mostly_empty_count`) so you can see the
+underlying numbers even when no warning fires.
 
 ## Analysis Phases
 

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -174,6 +174,8 @@ final class MemoryCommand extends Command
                     'cached_chunks_count' => $collected_memories->cached_chunks_count,
                     'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
                     'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
+                    'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
+                    'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -169,6 +169,11 @@ final class MemoryCommand extends Command
                     'memory_get_usage' => $collected_memories->memory_get_usage_size,
                     'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
                     'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                    'chunks_count' => $collected_memories->chunks_count,
+                    'peak_chunks_count' => $collected_memories->peak_chunks_count,
+                    'cached_chunks_count' => $collected_memories->cached_chunks_count,
+                    'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
+                    'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -115,6 +115,8 @@ final class CoreDumpReader
                     'cached_chunks_count' => $collected_memories->cached_chunks_count,
                     'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
                     'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
+                    'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
+                    'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -110,6 +110,11 @@ final class CoreDumpReader
                     'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
                     'memory_limit' => $collected_memories->memory_limit,
                     'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                    'chunks_count' => $collected_memories->chunks_count,
+                    'peak_chunks_count' => $collected_memories->peak_chunks_count,
+                    'cached_chunks_count' => $collected_memories->cached_chunks_count,
+                    'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
+                    'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
                 ]
                 + [
                     'heap_memory_analyzed_percentage' =>

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -276,6 +276,8 @@ final class MemoryDumpReader
                 'cached_chunks_count' => $collected_memories->cached_chunks_count,
                 'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
                 'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
+                'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
+                'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
             ]
             + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
             + [

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -271,6 +271,11 @@ final class MemoryDumpReader
                 'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
                 'memory_limit' => $collected_memories->memory_limit,
                 'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                'chunks_count' => $collected_memories->chunks_count,
+                'peak_chunks_count' => $collected_memories->peak_chunks_count,
+                'cached_chunks_count' => $collected_memories->cached_chunks_count,
+                'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
+                'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
             ]
             + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
             + [

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChunkCacheHeuristicPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChunkCacheHeuristicPass.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+
+/**
+ * Reports on ZendMM's chunk-delete heuristic state.
+ *
+ * ZendMM keeps a cache of freed chunks to avoid thrashing the OS allocator,
+ * and grows that cache (`cached_chunks_max`) when it detects repeated
+ * deletions at the same chunk-count boundary — the signal is
+ * `last_chunks_delete_count` reaching 4 while sitting at
+ * `last_chunks_delete_boundary`. This pass surfaces that state, and flags
+ * cache bloat where the cached-but-unused portion is a large fraction of
+ * live chunks.
+ */
+final class ChunkCacheHeuristicPass implements PassInterface
+{
+    private const DELETE_COUNT_BUMP_THRESHOLD = 4;
+
+    /** @param array<int, array<string, mixed>> $summary */
+    public function __construct(
+        private array $summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $flat = [];
+        foreach ($this->summary as $entry) {
+            foreach ($entry as $key => $value) {
+                $flat[$key] = $value;
+            }
+        }
+
+        $chunks_count = (int)($flat['chunks_count'] ?? 0);
+        $peak_chunks_count = (int)($flat['peak_chunks_count'] ?? 0);
+        $cached_chunks_count = (int)($flat['cached_chunks_count'] ?? 0);
+        $cached_chunks_size = (int)($flat['cached_chunks_size'] ?? 0);
+        $last_boundary = (int)($flat['last_chunks_delete_boundary'] ?? 0);
+        $last_delete_count = (int)($flat['last_chunks_delete_count'] ?? 0);
+
+        // No chunk data (e.g. summary produced by an older Reli version).
+        if ($chunks_count === 0 && $peak_chunks_count === 0 && $cached_chunks_count === 0) {
+            return [];
+        }
+
+        $findings = [];
+
+        $total_chunks = $chunks_count + $cached_chunks_count;
+        $facts = [
+            'chunks_count' => $chunks_count,
+            'peak_chunks_count' => $peak_chunks_count,
+            'cached_chunks_count' => $cached_chunks_count,
+            'cached_chunks_size' => $cached_chunks_size,
+            'last_chunks_delete_boundary' => $last_boundary,
+            'last_chunks_delete_count' => $last_delete_count,
+        ];
+
+        $findings[] = new Finding(
+            kind: 'zendmm_chunk_heuristic_state',
+            severity: FindingSeverity::Info,
+            confidence: FindingConfidence::High,
+            summary: sprintf(
+                'ZendMM chunks: %d in-use, %d cached (%s), peak %d;'
+                . ' chunk-delete heuristic at %d/%d on boundary %d',
+                $chunks_count,
+                $cached_chunks_count,
+                SizeFormatter::format($cached_chunks_size),
+                $peak_chunks_count,
+                $last_delete_count,
+                self::DELETE_COUNT_BUMP_THRESHOLD,
+                $last_boundary,
+            ),
+            facts: $facts,
+            replay_query: "SELECT key, value FROM summary WHERE key IN"
+                . " ('chunks_count', 'peak_chunks_count', 'cached_chunks_count',"
+                . " 'cached_chunks_size', 'last_chunks_delete_boundary',"
+                . " 'last_chunks_delete_count')",
+        );
+
+        // Heuristic is about to bump cached_chunks_max — the next free at the
+        // same boundary will keep the chunk cached rather than returning it.
+        if ($last_delete_count >= self::DELETE_COUNT_BUMP_THRESHOLD - 1) {
+            $findings[] = new Finding(
+                kind: 'zendmm_cache_expansion_imminent',
+                severity: FindingSeverity::Warning,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    'ZendMM has seen %d chunk deletions at boundary %d'
+                    . ' (threshold %d): cached_chunks_max will grow on the next free',
+                    $last_delete_count,
+                    $last_boundary,
+                    self::DELETE_COUNT_BUMP_THRESHOLD,
+                ),
+                facts: $facts,
+                hypothesis: 'Workload is cycling through a stable working set of chunks;'
+                    . ' ZendMM is about to keep more chunks cached instead of returning to OS,'
+                    . ' so RSS will stay elevated between bursts',
+                next_checks: [
+                    'Check whether this is a long-lived CLI / worker process',
+                    'Call gc_mem_caches() between jobs to drop cached chunks back to the OS',
+                ],
+            );
+        }
+
+        // Cache bloat: cached chunks dominate vs. live working set.
+        if (
+            $total_chunks >= 4
+            && $cached_chunks_count >= $chunks_count
+            && $cached_chunks_count >= 2
+        ) {
+            $findings[] = new Finding(
+                kind: 'zendmm_cache_bloat',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    'ZendMM is holding more cached chunks (%d, %s) than in-use chunks (%d)',
+                    $cached_chunks_count,
+                    SizeFormatter::format($cached_chunks_size),
+                    $chunks_count,
+                ),
+                facts: $facts,
+                hypothesis: 'Past peaks bumped cached_chunks_max and the cache has not shrunk;'
+                    . ' cached chunks are not returned to the OS until shutdown or gc_mem_caches()',
+                next_checks: [
+                    'Call gc_mem_caches() periodically to release cached chunks',
+                    'Compare cached_chunks_size against RSS to confirm the OS-level impact',
+                ],
+                impact_bytes: $cached_chunks_size,
+            );
+        }
+
+        return $findings;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChunkFragmentationPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChunkFragmentationPass.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+
+/**
+ * Reports on chunk-level fragmentation.
+ *
+ * A ZendMM chunk can only be returned to the OS when every page inside it is
+ * free; one long-lived allocation is enough to pin the entire 2 MB. This pass
+ * looks at aggregated free-page statistics collected during the chunk walk
+ * and surfaces both the total scattered free-page space and the count of
+ * chunks that are almost empty but cannot be released.
+ */
+final class ChunkFragmentationPass implements PassInterface
+{
+    /** @param array<int, array<string, mixed>> $summary */
+    public function __construct(
+        private array $summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $flat = [];
+        foreach ($this->summary as $entry) {
+            foreach ($entry as $key => $value) {
+                $flat[$key] = $value;
+            }
+        }
+
+        $chunks_count = (int)($flat['chunks_count'] ?? 0);
+        $total_free_bytes = (int)($flat['chunks_total_free_bytes'] ?? 0);
+        $mostly_empty_count = (int)($flat['chunks_mostly_empty_count'] ?? 0);
+        $heap_usage = (int)($flat['zend_mm_heap_usage'] ?? 0);
+
+        if ($chunks_count === 0) {
+            return [];
+        }
+
+        $findings = [];
+
+        // Info line: always emit so users can see the raw fragmentation signal.
+        $findings[] = new Finding(
+            kind: 'zendmm_chunk_fragmentation_state',
+            severity: FindingSeverity::Info,
+            confidence: FindingConfidence::High,
+            summary: sprintf(
+                'ZendMM fragmentation: %s of free space scattered across %d in-use chunks'
+                . ' (%d chunks are ≥90%% empty but pinned)',
+                SizeFormatter::format($total_free_bytes),
+                $chunks_count,
+                $mostly_empty_count,
+            ),
+            facts: [
+                'chunks_count' => $chunks_count,
+                'chunks_total_free_bytes' => $total_free_bytes,
+                'chunks_mostly_empty_count' => $mostly_empty_count,
+            ],
+            replay_query: "SELECT key, value FROM summary WHERE key IN"
+                . " ('chunks_count', 'chunks_total_free_bytes', 'chunks_mostly_empty_count')",
+        );
+
+        // Pinned mostly-empty chunks — the "one allocation holds 2 MB hostage"
+        // pattern. Even one is worth mentioning because gc_mem_caches() won't
+        // release these.
+        if ($mostly_empty_count > 0) {
+            $severity = $mostly_empty_count >= 4
+                ? FindingSeverity::Medium
+                : FindingSeverity::Warning;
+            $findings[] = new Finding(
+                kind: 'zendmm_chunks_pinned_by_fragmentation',
+                severity: $severity,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    '%d in-use chunk%s ≥90%% empty but cannot be returned to the OS',
+                    $mostly_empty_count,
+                    $mostly_empty_count === 1 ? ' is' : 's are',
+                ),
+                facts: [
+                    'chunks_mostly_empty_count' => $mostly_empty_count,
+                    'chunks_count' => $chunks_count,
+                ],
+                hypothesis: 'A small number of long-lived allocations are scattered across these chunks,'
+                    . ' preventing ZendMM from releasing them. gc_mem_caches() does not help here'
+                    . ' because the chunks are still in the in-use list, not the cache.',
+                next_checks: [
+                    'Inspect locations inside these chunks to identify the pinning allocations'
+                        . ' (interned strings, persistent class entries, long-lived HashTable buckets)',
+                    'Consider restarting long-lived workers between heavy jobs',
+                ],
+                impact_bytes: $mostly_empty_count * 2 * 1024 * 1024,
+            );
+        }
+
+        // Large total free-page area relative to heap usage: heap is bloated
+        // by per-chunk free gaps.
+        if ($heap_usage > 0 && $total_free_bytes > $heap_usage) {
+            $findings[] = new Finding(
+                kind: 'zendmm_heap_fragmentation_high',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    'Free-page space inside in-use chunks (%s) exceeds analyzed heap usage (%s)',
+                    SizeFormatter::format($total_free_bytes),
+                    SizeFormatter::format($heap_usage),
+                ),
+                facts: [
+                    'chunks_total_free_bytes' => $total_free_bytes,
+                    'heap_usage' => $heap_usage,
+                    'chunks_count' => $chunks_count,
+                ],
+                hypothesis: 'Live allocations are spread thin across many chunks;'
+                    . ' compaction would reclaim substantial memory but PHP cannot move allocations.',
+                next_checks: [
+                    'Check whether this is a long-running worker that processed a memory peak earlier',
+                    'If possible, recycle workers after large transient allocations',
+                ],
+                impact_bytes: $total_free_bytes,
+            );
+        }
+
+        return $findings;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -17,6 +17,8 @@ use Reli\Inspector\Output\MemoryOutput\Report\Pass\PassInterface;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BlameAllocationPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CallStackPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChokePointPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChunkCacheHeuristicPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChunkFragmentationPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ClassRankingPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CompanionDetectionPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CycleClusterPass;
@@ -107,6 +109,8 @@ final class ReportGenerator
         $findings = array_merge($findings, (new TypeBreakdownPass($location_types))->analyze());
         $findings = array_merge($findings, (new ClassRankingPass($class_objects))->analyze());
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
+        $findings = array_merge($findings, (new ChunkCacheHeuristicPass($summary))->analyze());
+        $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
 
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
         $run_phase3 = $full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000);
@@ -344,6 +348,8 @@ final class ReportGenerator
         $findings = array_merge($findings, (new TypeBreakdownPass($location_types))->analyze());
         $findings = array_merge($findings, (new ClassRankingPass($class_objects))->analyze());
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
+        $findings = array_merge($findings, (new ChunkCacheHeuristicPass($summary))->analyze());
+        $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
 
         // Phase 3: Substrate passes — binary goes straight here.
         //

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -63,6 +63,12 @@ final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $cached_chunks_count;
 
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $last_chunks_delete_boundary;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $last_chunks_delete_count;
+
     private ?FieldReader $field_reader = null;
 
     /**
@@ -85,6 +91,8 @@ final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
         unset($this->chunks_count);
         unset($this->peak_chunks_count);
         unset($this->cached_chunks_count);
+        unset($this->last_chunks_delete_boundary);
+        unset($this->last_chunks_delete_count);
     }
 
     #[\Override]
@@ -151,6 +159,14 @@ final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
                 $this->pointer,
                 'cached_chunks_count',
             ),
+            'last_chunks_delete_boundary' => $this->last_chunks_delete_boundary = $this->field_reader->readIntField(
+                $this->pointer,
+                'last_chunks_delete_boundary',
+            ),
+            'last_chunks_delete_count' => $this->last_chunks_delete_count = $this->field_reader->readIntField(
+                $this->pointer,
+                'last_chunks_delete_count',
+            ),
         };
     }
 
@@ -182,6 +198,10 @@ final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
             'chunks_count' => $this->chunks_count = $this->casted_cdata->casted->chunks_count,
             'peak_chunks_count' => $this->peak_chunks_count = $this->casted_cdata->casted->peak_chunks_count,
             'cached_chunks_count' => $this->cached_chunks_count = $this->casted_cdata->casted->cached_chunks_count,
+            'last_chunks_delete_boundary' => $this->last_chunks_delete_boundary
+                = $this->casted_cdata->casted->last_chunks_delete_boundary,
+            'last_chunks_delete_count' => $this->last_chunks_delete_count
+                = $this->casted_cdata->casted->last_chunks_delete_count,
         };
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -33,6 +33,8 @@ final class CollectedMemories
         public int $cached_chunks_count = 0,
         public int $last_chunks_delete_boundary = 0,
         public int $last_chunks_delete_count = 0,
+        public int $chunks_total_free_bytes = 0,
+        public int $chunks_mostly_empty_count = 0,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -28,6 +28,11 @@ final class CollectedMemories
         public int $memory_get_usage_real_size,
         public int $memory_get_peak_usage,
         public int $memory_limit,
+        public int $chunks_count = 0,
+        public int $peak_chunks_count = 0,
+        public int $cached_chunks_count = 0,
+        public int $last_chunks_delete_boundary = 0,
+        public int $last_chunks_delete_count = 0,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -161,7 +161,12 @@ final class MemoryLocationsCollector
         $memory_get_usage_real_size = $zend_mm_main_chunk->heap_slot->real_size;
         $memory_get_peak_usage = $zend_mm_main_chunk->heap_slot->peak;
         $memory_limit = $zend_mm_main_chunk->heap_slot->limit;
-        $cached_chunks_size = $zend_mm_main_chunk->heap_slot->cached_chunks_count * ZendMmChunk::SIZE;
+        $chunks_count = $zend_mm_main_chunk->heap_slot->chunks_count;
+        $peak_chunks_count = $zend_mm_main_chunk->heap_slot->peak_chunks_count;
+        $cached_chunks_count = $zend_mm_main_chunk->heap_slot->cached_chunks_count;
+        $cached_chunks_size = $cached_chunks_count * ZendMmChunk::SIZE;
+        $last_chunks_delete_boundary = $zend_mm_main_chunk->heap_slot->last_chunks_delete_boundary;
+        $last_chunks_delete_count = $zend_mm_main_chunk->heap_slot->last_chunks_delete_count;
 
         // Warn if chunk walk was incomplete (corrupt next pointer or
         // chunks outside dump region).
@@ -343,6 +348,11 @@ final class MemoryLocationsCollector
             $memory_get_usage_real_size,
             $memory_get_peak_usage,
             $memory_limit,
+            $chunks_count,
+            $peak_chunks_count,
+            $cached_chunks_count,
+            $last_chunks_delete_boundary,
+            $last_chunks_delete_count,
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -140,11 +140,21 @@ final class MemoryLocationsCollector
 
         $zend_mm_main_chunk = $dereferencer->deref($main_chunk_header_pointer);
         $walked_chunk_count = 0;
+        $chunks_total_free_bytes = 0;
+        $chunks_mostly_empty_count = 0;
+        // Threshold: chunks that are at least 90% free (so only a few pages
+        // pinning an otherwise-empty chunk).
+        $mostly_empty_free_pages_threshold = intdiv(ZendMmChunk::SIZE / ZendMmChunk::PAGE_SIZE * 9, 10);
         foreach ($zend_mm_main_chunk->iterateChunks($dereferencer) as $chunk) {
             $chunk_memory_location = ZendMmChunkMemoryLocation::fromZendMmChunk($chunk);
             $chunk_memory_locations->add(
                 $chunk_memory_location
             );
+            $free_pages = $chunk->free_pages;
+            $chunks_total_free_bytes += $free_pages * ZendMmChunk::PAGE_SIZE;
+            if ($free_pages >= $mostly_empty_free_pages_threshold) {
+                $chunks_mostly_empty_count++;
+            }
             $walked_chunk_count++;
         }
         $huge_memory_locations = new MemoryLocations();
@@ -353,6 +363,8 @@ final class MemoryLocationsCollector
             $cached_chunks_count,
             $last_chunks_delete_boundary,
             $last_chunks_delete_count,
+            $chunks_total_free_bytes,
+            $chunks_mostly_empty_count,
         );
     }
 

--- a/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
+++ b/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
@@ -153,6 +153,25 @@ class CoreDumpReaderIntegrationTest extends BaseTestCase
         $this->assertGreaterThan(0, $summary['memory_get_peak_usage']);
         $this->assertArrayHasKey('memory_limit', $summary);
         $this->assertGreaterThan(0, $summary['memory_limit']);
+
+        // ZendMM chunk counters and fragmentation aggregates surfaced from
+        // the heap_slot + chunk walk. The live process has at least one
+        // in-use chunk (main_chunk), and the heuristic fields are always
+        // present even when they're zero.
+        $this->assertArrayHasKey('chunks_count', $summary);
+        $this->assertGreaterThanOrEqual(1, $summary['chunks_count']);
+        $this->assertArrayHasKey('peak_chunks_count', $summary);
+        $this->assertGreaterThanOrEqual(
+            (int)$summary['chunks_count'],
+            (int)$summary['peak_chunks_count'],
+        );
+        $this->assertArrayHasKey('cached_chunks_count', $summary);
+        $this->assertArrayHasKey('last_chunks_delete_boundary', $summary);
+        $this->assertArrayHasKey('last_chunks_delete_count', $summary);
+        $this->assertArrayHasKey('chunks_total_free_bytes', $summary);
+        $this->assertGreaterThanOrEqual(0, $summary['chunks_total_free_bytes']);
+        $this->assertArrayHasKey('chunks_mostly_empty_count', $summary);
+        $this->assertGreaterThanOrEqual(0, $summary['chunks_mostly_empty_count']);
     }
 
     private function takeCoreDump(int $pid): string

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -438,6 +438,133 @@ class SummaryPassesTest extends BaseTestCase
         $this->assertSame([], $pass->analyze());
     }
 
+    public function testChunkCacheHeuristicPassStateFindingContainsAllFactsAndReplayQuery(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 3,
+                'peak_chunks_count' => 5,
+                'cached_chunks_count' => 2,
+                'cached_chunks_size' => 4 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 3,
+                'last_chunks_delete_count' => 1,
+            ],
+        ]);
+        $state = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_chunk_heuristic_state',
+        ));
+        $this->assertCount(1, $state);
+        $facts = $state[0]->facts;
+        foreach (
+            [
+                'chunks_count',
+                'peak_chunks_count',
+                'cached_chunks_count',
+                'cached_chunks_size',
+                'last_chunks_delete_boundary',
+                'last_chunks_delete_count',
+            ] as $key
+        ) {
+            $this->assertArrayHasKey($key, $facts, "fact '{$key}' missing");
+        }
+        $this->assertStringContainsString('summary', $state[0]->replay_query);
+    }
+
+    public function testChunkCacheHeuristicPassFlagsImminentAtExactThreshold(): void
+    {
+        // The heuristic bumps cached_chunks_max when last_chunks_delete_count
+        // reaches 4, so a value of exactly 4 is still "just triggered" and
+        // should be flagged as well as 3 (one-short).
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 10,
+                'peak_chunks_count' => 10,
+                'cached_chunks_count' => 0,
+                'cached_chunks_size' => 0,
+                'last_chunks_delete_boundary' => 10,
+                'last_chunks_delete_count' => 4,
+            ],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertContains('zendmm_cache_expansion_imminent', $kinds);
+    }
+
+    public function testChunkCacheHeuristicPassDoesNotFlagImminentBelowThreshold(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 10,
+                'peak_chunks_count' => 10,
+                'cached_chunks_count' => 0,
+                'cached_chunks_size' => 0,
+                'last_chunks_delete_boundary' => 10,
+                'last_chunks_delete_count' => 2,
+            ],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertNotContains('zendmm_cache_expansion_imminent', $kinds);
+    }
+
+    public function testChunkCacheHeuristicPassDoesNotFlagBloatWhenTotalTooSmall(): void
+    {
+        // total = chunks_count + cached_chunks_count = 3, below the minimum
+        // of 4; don't flag to avoid spurious findings on tiny heaps.
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 1,
+                'peak_chunks_count' => 3,
+                'cached_chunks_count' => 2,
+                'cached_chunks_size' => 2 * 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 1,
+                'last_chunks_delete_count' => 0,
+            ],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertNotContains('zendmm_cache_bloat', $kinds);
+    }
+
+    public function testChunkCacheHeuristicPassDoesNotFlagBloatWhenCachedEqualsOne(): void
+    {
+        // cached = 1 should not trigger bloat even if it >= in-use — a
+        // single cached chunk is just the normal steady-state buffer.
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 1,
+                'peak_chunks_count' => 5,
+                'cached_chunks_count' => 1,
+                'cached_chunks_size' => 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 1,
+                'last_chunks_delete_count' => 0,
+            ],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertNotContains('zendmm_cache_bloat', $kinds);
+    }
+
+    public function testChunkCacheHeuristicPassFlagsBloatAtBoundary(): void
+    {
+        // chunks_count + cached_chunks_count == 4 hits the minimum total,
+        // cached >= in-use, cached >= 2 — all three bloat conditions met.
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 2,
+                'peak_chunks_count' => 5,
+                'cached_chunks_count' => 2,
+                'cached_chunks_size' => 2 * 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 2,
+                'last_chunks_delete_count' => 0,
+            ],
+        ]);
+        $bloat = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_cache_bloat',
+        ));
+        $this->assertCount(1, $bloat);
+        $this->assertSame('medium', $bloat[0]->severity->value);
+        $this->assertSame(2 * 2 * 1024 * 1024, $bloat[0]->impact_bytes);
+    }
+
     // ---- ChunkFragmentationPass ----
 
     public function testChunkFragmentationPassEmitsStateFinding(): void
@@ -479,5 +606,129 @@ class SummaryPassesTest extends BaseTestCase
     {
         $pass = new ChunkFragmentationPass([[]]);
         $this->assertSame([], $pass->analyze());
+    }
+
+    public function testChunkFragmentationPassStateFindingContainsAllFactsAndReplayQuery(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 4,
+                'chunks_total_free_bytes' => 512 * 1024,
+                'chunks_mostly_empty_count' => 0,
+                'zend_mm_heap_usage' => 8 * 1024 * 1024,
+            ],
+        ]);
+        $state = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_chunk_fragmentation_state',
+        ));
+        $this->assertCount(1, $state);
+        $facts = $state[0]->facts;
+        $this->assertSame(4, $facts['chunks_count']);
+        $this->assertSame(512 * 1024, $facts['chunks_total_free_bytes']);
+        $this->assertSame(0, $facts['chunks_mostly_empty_count']);
+        $this->assertStringContainsString('summary', $state[0]->replay_query);
+    }
+
+    public function testChunkFragmentationPassPinnedChunksWarningSeverityBelowFour(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 8,
+                'chunks_total_free_bytes' => 0,
+                'chunks_mostly_empty_count' => 3,
+                'zend_mm_heap_usage' => 16 * 1024 * 1024,
+            ],
+        ]);
+        $pinned = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_chunks_pinned_by_fragmentation',
+        ));
+        $this->assertCount(1, $pinned);
+        $this->assertSame('warning', $pinned[0]->severity->value);
+        $this->assertSame(3 * 2 * 1024 * 1024, $pinned[0]->impact_bytes);
+    }
+
+    public function testChunkFragmentationPassPinnedChunksMediumSeverityAtFour(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 8,
+                'chunks_total_free_bytes' => 0,
+                'chunks_mostly_empty_count' => 4,
+                'zend_mm_heap_usage' => 16 * 1024 * 1024,
+            ],
+        ]);
+        $pinned = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_chunks_pinned_by_fragmentation',
+        ));
+        $this->assertCount(1, $pinned);
+        $this->assertSame('medium', $pinned[0]->severity->value);
+        $this->assertSame(4 * 2 * 1024 * 1024, $pinned[0]->impact_bytes);
+    }
+
+    public function testChunkFragmentationPassPinnedChunksSingularGrammar(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 4,
+                'chunks_total_free_bytes' => 0,
+                'chunks_mostly_empty_count' => 1,
+                'zend_mm_heap_usage' => 16 * 1024 * 1024,
+            ],
+        ]);
+        $pinned = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_chunks_pinned_by_fragmentation',
+        ));
+        $this->assertCount(1, $pinned);
+        $this->assertStringContainsString('1 in-use chunk is', $pinned[0]->summary);
+    }
+
+    public function testChunkFragmentationPassHeapFragmentationNotFlaggedWhenFreeBelowUsage(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 8,
+                'chunks_total_free_bytes' => 2 * 1024 * 1024,
+                'chunks_mostly_empty_count' => 0,
+                'zend_mm_heap_usage' => 16 * 1024 * 1024,
+            ],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertNotContains('zendmm_heap_fragmentation_high', $kinds);
+    }
+
+    public function testChunkFragmentationPassHeapFragmentationImpactBytes(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 20,
+                'chunks_total_free_bytes' => 30 * 1024 * 1024,
+                'chunks_mostly_empty_count' => 0,
+                'zend_mm_heap_usage' => 10 * 1024 * 1024,
+            ],
+        ]);
+        $high = array_values(array_filter(
+            $pass->analyze(),
+            fn(Finding $f) => $f->kind === 'zendmm_heap_fragmentation_high',
+        ));
+        $this->assertCount(1, $high);
+        $this->assertSame(30 * 1024 * 1024, $high[0]->impact_bytes);
+    }
+
+    public function testChunkFragmentationPassDegradesWhenFragmentationAggregatesMissing(): void
+    {
+        // Summary from an older Reli version: chunks_count present but not
+        // the new fragmentation aggregates. State finding still emits with
+        // zeros; no spurious pinned/high-fragmentation findings.
+        $pass = new ChunkFragmentationPass([
+            ['chunks_count' => 5, 'zend_mm_heap_usage' => 16 * 1024 * 1024],
+        ]);
+        $kinds = array_map(fn(Finding $f) => $f->kind, $pass->analyze());
+        $this->assertContains('zendmm_chunk_fragmentation_state', $kinds);
+        $this->assertNotContains('zendmm_chunks_pinned_by_fragmentation', $kinds);
+        $this->assertNotContains('zendmm_heap_fragmentation_high', $kinds);
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -367,4 +367,117 @@ class SummaryPassesTest extends BaseTestCase
         $this->assertSame('retained_approximate', $findings[0]->kind);
         $this->assertStringContainsString('1 cycle', $findings[0]->summary);
     }
+
+    // ---- ChunkCacheHeuristicPass ----
+
+    public function testChunkCacheHeuristicPassEmitsStateFinding(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 3,
+                'peak_chunks_count' => 5,
+                'cached_chunks_count' => 1,
+                'cached_chunks_size' => 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 3,
+                'last_chunks_delete_count' => 1,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $state = array_values(array_filter(
+            $findings,
+            fn(Finding $f) => $f->kind === 'zendmm_chunk_heuristic_state',
+        ));
+        $this->assertCount(1, $state);
+        $this->assertStringContainsString('1/4 on boundary 3', $state[0]->summary);
+    }
+
+    public function testChunkCacheHeuristicPassFlagsImminentCacheExpansion(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 10,
+                'peak_chunks_count' => 10,
+                'cached_chunks_count' => 0,
+                'cached_chunks_size' => 0,
+                'last_chunks_delete_boundary' => 10,
+                'last_chunks_delete_count' => 3,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $kinds = array_map(fn(Finding $f) => $f->kind, $findings);
+        $this->assertContains('zendmm_cache_expansion_imminent', $kinds);
+    }
+
+    public function testChunkCacheHeuristicPassFlagsCacheBloat(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([
+            [
+                'chunks_count' => 2,
+                'peak_chunks_count' => 10,
+                'cached_chunks_count' => 8,
+                'cached_chunks_size' => 8 * 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 2,
+                'last_chunks_delete_count' => 0,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $bloat = array_values(array_filter(
+            $findings,
+            fn(Finding $f) => $f->kind === 'zendmm_cache_bloat',
+        ));
+        $this->assertCount(1, $bloat);
+        $this->assertSame(8 * 2 * 1024 * 1024, $bloat[0]->impact_bytes);
+    }
+
+    public function testChunkCacheHeuristicPassReturnsEmptyWhenSummaryLacksCounters(): void
+    {
+        $pass = new ChunkCacheHeuristicPass([['zend_mm_heap_usage' => 1234]]);
+        $this->assertSame([], $pass->analyze());
+    }
+
+    // ---- ChunkFragmentationPass ----
+
+    public function testChunkFragmentationPassEmitsStateFinding(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 4,
+                'chunks_total_free_bytes' => 512 * 1024,
+                'chunks_mostly_empty_count' => 0,
+                'zend_mm_heap_usage' => 8 * 1024 * 1024,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $kinds = array_map(fn(Finding $f) => $f->kind, $findings);
+        $this->assertContains('zendmm_chunk_fragmentation_state', $kinds);
+        $this->assertNotContains('zendmm_chunks_pinned_by_fragmentation', $kinds);
+        $this->assertNotContains('zendmm_heap_fragmentation_high', $kinds);
+    }
+
+    public function testChunkFragmentationPassFlagsPinnedChunks(): void
+    {
+        $pass = new ChunkFragmentationPass([
+            [
+                'chunks_count' => 6,
+                'chunks_total_free_bytes' => 10 * 1024 * 1024,
+                'chunks_mostly_empty_count' => 5,
+                'zend_mm_heap_usage' => 3 * 1024 * 1024,
+            ],
+        ]);
+        $findings = $pass->analyze();
+
+        $kinds = array_map(fn(Finding $f) => $f->kind, $findings);
+        $this->assertContains('zendmm_chunks_pinned_by_fragmentation', $kinds);
+        $this->assertContains('zendmm_heap_fragmentation_high', $kinds);
+    }
+
+    public function testChunkFragmentationPassReturnsEmptyWhenNoChunks(): void
+    {
+        $pass = new ChunkFragmentationPass([[]]);
+        $this->assertSame([], $pass->analyze());
+    }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/ReportGeneratorTest.php
@@ -346,6 +346,96 @@ class ReportGeneratorTest extends BaseTestCase
         $this->assertTrue($graphPassRan, 'Graph-based passes should run with full_analysis=true');
     }
 
+    public function testChunkHeuristicStateFindingWiredIntoReport(): void
+    {
+        $this->buildMinimalDb([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'chunks_count' => 3,
+                'peak_chunks_count' => 5,
+                'cached_chunks_count' => 1,
+                'cached_chunks_size' => 2 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 3,
+                'last_chunks_delete_count' => 1,
+            ],
+        ]);
+        $result = $this->generateReport();
+
+        $state = $this->findByKind($result, 'zendmm_chunk_heuristic_state');
+        $this->assertCount(1, $state);
+        $this->assertSame('info', $state[0]->severity->value);
+    }
+
+    public function testChunkFragmentationStateFindingWiredIntoReport(): void
+    {
+        $this->buildMinimalDb([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'chunks_count' => 4,
+                'chunks_total_free_bytes' => 512 * 1024,
+                'chunks_mostly_empty_count' => 0,
+            ],
+        ]);
+        $result = $this->generateReport();
+
+        $state = $this->findByKind($result, 'zendmm_chunk_fragmentation_state');
+        $this->assertCount(1, $state);
+        $this->assertSame('info', $state[0]->severity->value);
+    }
+
+    public function testChunkCacheBloatEmittedWhenConditionsMet(): void
+    {
+        $this->buildMinimalDb([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'chunks_count' => 2,
+                'peak_chunks_count' => 10,
+                'cached_chunks_count' => 8,
+                'cached_chunks_size' => 16 * 1024 * 1024,
+                'last_chunks_delete_boundary' => 2,
+                'last_chunks_delete_count' => 0,
+            ],
+        ]);
+        $result = $this->generateReport();
+
+        $bloat = $this->findByKind($result, 'zendmm_cache_bloat');
+        $this->assertCount(1, $bloat);
+        $this->assertSame(16 * 1024 * 1024, $bloat[0]->impact_bytes);
+    }
+
+    public function testChunkPinnedByFragmentationEmittedWhenConditionsMet(): void
+    {
+        $this->buildMinimalDb([
+            [
+                'zend_mm_heap_total' => 10485760,
+                'zend_mm_heap_usage' => 8388608,
+                'chunks_count' => 6,
+                'chunks_total_free_bytes' => 10 * 1024 * 1024,
+                'chunks_mostly_empty_count' => 5,
+            ],
+        ]);
+        $result = $this->generateReport();
+
+        $pinned = $this->findByKind($result, 'zendmm_chunks_pinned_by_fragmentation');
+        $this->assertCount(1, $pinned);
+    }
+
+    public function testChunkPassesSkippedGracefullyWhenCountersMissing(): void
+    {
+        // Older-version summary without any chunk counters.
+        $this->buildMinimalDb([
+            ['zend_mm_heap_total' => 10485760, 'zend_mm_heap_usage' => 8388608],
+            ['heap_memory_analyzed_percentage' => 99.0],
+        ]);
+        $result = $this->generateReport();
+
+        $this->assertSame([], $this->findByKind($result, 'zendmm_chunk_heuristic_state'));
+        $this->assertSame([], $this->findByKind($result, 'zendmm_chunk_fragmentation_state'));
+    }
+
     // ---- Helpers ----
 
     private function generateReport(): ReportResult

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -206,6 +206,24 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
 
         $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
 
+        // Chunk counters are read from heap_slot on every collection.
+        // A live PHP process has at least one in-use chunk (main_chunk),
+        // and peak_chunks_count is always >= chunks_count by construction.
+        $this->assertGreaterThanOrEqual(1, $collected_memories->chunks_count);
+        $this->assertGreaterThanOrEqual(
+            $collected_memories->chunks_count,
+            $collected_memories->peak_chunks_count,
+        );
+        $this->assertGreaterThanOrEqual(0, $collected_memories->cached_chunks_count);
+        $this->assertGreaterThanOrEqual(0, $collected_memories->last_chunks_delete_boundary);
+        $this->assertGreaterThanOrEqual(0, $collected_memories->last_chunks_delete_count);
+        $this->assertGreaterThanOrEqual(0, $collected_memories->chunks_total_free_bytes);
+        $this->assertGreaterThanOrEqual(0, $collected_memories->chunks_mostly_empty_count);
+        $this->assertLessThanOrEqual(
+            $collected_memories->chunks_count,
+            $collected_memories->chunks_mostly_empty_count,
+        );
+
         // Verify PDO and PDOStatement objects are detected
         $object_class_analyzer = new ObjectClassAnalyzer();
         $sink->flush();

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -169,6 +169,8 @@ class zend_mm_heap extends CData
     public int $chunks_count;
     public int $peak_chunks_count;
     public int $cached_chunks_count;
+    public int $last_chunks_delete_boundary;
+    public int $last_chunks_delete_count;
 }
 class zend_mm_huge_list extends CData
 {


### PR DESCRIPTION
## Summary
This PR adds two new memory analysis passes to detect and report on ZendMM chunk-level memory issues: cache bloat from the chunk-delete heuristic and heap fragmentation from pinned chunks.

## Key Changes

### New Analysis Passes
- **ChunkCacheHeuristicPass**: Reports on ZendMM's chunk-delete heuristic state and detects:
  - Cache expansion imminent (when `last_chunks_delete_count` reaches the threshold of 4)
  - Cache bloat (when cached chunks dominate the in-use working set)
  
- **ChunkFragmentationPass**: Reports on chunk-level fragmentation and detects:
  - Pinned mostly-empty chunks (≥90% free but cannot be released due to long-lived allocations)
  - High heap fragmentation (when free-page space exceeds analyzed heap usage)

### Data Collection Enhancements
- Extended `ZendMmHeap` type to expose `last_chunks_delete_boundary` and `last_chunks_delete_count` fields from the heap structure
- Enhanced `MemoryLocationsCollector` to aggregate fragmentation statistics during chunk walks:
  - Total free bytes across all chunks
  - Count of mostly-empty chunks (≥90% free pages)
- Updated `CollectedMemories` to carry chunk counters and fragmentation data through the pipeline

### Integration
- Wired both new passes into `ReportGenerator` to run alongside existing memory analysis
- Updated all memory readers (CoreDumpReader, MemoryDumpReader, MemoryCommand) to surface the new chunk metrics in summaries
- Added comprehensive test coverage for both passes with edge cases (boundary conditions, missing data, singular/plural grammar)

## Implementation Details
- Both passes gracefully degrade when chunk counters are missing (e.g., from older Reli versions)
- Cache bloat detection uses a minimum total chunk threshold (4) to avoid spurious findings on tiny heaps
- Fragmentation detection distinguishes between pinned chunks (in-use list) and cached chunks (cache list)
- All findings include facts, replay queries, and actionable next-check recommendations

https://claude.ai/code/session_018dwDPu79uEgCVX2ox6t5sP