### PR TITLE
Add layout, formatting, and cropping options to rbt:analyze output

### DIFF
--- a/docs/tracing/rbt-analyze-and-explore.md
+++ b/docs/tracing/rbt-analyze-and-explore.md
@@ -130,6 +130,8 @@ for live tailing while a long-running script chugs along:
 ```bash
 ./reli rbt:analyze --last=5 < trace.rbt
 
+...self/total tables...
+
 # last 5 sample(s)
   ── sample (4 ago) ──
   [ 0] PDO::query /var/www/src/Db.php:142
@@ -141,6 +143,44 @@ for live tailing while a long-running script chugs along:
 ```
 
 `--last` alone defaults to 1, `--last=N` keeps a ring buffer of N.
+The tail prints after the aggregation tables so `watch` shows the
+(fixed-size) tables anchored at the top and lets the variable-depth
+stack sit at the bottom of the screen.
+
+**Stabilise the layout under `watch`** — the stack depth of each
+sample varies and can jitter the rest of the display. Three levers,
+usable together:
+
+```bash
+# Cap every tail stack at 5 leaf-most frames.
+watch './reli rbt:analyze --last --last-depth=5 --top=5 < trace.rbt'
+
+# Drop the directory portion of every file path ('Worker.php:42')
+# and hard-clip each line to the terminal width so a stray 200-char
+# FQN doesn't wrap-break the layout.
+./reli rbt:analyze --last=5 --path=short --crop=auto < trace.rbt
+```
+
+`--path` is display-only — aggregation still keys on the full path, so
+two files with the same basename stay distinct in the self/total
+counts.
+
+**Rearrange and side-by-side** — the `--sections` flag controls both
+the order of the report and whether sections stack or sit next to
+each other. `,` separates rows, `+` joins columns within a row:
+
+```bash
+# self/total side by side on top, the tail full-width below:
+./reli rbt:analyze --last=5 --sections='self+total,tail' < trace.rbt
+
+# three columns, tail at the right — trades vertical space for width:
+./reli rbt:analyze --last=5 --sections='self+total+tail' \
+  --path=short --crop=auto < trace.rbt
+```
+
+Known section names: `self`, `total`, `callers`, `callees`, `tail`.
+Sections that wouldn't have content this run (e.g. `callers` with no
+`--callers=` pattern) are silently skipped.
 
 **Suppress the default tables** (e.g. when you only want a callers
 view, no top-N noise) with `--top=0`:
@@ -154,12 +194,16 @@ view, no top-N noise) with `--top=0`:
 | Option | Default | Description |
 |---|---|---|
 | `--top=N` | `20` | Rows per table. `0` suppresses the default self/total tables. |
-| `--last[=N]` | off | Print the last N sample stacks (default 1) at the top of the report. |
+| `--last[=N]` | off | Print the last N sample stacks (default 1). |
+| `--last-depth=N` | `0` | Cap each `--last` stack at N leaf-most frames (`0` = no cap). Tail-only; doesn't affect aggregation. |
 | `--callers=PATTERN` | — | Show callers of frames matching this PCRE pattern (no delimiters needed). |
 | `--callees=PATTERN` | — | Show callees of frames matching this PCRE pattern. |
 | `--match=PATTERN` | — | Only count samples whose stack contains a matching frame. |
 | `--hide=PATTERN` | — | Drop frames matching this PCRE pattern from each stack *before* counting. |
 | `--no-line` | off | Group frames by function name only (ignore `file:line`). |
+| `--path=MODE` | `full` | `full` keeps the whole path; `short` displays only `basename:line`. Display-only. |
+| `--crop=N\|auto` | `0` | Hard-clip each output line at N chars (or the terminal width per column with `auto`). Appends an ellipsis when clipping. |
+| `--sections=SPEC` | `self,total,callers,callees,tail` | Layout spec. `,` stacks rows, `+` lays sections side by side. |
 
 All `*=PATTERN` flags take a raw PCRE regex without delimiters; reli
 wraps them in `#…#` internally.

--- a/docs/tracing/rbt-analyze-and-explore.md
+++ b/docs/tracing/rbt-analyze-and-explore.md
@@ -165,6 +165,19 @@ watch './reli rbt:analyze --last --last-depth=5 --top=5 < trace.rbt'
 two files with the same basename stay distinct in the self/total
 counts.
 
+By default `--crop` keeps the head of each frame and puts the
+ellipsis on the right. For deep-namespace frames like
+`Reli\Inspector\MemoryDump\FastPath\RegionByteProvider::regionBytes`
+that can hide the leaf; flip the anchor with `--crop-anchor=right`
+to keep the class/method/file instead:
+
+```bash
+./reli rbt:analyze --last=5 --path=short --crop=auto --crop-anchor=right < trace.rbt
+```
+
+Frames are cropped *before* going into the table, so Symfony's
+auto-sized borders stay intact either way.
+
 **Rearrange and side-by-side** — the `--sections` flag controls both
 the order of the report and whether sections stack or sit next to
 each other. `,` separates rows, `+` joins columns within a row:
@@ -202,7 +215,8 @@ view, no top-N noise) with `--top=0`:
 | `--hide=PATTERN` | — | Drop frames matching this PCRE pattern from each stack *before* counting. |
 | `--no-line` | off | Group frames by function name only (ignore `file:line`). |
 | `--path=MODE` | `full` | `full` keeps the whole path; `short` displays only `basename:line`. Display-only. |
-| `--crop=N\|auto` | `0` | Hard-clip each output line at N chars (or the terminal width per column with `auto`). Appends an ellipsis when clipping. |
+| `--crop=N\|auto` | `0` | Hard-clip each frame at N chars (or the terminal width per column with `auto`). Tables keep their borders — the crop applies to the frame column only. |
+| `--crop-anchor=left\|right` | `left` | Which end of the frame `--crop` preserves. `left` keeps the head (namespace); `right` keeps the leaf (class + method + file). |
 | `--sections=SPEC` | `self,total,callers,callees,tail` | Layout spec. `,` stacks rows, `+` lays sections side by side. |
 
 All `*=PATTERN` flags take a raw PCRE regex without delimiters; reli

--- a/src/Command/Rbt/AnalyzeCommand.php
+++ b/src/Command/Rbt/AnalyzeCommand.php
@@ -15,14 +15,18 @@ namespace Reli\Command\Rbt;
 
 use Reli\Converter\BinaryTrace\BinaryTraceReader;
 use Reli\Converter\StreamDecompressor;
+use Reli\Rbt\Analyze\FrameFormatter;
+use Reli\Rbt\Analyze\SectionLayout;
 use Reli\Rbt\Analyze\TraceAggregationResult;
 use Reli\Rbt\Analyze\TraceAggregator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 
 /**
  * Aggregates a binary trace (.rbt) into hot-frame and call-site reports.
@@ -42,7 +46,7 @@ final class AnalyzeCommand extends Command
                 'top',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Number of rows to show per table (0 to suppress aggregation tables)',
+                'Number of rows to show per table (0 to suppress the default self/total tables)',
                 '20',
             )
             ->addOption(
@@ -52,6 +56,14 @@ final class AnalyzeCommand extends Command
                 'Print the last N samples\' call stacks (default 1) — useful for'
                 . ' watching an in-progress trace and seeing the current execution position',
                 false,
+            )
+            ->addOption(
+                'last-depth',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Cap each --last stack at N leaf-most frames (0 = no cap) so deeper stacks'
+                . ' don\'t shove the rest of the report around under `watch`',
+                '0',
             )
             ->addOption(
                 'callers',
@@ -89,6 +101,31 @@ final class AnalyzeCommand extends Command
                 InputOption::VALUE_NONE,
                 'Include the VM opcode in each frame key (e.g. [ZEND_RECV])',
             )
+            ->addOption(
+                'path',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path display mode: full (default) or short (basename only'
+                . ' — display-only, does not affect aggregation)',
+                FrameFormatter::PATH_FULL,
+            )
+            ->addOption(
+                'crop',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Crop each output line at N characters (or "auto" for terminal width) to prevent wrap;'
+                . ' in multi-column layouts the width is split per column',
+                '0',
+            )
+            ->addOption(
+                'sections',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Layout spec: "," stacks rows, "+" lays sections out side by side.'
+                . ' Known sections: self, total, callers, callees, tail.'
+                . ' Example: "self+total,tail"',
+                SectionLayout::DEFAULT_SPEC,
+            )
         ;
     }
 
@@ -106,6 +143,7 @@ final class AnalyzeCommand extends Command
         $hide_pattern = $input->getOption('hide');
         $no_line = (bool) $input->getOption('no-line');
         $with_opcode = (bool) $input->getOption('with-opcode');
+        $last_depth = max(0, (int) $input->getOption('last-depth'));
 
         // --last:
         //   absent  → false (no tail)
@@ -118,6 +156,33 @@ final class AnalyzeCommand extends Command
             $last_count = $last_raw === null ? 1 : max(1, (int) $last_raw);
         }
 
+        /** @var string $path_mode */
+        $path_mode = $input->getOption('path');
+        if (!in_array($path_mode, [FrameFormatter::PATH_FULL, FrameFormatter::PATH_SHORT], true)) {
+            $output->writeln("<error>--path must be 'full' or 'short', got: {$path_mode}</error>");
+            return 1;
+        }
+
+        /** @var string $sections_spec */
+        $sections_spec = $input->getOption('sections');
+        try {
+            $layout = SectionLayout::parse($sections_spec);
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+
+        $terminal_width = (new Terminal())->getWidth();
+        $row_crop_widths = $this->resolveCrop(
+            (string) $input->getOption('crop'),
+            $layout,
+            $terminal_width,
+            $output,
+        );
+        if ($row_crop_widths === null) {
+            return 1;
+        }
+
         $aggregator = new TraceAggregator(
             no_line: $no_line,
             with_opcode: $with_opcode,
@@ -126,6 +191,7 @@ final class AnalyzeCommand extends Command
             callers_re: TraceAggregator::wrapPattern($callers_pattern),
             callees_re: TraceAggregator::wrapPattern($callees_pattern),
             last_count: $last_count,
+            last_depth: $last_depth,
         );
 
         $reader = new BinaryTraceReader();
@@ -138,56 +204,191 @@ final class AnalyzeCommand extends Command
 
         $this->writeSummary($err, $reader, $result->sample_count, $result->matched_samples);
 
-        if ($last_count > 0) {
-            $this->printTail($output, $result->tail);
-        }
+        $sections = $this->renderSections(
+            $result,
+            new FrameFormatter($path_mode),
+            $layout,
+            $row_crop_widths,
+            $top,
+            $last_count,
+            $callers_pattern,
+            $callees_pattern,
+        );
 
-        $denominator = $result->matched_samples > 0 ? $result->matched_samples : 1;
-
-        if ($top > 0) {
-            $this->printTable($output, 'self-time top', $result->self_counts, $denominator, $top);
-            $this->printTable($output, 'total-time top (inclusive)', $result->total_counts, $denominator, $top);
-        }
-
-        // --top 0 only suppresses the default self/total tables. The
-        // callers/callees tables are explicit asks; always render them
-        // (with their own row cap so the user can still bound output).
-        $explicit_top = $top > 0 ? $top : 20;
-
-        if ($aggregator->callers_re !== null) {
-            $this->printTable(
-                $output,
-                "callers of frames matching /{$callers_pattern}/",
-                $result->caller_counts,
-                $denominator,
-                $explicit_top,
-            );
-        }
-        if ($aggregator->callees_re !== null) {
-            $this->printTable(
-                $output,
-                "callees of frames matching /{$callees_pattern}/",
-                $result->callee_counts,
-                $denominator,
-                $explicit_top,
-            );
+        $lines = $layout->assemble($sections);
+        foreach ($lines as $line) {
+            $output->writeln($line);
         }
 
         return 0;
     }
 
     /**
-     * Render the most recent samples' call stacks with annotations.
+     * Resolve --crop into per-row per-column widths.
      *
-     * @param list<array{frames: list<string>, annotations: array<string, string>|null}> $tail
+     * For `auto`, each row's width budget is the terminal width minus the
+     * gaps between its columns, divided evenly across the columns. A row
+     * with one column gets the full terminal width; a 3-column row with
+     * an 180-char terminal gets ~58 chars per column.
+     *
+     * Returns null on parse error after writing to the output.
+     *
+     * @return array<int, list<int>>|null
      */
-    private function printTail(OutputInterface $output, array $tail): void
+    private function resolveCrop(
+        string $raw,
+        SectionLayout $layout,
+        int $terminal_width,
+        OutputInterface $output,
+    ): ?array {
+        $raw = trim($raw);
+        $is_auto = strcasecmp($raw, 'auto') === 0;
+        $fixed = 0;
+        if (!$is_auto) {
+            if (!preg_match('/^-?\d+$/', $raw)) {
+                $output->writeln("<error>--crop must be 'auto' or an integer, got: {$raw}</error>");
+                return null;
+            }
+            $fixed = max(0, (int) $raw);
+        }
+
+        $gap_width = strlen(SectionLayout::COLUMN_GAP);
+        /** @var array<int, list<int>> $per_row */
+        $per_row = [];
+        foreach ($layout->rows as $row_index => $row) {
+            $n = count($row);
+            if (!$is_auto) {
+                $per_row[$row_index] = array_fill(0, $n, $fixed);
+                continue;
+            }
+            if ($terminal_width <= 0 || $n === 0) {
+                $per_row[$row_index] = array_fill(0, $n, 0);
+                continue;
+            }
+            $usable = $terminal_width - ($n - 1) * $gap_width;
+            if ($usable <= 0) {
+                $per_row[$row_index] = array_fill(0, $n, 0);
+                continue;
+            }
+            $per_row[$row_index] = array_fill(0, $n, intdiv($usable, $n));
+        }
+
+        return $per_row;
+    }
+
+    /**
+     * Render every known section to a list of plain-text lines, keyed by
+     * section name so {@see SectionLayout::assemble()} can pick them up
+     * in the requested order. Sections that wouldn't have content this
+     * run (callers/callees without a pattern, tail without --last) are
+     * omitted rather than rendered empty.
+     *
+     * @param array<int, list<int>> $row_crop_widths
+     * @return array<string, list<string>>
+     */
+    private function renderSections(
+        TraceAggregationResult $result,
+        FrameFormatter $formatter,
+        SectionLayout $layout,
+        array $row_crop_widths,
+        int $top,
+        int $last_count,
+        ?string $callers_pattern,
+        ?string $callees_pattern,
+    ): array {
+        $denominator = $result->matched_samples > 0 ? $result->matched_samples : 1;
+        $explicit_top = $top > 0 ? $top : 20;
+
+        $crop_for_section = $this->buildSectionCropMap($layout, $row_crop_widths);
+
+        /** @var array<string, list<string>> $sections */
+        $sections = [];
+
+        if ($top > 0) {
+            $sections[SectionLayout::SECTION_SELF] = $this->renderTable(
+                'self-time top',
+                $result->self_counts,
+                $denominator,
+                $top,
+                $formatter,
+                $crop_for_section[SectionLayout::SECTION_SELF] ?? 0,
+            );
+            $sections[SectionLayout::SECTION_TOTAL] = $this->renderTable(
+                'total-time top (inclusive)',
+                $result->total_counts,
+                $denominator,
+                $top,
+                $formatter,
+                $crop_for_section[SectionLayout::SECTION_TOTAL] ?? 0,
+            );
+        }
+
+        if ($callers_pattern !== null && $callers_pattern !== '') {
+            $sections[SectionLayout::SECTION_CALLERS] = $this->renderTable(
+                "callers of frames matching /{$callers_pattern}/",
+                $result->caller_counts,
+                $denominator,
+                $explicit_top,
+                $formatter,
+                $crop_for_section[SectionLayout::SECTION_CALLERS] ?? 0,
+            );
+        }
+
+        if ($callees_pattern !== null && $callees_pattern !== '') {
+            $sections[SectionLayout::SECTION_CALLEES] = $this->renderTable(
+                "callees of frames matching /{$callees_pattern}/",
+                $result->callee_counts,
+                $denominator,
+                $explicit_top,
+                $formatter,
+                $crop_for_section[SectionLayout::SECTION_CALLEES] ?? 0,
+            );
+        }
+
+        if ($last_count > 0) {
+            $sections[SectionLayout::SECTION_TAIL] = $this->renderTail(
+                $result->tail,
+                $formatter,
+                $crop_for_section[SectionLayout::SECTION_TAIL] ?? 0,
+            );
+        }
+
+        return $sections;
+    }
+
+    /**
+     * Resolve each section's crop budget from its position in the layout.
+     *
+     * Sections not present in the layout aren't rendered to the screen
+     * either, so they don't need a crop entry.
+     *
+     * @param array<int, list<int>> $row_crop_widths
+     * @return array<string, int>
+     */
+    private function buildSectionCropMap(
+        SectionLayout $layout,
+        array $row_crop_widths,
+    ): array {
+        $map = [];
+        foreach ($layout->rows as $row_index => $row) {
+            foreach ($row as $col_index => $name) {
+                $map[$name] = $row_crop_widths[$row_index][$col_index] ?? 0;
+            }
+        }
+        return $map;
+    }
+
+    /**
+     * @param list<array{frames: list<string>, annotations: array<string, string>|null}> $tail
+     * @return list<string>
+     */
+    private function renderTail(array $tail, FrameFormatter $formatter, int $crop_width): array
     {
-        $output->writeln('');
-        $output->writeln('<comment># last ' . count($tail) . ' sample(s)</comment>');
+        $lines = [];
+        $lines[] = '# last ' . count($tail) . ' sample(s)';
         if ($tail === []) {
-            $output->writeln('  (no samples)');
-            return;
+            $lines[] = '  (no samples)';
+            return $this->applyCrop($lines, $crop_width);
         }
         $count = count($tail);
         foreach ($tail as $i => $entry) {
@@ -195,16 +396,79 @@ final class AnalyzeCommand extends Command
             $label = $count === 1
                 ? '(now)'
                 : ($offset === 0 ? '(now)' : sprintf('(%d ago)', $offset));
-            $output->writeln("  ── sample {$label} ──");
+            $lines[] = "  ── sample {$label} ──";
             foreach ($entry['frames'] as $depth => $frame) {
-                $output->writeln(sprintf('  [%2d] %s', $depth, $frame));
+                $lines[] = sprintf('  [%2d] %s', $depth, $formatter->formatFrame($frame));
             }
             if (($entry['annotations'] ?? null) !== null && $entry['annotations'] !== []) {
                 foreach ($entry['annotations'] as $key => $value) {
-                    $output->writeln(sprintf('  # %s = %s', $key, $value));
+                    $lines[] = sprintf('  # %s = %s', $key, $value);
                 }
             }
         }
+        return $this->applyCrop($lines, $crop_width);
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @return list<string>
+     */
+    private function renderTable(
+        string $title,
+        array $counts,
+        int $denominator,
+        int $top,
+        FrameFormatter $formatter,
+        int $crop_width,
+    ): array {
+        arsort($counts);
+        $rows = array_slice($counts, 0, $top, preserve_keys: true);
+
+        $lines = [];
+        $lines[] = "# {$title}";
+
+        if ($rows === []) {
+            $lines[] = '  (no matches)';
+            return $this->applyCrop($lines, $crop_width);
+        }
+
+        $buffer = new BufferedOutput();
+        $denom = (float)max(1, $denominator);
+        $table = new Table($buffer);
+        $table->setHeaders(['count', 'pct', 'frame']);
+        foreach ($rows as $key => $count) {
+            $pct = (float)$count * 100.0 / $denom;
+            $table->addRow([
+                (string) $count,
+                sprintf('%5.1f%%', $pct),
+                $formatter->formatFrame($key),
+            ]);
+        }
+        $table->render();
+
+        $rendered = rtrim($buffer->fetch(), "\n");
+        if ($rendered !== '') {
+            foreach (explode("\n", $rendered) as $row_line) {
+                $lines[] = $row_line;
+            }
+        }
+        return $this->applyCrop($lines, $crop_width);
+    }
+
+    /**
+     * @param list<string> $lines
+     * @return list<string>
+     */
+    private function applyCrop(array $lines, int $crop_width): array
+    {
+        if ($crop_width <= 0) {
+            return $lines;
+        }
+        $out = [];
+        foreach ($lines as $line) {
+            $out[] = FrameFormatter::cropLine($line, $crop_width);
+        }
+        return $out;
     }
 
     private function writeSummary(
@@ -222,40 +486,5 @@ final class AnalyzeCommand extends Command
             $period,
             $duration_s,
         ));
-    }
-
-    /**
-     * @param array<string, int> $counts
-     */
-    private function printTable(
-        OutputInterface $output,
-        string $title,
-        array $counts,
-        int $denominator,
-        int $top,
-    ): void {
-        arsort($counts);
-        $rows = array_slice($counts, 0, $top, preserve_keys: true);
-
-        $output->writeln('');
-        $output->writeln("<comment># {$title}</comment>");
-
-        if ($rows === []) {
-            $output->writeln('  (no matches)');
-            return;
-        }
-
-        $denom = (float)max(1, $denominator);
-        $table = new Table($output);
-        $table->setHeaders(['count', 'pct', 'frame']);
-        foreach ($rows as $key => $count) {
-            $pct = (float)$count * 100.0 / $denom;
-            $table->addRow([
-                (string) $count,
-                sprintf('%5.1f%%', $pct),
-                $key,
-            ]);
-        }
-        $table->render();
     }
 }

--- a/src/Command/Rbt/AnalyzeCommand.php
+++ b/src/Command/Rbt/AnalyzeCommand.php
@@ -118,6 +118,14 @@ final class AnalyzeCommand extends Command
                 '0',
             )
             ->addOption(
+                'crop-anchor',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'When --crop clips a frame, anchor at "left" (keep the head, ellipsis on the right — default)'
+                . ' or "right" (keep the leaf, ellipsis on the left). Tables keep their borders intact either way.',
+                FrameFormatter::ANCHOR_LEFT,
+            )
+            ->addOption(
                 'sections',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -160,6 +168,13 @@ final class AnalyzeCommand extends Command
         $path_mode = $input->getOption('path');
         if (!in_array($path_mode, [FrameFormatter::PATH_FULL, FrameFormatter::PATH_SHORT], true)) {
             $output->writeln("<error>--path must be 'full' or 'short', got: {$path_mode}</error>");
+            return 1;
+        }
+
+        /** @var string $crop_anchor */
+        $crop_anchor = $input->getOption('crop-anchor');
+        if (!in_array($crop_anchor, [FrameFormatter::ANCHOR_LEFT, FrameFormatter::ANCHOR_RIGHT], true)) {
+            $output->writeln("<error>--crop-anchor must be 'left' or 'right', got: {$crop_anchor}</error>");
             return 1;
         }
 
@@ -206,7 +221,7 @@ final class AnalyzeCommand extends Command
 
         $sections = $this->renderSections(
             $result,
-            new FrameFormatter($path_mode),
+            new FrameFormatter($path_mode, $crop_anchor),
             $layout,
             $row_crop_widths,
             $top,
@@ -391,6 +406,10 @@ final class AnalyzeCommand extends Command
             return $this->applyCrop($lines, $crop_width);
         }
         $count = count($tail);
+        // "  [NN] " prefix is 7 chars (2 indent + 2 bracket + 2 digits + 1 space).
+        // Bake that into the frame budget so --crop-anchor actually bites the
+        // frame text rather than a late line-level crop eating the tail end.
+        $frame_budget = $crop_width > 0 ? max(1, $crop_width - 7) : 0;
         foreach ($tail as $i => $entry) {
             $offset = $count - $i - 1;
             $label = $count === 1
@@ -398,7 +417,7 @@ final class AnalyzeCommand extends Command
                 : ($offset === 0 ? '(now)' : sprintf('(%d ago)', $offset));
             $lines[] = "  ── sample {$label} ──";
             foreach ($entry['frames'] as $depth => $frame) {
-                $lines[] = sprintf('  [%2d] %s', $depth, $formatter->formatFrame($frame));
+                $lines[] = sprintf('  [%2d] %s', $depth, $formatter->cropFrame($frame, $frame_budget));
             }
             if (($entry['annotations'] ?? null) !== null && $entry['annotations'] !== []) {
                 foreach ($entry['annotations'] as $key => $value) {
@@ -406,6 +425,9 @@ final class AnalyzeCommand extends Command
                 }
             }
         }
+        // Safety net: the sample separator line and annotations are
+        // fixed-format and normally short, but line-crop them anyway in
+        // case someone feeds an absurdly wide annotation value.
         return $this->applyCrop($lines, $crop_width);
     }
 
@@ -425,11 +447,30 @@ final class AnalyzeCommand extends Command
         $rows = array_slice($counts, 0, $top, preserve_keys: true);
 
         $lines = [];
-        $lines[] = "# {$title}";
+        $lines[] = FrameFormatter::cropLine("# {$title}", $crop_width);
 
         if ($rows === []) {
-            $lines[] = '  (no matches)';
-            return $this->applyCrop($lines, $crop_width);
+            $lines[] = FrameFormatter::cropLine('  (no matches)', $crop_width);
+            return $lines;
+        }
+
+        // Pre-size the frame column: we crop each frame *before* handing
+        // it to Symfony's Table, so the Table then auto-sizes its borders
+        // around the already-short content. That preserves the right-hand
+        // `|` border instead of having a post-render line crop eat it.
+        //
+        // Overhead per row: "| " + count + " | " + pct + " | " + frame + " |"
+        // count column widens to max(len("count"), widest numeric value);
+        // pct is fixed at 6 chars ("100.0%").
+        $frame_budget = 0;
+        if ($crop_width > 0) {
+            $count_col = strlen('count');
+            foreach ($rows as $row_count) {
+                $count_col = max($count_col, strlen((string) $row_count));
+            }
+            $pct_col = 6; // "100.0%"
+            $fixed_overhead = 2 + $count_col + 3 + $pct_col + 3 + 2;
+            $frame_budget = max(1, $crop_width - $fixed_overhead);
         }
 
         $buffer = new BufferedOutput();
@@ -438,10 +479,13 @@ final class AnalyzeCommand extends Command
         $table->setHeaders(['count', 'pct', 'frame']);
         foreach ($rows as $key => $count) {
             $pct = (float)$count * 100.0 / $denom;
+            $frame_cell = $frame_budget > 0
+                ? $formatter->cropFrame($key, $frame_budget)
+                : $formatter->formatFrame($key);
             $table->addRow([
                 (string) $count,
                 sprintf('%5.1f%%', $pct),
-                $formatter->formatFrame($key),
+                $frame_cell,
             ]);
         }
         $table->render();
@@ -452,7 +496,10 @@ final class AnalyzeCommand extends Command
                 $lines[] = $row_line;
             }
         }
-        return $this->applyCrop($lines, $crop_width);
+        // Note: no line-level applyCrop() on table rows — the frames are
+        // already cropped, and Symfony's Table has sized the borders to
+        // match. Clipping here would chew off the right border.
+        return $lines;
     }
 
     /**

--- a/src/Rbt/Analyze/FrameFormatter.php
+++ b/src/Rbt/Analyze/FrameFormatter.php
@@ -15,42 +15,99 @@ namespace Reli\Rbt\Analyze;
 
 /**
  * Display-time transforms for frame strings produced by
- * {@see TraceAggregator}: frame-level path shortening, and line-level
- * width cropping with a trailing ellipsis.
+ * {@see TraceAggregator}: frame-level path shortening and
+ * anchor-directional width cropping.
  *
  * Both transforms are purely cosmetic — aggregation keys are untouched,
  * so two distinct call sites that collapse to the same basename still
  * retain separate counts in the self/total tables.
  *
- * The two live together because they're the two cooperating levers the
- * CLI exposes to tame wide traces: `--path=short` shrinks the natural
- * column width; `--crop` hard-caps whatever's left so very long
- * FQN-only frames don't line-wrap the layout.
+ * Cropping anchor:
+ *   - ANCHOR_LEFT  → keep the head of the string, trailing ellipsis:
+ *                    `Reli\Inspector\MemoryDump\FastPath\Re…`
+ *                    — good when the distinguishing prefix is what you care about.
+ *   - ANCHOR_RIGHT → keep the tail of the string, leading ellipsis:
+ *                    `…\FastPath\RegionByteProvider::region`
+ *                    — good when you care about the leaf function and
+ *                    deep namespace prefixes are share-able noise.
+ *
+ * Frame cropping happens *before* a Table row is built, not after the
+ * line is rendered, so Symfony's Table auto-sizes its borders around
+ * the already-cropped content. That keeps the right-hand `|` border
+ * intact instead of getting chewed off by a naive line-level crop.
  */
 final class FrameFormatter
 {
     public const PATH_FULL = 'full';
     public const PATH_SHORT = 'short';
 
-    /**
-     * `path_mode`:
-     *   - PATH_FULL  → leave frame strings as-is.
-     *   - PATH_SHORT → replace the directory portion of `file:line`
-     *                  with the basename (`Worker.php:42`).
-     */
+    public const ANCHOR_LEFT = 'left';
+    public const ANCHOR_RIGHT = 'right';
+
     public function __construct(
         public readonly string $path_mode = self::PATH_FULL,
+        public readonly string $anchor = self::ANCHOR_LEFT,
     ) {
     }
 
     /**
-     * Frame-level transform: applies path shortening only.
-     *
-     * Use this on the value that will end up in the "frame" column of
-     * a table, or the body of a tail line — i.e. on content that's
-     * still going to be laid out / padded downstream.
+     * Path-shorten the frame but leave its length alone. Use this when
+     * the caller has no width budget (no `--crop`, or the section it's
+     * going into lays out at natural width).
      */
     public function formatFrame(string $frame): string
+    {
+        return $this->shortenPath($frame);
+    }
+
+    /**
+     * Path-shorten, then crop to `$budget` characters (anchor-aware).
+     *
+     * `$budget <= 0` disables cropping (returns the path-shortened
+     * frame as-is). A budget of 1 collapses to a lone `…`, which is
+     * a degenerate corner we guard against explicitly.
+     */
+    public function cropFrame(string $frame, int $budget): string
+    {
+        $frame = $this->shortenPath($frame);
+        if ($budget <= 0) {
+            return $frame;
+        }
+        $len = mb_strlen($frame);
+        if ($len <= $budget) {
+            return $frame;
+        }
+        if ($budget === 1) {
+            return '…';
+        }
+        if ($this->anchor === self::ANCHOR_RIGHT) {
+            return '…' . mb_substr($frame, $len - ($budget - 1));
+        }
+        return mb_substr($frame, 0, $budget - 1) . '…';
+    }
+
+    /**
+     * Line-level hard cap: crop a fully rendered output line at
+     * `$width` chars with a trailing ellipsis. Anchor-agnostic — used
+     * for section titles and other non-table lines that don't have
+     * borders to protect.
+     */
+    public static function cropLine(string $line, int $width): string
+    {
+        if ($width <= 0) {
+            return $line;
+        }
+        $len = mb_strlen($line);
+        if ($len <= $width) {
+            return $line;
+        }
+        if ($width === 1) {
+            return '…';
+        }
+        return mb_substr($line, 0, $width - 1) . '…';
+    }
+
+    private function shortenPath(string $frame): string
     {
         if ($this->path_mode !== self::PATH_SHORT) {
             return $frame;
@@ -78,28 +135,5 @@ final class FrameFormatter
             return $frame;
         }
         return $m[1] . ' ' . $basename . ':' . $m[3] . $opcode_suffix;
-    }
-
-    /**
-     * Line-level transform: hard-cap a fully rendered output line
-     * (including any table borders) at `$width` characters, replacing
-     * the last visible character with an ellipsis when clipping.
-     *
-     * `$width <= 0` is a no-op so callers can unconditionally route
-     * lines through this when crop is disabled.
-     */
-    public static function cropLine(string $line, int $width): string
-    {
-        if ($width <= 0) {
-            return $line;
-        }
-        $len = mb_strlen($line);
-        if ($len <= $width) {
-            return $line;
-        }
-        if ($width === 1) {
-            return '…';
-        }
-        return mb_substr($line, 0, $width - 1) . '…';
     }
 }

--- a/src/Rbt/Analyze/FrameFormatter.php
+++ b/src/Rbt/Analyze/FrameFormatter.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Analyze;
+
+/**
+ * Display-time transforms for frame strings produced by
+ * {@see TraceAggregator}: frame-level path shortening, and line-level
+ * width cropping with a trailing ellipsis.
+ *
+ * Both transforms are purely cosmetic — aggregation keys are untouched,
+ * so two distinct call sites that collapse to the same basename still
+ * retain separate counts in the self/total tables.
+ *
+ * The two live together because they're the two cooperating levers the
+ * CLI exposes to tame wide traces: `--path=short` shrinks the natural
+ * column width; `--crop` hard-caps whatever's left so very long
+ * FQN-only frames don't line-wrap the layout.
+ */
+final class FrameFormatter
+{
+    public const PATH_FULL = 'full';
+    public const PATH_SHORT = 'short';
+
+    /**
+     * `path_mode`:
+     *   - PATH_FULL  → leave frame strings as-is.
+     *   - PATH_SHORT → replace the directory portion of `file:line`
+     *                  with the basename (`Worker.php:42`).
+     */
+    public function __construct(
+        public readonly string $path_mode = self::PATH_FULL,
+    ) {
+    }
+
+    /**
+     * Frame-level transform: applies path shortening only.
+     *
+     * Use this on the value that will end up in the "frame" column of
+     * a table, or the body of a tail line — i.e. on content that's
+     * still going to be laid out / padded downstream.
+     */
+    public function formatFrame(string $frame): string
+    {
+        if ($this->path_mode !== self::PATH_SHORT) {
+            return $frame;
+        }
+
+        // Pull off a trailing " [OPCODE]" suffix (added by --with-opcode)
+        // so the path regex below only has to worry about "... file:line".
+        $opcode_suffix = '';
+        $body = $frame;
+        if (preg_match('/ \[[^\]]+\]$/', $body, $m) === 1) {
+            $opcode_suffix = $m[0];
+            $body = substr($body, 0, -strlen($m[0]));
+        }
+
+        // function_name never contains spaces in PHP traces, and lineno
+        // is an integer, so "<everything> <path>:<lineno>" splits
+        // unambiguously on the last space. Pseudo-paths like "<internal>"
+        // stay unchanged because basename leaves them alone.
+        if (preg_match('/^(.*) ([^ ]+):(-?\d+)$/', $body, $m) !== 1) {
+            return $frame;
+        }
+
+        $basename = basename($m[2]);
+        if ($basename === '') {
+            return $frame;
+        }
+        return $m[1] . ' ' . $basename . ':' . $m[3] . $opcode_suffix;
+    }
+
+    /**
+     * Line-level transform: hard-cap a fully rendered output line
+     * (including any table borders) at `$width` characters, replacing
+     * the last visible character with an ellipsis when clipping.
+     *
+     * `$width <= 0` is a no-op so callers can unconditionally route
+     * lines through this when crop is disabled.
+     */
+    public static function cropLine(string $line, int $width): string
+    {
+        if ($width <= 0) {
+            return $line;
+        }
+        $len = mb_strlen($line);
+        if ($len <= $width) {
+            return $line;
+        }
+        if ($width === 1) {
+            return '…';
+        }
+        return mb_substr($line, 0, $width - 1) . '…';
+    }
+}

--- a/src/Rbt/Analyze/SectionLayout.php
+++ b/src/Rbt/Analyze/SectionLayout.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Analyze;
+
+/**
+ * Parses the `--sections` layout spec and assembles pre-rendered section
+ * bodies into the final text report.
+ *
+ * Spec syntax:
+ *   - `,` separates rows (vertical stacking, top to bottom).
+ *   - `+` separates columns within a row (horizontal stacking).
+ *
+ * Examples:
+ *   - `tail,self,total`          → three rows, stacked (current default).
+ *   - `self+total,tail`          → self/total side by side, tail full-width below.
+ *   - `self+total+tail`          → three columns in one row.
+ *
+ * Recognised section names: `self`, `total`, `callers`, `callees`, `tail`.
+ * Unknown names are rejected at parse time so typos fail loudly instead
+ * of silently dropping a table.
+ */
+final class SectionLayout
+{
+    public const SECTION_SELF = 'self';
+    public const SECTION_TOTAL = 'total';
+    public const SECTION_CALLERS = 'callers';
+    public const SECTION_CALLEES = 'callees';
+    public const SECTION_TAIL = 'tail';
+
+    public const KNOWN_SECTIONS = [
+        self::SECTION_SELF,
+        self::SECTION_TOTAL,
+        self::SECTION_CALLERS,
+        self::SECTION_CALLEES,
+        self::SECTION_TAIL,
+    ];
+
+    public const DEFAULT_SPEC = 'self,total,callers,callees,tail';
+
+    public const COLUMN_GAP = '  ';
+
+    /**
+     * @param list<list<string>> $rows each inner list is one row of section names
+     */
+    public function __construct(
+        public readonly array $rows,
+    ) {
+    }
+
+    /**
+     * @throws \InvalidArgumentException on unknown section names
+     */
+    public static function parse(string $spec): self
+    {
+        /** @var list<list<string>> $rows */
+        $rows = [];
+        foreach (explode(',', $spec) as $row_spec) {
+            $row_spec = trim($row_spec);
+            if ($row_spec === '') {
+                continue;
+            }
+            $columns = [];
+            foreach (explode('+', $row_spec) as $name) {
+                $name = trim($name);
+                if ($name === '') {
+                    continue;
+                }
+                if (!in_array($name, self::KNOWN_SECTIONS, true)) {
+                    throw new \InvalidArgumentException(
+                        "unknown section '{$name}' in --sections "
+                        . '(known: ' . implode(', ', self::KNOWN_SECTIONS) . ')',
+                    );
+                }
+                $columns[] = $name;
+            }
+            if ($columns !== []) {
+                $rows[] = $columns;
+            }
+        }
+        return new self($rows);
+    }
+
+    /**
+     * Assemble a flat list of output lines.
+     *
+     * `$sections` maps section name → rendered body (list of plain text lines,
+     * no ANSI/format tags). A missing key or an empty list means "section
+     * wasn't produced this run" — it's silently dropped from its row. Rows
+     * that end up empty after dropping missing sections are skipped whole
+     * (no dangling blank line).
+     *
+     * @param array<string, list<string>> $sections
+     * @return list<string>
+     */
+    public function assemble(array $sections): array
+    {
+        $output = [];
+        $first = true;
+        foreach ($this->rows as $row) {
+            $columns = [];
+            foreach ($row as $name) {
+                $lines = $sections[$name] ?? [];
+                if ($lines !== []) {
+                    $columns[] = $lines;
+                }
+            }
+            if ($columns === []) {
+                continue;
+            }
+            if (!$first) {
+                $output[] = '';
+            }
+            $first = false;
+            foreach ($this->combineRow($columns) as $line) {
+                $output[] = $line;
+            }
+        }
+        return $output;
+    }
+
+    /**
+     * Horizontally zip already-rendered columns into a single block.
+     *
+     * Each column is left-aligned to its own max width; shorter columns
+     * are bottom-padded with blank lines so neighbouring columns don't
+     * smear into them. Trailing whitespace is stripped so terminals
+     * don't paint spurious background colour past the last column.
+     *
+     * @param list<list<string>> $columns
+     * @return list<string>
+     */
+    private function combineRow(array $columns): array
+    {
+        if (count($columns) === 1) {
+            return $columns[0];
+        }
+
+        $height = 0;
+        $widths = [];
+        foreach ($columns as $col) {
+            $height = max($height, count($col));
+            $widths[] = self::columnWidth($col);
+        }
+
+        $lines = [];
+        $last = count($columns) - 1;
+        for ($i = 0; $i < $height; $i++) {
+            $parts = [];
+            foreach ($columns as $ci => $col) {
+                $cell = $col[$i] ?? '';
+                if ($ci !== $last) {
+                    $pad = $widths[$ci] - mb_strlen($cell);
+                    if ($pad > 0) {
+                        $cell .= str_repeat(' ', $pad);
+                    }
+                }
+                $parts[] = $cell;
+            }
+            $lines[] = rtrim(implode(self::COLUMN_GAP, $parts));
+        }
+        return $lines;
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function columnWidth(array $lines): int
+    {
+        $w = 0;
+        foreach ($lines as $line) {
+            $lw = mb_strlen($line);
+            if ($lw > $w) {
+                $w = $lw;
+            }
+        }
+        return $w;
+    }
+}

--- a/src/Rbt/Analyze/TraceAggregator.php
+++ b/src/Rbt/Analyze/TraceAggregator.php
@@ -41,6 +41,10 @@ use Reli\Converter\BinaryTrace\BinaryTraceSample;
  * `last_count > 0` keeps a ring buffer of the most recent samples'
  * formatted frame stacks (with the same hide/no-line rules applied)
  * so the CLI can render a `--last N` tail without re-processing.
+ *
+ * `last_depth > 0` truncates each tail sample's stack to the `last_depth`
+ * leaf-most frames so variable stack depth doesn't shove the rest of the
+ * report around when `--last` is piped through `watch`.
  */
 final class TraceAggregator
 {
@@ -58,6 +62,7 @@ final class TraceAggregator
         public readonly ?string $callers_re = null,
         public readonly ?string $callees_re = null,
         public readonly int $last_count = 0,
+        public readonly int $last_depth = 0,
     ) {
     }
 
@@ -185,8 +190,11 @@ final class TraceAggregator
             }
 
             if ($this->last_count > 0) {
+                $tail_frames = $this->last_depth > 0
+                    ? array_slice($keys, 0, $this->last_depth)
+                    : $keys;
                 $tail_buffer[] = [
-                    'frames' => $keys,
+                    'frames' => $tail_frames,
                     'annotations' => $sample->annotations,
                 ];
                 if (count($tail_buffer) > $this->last_count) {

--- a/tests/Rbt/Analyze/FrameFormatterTest.php
+++ b/tests/Rbt/Analyze/FrameFormatterTest.php
@@ -92,4 +92,63 @@ class FrameFormatterTest extends BaseTestCase
         // count — actual visual width is the terminal's concern.
         $this->assertSame('日本語…', FrameFormatter::cropLine('日本語です', 4));
     }
+
+    public function testCropFrameDefaultAnchorIsLeftKeepsHead(): void
+    {
+        // Default anchor = left ⇒ keep the head, ellipsis on the right.
+        // Useful when the distinguishing prefix is what you're scanning.
+        $f = new FrameFormatter();
+        $this->assertSame('abcd…', $f->cropFrame('abcdefghij', 5));
+    }
+
+    public function testCropFrameRightAnchorKeepsTail(): void
+    {
+        // Right anchor = keep the leaf. With a long FQN frame, the
+        // class/method at the end survives and the namespace prefix
+        // collapses into a leading ellipsis.
+        $f = new FrameFormatter(FrameFormatter::PATH_FULL, FrameFormatter::ANCHOR_RIGHT);
+        $this->assertSame('…fghij', $f->cropFrame('abcdefghij', 6));
+    }
+
+    public function testCropFrameRightAnchorWithRealisticFqn(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT, FrameFormatter::ANCHOR_RIGHT);
+        $frame = 'Reli\\Inspector\\MemoryDump\\FastPath\\RegionByteProvider::region /tmp/a.php:42';
+        // Path shortening applies first, then the right-anchor crop
+        // keeps the tail (method + shortened filename).
+        $cropped = $f->cropFrame($frame, 30);
+        $this->assertSame(30, mb_strlen($cropped));
+        $this->assertStringStartsWith('…', $cropped);
+        $this->assertStringEndsWith('a.php:42', $cropped);
+    }
+
+    public function testCropFrameBudgetZeroLeavesFrameAlone(): void
+    {
+        $f = new FrameFormatter();
+        $this->assertSame('abcdefghij', $f->cropFrame('abcdefghij', 0));
+    }
+
+    public function testCropFrameShortEnoughIsUntouched(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_FULL, FrameFormatter::ANCHOR_RIGHT);
+        $this->assertSame('abc', $f->cropFrame('abc', 10));
+    }
+
+    public function testCropFrameAppliesPathShorteningFirst(): void
+    {
+        // With PATH_SHORT, "frame /long/path/File.php:10" becomes
+        // "frame File.php:10" (17 chars), which fits in 20 without
+        // needing further cropping.
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT);
+        $this->assertSame(
+            'frame File.php:10',
+            $f->cropFrame('frame /a/b/c/File.php:10', 20),
+        );
+    }
+
+    public function testCropFrameBudgetOneReturnsEllipsis(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_FULL, FrameFormatter::ANCHOR_RIGHT);
+        $this->assertSame('…', $f->cropFrame('abcdef', 1));
+    }
 }

--- a/tests/Rbt/Analyze/FrameFormatterTest.php
+++ b/tests/Rbt/Analyze/FrameFormatterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Analyze;
+
+use Reli\BaseTestCase;
+
+class FrameFormatterTest extends BaseTestCase
+{
+    public function testPathFullLeavesFrameUnchanged(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_FULL);
+        $this->assertSame(
+            'App\\Worker::loop /var/www/src/Worker.php:42',
+            $f->formatFrame('App\\Worker::loop /var/www/src/Worker.php:42'),
+        );
+    }
+
+    public function testPathShortReplacesDirectoryWithBasename(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT);
+        $this->assertSame(
+            'App\\Worker::loop Worker.php:42',
+            $f->formatFrame('App\\Worker::loop /var/www/src/Worker.php:42'),
+        );
+    }
+
+    public function testPathShortPreservesOpcodeSuffix(): void
+    {
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT);
+        $this->assertSame(
+            'foo a.php:1 [ASSIGN]',
+            $f->formatFrame('foo /tmp/a.php:1 [ASSIGN]'),
+        );
+    }
+
+    public function testPathShortHandlesInternalPseudoPath(): void
+    {
+        // "<internal>" has no directory separator — basename() returns it
+        // as-is, so the frame should come out unchanged.
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT);
+        $this->assertSame(
+            'sleep <internal>:-1',
+            $f->formatFrame('sleep <internal>:-1'),
+        );
+    }
+
+    public function testPathShortLeavesNoLineFramesAlone(): void
+    {
+        // --no-line produces frames without a trailing " path:lineno".
+        $f = new FrameFormatter(FrameFormatter::PATH_SHORT);
+        $this->assertSame('App\\Worker::loop', $f->formatFrame('App\\Worker::loop'));
+        $this->assertSame('<root>', $f->formatFrame('<root>'));
+    }
+
+    public function testCropLineNoOpWhenWidthZero(): void
+    {
+        $this->assertSame('abcdef', FrameFormatter::cropLine('abcdef', 0));
+        $this->assertSame('abcdef', FrameFormatter::cropLine('abcdef', -1));
+    }
+
+    public function testCropLineLeavesShortLinesAlone(): void
+    {
+        $this->assertSame('abc', FrameFormatter::cropLine('abc', 10));
+        $this->assertSame('abc', FrameFormatter::cropLine('abc', 3));
+    }
+
+    public function testCropLineClipsAndAppendsEllipsis(): void
+    {
+        $this->assertSame('abcd…', FrameFormatter::cropLine('abcdefghij', 5));
+    }
+
+    public function testCropLineAtWidthOneReturnsEllipsisOnly(): void
+    {
+        $this->assertSame('…', FrameFormatter::cropLine('abcdef', 1));
+    }
+
+    public function testCropLineCountsMultibyteCharsCorrectly(): void
+    {
+        // Each 日本語 char is 1 in mb_strlen; narrow terminals would
+        // display them wider but our crop only guards the character
+        // count — actual visual width is the terminal's concern.
+        $this->assertSame('日本語…', FrameFormatter::cropLine('日本語です', 4));
+    }
+}

--- a/tests/Rbt/Analyze/SectionLayoutTest.php
+++ b/tests/Rbt/Analyze/SectionLayoutTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rbt\Analyze;
+
+use Reli\BaseTestCase;
+
+class SectionLayoutTest extends BaseTestCase
+{
+    public function testParseDefaultSpecStacksOneSectionPerRow(): void
+    {
+        $layout = SectionLayout::parse(SectionLayout::DEFAULT_SPEC);
+        $this->assertSame(
+            [['self'], ['total'], ['callers'], ['callees'], ['tail']],
+            $layout->rows,
+        );
+    }
+
+    public function testParsePlusJoinsColumnsWithinRow(): void
+    {
+        $layout = SectionLayout::parse('self+total,tail');
+        $this->assertSame(
+            [['self', 'total'], ['tail']],
+            $layout->rows,
+        );
+    }
+
+    public function testParseIgnoresWhitespaceAndEmptySegments(): void
+    {
+        $layout = SectionLayout::parse(' self + total , , tail ');
+        $this->assertSame(
+            [['self', 'total'], ['tail']],
+            $layout->rows,
+        );
+    }
+
+    public function testParseRejectsUnknownSectionName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/unknown section \'nope\'/');
+        SectionLayout::parse('self,nope');
+    }
+
+    public function testAssembleStacksRowsWithBlankLineBetween(): void
+    {
+        $layout = SectionLayout::parse('self,tail');
+        $lines = $layout->assemble([
+            'self' => ['self line 1', 'self line 2'],
+            'tail' => ['tail line 1'],
+        ]);
+        $this->assertSame(
+            ['self line 1', 'self line 2', '', 'tail line 1'],
+            $lines,
+        );
+    }
+
+    public function testAssembleSkipsMissingOrEmptySections(): void
+    {
+        $layout = SectionLayout::parse('self,callers,tail');
+        $lines = $layout->assemble([
+            'self' => ['self line'],
+            // 'callers' missing
+            'tail' => [],
+        ]);
+        // Only self rendered; no dangling blank line.
+        $this->assertSame(['self line'], $lines);
+    }
+
+    public function testAssemblePlusPutsColumnsSideBySide(): void
+    {
+        $layout = SectionLayout::parse('self+total');
+        $lines = $layout->assemble([
+            'self' => ['aaa', 'bb'],
+            'total' => ['xx', 'y', 'zzz'],
+        ]);
+        // Column widths: self=3, total=3 (but last column doesn't pad).
+        // Gap is two spaces between columns.
+        $this->assertSame(
+            [
+                'aaa  xx',
+                'bb   y',
+                '     zzz',
+            ],
+            $lines,
+        );
+    }
+
+    public function testAssemblePlusDropsColumnsThatHaveNoContent(): void
+    {
+        // A missing side section should just collapse — the remaining
+        // column renders as a single-column row instead of leaving a
+        // hanging empty gap.
+        $layout = SectionLayout::parse('self+total');
+        $lines = $layout->assemble([
+            'self' => ['a', 'b'],
+            // 'total' missing entirely
+        ]);
+        $this->assertSame(['a', 'b'], $lines);
+    }
+
+    public function testAssembleStripsTrailingWhitespaceFromRightmostColumn(): void
+    {
+        $layout = SectionLayout::parse('self+tail');
+        $lines = $layout->assemble([
+            'self' => ['left'],
+            'tail' => ['right   '],
+        ]);
+        $this->assertSame(['left  right'], $lines);
+    }
+}

--- a/tests/Rbt/Analyze/TraceAggregatorTest.php
+++ b/tests/Rbt/Analyze/TraceAggregatorTest.php
@@ -196,6 +196,52 @@ class TraceAggregatorTest extends BaseTestCase
         $this->assertSame([], $result->tail);
     }
 
+    public function testLastDepthKeepsOnlyLeafMostFrames(): void
+    {
+        $samples = [
+            $this->makeSample(['leaf', 'mid', 'outer', 'root']),
+        ];
+        $result = (new TraceAggregator(
+            no_line: true,
+            last_count: 1,
+            last_depth: 2,
+        ))->aggregate($samples);
+
+        // Only the 2 leaf-most frames survive in the tail. Aggregation
+        // tables are unchanged — last_depth is tail-only.
+        $this->assertSame(['leaf', 'mid'], $result->tail[0]['frames']);
+        $this->assertSame(1, $result->total_counts['root']);
+        $this->assertSame(1, $result->total_counts['outer']);
+    }
+
+    public function testLastDepthZeroLeavesFullStack(): void
+    {
+        $samples = [
+            $this->makeSample(['leaf', 'mid', 'root']),
+        ];
+        $result = (new TraceAggregator(
+            no_line: true,
+            last_count: 1,
+            last_depth: 0,
+        ))->aggregate($samples);
+
+        $this->assertSame(['leaf', 'mid', 'root'], $result->tail[0]['frames']);
+    }
+
+    public function testLastDepthLargerThanStackJustReturnsStack(): void
+    {
+        $samples = [
+            $this->makeSample(['leaf', 'root']),
+        ];
+        $result = (new TraceAggregator(
+            no_line: true,
+            last_count: 1,
+            last_depth: 10,
+        ))->aggregate($samples);
+
+        $this->assertSame(['leaf', 'root'], $result->tail[0]['frames']);
+    }
+
     public function testWithOpcodeAppendsOpcodeToKey(): void
     {
         $samples = [


### PR DESCRIPTION
## Summary

This PR enhances the `rbt:analyze` command with comprehensive display customization options, allowing users to control frame formatting, output layout, and line width constraints. The changes enable better integration with tools like `watch` and support for terminals with varying widths.

## Key Changes

- **New `FrameFormatter` class**: Handles display-time frame transformations including:
  - Path shortening (`--path=short` shows only basename instead of full path)
  - Anchor-directional line cropping (`--crop-anchor=left|right` controls which end of a clipped frame is preserved)
  - Both transforms are display-only and don't affect aggregation keys

- **New `SectionLayout` class**: Manages report structure and assembly:
  - Parses `--sections` spec to control row/column layout (`,` stacks rows, `+` joins columns)
  - Assembles pre-rendered sections into final output with proper spacing and alignment
  - Supports side-by-side rendering of multiple tables (e.g., `self+total,tail`)

- **New command-line options**:
  - `--last-depth=N`: Cap each tail stack at N leaf-most frames to stabilize layout under `watch`
  - `--path=full|short`: Display-only path shortening (default: full)
  - `--crop=N|auto`: Hard-clip output lines at N characters or terminal width (default: 0, disabled)
  - `--crop-anchor=left|right`: Control which end of cropped frames is preserved (default: left)
  - `--sections=SPEC`: Customize report layout with comma/plus-separated section names (default: stacked)

- **Refactored output rendering**:
  - Replaced direct `printTable()` and `printTail()` calls with `renderSections()` that returns pre-formatted line arrays
  - Sections are rendered independently then assembled by `SectionLayout` for flexible layout
  - Frame cropping happens before table rendering so Symfony's auto-sized borders stay intact

- **TraceAggregator enhancement**:
  - Added `last_depth` parameter to truncate tail stacks to leaf-most N frames
  - Aggregation tables unaffected; tail-only feature for display stability

## Implementation Details

- Frame cropping uses `mb_strlen()` for correct multibyte character handling
- Crop widths are pre-calculated per row/column based on terminal width and layout structure
- Missing or empty sections are silently dropped from their rows (no dangling blank lines)
- Path shortening preserves opcode suffixes (from `--with-opcode`) and handles pseudo-paths like `<internal>`
- Right-anchor cropping keeps the leaf function/file while left-anchor keeps the namespace prefix

https://claude.ai/code/session_01BvoZ7rNdhaC16cu5Xnigms