### PR TITLE
Add root-distance tie-breaker to frame aggregation sorting

### DIFF
--- a/src/Rbt/Explore/Aggregator.php
+++ b/src/Rbt/Explore/Aggregator.php
@@ -18,13 +18,22 @@ namespace Reli\Rbt\Explore;
  *
  * Each method returns the same shape:
  *   [
- *     'counts' => array<int, int>  // key_id => count
+ *     'counts' => array<int, int>              // key_id => count
+ *     'root_distance_sum' => array<int, int>   // key_id => sum of distances-to-root across counted occurrences
  *     'matched_samples' => int
  *   ]
  *
  * `key_id` is a frame_id from `TraceModel::keysFor($no_line)`. The TUI
  * uses these maps to render tables and to map a selected row back to a
  * focusable frame.
+ *
+ * `root_distance_sum` is used by the TUI as a tie-breaker so that, when
+ * two frames have the same count, the one that tends to appear closer
+ * to the stack root (lower distance) is ranked higher. Distance is
+ * measured as `n - 1 - i` for a frame at stack index `i` in a sample of
+ * depth `n`, i.e. 0 at the rootward end of the stack. Synthetic `<root>`
+ * is assigned -1 and synthetic `<leaf>` is assigned `n` so they sort to
+ * the extremes on ties.
  */
 final class Aggregator
 {
@@ -34,11 +43,12 @@ final class Aggregator
     public const VIEW_CALLEES = 'callees';
 
     /**
-     * @return array{counts: array<int, int>, matched_samples: int}
+     * @return array{counts: array<int, int>, root_distance_sum: array<int, int>, matched_samples: int}
      */
     public static function selfTime(TraceModel $model, ViewOptions $opts): array
     {
         $counts = [];
+        $root_distance_sum = [];
         $matched = 0;
         foreach ($model->samples as $stack) {
             if ($stack === []) {
@@ -48,18 +58,26 @@ final class Aggregator
                 continue;
             }
             $matched++;
+            $n = count($stack);
             $leaf_id = self::projectId($model, $stack[0], $opts->no_line, $opts->with_opcode);
             $counts[$leaf_id] = ($counts[$leaf_id] ?? 0) + 1;
+            // Leaf is at index 0, so its distance from the rootward end is n - 1.
+            $root_distance_sum[$leaf_id] = ($root_distance_sum[$leaf_id] ?? 0) + ($n - 1);
         }
-        return ['counts' => $counts, 'matched_samples' => $matched];
+        return [
+            'counts' => $counts,
+            'root_distance_sum' => $root_distance_sum,
+            'matched_samples' => $matched,
+        ];
     }
 
     /**
-     * @return array{counts: array<int, int>, matched_samples: int}
+     * @return array{counts: array<int, int>, root_distance_sum: array<int, int>, matched_samples: int}
      */
     public static function totalTime(TraceModel $model, ViewOptions $opts): array
     {
         $counts = [];
+        $root_distance_sum = [];
         $matched = 0;
         foreach ($model->samples as $stack) {
             if ($stack === []) {
@@ -69,28 +87,35 @@ final class Aggregator
                 continue;
             }
             $matched++;
+            $n = count($stack);
             $seen = [];
-            foreach ($stack as $fid) {
+            foreach ($stack as $i => $fid) {
                 $kid = self::projectId($model, $fid, $opts->no_line, $opts->with_opcode);
                 if (isset($seen[$kid])) {
                     continue;
                 }
                 $seen[$kid] = true;
                 $counts[$kid] = ($counts[$kid] ?? 0) + 1;
+                $root_distance_sum[$kid] = ($root_distance_sum[$kid] ?? 0) + ($n - 1 - $i);
             }
         }
-        return ['counts' => $counts, 'matched_samples' => $matched];
+        return [
+            'counts' => $counts,
+            'root_distance_sum' => $root_distance_sum,
+            'matched_samples' => $matched,
+        ];
     }
 
     /**
      * Aggregate the immediate caller (one step toward the root) of the
      * focus frame for each sample whose stack contains it.
      *
-     * @return array{counts: array<int, int>, matched_samples: int}
+     * @return array{counts: array<int, int>, root_distance_sum: array<int, int>, matched_samples: int}
      */
     public static function callersOf(TraceModel $model, int $focus_id, ViewOptions $opts): array
     {
         $counts = [];
+        $root_distance_sum = [];
         $matched = 0;
         // <root> is represented as -1.
         foreach ($model->samples as $stack) {
@@ -108,25 +133,36 @@ final class Aggregator
                 $matched++;
                 if ($i + 1 < $n) {
                     $caller = self::projectId($model, $stack[$i + 1], $opts->no_line, $opts->with_opcode);
+                    $dist = $n - 2 - $i;
                 } else {
+                    // Synthetic <root>: focus was at the stack bottom, so this
+                    // virtual caller sits "beyond" the root. Use -1 to sort it
+                    // above any real caller on ties.
                     $caller = -1;
+                    $dist = -1;
                 }
                 $counts[$caller] = ($counts[$caller] ?? 0) + 1;
+                $root_distance_sum[$caller] = ($root_distance_sum[$caller] ?? 0) + $dist;
                 break;
             }
         }
-        return ['counts' => $counts, 'matched_samples' => $matched];
+        return [
+            'counts' => $counts,
+            'root_distance_sum' => $root_distance_sum,
+            'matched_samples' => $matched,
+        ];
     }
 
     /**
      * Aggregate the immediate callee (one step toward the leaf) of the
      * focus frame.
      *
-     * @return array{counts: array<int, int>, matched_samples: int}
+     * @return array{counts: array<int, int>, root_distance_sum: array<int, int>, matched_samples: int}
      */
     public static function calleesOf(TraceModel $model, int $focus_id, ViewOptions $opts): array
     {
         $counts = [];
+        $root_distance_sum = [];
         $matched = 0;
         // <leaf> is represented as -2.
         foreach ($model->samples as $stack) {
@@ -145,14 +181,24 @@ final class Aggregator
                 $prev = $i - 1;
                 if ($prev >= 0) {
                     $callee = self::projectId($model, $stack[$prev], $opts->no_line, $opts->with_opcode);
+                    $dist = $n - $i;
                 } else {
+                    // Synthetic <leaf>: focus was at the stack top, so this
+                    // virtual callee sits "beyond" the leaf. Use n to sort it
+                    // below any real callee on ties.
                     $callee = -2;
+                    $dist = $n;
                 }
                 $counts[$callee] = ($counts[$callee] ?? 0) + 1;
+                $root_distance_sum[$callee] = ($root_distance_sum[$callee] ?? 0) + $dist;
                 break;
             }
         }
-        return ['counts' => $counts, 'matched_samples' => $matched];
+        return [
+            'counts' => $counts,
+            'root_distance_sum' => $root_distance_sum,
+            'matched_samples' => $matched,
+        ];
     }
 
     /**

--- a/src/Rbt/Explore/ExploreTui.php
+++ b/src/Rbt/Explore/ExploreTui.php
@@ -2191,13 +2191,28 @@ final class ExploreTui
     }
 
     /**
-     * @param array{counts: array<int, int>, matched_samples: int} $view
+     * @param array{counts: array<int, int>, root_distance_sum: array<int, int>, matched_samples: int} $view
      * @return array{matched_samples:int, rows:list<array{int,int,string}>}
      */
     private function buildCache(array $view, bool $no_line): array
     {
         $counts = $view['counts'];
-        arsort($counts);
+        $sums = $view['root_distance_sum'];
+        // Count descending is the primary sort; root-distance sum ascending
+        // is a tie-breaker so entry-point-like frames (small accumulated
+        // distance from the stack root) bubble above their immediate callees
+        // when they appear in exactly the same number of samples. Without
+        // this, <main> can end up below a function it always calls.
+        uksort(
+            $counts,
+            static function (int $a, int $b) use ($counts, $sums): int {
+                $by_count = $counts[$b] <=> $counts[$a];
+                if ($by_count !== 0) {
+                    return $by_count;
+                }
+                return ($sums[$a] ?? 0) <=> ($sums[$b] ?? 0);
+            },
+        );
         $rows = [];
         foreach ($counts as $key_id => $count) {
             $label = Aggregator::labelFor($this->model, $key_id, $no_line, $this->opts->with_opcode);

--- a/tests/Rbt/Explore/AggregatorTest.php
+++ b/tests/Rbt/Explore/AggregatorTest.php
@@ -252,4 +252,80 @@ class AggregatorTest extends BaseTestCase
         $this->assertSame('mid /m.php:1', Aggregator::labelFor($model, 2, false));
         $this->assertSame('mid', Aggregator::labelFor($model, 1, true));
     }
+
+    public function testTotalTimeReportsRootDistanceSum(): void
+    {
+        $model = $this->buildModel();
+        $r = Aggregator::totalTime($model, new ViewOptions());
+        // Per-sample positions (leaf→root indexing in stack arrays):
+        //   [0,2,3] n=3 → leaf_a:1 dist=2, mid dist=1, root dist=0
+        //   [0,2,3] same
+        //   [1,2,3] n=3 → leaf_a:2 dist=2, mid dist=1, root dist=0
+        //   [2,3]   n=2 → mid dist=1, root dist=0
+        $this->assertSame(
+            [
+                0 => 4, // leaf_a:1 appears twice, each at dist 2
+                2 => 4, // mid appears in 4 samples, each at dist 1
+                3 => 0, // root appears in 4 samples, each at dist 0
+                1 => 2, // leaf_a:2 appears once at dist 2
+            ],
+            $r['root_distance_sum'],
+        );
+    }
+
+    public function testSelfTimeReportsRootDistanceSum(): void
+    {
+        $model = $this->buildModel();
+        $r = Aggregator::selfTime($model, new ViewOptions());
+        // Leaf-only credits: dist is n-1 for the sample.
+        //   samples 0,1: leaf=0, n=3 → +2 each
+        //   sample 2:    leaf=1, n=3 → +2
+        //   sample 3:    leaf=2 (mid), n=2 → +1
+        $this->assertSame(
+            [
+                0 => 4,
+                1 => 2,
+                2 => 1,
+            ],
+            $r['root_distance_sum'],
+        );
+    }
+
+    public function testCallersOfReportsRootDistanceSum(): void
+    {
+        $model = $this->buildModel();
+        // Focus mid. Real caller is root in all four samples; distance
+        // from root is 0 in every case.
+        $r = Aggregator::callersOf($model, 2, new ViewOptions());
+        $this->assertSame([3 => 0], $r['root_distance_sum']);
+    }
+
+    public function testCallersOfSyntheticRootUsesNegativeOneDistance(): void
+    {
+        $model = $this->buildModel();
+        // Focus root; it is always the bottom of the stack so the
+        // synthetic <root> marker accumulates -1 per sample.
+        $r = Aggregator::callersOf($model, 3, new ViewOptions());
+        $this->assertSame([-1 => -4], $r['root_distance_sum']);
+    }
+
+    public function testCalleesOfReportsRootDistanceSum(): void
+    {
+        $model = $this->buildModel();
+        // Focus mid. Callee dist from root:
+        //   [0,2,3] callee=0 at i=0, n=3 → dist = n - i_focus = 3 - 1 = 2
+        //   [0,2,3] same
+        //   [1,2,3] callee=1, same → dist = 2
+        //   [2,3]   no callee → synthetic <leaf> at virtual position,
+        //                       dist = n = 2
+        $r = Aggregator::calleesOf($model, 2, new ViewOptions());
+        $this->assertSame(
+            [
+                0 => 4,
+                1 => 2,
+                -2 => 2,
+            ],
+            $r['root_distance_sum'],
+        );
+    }
 }

--- a/tests/Rbt/Explore/ExploreTuiStateTest.php
+++ b/tests/Rbt/Explore/ExploreTuiStateTest.php
@@ -191,6 +191,48 @@ class ExploreTuiStateTest extends BaseTestCase
         $this->assertSame($result, $second);
     }
 
+    public function testEnsureOverviewBreaksCountTiesByRootCloseness(): void
+    {
+        // Pathological-but-realistic case: every sample has the same
+        // three frames, so main, mid and leaf all tie at count N on the
+        // total view. Without a tie-breaker the insertion order (leaf →
+        // root) bubbles the leaf to the top of the sidebar; with the
+        // root-distance tie-breaker the entry point (main) comes first
+        // and the call order is reflected when drilling down.
+        $frame_keys = [
+            'leaf /a.php:1',
+            'mid /m.php:1',
+            'main /r.php:1',
+        ];
+        $model = new TraceModel(
+            frame_keys: $frame_keys,
+            frame_keys_no_line: $frame_keys,
+            no_line_map: [0, 1, 2],
+            samples: [
+                [0, 1, 2],
+                [0, 1, 2],
+                [0, 1, 2],
+            ],
+            sampling_period_us: 10000,
+            source_path: '/dev/null',
+        );
+        $tui = $this->makeTui($model);
+        // Switch the overview sort to 'total' so all three tie at 3.
+        $this->set($tui, 'overview_sort', 'total');
+
+        /** @var array{matched_samples:int, rows:list<array{int,int,string}>} $result */
+        $result = $this->inv($tui, 'ensureOverview');
+
+        // All three frames appear in every sample, so counts tie at 3.
+        $this->assertSame(3, $result['rows'][0][0]);
+        $this->assertSame(3, $result['rows'][1][0]);
+        $this->assertSame(3, $result['rows'][2][0]);
+        // Order is now root-first because of the root-distance tie-breaker.
+        $this->assertSame('main /r.php:1', $result['rows'][0][2]);
+        $this->assertSame('mid /m.php:1', $result['rows'][1][2]);
+        $this->assertSame('leaf /a.php:1', $result['rows'][2][2]);
+    }
+
     public function testInvalidateClearsListCacheButPreservesOverview(): void
     {
         $tui = $this->makeTui();


### PR DESCRIPTION
## Summary
This change enhances the frame aggregation system to track and use "root distance" as a tie-breaker when sorting frames by count. This ensures that when multiple frames appear in the same number of samples, frames closer to the stack root (entry points) are ranked higher than their callees.

## Key Changes

- **Aggregator class**: Modified all four aggregation methods (`selfTime`, `totalTime`, `callersOf`, `calleesOf`) to track `root_distance_sum` alongside counts
  - Root distance is calculated as `n - 1 - i` for a frame at stack index `i` in a sample of depth `n`
  - Synthetic `<root>` marker uses distance `-1` to sort above real callers
  - Synthetic `<leaf>` marker uses distance `n` to sort below real callees
  - Return type now includes `root_distance_sum: array<int, int>` in the result array

- **ExploreTui class**: Updated `buildCache()` method to use root-distance sum as a secondary sort key
  - Primary sort: count descending (unchanged)
  - Secondary sort: root-distance sum ascending (new tie-breaker)
  - Uses `uksort()` with a custom comparator to implement the two-level sort

- **Tests**: Added comprehensive test coverage
  - `AggregatorTest`: Four new tests validating root-distance calculations for each aggregation method
  - `ExploreTuiStateTest`: New test demonstrating the tie-breaker in action with a pathological case where all frames tie at the same count

## Implementation Details

The root-distance metric measures how far a frame is from the rootward end of the stack (0 = root, increasing toward leaves). This naturally reflects the call hierarchy: entry points have low accumulated distances while leaf functions have high accumulated distances. When frames appear equally often, preferring those with lower root-distance sums ensures the TUI displays the call graph in a more intuitive order (root-first rather than leaf-first).

https://claude.ai/code/session_01McrLjAdUktUxJJi1PBrVGS