### PR TITLE
Add Docker wrapper command and socket path resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM php:8.5-cli
 
+# libcap2-bin provides setcap; the file-capability set on /usr/local/bin/php
+# lets reli use CAP_SYS_PTRACE when the container is run as a non-root
+# `--user` (the normal mode under docker:print-wrapper). Without it, the
+# capability is in the bounding set only and memory reads fail with EPERM.
 RUN apt-get update && apt-get install -y \
       libffi-dev \
       libzip-dev \
+      libcap2-bin \
     && docker-php-ext-install ffi \
     && docker-php-ext-install pcntl \
     && docker-php-ext-install zip \
+    && setcap cap_sys_ptrace=eip /usr/local/bin/php \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Capture to `.rbt` in one terminal while running `rbt:analyze` through `watch(1)`
 
 ```bash
 # Terminal A — capture
-$ sudo php ./reli inspector:trace -p <pid> -F rbt -o trace.rbt
+$ reli inspector:trace -p <pid> -F rbt -o trace.rbt
 
 # Terminal B — live analysis, refreshed every 0.2 seconds
-$ watch -n0.2 './reli rbt:analyze --last --last-depth=10 --top=10 --sections="tail,self+total" --crop-anchor=right --path=short --crop=auto < trace.rbt'
+$ watch -n0.2 'reli rbt:analyze --last --last-depth=10 --top=10 --sections="tail,self+total" --crop-anchor=right --path=short --crop=auto < trace.rbt'
 ```
 
 <p align="center">
@@ -42,8 +42,8 @@ Analyser reference: [docs/tracing/rbt-analyze-and-explore.md](docs/tracing/rbt-a
 Capture to `.rbt`, open the sandwich / flamegraph / tree TUI.
 
 ```bash
-$ sudo php ./reli inspector:trace -p <pid> -F rbt -o trace.rbt
-$ ./reli rbt:explore trace.rbt
+$ reli inspector:trace -p <pid> -F rbt -o trace.rbt
+$ reli rbt:explore trace.rbt
 ```
 
 <p align="center">
@@ -58,14 +58,14 @@ Render the heap as a standalone HTML file — Circle Pack, Treemap, Sunburst, 3D
 
 ```bash
 # Capture a snapshot first (one-shot; or use inspector:memory:dump + inspector:memory:analyze in production — see docs/memory/memory-dump.md)
-$ sudo php ./reli inspector:memory -p <pid> -f binary -o snapshot.rmem
+$ reli inspector:memory -p <pid> -f binary -o snapshot.rmem
 
 # Standalone HTML
-$ php ./reli rmem:viz snapshot.rmem
+$ reli rmem:viz snapshot.rmem
 # wrote snapshot.rmem.viz.html
 
 # Live (HTTP/SSE) with follow-from-TUI
-$ php ./reli rmem:explore snapshot.rmem --http-bridge 8080
+$ reli rmem:explore snapshot.rmem --http-bridge 8080
 # press `f` in the TUI, then open http://127.0.0.1:8080/
 ```
 
@@ -82,8 +82,8 @@ Full tour (views, palettes, focus bus, mouse, MCP): [docs/memory/rmem-explore-an
 Capture a snapshot and get a prioritised report back — dominant classes, cycles, choke points, deduplication candidates — each with severity, hypothesis, and next steps.
 
 ```bash
-$ sudo php ./reli inspector:memory -p <pid> -f binary -o snapshot.rmem
-$ php ./reli inspector:memory:report snapshot.rmem
+$ reli inspector:memory -p <pid> -f binary -o snapshot.rmem
+$ reli inspector:memory:report snapshot.rmem
 ```
 
 <p align="center">
@@ -95,7 +95,7 @@ $ php ./reli inspector:memory:report snapshot.rmem
 Compare two snapshots to track regressions or verify fixes:
 
 ```bash
-$ php ./reli inspector:memory:compare before.rmem after.rmem
+$ reli inspector:memory:compare before.rmem after.rmem
 ```
 
 Full reference (output formats, thresholds, JSON mode): [docs/memory/memory-report.md](docs/memory/memory-report.md). Capture options (`--exclude-heap`, portable dumps, core-file analysis): [docs/memory/memory-dump.md](docs/memory/memory-dump.md), [docs/memory/coredump.md](docs/memory/coredump.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ this file links out to a dedicated doc or a section of the top-level
 ## Getting started
 
 - **New here?** [getting-started.md](getting-started.md) walks you from install to your first trace in 5 minutes.
+- Docker wrapper (`reli` / `reli-view` installed via `eval "$(... docker:print-wrapper)"`) — [docker-wrapper.md](docker-wrapper.md)
 - How it works (architecture overview) — [README § How it works](../README.md#how-it-works)
 - Supported PHP versions and platforms — [getting-started.md § Requirements](getting-started.md#requirements)
 

--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -1,0 +1,139 @@
+# Docker wrapper reference
+
+The Docker image ships with `docker:print-wrapper`, a command that emits a
+shell function you `eval` into your shell. The function makes `reli <cmd>
+...` work exactly like a native install (same examples, same flags),
+routed through `docker run` transparently.
+
+## Install
+
+```bash
+# Full profile (default) — attaches to live processes.
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+
+# Minimal profile — viewers / converters only, lower privilege.
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper --profile=minimal)"
+```
+
+Add the line to `~/.bashrc` / `~/.zshrc` for persistence. The image tag is
+baked into the emitted wrapper (matching the image the `docker run` pulled),
+so you don't get accidental `:latest` drift.
+
+## Profiles
+
+| Flag / setting                       | Full | Minimal | Notes                                                    |
+|--------------------------------------|:----:|:-------:|----------------------------------------------------------|
+| `--cap-add=SYS_PTRACE`               | ✓    |         | Required for attaching to live processes.                |
+| `--security-opt=apparmor=unconfined` | ✓    |         | Needed for ptrace on AppArmor-enabled distros.           |
+| `--pid=host`                         | ✓    |         | Makes host PIDs visible in the container.                |
+| `--network=host`                     | ✓    |         | Required for `rmem:live` HTTP/SSE and similar.           |
+| `--user $UID:$GID`                   | ✓    | ✓       | Generated files are host-user-owned.                     |
+| `--read-only` rootfs + tmpfs         |      | ✓       | Container filesystem is immutable under Minimal.         |
+| cwd bind mount (`$PWD:$PWD`)         | ✓    | ✓       | Relative and cwd-anchored paths Just Work.               |
+
+Full is the default because most canonical reli invocations (tracing,
+memory dump, peek-var, sidecar, watch) need host PID / ptrace access.
+Minimal omits all four privilege flags — use it when you only need to
+`rbt:explore` / `rmem:explore` / `rmem:viz` / `converter:*` an existing
+capture, or on a shared / multi-tenant host where granting
+`CAP_SYS_PTRACE` to a container is inappropriate.
+
+### Commands safe under Minimal
+
+`docker:print-wrapper --profile=minimal` prints the current allowlist at
+the top of the emitted wrapper. At the time of writing:
+
+- `cache:clear`
+- `converter:*` (callgrind, flamegraph, folded, phpspy, pprof, rbt, speedscope)
+- `inspector:memory:compare`, `inspector:memory:dump:inspect`,
+  `inspector:memory:normalize-dump`, `inspector:memory:report`,
+  `inspector:optimize-memory-db`
+- `rbt:analyze`, `rbt:explore`, `rbt:recover`
+- `rmem:*` (explore, live, mcp, query, serve, viz)
+
+Running a Full-profile command under the Minimal wrapper will fail when
+reli tries to use a capability it does not have (usually `EPERM` on a
+ptrace call or an `address already in use` on a host-port bind). If a
+command fails for an unexpected reason, reinstall with `--profile=full`
+and retry.
+
+## Options
+
+```
+docker:print-wrapper [--profile=PROFILE] [--name=NAME] [--image=IMAGE] [--shell=SHELL]
+
+--profile=PROFILE  full (default) or minimal.
+--name=NAME        Shell function name. Default: reli for full, reli-view
+                   for minimal. Use this to run both profiles side-by-side:
+                     eval "$(docker run ... --profile=full --name=reli)"
+                     eval "$(docker run ... --profile=minimal --name=reliv)"
+--image=IMAGE      Image reference to bake in. Defaults to
+                   reliforp/reli-prof:<current-version>; dev / unknown
+                   versions fall back to :latest.
+--shell=SHELL      Target shell dialect (bash|zsh|posix). Currently
+                   informational; all emitted output uses bash-compatible
+                   syntax (`local`, `[[ ]]`).
+```
+
+## Environment knobs
+
+### `RELI_DOCKER_EXTRA_ARGS`
+
+Passed verbatim to `docker run`. The main use cases:
+
+```bash
+# Make a directory outside cwd visible inside the container.
+RELI_DOCKER_EXTRA_ARGS='-v /var/log:/var/log' reli inspector:trace ...
+
+# Share the host's reli config read-only.
+RELI_DOCKER_EXTRA_ARGS='-v "$HOME/.config/reli":"$HOME/.config/reli":ro' reli ...
+
+# Extra capability you know you need (e.g. SYS_ADMIN for some edge case).
+RELI_DOCKER_EXTRA_ARGS='--cap-add=SYS_ADMIN' reli ...
+```
+
+### Scratch directory
+
+The wrapper chooses a scratch dir from `$XDG_RUNTIME_DIR/reli-docker`
+(on systemd hosts) or `$HOME/.cache/reli-docker`, and exports
+`HOME` / `XDG_STATE_HOME` / `XDG_CACHE_HOME` / `XDG_RUNTIME_DIR` to
+sub-paths inside it. This keeps daemon output, binary-analysis cache,
+sidecar sockets, and other state on the host user's filesystem.
+
+The wrapper strictly validates the scratch dir (owner, mode 0700,
+non-symlink) before each run. If the check fails, the wrapper aborts
+with a reason-specific hint — typically `chmod 0700 '<path>'` is all
+that's needed.
+
+## Limitations
+
+| Scenario                                                   | Guidance                                              |
+|------------------------------------------------------------|-------------------------------------------------------|
+| Absolute path outside cwd (`-o /var/log/...`)              | `RELI_DOCKER_EXTRA_ARGS='-v /var/log:/var/log'`.      |
+| `inspector:trace -- python3 script.py` (non-PHP spawn)     | Not supported by default image; build a custom image. |
+| `inspector:trace -- php7.3 ...` (specific PHP target)      | Not supported by default image; build a custom image. |
+| `phpspy:*` commands                                        | Not bundled; build a custom image.                    |
+| `ptrace_scope=2/3` on the host                             | Temporarily raise `yama.ptrace_scope`, or use a native install. |
+| Multi-tenant host                                          | Prefer `--profile=minimal`; avoid installing the Full wrapper if multiple tenants share the host. |
+
+## Security
+
+The Full profile grants the container a substantial subset of host
+privilege:
+
+- `CAP_SYS_PTRACE` lets the container read `/proc/<pid>/mem` and ptrace
+  any host process, not just PHP ones.
+- `--pid=host` exposes every host process (argv, environment, cwd) in
+  the container's `/proc`.
+- `--network=host` lets the container bind directly on host interfaces.
+- `--security-opt=apparmor=unconfined` removes AppArmor constraints.
+
+Inside the container, reli runs as the host user (`--user $(id -u):$(id -g)`);
+`CAP_SYS_PTRACE` is made effective via file capabilities on
+`/usr/local/bin/php` in the image (installed at build time).
+
+Trust the wrapper accordingly: the Full profile is fine for
+single-user laptops and dedicated CI runners, but think twice on
+shared hosts. The Minimal profile drops all four privilege flags
+above; running it on any machine you'd trust to run an ordinary
+unprivileged container is equivalent.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,25 +57,39 @@ For the full catalogue of tasks-and-commands, see the
 
 ## 1. Install
 
-The provided Docker image is usually the easiest starting point —
-PHP 8.5, FFI and PCNTL already enabled, and `--cap-add=SYS_PTRACE`
-+ `--pid=host` let you target PHP processes running on the host or
-in other containers without touching the host shell:
+The Docker image is the easiest starting point — PHP 8.5, FFI, and
+PCNTL pre-built, no host toolchain needed. A one-line command
+installs a shell function `reli` so the rest of this doc works
+exactly as written, with no docker flag incantations to remember:
 
 ```bash
-docker pull reliforp/reli-prof
-docker run -it --security-opt="apparmor=unconfined" \
-                --cap-add=SYS_PTRACE --pid=host \
-                reliforp/reli-prof
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
 ```
 
-`--cap-add=SYS_PTRACE` grants reli the ptrace capability, and
-`--pid=host` makes PHP processes running on the host (or in other
-containers) visible as targets — no extra setup on the host side.
+Then, still in the same shell:
 
-Inside the container the CLI is available as `reli` (and also as
-`./reli`). Everything below is the same whether you invoke it from
-the container or from a native install.
+```bash
+reli --version
+```
+
+Append the `eval "$(...)"` line to your `~/.bashrc` / `~/.zshrc` to
+keep it. The wrapper baked-in image tag matches the version of reli
+the `docker run` invocation pulled, so there's no `:latest` drift.
+
+The wrapper runs each `reli` invocation as a container with
+`--cap-add=SYS_PTRACE --pid=host --network=host`, which gives reli
+the access it needs to profile PHP processes on the host. See
+[docker-wrapper.md](docker-wrapper.md) for the security trade-offs
+and for the lower-privilege `reli-view` variant (viewer-only, safe
+on shared hosts):
+
+```bash
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper --profile=minimal)"
+```
+
+If a command fails unexpectedly under `reli-view`, reinstall with
+`--profile=full` and retry — `reli-view` intentionally omits the
+host privileges needed for attaching to live processes.
 
 ### From Composer
 
@@ -130,12 +144,15 @@ Run your workload in one terminal, attach reli from another:
 php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
-sudo php ./reli inspector:trace -p "$(pgrep -f your-script.php)" \
-                                -F rbt -o trace.rbt
+reli inspector:trace -p "$(pgrep -f your-script.php)" \
+                     -F rbt -o trace.rbt
 ```
 
-The target process must be reachable with `ptrace(2)` — usually this
-means running reli as root (or granting `CAP_SYS_PTRACE`).
+The target process must be reachable with `ptrace(2)`. Under the
+Docker wrapper this is already handled (the container has
+`CAP_SYS_PTRACE`). On a native install you need either to run reli
+as root (`sudo`) or set `CAP_SYS_PTRACE` on the `php` binary you
+use to run reli.
 
 ## 4. Read the trace
 

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -105,10 +105,12 @@ reli() {
     return 2
   fi
   mkdir -m 0700 -p "$scratch" || return $?
-  # Strictly reject if owner or mode don't match — don't silently coerce.
-  if ! reli_assert_scratch_safe "$scratch"; then
-    echo "reli: scratch dir $scratch failed safety check; aborting" >&2
-    echo "reli: if you own the dir, run: chmod 0700 '$scratch'" >&2
+  # Strictly reject if owner / mode / symlink don't match — don't
+  # silently coerce. The validator echoes a reason-specific hint so
+  # the user sees the actual problem, not a generic "chmod and retry".
+  local reason
+  if ! reason=$(reli_assert_scratch_safe "$scratch"); then
+    echo "reli: scratch dir $scratch failed safety check: $reason" >&2
     return 2
   fi
 
@@ -129,24 +131,26 @@ reli() {
 }
 
 reli_assert_scratch_safe() {
-  # Host-side check. The wrapper function runs on whichever shell invokes
-  # `docker run` (Linux bash, macOS zsh, WSL bash, ...), NOT inside the
-  # container. `stat` flag syntax therefore varies with host OS: GNU
-  # userland (`-c`) on Linux / WSL, BSD userland (`-f`) on macOS. The
-  # print-wrapper subcommand detects the target shell and host OS (via
-  # `--shell`) and emits the matching probe; the form below is the
-  # portable fallback that tries both.
+  # Host-side check. Runs on whichever shell invokes `docker run`
+  # (Linux bash, macOS zsh, WSL bash, ...), NOT inside the container.
+  # `stat` flag syntax differs between GNU (-c) and BSD (-f) userland;
+  # the form below tries both. On stdout, emits a reason string when
+  # the check fails so the caller can surface the actual problem; on
+  # success, emits nothing.
   local d="$1"
-  [ -d "$d" ] && [ ! -L "$d" ] || return 1
+  [ -d "$d" ]    || { echo "not a directory"; return 1; }
+  [ ! -L "$d" ]  || { echo "scratch entry is a symlink; remove it and retry"; return 1; }
   local owner mode
   owner=$(stat -c '%u' "$d" 2>/dev/null) \
     || owner=$(stat -f '%u' "$d" 2>/dev/null) \
-    || return 1
-  [ "$owner" = "$(id -u)" ] || return 1
+    || { echo "could not stat"; return 1; }
+  [ "$owner" = "$(id -u)" ] \
+    || { echo "not owned by uid $(id -u) (owned by $owner); rename or remove with appropriate privilege"; return 1; }
   mode=$(stat -c '%a' "$d" 2>/dev/null) \
     || mode=$(stat -f '%Lp' "$d" 2>/dev/null) \
-    || return 1
-  [ "$mode" = "700" ] || return 1
+    || { echo "could not stat mode"; return 1; }
+  [ "$mode" = "700" ] \
+    || { echo "mode is $mode, want 700; fix with: chmod 0700 '$d'"; return 1; }
   return 0
 }
 ```
@@ -167,11 +171,19 @@ Key properties:
   user-private on single-user laptops and conventional home-directory
   setups, but less categorical — shared NFS homes or unusual permission
   regimes weaken the guarantee).
-  `reli_assert_scratch_safe` stats the resolved path and rejects
-  (loud abort, not silent coerce) anything that is a symlink, not
-  owned by the current uid, or not exactly mode 0700. The abort message
-  points at an explicit `chmod` recovery command so users who hit this
-  on a legitimately misconfigured dir know what to do.
+  `reli_assert_scratch_safe` inspects the scratch dir entry itself and
+  rejects (loud abort, not silent coerce) if it is not a directory,
+  if it is a symlink, if it is not owned by the current uid, or if it
+  is not exactly mode 0700. The check is local to the entry: symlinks
+  on path components *above* the scratch dir (e.g., a symlinked
+  `$HOME` or `$XDG_RUNTIME_DIR`) are not traversed / validated — those
+  rely on the underlying filesystem's per-user permission model being
+  sane (which is the normal case for systemd-managed runtime dirs and
+  for conventional home directories, but not an absolute guarantee).
+  Each failure emits a reason-specific hint (e.g. `chmod 0700 '$d'`
+  only when the mode is the actual issue; an ownership mismatch
+  instead suggests rename / remove) rather than a one-size-fits-all
+  message.
 - `--user "$UID:$GID"` makes generated files owned by the host user
   (no `sudo rm` required after profiling).
 - `HOME="${scratch}"` aligns in-container config discovery
@@ -392,7 +404,7 @@ Inventoried via a pass over every Symfony Console command definition.
 | TUI (`rbt:explore`, `rmem:explore`)                | auto `-t`.                                        |
 | File ownership                                     | `--user "$UID:$GID"`.                             |
 | Daemon output default                              | `HOME` / `XDG_STATE_HOME` → scratch.              |
-| Scratch-dir pre-creation / symlink attacks         | parent path chosen from normally user-private locations (XDG runtime / `$HOME/.cache`); strict owner + mode + non-symlink check on every invocation rejects anything that doesn't match, rather than relying on the parent's assumed permissions. |
+| Scratch-dir pre-creation / symlink attacks         | parent path chosen from normally user-private locations (XDG runtime / `$HOME/.cache`); strict owner + mode + "entry is not a symlink" check on every invocation rejects anything that doesn't match. Upstream path components (e.g. a symlinked `$HOME`) are not traversed — relies on the underlying FS's per-user permission model for those. |
 
 ### Handled by core changes
 

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -101,10 +101,11 @@ reli() {
     echo "reli: neither XDG_RUNTIME_DIR nor HOME is set; refusing to start" >&2
     return 2
   fi
-  mkdir -p "$scratch" || return $?
-  # Validate: must be a real directory owned by us, mode 0700, not a symlink.
-  if ! reli_validate_scratch "$scratch"; then
-    echo "reli: scratch dir $scratch failed owner/mode validation; aborting" >&2
+  mkdir -m 0700 -p "$scratch" || return $?
+  # Strictly reject if owner or mode don't match — don't silently coerce.
+  if ! reli_assert_scratch_safe "$scratch"; then
+    echo "reli: scratch dir $scratch failed safety check; aborting" >&2
+    echo "reli: if you own the dir, run: chmod 0700 '$scratch'" >&2
     return 2
   fi
 
@@ -124,15 +125,25 @@ reli() {
     reliforp/reli-prof:<TAG_PINNED_AT_GENERATION> "$@"
 }
 
-reli_validate_scratch() {
-  # POSIX-ish: stat format differs on BSD/macOS, but on Docker hosts (Linux)
-  # GNU stat is assumed. The print-wrapper subcommand may emit a platform-
-  # adjusted variant.
+reli_assert_scratch_safe() {
+  # Host-side check. The wrapper function runs on whichever shell invokes
+  # `docker run` (Linux bash, macOS zsh, WSL bash, ...), NOT inside the
+  # container. `stat` flag syntax therefore varies with host OS: GNU
+  # userland (`-c`) on Linux / WSL, BSD userland (`-f`) on macOS. The
+  # print-wrapper subcommand detects the target shell and host OS (via
+  # `--shell`) and emits the matching probe; the form below is the
+  # portable fallback that tries both.
   local d="$1"
   [ -d "$d" ] && [ ! -L "$d" ] || return 1
-  local owner; owner=$(stat -c '%u' "$d") || return 1
+  local owner mode
+  owner=$(stat -c '%u' "$d" 2>/dev/null) \
+    || owner=$(stat -f '%u' "$d" 2>/dev/null) \
+    || return 1
   [ "$owner" = "$(id -u)" ] || return 1
-  chmod 0700 "$d" || return 1
+  mode=$(stat -c '%a' "$d" 2>/dev/null) \
+    || mode=$(stat -f '%Lp' "$d" 2>/dev/null) \
+    || return 1
+  [ "$mode" = "700" ] || return 1
   return 0
 }
 ```
@@ -148,11 +159,16 @@ Key properties:
 - `-v "$PWD":"$PWD" -w "$PWD"` makes every cwd-relative or cwd-anchored
   absolute path Just Work (`-o trace.rbt`, `-o ./sub/trace.rbt`,
   `-o $PWD/trace.rbt` all resolve identically inside and outside).
-- Scratch dir under `$XDG_RUNTIME_DIR` (systemd: `/run/user/$UID`, 0700)
-  or `$HOME/.cache` — both are inside host-user-owned filesystem space,
-  so other local users cannot pre-create or symlink-hijack the path.
-  Validation (`reli_validate_scratch`) rejects compromised dirs with a
-  loud error rather than falling through.
+- Scratch dir under `$XDG_RUNTIME_DIR` (systemd: `/run/user/$UID`, 0700,
+  strongly per-user by construction) or `$HOME/.cache` (typically
+  user-private on single-user laptops and conventional home-directory
+  setups, but less categorical — shared NFS homes or unusual permission
+  regimes weaken the guarantee).
+  `reli_assert_scratch_safe` stats the resolved path and rejects
+  (loud abort, not silent coerce) anything that is a symlink, not
+  owned by the current uid, or not exactly mode 0700. The abort message
+  points at an explicit `chmod` recovery command so users who hit this
+  on a legitimately misconfigured dir know what to do.
 - `--user "$UID:$GID"` makes generated files owned by the host user
   (no `sudo rm` required after profiling).
 - `HOME="${scratch}"` aligns in-container config discovery
@@ -203,6 +219,25 @@ Commands safe under Minimal are those annotated
 change D). Running a Full-profile command under Minimal will fail at
 reli's first ptrace / network attempt — by design, not via an
 explicit wrapper-level guard.
+
+Because the failure path is generic (`EPERM` from ptrace, address
+bind failure, etc.) and the user may not immediately connect it to
+the profile choice, two mitigations ship together:
+
+1. `docker:print-wrapper --profile=minimal` prepends a header comment
+   to the emitted function listing the Minimal-safe commands
+   (generated via reflection over `ReliCommand` subclasses), so the
+   installed wrapper self-documents its scope.
+2. README explicitly says: "if a command fails unexpectedly under
+   `reli-view`, reinstall the wrapper with `--profile=full` and try
+   again." — the first-run troubleshooting path should be one
+   command, not a spelunking expedition.
+
+A wrapper-level runtime guard that pattern-matches `$1` and refuses
+incompatible commands up-front was considered and declined (see Out
+of scope): it would add a second enforcement layer that must be kept
+in sync with `DockerProfile`, and reli's own error is ultimately
+more accurate about *why* a command fails.
 
 ## Privilege and trust surface
 
@@ -437,6 +472,16 @@ Options:
 
 Output: shell code on stdout, no trailing prose. Safe to `eval`.
 
+`--shell` governs syntactic variant (`local`, `[[ ]]`, POSIX-portable
+fallbacks) of the emitted shell, not host-OS assumptions. The wrapper
+function executes on the user's host shell — which may be Linux
+bash / zsh, macOS zsh (Docker Desktop), WSL bash, etc. — not inside
+the container. Userland-level differences (notably `stat` flag
+syntax between GNU and BSD) are handled by emitting a portable probe
+that tries both. An explicit `--host-os=linux|macos|wsl` option is
+**out of scope for v1** but reserved as a future extension if the
+portable probe proves unreliable in practice.
+
 When `--profile=minimal`, the emitted output includes a leading comment
 block listing the commands classified as `DockerProfile::Minimal` (for
 user reference), gathered via reflection over the `ReliCommand`
@@ -485,7 +530,11 @@ Non-zero exit on unknown shell, unknown profile, or malformed option.
 8. **README.md** — replace "From Docker" snippet with the
    `eval "$(...)"` one-liner; also mention the `--profile=minimal`
    variant. Drop `sudo` from examples where it was only for ptrace
-   permission. Add a privilege / trust surface warning section.
+   permission. Add a privilege / trust surface warning section. Add
+   a one-line troubleshooting note: "if a command fails unexpectedly
+   under `reli-view` (Minimal), reinstall with `--profile=full` and
+   retry" — so first-time users don't have to diagnose the
+   profile-mismatch case themselves.
 9. **`docs/docker-wrapper.md`** (new) — full reference: profile
    comparison table, `RELI_DOCKER_EXTRA_ARGS` recipes, limitation
    table (reproduced from this design), security notes, FAQ

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -62,7 +62,7 @@ the intended envelope.
 
 | Scenario              | wrapper default guards                             | wrapper default does NOT guard                  |
 |-----------------------|----------------------------------------------------|-------------------------------------------------|
-| Single-user laptop    | cwd isolation (mounted), file ownership (via `--user`), host-owned scratch dir, sidecar socket under per-user 0700 dir | (nothing — the host user trusts themselves)     |
+| Single-user laptop    | cwd isolation (mounted), file ownership (via `--user`), user-private scratch dir (strict-checked), sidecar socket under per-user 0700 dir | (nothing — the host user trusts themselves)     |
 | CI runner (dedicated) | same as laptop, plus cache directories confined to host user scope | (same — assumes runner is ephemeral / trusted)  |
 | Multi-tenant host     | (partial — scratch uses `$XDG_RUNTIME_DIR` which systemd sets 0700 per-user; `--user` preserves per-user file ownership) | **ptrace of other tenants' processes** (wrapper grants `CAP_SYS_PTRACE` + `--pid=host`), **port conflicts via `--network=host`**, **apparmor removal** |
 
@@ -90,8 +90,11 @@ reli() {
   local tty=
   [ -t 0 ] && [ -t 1 ] && tty=-t
 
-  # Scratch dir lives under host-user-owned filesystem to prevent
-  # pre-creation / symlink attacks from other local users.
+  # Scratch dir path is chosen from locations that are normally user-
+  # private ($XDG_RUNTIME_DIR under systemd; $HOME/.cache otherwise).
+  # We do not *rely* on that — the mkdir below only sets mode 0700 on
+  # fresh creation (no-op if the dir exists), and the strict check
+  # after rejects anything we don't already own at mode 0700.
   local scratch
   if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ]; then
     scratch="${XDG_RUNTIME_DIR}/reli-docker"
@@ -322,8 +325,9 @@ sidecar (no more `/var/run` write).
 (typically `$HOME/.local/state/reli/...`).
 
 **Decision**: **keep the default unchanged**. Under the wrapper, `HOME`
-and `XDG_STATE_HOME` are already steered to the host-user-owned scratch
-dir (see wrapper shape). No core change needed. Reasoning:
+and `XDG_STATE_HOME` are already steered to the wrapper-managed scratch
+dir (see wrapper shape), which is itself owner/mode-validated before
+use. No core change needed. Reasoning:
 
 - Profile data is sensitive (variable values via `--trace-var`, heap
   contents via memory dumps — routinely contains credentials / PII).
@@ -388,7 +392,7 @@ Inventoried via a pass over every Symfony Console command definition.
 | TUI (`rbt:explore`, `rmem:explore`)                | auto `-t`.                                        |
 | File ownership                                     | `--user "$UID:$GID"`.                             |
 | Daemon output default                              | `HOME` / `XDG_STATE_HOME` → scratch.              |
-| Scratch-dir pre-creation attacks                   | scratch rooted in host-user-owned FS + owner/mode validation. |
+| Scratch-dir pre-creation / symlink attacks         | parent path chosen from normally user-private locations (XDG runtime / `$HOME/.cache`); strict owner + mode + non-symlink check on every invocation rejects anything that doesn't match, rather than relying on the parent's assumed permissions. |
 
 ### Handled by core changes
 

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -54,32 +54,86 @@ The downside — shell argv handling is more fragile than PHP — is mitigated
 by using namespace-sharing flags (`--pid=host`, `--network=host`) that
 remove the need for argv-level port/PID translation entirely.
 
-## Wrapper shape (draft)
+## Threat model
+
+The wrapper is shipped with different guarantees per environment. The
+design makes this explicit so README can warn users operating outside
+the intended envelope.
+
+| Scenario              | wrapper default guards                             | wrapper default does NOT guard                  |
+|-----------------------|----------------------------------------------------|-------------------------------------------------|
+| Single-user laptop    | cwd isolation (mounted), file ownership (via `--user`), host-owned scratch dir, sidecar socket under per-user 0700 dir | (nothing — the host user trusts themselves)     |
+| CI runner (dedicated) | same as laptop, plus cache directories confined to host user scope | (same — assumes runner is ephemeral / trusted)  |
+| Multi-tenant host     | (partial — scratch uses `$XDG_RUNTIME_DIR` which systemd sets 0700 per-user; `--user` preserves per-user file ownership) | **ptrace of other tenants' processes** (wrapper grants `CAP_SYS_PTRACE` + `--pid=host`), **port conflicts via `--network=host`**, **apparmor removal** |
+
+The `Full` profile (default) is unsafe on multi-tenant hosts by design:
+it gives the container the capability to ptrace any host process, which
+means any same-uid or cross-uid compromise of the container grants the
+ability to read arbitrary process memory on the host.
+
+The `Minimal` profile (opt-in; see below) drops `CAP_SYS_PTRACE`,
+`--pid=host`, `--network=host`, and `apparmor=unconfined` — giving up
+the ability to profile other processes in exchange for an isolation
+profile comparable to an ordinary container. Viewer-only commands
+(`rbt:explore`, `rmem:explore`, etc.) run correctly under Minimal.
+
+README **must** call out that users on shared hosts should prefer the
+Minimal profile when they only need to inspect previously-captured
+traces / dumps, and should assess whether Full is appropriate at all.
+
+## Wrapper shape
+
+### Full profile (default)
 
 ```bash
 reli() {
   local tty=
   [ -t 0 ] && [ -t 1 ] && tty=-t
 
-  # Per-user scratch dirs (mode 700) to avoid cross-user leaks on shared hosts.
-  local uid; uid=$(id -u)
-  local scratch="/tmp/reli-${uid}"
-  mkdir -m 700 -p "${scratch}/state" "${scratch}/cache" "${scratch}/runtime" 2>/dev/null || true
+  # Scratch dir lives under host-user-owned filesystem to prevent
+  # pre-creation / symlink attacks from other local users.
+  local scratch
+  if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ]; then
+    scratch="${XDG_RUNTIME_DIR}/reli-docker"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+    scratch="${HOME}/.cache/reli-docker"
+  else
+    echo "reli: neither XDG_RUNTIME_DIR nor HOME is set; refusing to start" >&2
+    return 2
+  fi
+  mkdir -p "$scratch" || return $?
+  # Validate: must be a real directory owned by us, mode 0700, not a symlink.
+  if ! reli_validate_scratch "$scratch"; then
+    echo "reli: scratch dir $scratch failed owner/mode validation; aborting" >&2
+    return 2
+  fi
 
   docker run --rm -i ${tty} \
     --cap-add=SYS_PTRACE \
     --security-opt=apparmor=unconfined \
     --pid=host \
     --network=host \
-    --user "${uid}:$(id -g)" \
+    --user "$(id -u):$(id -g)" \
     -v "$PWD":"$PWD" -w "$PWD" \
     -v "${scratch}":"${scratch}" \
+    -e HOME="${scratch}" \
     -e XDG_STATE_HOME="${scratch}/state" \
     -e XDG_CACHE_HOME="${scratch}/cache" \
     -e XDG_RUNTIME_DIR="${scratch}/runtime" \
-    -e HOME="${scratch}" \
     ${RELI_DOCKER_EXTRA_ARGS:-} \
     reliforp/reli-prof:<TAG_PINNED_AT_GENERATION> "$@"
+}
+
+reli_validate_scratch() {
+  # POSIX-ish: stat format differs on BSD/macOS, but on Docker hosts (Linux)
+  # GNU stat is assumed. The print-wrapper subcommand may emit a platform-
+  # adjusted variant.
+  local d="$1"
+  [ -d "$d" ] && [ ! -L "$d" ] || return 1
+  local owner; owner=$(stat -c '%u' "$d") || return 1
+  [ "$owner" = "$(id -u)" ] || return 1
+  chmod 0700 "$d" || return 1
+  return 0
 }
 ```
 
@@ -87,16 +141,24 @@ Key properties:
 
 - `--pid=host` + `CAP_SYS_PTRACE` cover attach (`-p <pid>`), `/proc/<pid>/*`
   reads, and daemon regex matching against host process list.
+  Non-root `--user` makes `CAP_SYS_PTRACE` effective only when the `php`
+  binary in the image has file capabilities set (see core change A).
 - `--network=host` covers `rmem:live`, any HTTP/SSE, and host-visible TCP
   listeners — eliminates per-command `-p host:container` reasoning.
 - `-v "$PWD":"$PWD" -w "$PWD"` makes every cwd-relative or cwd-anchored
   absolute path Just Work (`-o trace.rbt`, `-o ./sub/trace.rbt`,
   `-o $PWD/trace.rbt` all resolve identically inside and outside).
-- Per-user scratch in `/tmp/reli-$UID` (mode 700) hosts XDG-derived
-  defaults that would otherwise fall under `$HOME` inside the container
-  and vanish on exit.
+- Scratch dir under `$XDG_RUNTIME_DIR` (systemd: `/run/user/$UID`, 0700)
+  or `$HOME/.cache` — both are inside host-user-owned filesystem space,
+  so other local users cannot pre-create or symlink-hijack the path.
+  Validation (`reli_validate_scratch`) rejects compromised dirs with a
+  loud error rather than falling through.
 - `--user "$UID:$GID"` makes generated files owned by the host user
   (no `sudo rm` required after profiling).
+- `HOME="${scratch}"` aligns in-container config discovery
+  (`~/.config/reli/config.php`) with the wrapper-provided scratch, so
+  the limitation table's "share host config" example points to a
+  consistent location.
 - `RELI_DOCKER_EXTRA_ARGS` is the documented escape hatch for extra
   mounts (paths outside cwd), extra capabilities, custom `/etc/hosts`, etc.
 
@@ -105,38 +167,96 @@ Dropped from earlier drafts:
 - `--ipc=host` — unnecessary. reli's IPC (sidecar, rmem-serve) is Unix
   sockets on filesystem paths, not System V IPC. Dropping reduces
   privilege surface.
-- `-v /tmp:/tmp` — replaced by the narrower per-user scratch mount. The
-  sidecar socket default will be moved (see below) so that a broad
-  `/tmp` mount is not needed.
+- `-v /tmp:/tmp` — sidecar socket default is being moved to
+  `$XDG_RUNTIME_DIR/reli/sidecar.sock` (see core change B), so a broad
+  `/tmp` mount is no longer needed.
+- `/tmp/reli-$UID` scratch — replaced with `$XDG_RUNTIME_DIR` /
+  `$HOME/.cache` based paths that are inherently protected by host
+  filesystem user boundaries rather than by our own `mkdir -m 700`
+  (which did not protect against pre-existing dirs).
+
+### Minimal profile (`--profile=minimal`)
+
+Installed separately as a distinct shell function (default name
+`reli-view`). Intended for running viewer commands on files already
+captured elsewhere, on untrusted hosts, or inside CI.
+
+```bash
+reli-view() {
+  local tty=
+  [ -t 0 ] && [ -t 1 ] && tty=-t
+  docker run --rm -i ${tty} \
+    --user "$(id -u):$(id -g)" \
+    --read-only \
+    --tmpfs /tmp:rw,nosuid,nodev,size=64m \
+    -v "$PWD":"$PWD" -w "$PWD" \
+    ${RELI_DOCKER_EXTRA_ARGS:-} \
+    reliforp/reli-prof:<TAG> "$@"
+}
+```
+
+Dropped vs Full: `CAP_SYS_PTRACE`, `--pid=host`, `--network=host`,
+`apparmor=unconfined`, XDG mounts (tmpfs covers ephemeral needs).
+
+Commands safe under Minimal are those annotated
+`DockerProfile::Minimal` in the command classification (see core
+change D). Running a Full-profile command under Minimal will fail at
+reli's first ptrace / network attempt — by design, not via an
+explicit wrapper-level guard.
 
 ## Privilege and trust surface
 
-The wrapper grants the container a substantial subset of host privilege.
-README **must** call this out explicitly so that users on shared or
-multi-tenant hosts understand the bargain:
+| Flag / setting                       | Full profile | Minimal profile | Effect                                                        |
+|--------------------------------------|:---:|:---:|----------------------------------------------------------------------|
+| `--cap-add=SYS_PTRACE`               | ✓   |     | Can ptrace / read `/proc/<pid>/mem` of host processes.               |
+| `--security-opt=apparmor=unconfined` | ✓   |     | Removes AppArmor confinement on the container.                       |
+| `--pid=host`                         | ✓   |     | Container `/proc` shows all host processes (argv, env).              |
+| `--network=host`                     | ✓   |     | Container binds directly on host interfaces.                         |
+| `--user $UID:$GID`                   | ✓   | ✓   | Non-root in container; generated files host-user-owned.              |
+| `--read-only` + tmpfs                |     | ✓   | Container rootfs immutable; only `/tmp` and bind mounts writable.    |
+| cwd bind mount                       | ✓   | ✓   | Inputs / outputs accessible at same path inside container.           |
 
-| Flag                              | Effect                                                      |
-|-----------------------------------|-------------------------------------------------------------|
-| `--cap-add=SYS_PTRACE`            | Can ptrace / read `/proc/<pid>/mem` of any host process.    |
-| `--security-opt=apparmor=unconfined` | Removes AppArmor confinement on the container.           |
-| `--pid=host`                      | Container `/proc` shows all host processes (argv, env).     |
-| `--network=host`                  | Container binds directly on host interfaces.                |
-
-Recommendation for shared hosts: document `RELI_DOCKER_EXTRA_ARGS` usage
-to narrow the profile, or discourage the wrapper entirely on
-multi-tenant machines.
-
-Viewer-only commands (`rbt:explore`, `rmem:explore`, `rmem:viz`) do not
-need ptrace, pid=host, or network=host — they only read local files.
-A least-privilege variant could be emitted per-command (wrapper dispatches
-on `$1`), but this was **deferred**: it violates the "same look"
-invariant slightly (behavioural asymmetry across commands) and adds a
-maintenance surface (every new command requires a classification entry).
-Revisit if users request it.
+`CAP_SYS_PTRACE` under non-root `--user` requires file capabilities on
+the `php` binary inside the image. See core change A.
 
 ## Changes required in reli core
 
-### A. `inspector:sidecar` socket default
+### A. Dockerfile: file capabilities on the PHP binary
+
+**Problem**: Linux clears the effective capability set when a process is
+non-root, so `--cap-add=SYS_PTRACE` + `--user 1000:1000` leaves
+`CAP_SYS_PTRACE` in the bounding set but *not* effective. reli's memory
+reads (`process_vm_readv` / pread on `/proc/<pid>/mem`) then fail with
+`EPERM`.
+
+**Verified on Ubuntu 24.04 (kernel 6.17, ptrace_scope=1)**: running the
+reli image as `--user $(id -u):$(id -g) --cap-add=SYS_PTRACE --pid=host`
+reproducibly failed with `failed to read memory ... errno=1` in
+`MemoryReader.php:94`. Rebuilding the image with
+`setcap cap_sys_ptrace=eip /usr/local/bin/php` and re-running produced
+correct sampling output — no other changes needed. FFI, process
+introspection, and Symfony console behaviour were unaffected.
+
+**Change**: add to the image Dockerfile:
+
+```dockerfile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libcap2-bin \
+    && setcap cap_sys_ptrace=eip /usr/local/bin/php \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Side effects to be aware of (none of which affect reli in testing):
+
+- `PR_DUMPABLE` becomes 0 on setcap'd binaries; core dumps of the
+  container's `php` process are suppressed.
+- `LD_PRELOAD` / `LD_LIBRARY_PATH` are filtered by `ld.so` for binaries
+  with file capabilities. reli's image does not rely on either.
+- The capability is image-scoped. Users who rebuild / re-layer the image
+  in a way that loses `xattr`s (some registry tooling, some filesystems)
+  need to re-apply `setcap` post-build.
+
+### B. `inspector:sidecar` socket default
 
 **Current**: `SidecarSettings::DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock'`.
 
@@ -144,46 +264,77 @@ Revisit if users request it.
 container user. Even for native installs, the current default forces
 `sudo` usage for sidecar startup.
 
-**Change**: default to `${XDG_RUNTIME_DIR}/reli/sidecar.sock`, resolved at
-runtime. On most systemd distros `$XDG_RUNTIME_DIR` is `/run/user/$UID`
-(mode 0700, per-user). Fallback when unset: `/tmp/reli-$UID/sidecar.sock`
-where `/tmp/reli-$UID` is created with mode 0700 by reli itself before
-binding.
+**Change**: default to `${XDG_RUNTIME_DIR}/reli/sidecar.sock`, resolved
+at runtime. On most systemd distros `$XDG_RUNTIME_DIR` is
+`/run/user/$UID` (mode 0700, per-user). When `XDG_RUNTIME_DIR` is
+unset, **fail closed** with an instructive error (`RELI_SIDECAR_SOCKET=<path>`
+override, or point at a user-owned 0700 parent dir). No `/tmp`
+fallback: `/tmp` is world-writable, and a concurrent attacker could
+pre-create the socket path, intercepting the target app's sidecar IPC
+(which has no authentication on the wire). Requiring an explicit
+user-scoped path preserves the privilege-boundary property.
 
-Why not just `/tmp/reli-sidecar.sock`: `/tmp` is world-writable. A
-concurrent attacker on the same host could pre-create the socket path,
-intercepting the target app's sidecar IPC (which has no authentication
-on the wire). The per-user 0700 parent directory prevents this.
+Before binding, reli stats the parent dir and refuses if it is not
+a real directory, not owned by the current uid, not mode 0700, or is
+a symlink.
 
 Secondary benefit: native installs lose the `sudo` requirement for
-sidecar.
+sidecar (no more `/var/run` write).
 
-### B. `inspector:daemon` output default
+### C. `inspector:daemon` output default
 
 **Current**: resolves to `$XDG_STATE_HOME/reli/daemon-traces/{session}/`
 (typically `$HOME/.local/state/reli/...`).
 
-**Decision**: **keep the default unchanged**. Move the problem entirely
-into the wrapper by setting `XDG_STATE_HOME=/tmp/reli-$UID/state` in the
-container's environment. Reasoning:
+**Decision**: **keep the default unchanged**. Under the wrapper, `HOME`
+and `XDG_STATE_HOME` are already steered to the host-user-owned scratch
+dir (see wrapper shape). No core change needed. Reasoning:
 
 - Profile data is sensitive (variable values via `--trace-var`, heap
   contents via memory dumps — routinely contains credentials / PII).
-- Defaulting to cwd normalises writing such data into directories that
-  may be world-readable, git-tracked, or cloud-synced.
+- Defaulting to cwd would normalise writing such data into directories
+  that may be world-readable, git-tracked, or cloud-synced.
 - XDG state home (mode 0700, per-user) is the privacy-conserving default.
 
-### C. XDG handling in wrapper
+### D. `ReliCommand` base class + `getDockerProfile()`
 
-Wrapper pre-creates `/tmp/reli-$UID/{state,cache,runtime}` with mode 0700
-and exports the three XDG env vars pointing at them. `HOME` is set to
-`/tmp/reli-$UID` so that any `$HOME`-derived config path (e.g.
-`~/.config/reli/config.php` discovery) has a stable, per-user, mounted
-location.
+**Purpose**: classify each CLI command as "needs full host privilege"
+vs "viewer-only, safe under Minimal". Used by `docker:print-wrapper` to
+document which commands are safe under which profile, and (indirectly)
+used by users to choose the right profile to install.
 
-Users who want to share state with host can override via
-`RELI_DOCKER_EXTRA_ARGS` — e.g.,
-`-v "$HOME/.local/state/reli":"$HOME/.local/state/reli" -e HOME="$HOME"`.
+**Shape**:
+
+```php
+enum DockerProfile {
+    case Full;     // needs ptrace / pid=host / network=host
+    case Minimal;  // operates on local files only
+}
+
+abstract class ReliCommand extends \Symfony\Component\Console\Command\Command
+{
+    abstract public static function getDockerProfile(): DockerProfile;
+}
+```
+
+Every existing concrete command class is retargeted to extend
+`ReliCommand` instead of Symfony `Command` directly. The abstract method
+means **any new command must classify itself at the source level** — a
+concrete subclass without `getDockerProfile()` produces a class-load
+fatal error, triggered at reli startup the moment the DI container
+registers the command. CI (or even a developer's first `./reli --version`
+after adding the class) catches the omission immediately; no separate
+lint rule is needed.
+
+`docker:print-wrapper` reads the classification via reflection. The
+emitted wrapper for `--profile=minimal` can include the allowlist of
+Minimal-compatible command names in a comment block for user reference.
+
+**Default stance on misclassification**: there is no runtime default —
+the abstract method forces an explicit choice. If in doubt, annotate
+`Full` (errs toward over-privilege, but the user can escape by picking
+the wrong profile, which surfaces a clear error rather than a silent
+security downgrade).
 
 ## Integrity hazards: known and handled
 
@@ -191,23 +342,26 @@ Inventoried via a pass over every Symfony Console command definition.
 
 ### Handled by wrapper
 
-| Hazard                                             | Handling                                |
-|----------------------------------------------------|-----------------------------------------|
-| `-o trace.rbt` / `-o ./foo/bar.rbt`                | cwd mounted at same path.               |
-| Absolute output paths inside cwd                   | cwd mounted at same path.               |
-| `-p <pid>` attach                                  | `--pid=host` + `CAP_SYS_PTRACE`.        |
-| `/proc/<pid>/{exe,maps,mem}` reads                 | `--pid=host` + `CAP_SYS_PTRACE`.        |
-| HTTP/SSE listeners (`rmem:live`)                   | `--network=host`.                       |
-| Unix sockets under `$XDG_RUNTIME_DIR`              | scratch mount + XDG override.           |
-| TUI (`rbt:explore`, `rmem:explore`)                | auto `-t`.                              |
-| File ownership                                     | `--user "$UID:$GID"`.                   |
-| Daemon output default                              | XDG_STATE_HOME → scratch.               |
+| Hazard                                             | Handling                                          |
+|----------------------------------------------------|---------------------------------------------------|
+| `-o trace.rbt` / `-o ./foo/bar.rbt`                | cwd mounted at same path.                         |
+| Absolute output paths inside cwd                   | cwd mounted at same path.                         |
+| `-p <pid>` attach                                  | `--pid=host` + `CAP_SYS_PTRACE` (via setcap).     |
+| `/proc/<pid>/{exe,maps,mem}` reads                 | `--pid=host` + `CAP_SYS_PTRACE` (via setcap).     |
+| HTTP/SSE listeners (`rmem:live`)                   | `--network=host`.                                 |
+| Unix sockets under `$XDG_RUNTIME_DIR`              | scratch mount + XDG override.                     |
+| TUI (`rbt:explore`, `rmem:explore`)                | auto `-t`.                                        |
+| File ownership                                     | `--user "$UID:$GID"`.                             |
+| Daemon output default                              | `HOME` / `XDG_STATE_HOME` → scratch.              |
+| Scratch-dir pre-creation attacks                   | scratch rooted in host-user-owned FS + owner/mode validation. |
 
 ### Handled by core changes
 
-| Hazard                        | Change                                          |
-|-------------------------------|-------------------------------------------------|
-| sidecar socket at `/var/run`  | default → `$XDG_RUNTIME_DIR/reli/sidecar.sock`  |
+| Hazard                                           | Change                                          |
+|--------------------------------------------------|-------------------------------------------------|
+| sidecar socket at `/var/run`                     | default → `$XDG_RUNTIME_DIR/reli/sidecar.sock`. |
+| `CAP_SYS_PTRACE` ineffective under `--user`      | `setcap cap_sys_ptrace=eip` on `php` in image.  |
+| Missing profile classification on new commands   | abstract `getDockerProfile()` on `ReliCommand`. |
 
 ### Documented limitations (not auto-handled)
 
@@ -217,69 +371,144 @@ Inventoried via a pass over every Symfony Console command definition.
 | `inspector:trace -- python3 script.py` (non-PHP spawn)     | Not supported via default image; use custom image.    |
 | `inspector:trace -- php7.3 script.php` (specific PHP ver)  | Not supported via default image; use custom image.    |
 | `phpspy:*` commands                                        | Not supported via default image (phpspy not bundled). |
-| Host `~/.config/reli/` visibility                          | `RELI_DOCKER_EXTRA_ARGS='-v $HOME/.config/reli:/.config/reli:ro'`. |
-| ptrace_scope=2/3 on host                                   | `--user 0:0` fallback via `RELI_DOCKER_AS_ROOT=1`.    |
-| Multi-tenant host                                          | README warning; discourage default wrapper.           |
+| Host `~/.config/reli/` visibility                          | `RELI_DOCKER_EXTRA_ARGS='-v $HOME/.config/reli:"$scratch/.config/reli":ro'` (target path must align with the in-container `HOME=$scratch`). |
+| ptrace_scope=2/3 on host                                   | Raise scope temporarily on host, or use native install. |
+| Multi-tenant host                                          | README warning; prefer `--profile=minimal` or avoid Docker wrapper entirely. |
 
-### Open verification items
+### Release blockers
 
-- `CAP_SYS_PTRACE` under `--user non-root`: confirmed by spec
-  (CAP_SYS_PTRACE bypasses ptrace_scope=1 and the uid check in
-  `/proc/*/mem`), but should be verified on a distro sample
-  (Ubuntu 24.04, Alpine, Amazon Linux 2023) before release.
-- `/dev/tty` open inside container (used by `Terminal`): confirmed
-  to work with `-it`, but needs verification for `reli ... | less`
-  style pipelines (wrapper's TTY auto-detect sees stdout=pipe and
-  skips `-t`, which is correct but may surprise users of TUI commands).
-- Read access on image files (composer vendor, resources) under
-  non-root `--user`: verify image build does not leave root-only
-  modes on these trees.
+These must be resolved (or an explicit workaround documented) before
+the wrapper is recommended to end users via README.
+
+- **Non-root `--user` with image files readable**: `docker run --user
+  "$(id -u):$(id -g)" --entrypoint php reliforp/reli-prof:<new-tag> -r
+  'echo readable'` must succeed after image rebuild. Verify composer
+  `vendor/` tree, reli sources, and any generated caches are not
+  root-only-readable.
+- **`/dev/tty` under piped stdout**: `reli rbt:explore trace.rbt | cat`
+  should either work or fail with a comprehensible error (not a silent
+  hang). The wrapper's TTY auto-detect sees stdout=pipe and skips `-t`,
+  which is correct in principle but needs a smoke test against TUI
+  commands.
+- **Distro spot-check** (at minimum one systemd + `ptrace_scope=1`
+  non-Ubuntu host — e.g. Fedora or Amazon Linux 2023): end-to-end run
+  of the wrapper attaching to a PHP process. The `setcap` file-cap
+  mechanism is kernel-level and portable, but AppArmor /
+  SELinux / seccomp interactions vary.
+- **Docker Desktop on macOS**: wrapper should at least produce a
+  comprehensible error on commands that need `--pid=host`, rather than
+  a confusing no-match. (Full attach may or may not work under Docker
+  Desktop's VM — document the result.)
+
+Verified items (no longer blocking):
+
+- Non-root `--user` + `CAP_SYS_PTRACE` via file capabilities on `php`:
+  verified on Ubuntu 24.04 (kernel 6.17.0-22-generic, Docker 29.1.3,
+  `ptrace_scope=1`). Control case `--user 0:0 --cap-add=SYS_PTRACE`
+  also works. See core change A for mechanism.
+
+## Related issues discovered (out of wrapper scope)
+
+- **Large ELF OOM in `NativeFileReader::readAll`**. When the target
+  process's PHP binary has debug symbols (common with phpenv / asdf
+  managed PHP versions — e.g. a 65 MB `php` with DWARF sections), reli
+  aborts during ELF symbol resolution with PHP's 128 MB `memory_limit`
+  exhausted (trace: `Elf64SymbolResolverCreator.php:39`
+  → `NativeFileReader::readAll('/proc/<pid>/root/...')`). Independent of
+  Docker. Filed separately; the Docker wrapper should raise
+  `memory_limit` via a container-side `php.ini` tweak as a temporary
+  mitigation, and the core fix is streaming / mmap-based ELF parsing.
 
 ## CLI shape
 
 New command: `docker:print-wrapper`.
 
 ```
-docker:print-wrapper [--name=NAME] [--image=IMAGE] [--shell=SHELL]
+docker:print-wrapper [--profile=PROFILE] [--name=NAME] [--image=IMAGE] [--shell=SHELL]
 
 Options:
-  --name=NAME   Shell function name (default: reli)
-  --image=IMAGE Image reference (default: reliforp/reli-prof:<current-version>)
-  --shell=SHELL Target shell syntax: bash|zsh|posix (default: posix)
+  --profile=PROFILE  full (default) or minimal
+  --name=NAME        Shell function name
+                     (default: reli for full, reli-view for minimal)
+  --image=IMAGE      Image reference
+                     (default: reliforp/reli-prof:<current-version>)
+  --shell=SHELL      Target shell syntax: bash|zsh|posix (default: posix)
 ```
 
 Output: shell code on stdout, no trailing prose. Safe to `eval`.
 
-Non-zero exit on unknown shell or malformed option.
+When `--profile=minimal`, the emitted output includes a leading comment
+block listing the commands classified as `DockerProfile::Minimal` (for
+user reference), gathered via reflection over the `ReliCommand`
+subclasses.
+
+Non-zero exit on unknown shell, unknown profile, or malformed option.
 
 ## Implementation scope
 
-1. `src/Command/Docker/PrintWrapperCommand.php` — new Symfony Console
-   Command. Emits the function body as a heredoc with the current image
-   tag substituted in. Image tag source: composer.json or a dedicated
-   `VERSION` constant — whichever matches existing conventions.
-2. DI container / command registration — wherever existing commands
-   register (to confirm: `config/` directory).
-3. Core change: `SidecarSettings::DEFAULT_SOCKET_PATH` →
-   `$XDG_RUNTIME_DIR/reli/sidecar.sock` resolution. Creates parent dir
-   with 0700 if absent. Falls back to `/tmp/reli-$UID/sidecar.sock`
-   when `$XDG_RUNTIME_DIR` is unset (same directory-creation protocol).
-4. `tests/Command/Docker/PrintWrapperCommandTest.php` — snapshot of
-   emitted output for `--shell=posix` and `--shell=bash`.
-5. `tests/...SidecarSettingsTest.php` — XDG resolution and fallback.
-6. `README.md` — replace "From Docker" install snippet with the
-   `eval "$(...)"` one-liner. Drop `sudo` from examples that use it
-   only for ptrace permission. Add a warning section on privilege
-   surface and multi-tenant hosts.
-7. `docs/docker-wrapper.md` — full reference: env vars
-   (`RELI_DOCKER_EXTRA_ARGS`, `RELI_DOCKER_AS_ROOT`), limitation table
-   (reproduced from above), security notes.
+1. **`src/Command/ReliCommand.php` (new abstract base)** — defines
+   `abstract public static function getDockerProfile(): DockerProfile`.
+   Plus `src/Command/DockerProfile.php` enum (`Full`, `Minimal`).
+2. **Retarget every existing concrete command** from
+   `\Symfony\Component\Console\Command\Command` to `ReliCommand`, and
+   implement `getDockerProfile()` on each. Mostly mechanical; the
+   abstract method makes missing entries fatal at startup.
+3. **`src/Command/Docker/PrintWrapperCommand.php`** — new Symfony
+   Console Command. Emits the function body as a heredoc with the
+   current image tag and profile-appropriate flag set substituted in.
+   Image tag source: composer.json version field or a dedicated
+   `VERSION` constant — match existing project convention.
+4. **DI container / command registration** — add
+   `PrintWrapperCommand` wherever existing commands register
+   (likely `config/console.php` or similar).
+5. **Core change: sidecar socket default** —
+   `SidecarSettings::DEFAULT_SOCKET_PATH` resolution:
+   `$XDG_RUNTIME_DIR/reli/sidecar.sock` when `XDG_RUNTIME_DIR` is set,
+   otherwise fail closed with an instructive error (no `/tmp` fallback
+   — keep the privilege-boundary property). Parent dir created mode
+   0700 with owner validation before bind.
+6. **Dockerfile change** — install `libcap2-bin` and apply
+   `setcap cap_sys_ptrace=eip /usr/local/bin/php`.
+7. **Tests**:
+   - `tests/Command/Docker/PrintWrapperCommandTest.php` — snapshot of
+     emitted output for each `--profile` × `--shell` combination.
+   - `tests/Command/DockerProfileCoverageTest.php` — iterates
+     `Application::all()`, asserts each command is a `ReliCommand`
+     subclass and `getDockerProfile()` returns a known enum value.
+     (Redundant given the abstract-method enforcement, but catches the
+     "accidentally extended Symfony Command directly" case.)
+   - `tests/...SidecarSettingsTest.php` — XDG resolution and failure
+     mode.
+   - Integration smoke test (optional, CI may skip if Docker
+     unavailable): `docker run --rm --user $(id -u) --cap-add=SYS_PTRACE
+     reliforp/reli-prof:local --version` succeeds without `EPERM`.
+8. **README.md** — replace "From Docker" snippet with the
+   `eval "$(...)"` one-liner; also mention the `--profile=minimal`
+   variant. Drop `sudo` from examples where it was only for ptrace
+   permission. Add a privilege / trust surface warning section.
+9. **`docs/docker-wrapper.md`** (new) — full reference: profile
+   comparison table, `RELI_DOCKER_EXTRA_ARGS` recipes, limitation
+   table (reproduced from this design), security notes, FAQ
+   (distinguishing "which commands work under Minimal" from the
+   profile runtime behaviour).
 
 ## Out of scope (future work)
 
-- Per-command least-privilege profiles (drop ptrace for viewers).
+- Fine-grained per-command capability profiles (beyond the binary
+  Full / Minimal split). If `DockerProfile` grows additional cases
+  (e.g. `NetworkOnly`, `LocalFsOnly`), the wrapper can emit
+  correspondingly trimmed flag sets, but we intentionally start
+  with two.
 - Bundling phpspy in the default image.
 - Multi-PHP-version spawn (`-- php7.3 ...`) via alternate image tags.
 - PHP-based wrapper for Composer/Git installs (the host-PHP path uses
   `./reli` natively; no wrapper needed).
 - Automatic argv path scanning to auto-`-v` mount out-of-cwd paths.
+- Wrapper-level runtime guard that refuses to run Full-profile commands
+  under the Minimal wrapper (the reli-side failure is considered
+  sufficient; a second enforcement layer adds maintenance cost without
+  raising the security floor).
+- macOS-native / non-Linux host targeting. Docker Desktop's Linux VM
+  can run the wrapper but only against Linux PHP processes inside
+  containers; host-native PHP on macOS / Windows is not in reli's
+  supported target set.

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -1,0 +1,285 @@
+# Design: Docker wrapper for reli
+
+## Motivation
+
+README examples use `./reli <command> ...` — a bare-install invocation. In
+practice many users will run reli via Docker (PHP 8.5 + FFI + PCNTL pre-built,
+no host toolchain required). Under Docker the required invocation differs
+substantially (flags for capabilities / namespaces / mounts, entrypoint
+pinning, output path translation), so the documented examples are not
+copy-pasteable for the Docker path.
+
+Goal: every documented `./reli <command> ...` example should work as
+`reli <command> ...` under a thin wrapper, **unchanged** (except `sudo`, which
+is unnecessary inside the container).
+
+Non-goal: making Docker-on-macOS / Windows host profile the *host* PHP.
+reli targets Linux processes only; the wrapper is useful to Docker Desktop
+users only for targeting processes that are themselves inside Linux
+containers.
+
+## Distribution
+
+The wrapper is a **shell function**, emitted by a new reli CLI subcommand
+that prints a shell snippet to stdout. Install with one command:
+
+```bash
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+```
+
+This defines `reli` as a shell function in the current session. To persist,
+users append the command to their `~/.bashrc` / `~/.zshrc`.
+
+### Why a CLI subcommand (not a standalone script / README snippet)
+
+- **Version-pinned by construction**: the subcommand bakes its own image
+  tag (`reliforp/reli-prof:0.12.1`) into the emitted function. A user who
+  pulls the 0.12 image gets a wrapper that always invokes the 0.12 image —
+  no accidental version skew with later pulls of `:latest`.
+- **Single source of truth**: README points at one command; bug fixes to
+  the wrapper ship with the image.
+- **Self-describing**: `docker run --rm reliforp/reli-prof docker:print-wrapper --help`
+  documents options (`--name=`, `--image=`).
+
+### Why a shell function (not a standalone PHP-based wrapper)
+
+PHP was considered as the wrapper host language (it would allow reusing
+Symfony Console metadata to drive argv analysis for auto-mounting,
+port-opening, etc.). Rejected because **requiring host PHP contradicts the
+entire reason users choose the Docker path**. A pure shell function works
+identically on any POSIX shell, including macOS zsh and WSL bash, with no
+host toolchain.
+
+The downside — shell argv handling is more fragile than PHP — is mitigated
+by using namespace-sharing flags (`--pid=host`, `--network=host`) that
+remove the need for argv-level port/PID translation entirely.
+
+## Wrapper shape (draft)
+
+```bash
+reli() {
+  local tty=
+  [ -t 0 ] && [ -t 1 ] && tty=-t
+
+  # Per-user scratch dirs (mode 700) to avoid cross-user leaks on shared hosts.
+  local uid; uid=$(id -u)
+  local scratch="/tmp/reli-${uid}"
+  mkdir -m 700 -p "${scratch}/state" "${scratch}/cache" "${scratch}/runtime" 2>/dev/null || true
+
+  docker run --rm -i ${tty} \
+    --cap-add=SYS_PTRACE \
+    --security-opt=apparmor=unconfined \
+    --pid=host \
+    --network=host \
+    --user "${uid}:$(id -g)" \
+    -v "$PWD":"$PWD" -w "$PWD" \
+    -v "${scratch}":"${scratch}" \
+    -e XDG_STATE_HOME="${scratch}/state" \
+    -e XDG_CACHE_HOME="${scratch}/cache" \
+    -e XDG_RUNTIME_DIR="${scratch}/runtime" \
+    -e HOME="${scratch}" \
+    ${RELI_DOCKER_EXTRA_ARGS:-} \
+    reliforp/reli-prof:<TAG_PINNED_AT_GENERATION> "$@"
+}
+```
+
+Key properties:
+
+- `--pid=host` + `CAP_SYS_PTRACE` cover attach (`-p <pid>`), `/proc/<pid>/*`
+  reads, and daemon regex matching against host process list.
+- `--network=host` covers `rmem:live`, any HTTP/SSE, and host-visible TCP
+  listeners — eliminates per-command `-p host:container` reasoning.
+- `-v "$PWD":"$PWD" -w "$PWD"` makes every cwd-relative or cwd-anchored
+  absolute path Just Work (`-o trace.rbt`, `-o ./sub/trace.rbt`,
+  `-o $PWD/trace.rbt` all resolve identically inside and outside).
+- Per-user scratch in `/tmp/reli-$UID` (mode 700) hosts XDG-derived
+  defaults that would otherwise fall under `$HOME` inside the container
+  and vanish on exit.
+- `--user "$UID:$GID"` makes generated files owned by the host user
+  (no `sudo rm` required after profiling).
+- `RELI_DOCKER_EXTRA_ARGS` is the documented escape hatch for extra
+  mounts (paths outside cwd), extra capabilities, custom `/etc/hosts`, etc.
+
+Dropped from earlier drafts:
+
+- `--ipc=host` — unnecessary. reli's IPC (sidecar, rmem-serve) is Unix
+  sockets on filesystem paths, not System V IPC. Dropping reduces
+  privilege surface.
+- `-v /tmp:/tmp` — replaced by the narrower per-user scratch mount. The
+  sidecar socket default will be moved (see below) so that a broad
+  `/tmp` mount is not needed.
+
+## Privilege and trust surface
+
+The wrapper grants the container a substantial subset of host privilege.
+README **must** call this out explicitly so that users on shared or
+multi-tenant hosts understand the bargain:
+
+| Flag                              | Effect                                                      |
+|-----------------------------------|-------------------------------------------------------------|
+| `--cap-add=SYS_PTRACE`            | Can ptrace / read `/proc/<pid>/mem` of any host process.    |
+| `--security-opt=apparmor=unconfined` | Removes AppArmor confinement on the container.           |
+| `--pid=host`                      | Container `/proc` shows all host processes (argv, env).     |
+| `--network=host`                  | Container binds directly on host interfaces.                |
+
+Recommendation for shared hosts: document `RELI_DOCKER_EXTRA_ARGS` usage
+to narrow the profile, or discourage the wrapper entirely on
+multi-tenant machines.
+
+Viewer-only commands (`rbt:explore`, `rmem:explore`, `rmem:viz`) do not
+need ptrace, pid=host, or network=host — they only read local files.
+A least-privilege variant could be emitted per-command (wrapper dispatches
+on `$1`), but this was **deferred**: it violates the "same look"
+invariant slightly (behavioural asymmetry across commands) and adds a
+maintenance surface (every new command requires a classification entry).
+Revisit if users request it.
+
+## Changes required in reli core
+
+### A. `inspector:sidecar` socket default
+
+**Current**: `SidecarSettings::DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock'`.
+
+**Problem**: `/var/run` is root-owned and not writable by the non-root
+container user. Even for native installs, the current default forces
+`sudo` usage for sidecar startup.
+
+**Change**: default to `${XDG_RUNTIME_DIR}/reli/sidecar.sock`, resolved at
+runtime. On most systemd distros `$XDG_RUNTIME_DIR` is `/run/user/$UID`
+(mode 0700, per-user). Fallback when unset: `/tmp/reli-$UID/sidecar.sock`
+where `/tmp/reli-$UID` is created with mode 0700 by reli itself before
+binding.
+
+Why not just `/tmp/reli-sidecar.sock`: `/tmp` is world-writable. A
+concurrent attacker on the same host could pre-create the socket path,
+intercepting the target app's sidecar IPC (which has no authentication
+on the wire). The per-user 0700 parent directory prevents this.
+
+Secondary benefit: native installs lose the `sudo` requirement for
+sidecar.
+
+### B. `inspector:daemon` output default
+
+**Current**: resolves to `$XDG_STATE_HOME/reli/daemon-traces/{session}/`
+(typically `$HOME/.local/state/reli/...`).
+
+**Decision**: **keep the default unchanged**. Move the problem entirely
+into the wrapper by setting `XDG_STATE_HOME=/tmp/reli-$UID/state` in the
+container's environment. Reasoning:
+
+- Profile data is sensitive (variable values via `--trace-var`, heap
+  contents via memory dumps — routinely contains credentials / PII).
+- Defaulting to cwd normalises writing such data into directories that
+  may be world-readable, git-tracked, or cloud-synced.
+- XDG state home (mode 0700, per-user) is the privacy-conserving default.
+
+### C. XDG handling in wrapper
+
+Wrapper pre-creates `/tmp/reli-$UID/{state,cache,runtime}` with mode 0700
+and exports the three XDG env vars pointing at them. `HOME` is set to
+`/tmp/reli-$UID` so that any `$HOME`-derived config path (e.g.
+`~/.config/reli/config.php` discovery) has a stable, per-user, mounted
+location.
+
+Users who want to share state with host can override via
+`RELI_DOCKER_EXTRA_ARGS` — e.g.,
+`-v "$HOME/.local/state/reli":"$HOME/.local/state/reli" -e HOME="$HOME"`.
+
+## Integrity hazards: known and handled
+
+Inventoried via a pass over every Symfony Console command definition.
+
+### Handled by wrapper
+
+| Hazard                                             | Handling                                |
+|----------------------------------------------------|-----------------------------------------|
+| `-o trace.rbt` / `-o ./foo/bar.rbt`                | cwd mounted at same path.               |
+| Absolute output paths inside cwd                   | cwd mounted at same path.               |
+| `-p <pid>` attach                                  | `--pid=host` + `CAP_SYS_PTRACE`.        |
+| `/proc/<pid>/{exe,maps,mem}` reads                 | `--pid=host` + `CAP_SYS_PTRACE`.        |
+| HTTP/SSE listeners (`rmem:live`)                   | `--network=host`.                       |
+| Unix sockets under `$XDG_RUNTIME_DIR`              | scratch mount + XDG override.           |
+| TUI (`rbt:explore`, `rmem:explore`)                | auto `-t`.                              |
+| File ownership                                     | `--user "$UID:$GID"`.                   |
+| Daemon output default                              | XDG_STATE_HOME → scratch.               |
+
+### Handled by core changes
+
+| Hazard                        | Change                                          |
+|-------------------------------|-------------------------------------------------|
+| sidecar socket at `/var/run`  | default → `$XDG_RUNTIME_DIR/reli/sidecar.sock`  |
+
+### Documented limitations (not auto-handled)
+
+| Scenario                                                   | Guidance                                              |
+|------------------------------------------------------------|-------------------------------------------------------|
+| `-o /var/log/...` (absolute path outside cwd)              | Use `RELI_DOCKER_EXTRA_ARGS='-v /var/log:/var/log'`.  |
+| `inspector:trace -- python3 script.py` (non-PHP spawn)     | Not supported via default image; use custom image.    |
+| `inspector:trace -- php7.3 script.php` (specific PHP ver)  | Not supported via default image; use custom image.    |
+| `phpspy:*` commands                                        | Not supported via default image (phpspy not bundled). |
+| Host `~/.config/reli/` visibility                          | `RELI_DOCKER_EXTRA_ARGS='-v $HOME/.config/reli:/.config/reli:ro'`. |
+| ptrace_scope=2/3 on host                                   | `--user 0:0` fallback via `RELI_DOCKER_AS_ROOT=1`.    |
+| Multi-tenant host                                          | README warning; discourage default wrapper.           |
+
+### Open verification items
+
+- `CAP_SYS_PTRACE` under `--user non-root`: confirmed by spec
+  (CAP_SYS_PTRACE bypasses ptrace_scope=1 and the uid check in
+  `/proc/*/mem`), but should be verified on a distro sample
+  (Ubuntu 24.04, Alpine, Amazon Linux 2023) before release.
+- `/dev/tty` open inside container (used by `Terminal`): confirmed
+  to work with `-it`, but needs verification for `reli ... | less`
+  style pipelines (wrapper's TTY auto-detect sees stdout=pipe and
+  skips `-t`, which is correct but may surprise users of TUI commands).
+- Read access on image files (composer vendor, resources) under
+  non-root `--user`: verify image build does not leave root-only
+  modes on these trees.
+
+## CLI shape
+
+New command: `docker:print-wrapper`.
+
+```
+docker:print-wrapper [--name=NAME] [--image=IMAGE] [--shell=SHELL]
+
+Options:
+  --name=NAME   Shell function name (default: reli)
+  --image=IMAGE Image reference (default: reliforp/reli-prof:<current-version>)
+  --shell=SHELL Target shell syntax: bash|zsh|posix (default: posix)
+```
+
+Output: shell code on stdout, no trailing prose. Safe to `eval`.
+
+Non-zero exit on unknown shell or malformed option.
+
+## Implementation scope
+
+1. `src/Command/Docker/PrintWrapperCommand.php` — new Symfony Console
+   Command. Emits the function body as a heredoc with the current image
+   tag substituted in. Image tag source: composer.json or a dedicated
+   `VERSION` constant — whichever matches existing conventions.
+2. DI container / command registration — wherever existing commands
+   register (to confirm: `config/` directory).
+3. Core change: `SidecarSettings::DEFAULT_SOCKET_PATH` →
+   `$XDG_RUNTIME_DIR/reli/sidecar.sock` resolution. Creates parent dir
+   with 0700 if absent. Falls back to `/tmp/reli-$UID/sidecar.sock`
+   when `$XDG_RUNTIME_DIR` is unset (same directory-creation protocol).
+4. `tests/Command/Docker/PrintWrapperCommandTest.php` — snapshot of
+   emitted output for `--shell=posix` and `--shell=bash`.
+5. `tests/...SidecarSettingsTest.php` — XDG resolution and fallback.
+6. `README.md` — replace "From Docker" install snippet with the
+   `eval "$(...)"` one-liner. Drop `sudo` from examples that use it
+   only for ptrace permission. Add a warning section on privilege
+   surface and multi-tenant hosts.
+7. `docs/docker-wrapper.md` — full reference: env vars
+   (`RELI_DOCKER_EXTRA_ARGS`, `RELI_DOCKER_AS_ROOT`), limitation table
+   (reproduced from above), security notes.
+
+## Out of scope (future work)
+
+- Per-command least-privilege profiles (drop ptrace for viewers).
+- Bundling phpspy in the default image.
+- Multi-PHP-version spawn (`-- php7.3 ...`) via alternate image tags.
+- PHP-based wrapper for Composer/Git installs (the host-PHP path uses
+  `./reli` natively; no wrapper needed).
+- Automatic argv path scanning to auto-`-v` mount out-of-cwd paths.

--- a/src/Command/Cache/ClearCommand.php
+++ b/src/Command/Cache/ClearCommand.php
@@ -14,12 +14,19 @@ declare(strict_types=1);
 namespace Reli\Command\Cache;
 
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class ClearCommand extends Command
+final class ClearCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     public function __construct(
         private BinaryAnalysisCache $binary_analysis_cache,
     ) {

--- a/src/Command/Converter/CallgrindCommand.php
+++ b/src/Command/Converter/CallgrindCommand.php
@@ -15,12 +15,19 @@ namespace Reli\Command\Converter;
 
 use Reli\Converter\Callgrind\Profile;
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CallgrindCommand extends Command
+final class CallgrindCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Converter/FlameGraphCommand.php
+++ b/src/Command/Converter/FlameGraphCommand.php
@@ -15,12 +15,19 @@ namespace Reli\Command\Converter;
 
 use Noodlehaus\Config;
 use PhpCast\Cast;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class FlameGraphCommand extends Command
+final class FlameGraphCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     public function __construct(
         private Config $config,
     ) {

--- a/src/Command/Converter/FoldedCommand.php
+++ b/src/Command/Converter/FoldedCommand.php
@@ -15,12 +15,19 @@ namespace Reli\Command\Converter;
 
 use Reli\Converter\BinaryTrace\FoldedStacksFormatter;
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class FoldedCommand extends Command
+final class FoldedCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Converter/PhpspyCommand.php
+++ b/src/Command/Converter/PhpspyCommand.php
@@ -14,12 +14,19 @@ declare(strict_types=1);
 namespace Reli\Command\Converter;
 
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PhpspyCommand extends Command
+final class PhpspyCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Converter/PprofCommand.php
+++ b/src/Command/Converter/PprofCommand.php
@@ -15,12 +15,19 @@ namespace Reli\Command\Converter;
 
 use Reli\Converter\BinaryTrace\PprofEncoder;
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PprofCommand extends Command
+final class PprofCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Converter/RbtCommand.php
+++ b/src/Command/Converter/RbtCommand.php
@@ -15,13 +15,20 @@ namespace Reli\Command\Converter;
 
 use Reli\Converter\BinaryTrace\BinaryTraceWriter;
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class RbtCommand extends Command
+final class RbtCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Converter/SpeedscopeCommand.php
+++ b/src/Command/Converter/SpeedscopeCommand.php
@@ -16,12 +16,19 @@ namespace Reli\Command\Converter;
 use Reli\Converter\Speedscope\Settings\SpeedscopeConverterSettingsFromConsoleInput;
 use Reli\Converter\Speedscope\SpeedscopeConverter;
 use Reli\Converter\TraceInputReader;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class SpeedscopeCommand extends Command
+final class SpeedscopeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     public function __construct(
         private SpeedscopeConverter $speedscope_converter,
         private SpeedscopeConverterSettingsFromConsoleInput $settings_from_console_input,

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Docker;
+
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
+use Reli\ReliProfiler;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PrintWrapperCommand extends ReliCommand
+{
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('docker:print-wrapper')
+            ->setDescription(
+                'emit a shell function that runs reli via docker '
+                . '(eval the output to install)'
+            )
+            ->addOption(
+                'profile',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'wrapper profile (full|minimal)',
+                'full',
+            )
+            ->addOption(
+                'name',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'shell function name (default: reli for full, reli-view for minimal)',
+            )
+            ->addOption(
+                'image',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'image reference to bake into the wrapper',
+            )
+            ->addOption(
+                'shell',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'target shell dialect (bash|zsh|posix) — currently informational',
+                'bash',
+            )
+        ;
+    }
+
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $profile = DockerProfile::tryFrom((string)$input->getOption('profile'));
+        if ($profile === null) {
+            $output->writeln(
+                "<error>unknown --profile: "
+                . (string)$input->getOption('profile')
+                . " (expected: full, minimal)</error>"
+            );
+            return 2;
+        }
+
+        $name = (string)($input->getOption('name') ?? match ($profile) {
+            DockerProfile::Full => 'reli',
+            DockerProfile::Minimal => 'reli-view',
+        });
+
+        $image = (string)($input->getOption('image') ?? $this->defaultImage());
+
+        $output->write($this->renderWrapper($profile, $name, $image));
+        return 0;
+    }
+
+    private function defaultImage(): string
+    {
+        $version = ReliProfiler::getVersion();
+        // Prefer a concrete semver-looking tag; fall back to 'latest' for
+        // any dev / branch / unknown variant since those don't correspond
+        // to a published image.
+        $isDev = $version === 'unknown'
+            || str_contains(strtolower($version), 'dev');
+        $tag = $isDev ? 'latest' : $version;
+        return "reliforp/reli-prof:{$tag}";
+    }
+
+    private function renderWrapper(DockerProfile $profile, string $name, string $image): string
+    {
+        return match ($profile) {
+            DockerProfile::Full => $this->renderFull($name, $image),
+            DockerProfile::Minimal => $this->renderMinimal($name, $image),
+        };
+    }
+
+    private function renderFull(string $name, string $image): string
+    {
+        $template = <<<'SHELL'
+# reli docker wrapper (full profile)
+# Runs reli in a container with the capabilities needed to attach to host
+# PHP processes (ptrace, pid=host, network=host). Files written by the
+# container to bind-mounted paths are owned by the host user via --user.
+{{NAME}}() {
+    local tty=
+    [ -t 0 ] && [ -t 1 ] && tty=-t
+
+    # Scratch dir path is chosen from locations that are normally
+    # user-private ($XDG_RUNTIME_DIR under systemd; $HOME/.cache
+    # otherwise). The strict check below rejects anything we don't
+    # already own at mode 0700, rather than relying on the parent's
+    # assumed permissions.
+    local scratch
+    if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ]; then
+        scratch="${XDG_RUNTIME_DIR}/reli-docker"
+    elif [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+        scratch="${HOME}/.cache/reli-docker"
+    else
+        echo "{{NAME}}: neither XDG_RUNTIME_DIR nor HOME is set; refusing to start" >&2
+        return 2
+    fi
+    mkdir -m 0700 -p "$scratch" || return $?
+    local reason
+    if ! reason=$(reli_assert_scratch_safe "$scratch"); then
+        echo "{{NAME}}: scratch dir $scratch failed safety check: $reason" >&2
+        return 2
+    fi
+
+    docker run --rm -i ${tty} \
+        --cap-add=SYS_PTRACE \
+        --security-opt=apparmor=unconfined \
+        --pid=host \
+        --network=host \
+        --user "$(id -u):$(id -g)" \
+        -v "$PWD":"$PWD" -w "$PWD" \
+        -v "${scratch}":"${scratch}" \
+        -e HOME="${scratch}" \
+        -e XDG_STATE_HOME="${scratch}/state" \
+        -e XDG_CACHE_HOME="${scratch}/cache" \
+        -e XDG_RUNTIME_DIR="${scratch}/runtime" \
+        ${RELI_DOCKER_EXTRA_ARGS:-} \
+        {{IMAGE}} "$@"
+}
+
+reli_assert_scratch_safe() {
+    # Host-side check. `stat` flag syntax differs between GNU (-c) and
+    # BSD (-f) userland; we try both so the function works on Linux
+    # bash, macOS zsh, and WSL bash alike.
+    local d="$1"
+    [ -d "$d" ]    || { echo "not a directory"; return 1; }
+    [ ! -L "$d" ]  || { echo "scratch entry is a symlink; remove it and retry"; return 1; }
+    local owner mode
+    owner=$(stat -c '%u' "$d" 2>/dev/null) \
+        || owner=$(stat -f '%u' "$d" 2>/dev/null) \
+        || { echo "could not stat"; return 1; }
+    [ "$owner" = "$(id -u)" ] \
+        || { echo "not owned by uid $(id -u) (got $owner); chown or remove and retry"; return 1; }
+    mode=$(stat -c '%a' "$d" 2>/dev/null) \
+        || mode=$(stat -f '%Lp' "$d" 2>/dev/null) \
+        || { echo "could not stat mode"; return 1; }
+    [ "$mode" = "700" ] \
+        || { echo "mode is $mode, want 700; fix with: chmod 0700 '$d'"; return 1; }
+    return 0
+}
+
+SHELL;
+        return strtr($template, [
+            '{{NAME}}' => $name,
+            '{{IMAGE}}' => $image,
+        ]);
+    }
+
+    private function renderMinimal(string $name, string $image): string
+    {
+        $allowlist = $this->buildMinimalAllowlist();
+
+        $template = <<<'SHELL'
+# reli docker wrapper (minimal profile)
+# No ptrace, no host pid / network namespace sharing, no apparmor changes.
+# Suitable for viewer / converter commands that operate on local files.
+# If a command fails unexpectedly, reinstall with --profile=full.
+{{ALLOWLIST}}
+{{NAME}}() {
+    local tty=
+    [ -t 0 ] && [ -t 1 ] && tty=-t
+    docker run --rm -i ${tty} \
+        --user "$(id -u):$(id -g)" \
+        --read-only \
+        --tmpfs /tmp:rw,nosuid,nodev,size=64m \
+        -v "$PWD":"$PWD" -w "$PWD" \
+        ${RELI_DOCKER_EXTRA_ARGS:-} \
+        {{IMAGE}} "$@"
+}
+
+SHELL;
+        return strtr($template, [
+            '{{NAME}}' => $name,
+            '{{IMAGE}}' => $image,
+            '{{ALLOWLIST}}' => $allowlist,
+        ]);
+    }
+
+    private function buildMinimalAllowlist(): string
+    {
+        $application = $this->getApplication();
+        if ($application === null) {
+            return '# (command classification unavailable — Application not set)';
+        }
+
+        $names = [];
+        foreach ($application->all() as $registeredName => $cmd) {
+            $registeredName = (string)$registeredName;
+            if (
+                $cmd instanceof ReliCommand
+                && $cmd::getDockerProfile() === DockerProfile::Minimal
+                && !str_starts_with($registeredName, '_')
+            ) {
+                $names[$registeredName] = true;
+            }
+        }
+        $names = array_keys($names);
+        sort($names);
+
+        if ($names === []) {
+            return '# (no commands are currently classified as Minimal-safe;'
+                . ' reli commands have not yet adopted the DockerProfile enum)';
+        }
+
+        return "# Commands classified as Minimal-safe:\n#   "
+            . implode("\n#   ", $names);
+    }
+}

--- a/src/Command/DockerProfile.php
+++ b/src/Command/DockerProfile.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command;
+
+enum DockerProfile: string
+{
+    case Full = 'full';
+    case Minimal = 'minimal';
+}

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -28,14 +28,21 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessSpecifier;
 use Reli\ReliProfiler;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CoreDumpCommand extends Command
+final class CoreDumpCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private MemoryProfilerSettingsFromConsoleInput $memory_profiler_settings_from_console_input,
         private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -35,7 +35,8 @@ use Reli\Lib\Console\EchoBackCanceller;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 use Revolt\EventLoop;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,8 +47,14 @@ use function fread;
 
 use const STDIN;
 
-final class DaemonCommand extends Command
+final class DaemonCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpSearcherContextCreator $php_searcher_context_creator,
         private PhpReaderContextCreator $php_reader_context_creator,

--- a/src/Command/Inspector/GetEgAddressCommand.php
+++ b/src/Command/Inspector/GetEgAddressCommand.php
@@ -25,7 +25,8 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Elf\Process\ProcessSymbolReaderException;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,8 +34,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function dechex;
 use function sprintf;
 
-final class GetEgAddressCommand extends Command
+final class GetEgAddressCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private TargetPhpSettingsFromConsoleInput $target_php_settings_from_console_input,

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -43,15 +43,22 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Reli\Lib\Defer\defer;
 
-final class GetTraceCommand extends Command
+final class GetTraceCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -18,14 +18,21 @@ use Reli\Inspector\MemoryDump\MemoryDumpReaderFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettingsFromConsoleInput;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Log\Log;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MemoryAnalyzeCommand extends Command
+final class MemoryAnalyzeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private MemoryProfilerSettingsFromConsoleInput $memory_profiler_settings_from_console_input,
         private MemoryDumpReaderFactory $memory_dump_reader_factory,

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -27,15 +27,22 @@ use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Reli\ReliProfiler;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Reli\Lib\Defer\defer;
 
-final class MemoryCommand extends Command
+final class MemoryCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private MemoryProfilerSettingsFromConsoleInput $memory_profiler_settings_from_console_input,

--- a/src/Command/Inspector/MemoryCompareCommand.php
+++ b/src/Command/Inspector/MemoryCompareCommand.php
@@ -23,14 +23,21 @@ use Reli\Inspector\Output\MemoryOutput\Comparison\Formatter\TextComparisonFormat
 use Reli\Inspector\Output\MemoryOutput\Comparison\PdoComparisonDataProvider;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 use Reli\Lib\Log\Log;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MemoryCompareCommand extends Command
+final class MemoryCompareCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -14,14 +14,21 @@ declare(strict_types=1);
 namespace Reli\Command\Inspector;
 
 use PhpCast\NullableCast;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MemoryDbOptimizeCommand extends Command
+final class MemoryDbOptimizeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -23,15 +23,22 @@ use Reli\Lib\Log\Log;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Reli\Lib\Defer\defer;
 
-final class MemoryDumpCommand extends Command
+final class MemoryDumpCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private MemoryDumpSettingsFromConsoleInput $memory_dump_settings_from_console_input,

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -14,13 +14,20 @@ declare(strict_types=1);
 namespace Reli\Command\Inspector;
 
 use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MemoryDumpInspectCommand extends Command
+final class MemoryDumpInspectCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     private const MAGIC = "RELIMEM\0";
 
     public function __construct()

--- a/src/Command/Inspector/MemoryDumpNormalizeCommand.php
+++ b/src/Command/Inspector/MemoryDumpNormalizeCommand.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 namespace Reli\Command\Inspector;
 
 use Reli\Inspector\MemoryDump\MemoryDumpNormalizer;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,8 +26,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  * that force the analyzer into O(n) linear scans; this command
  * rewrites them so binary search always works.
  */
-final class MemoryDumpNormalizeCommand extends Command
+final class MemoryDumpNormalizeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -20,14 +20,21 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\LinkCacheMode;
 use Reli\Inspector\Watch\HeapStats;
 use Reli\Lib\File\LibcFileReader;
 use Reli\Lib\Log\Log;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MemoryReportCommand extends Command
+final class MemoryReportCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Inspector/PeekVarCommand.php
+++ b/src/Command/Inspector/PeekVarCommand.php
@@ -23,13 +23,20 @@ use Reli\Inspector\Watch\VariableValue;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PeekVarCommand extends Command
+final class PeekVarCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,

--- a/src/Command/Inspector/SidecarCommand.php
+++ b/src/Command/Inspector/SidecarCommand.php
@@ -27,13 +27,20 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class SidecarCommand extends Command
+final class SidecarCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,

--- a/src/Command/Inspector/SidecarCommand.php
+++ b/src/Command/Inspector/SidecarCommand.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Settings\SidecarSettings\SidecarSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Sidecar\SidecarDumpHandler;
 use Reli\Inspector\Sidecar\SidecarServer;
+use Reli\Inspector\Sidecar\SocketPathResolver;
 use Reli\Inspector\Watch\DiskUsageTracker;
 use Reli\Inspector\Watch\HeapStatsReader;
 use Reli\Inspector\Watch\RssReader;
@@ -89,7 +90,7 @@ final class SidecarCommand extends ReliCommand
         }
 
         AppDirectory::ensureDirectoryExists($settings->output_dir);
-        AppDirectory::ensureDirectoryExists(dirname($settings->socket_path));
+        SocketPathResolver::assertParentSafe($settings->socket_path);
 
         $disk_tracker = new DiskUsageTracker(
             $settings->disk_usage_limit_bytes,

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -40,7 +40,8 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
 use Revolt\EventLoop;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,8 +50,14 @@ use function Amp\async;
 use function Amp\Future\await;
 use function Reli\Lib\Defer\defer;
 
-final class TopLikeCommand extends Command
+final class TopLikeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpSearcherContextCreator $php_searcher_context_creator,
         private PhpReaderContextCreator $php_reader_context_creator,

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -64,7 +64,8 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\TraceCache;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessStopper\ProcessStopper;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -76,8 +77,14 @@ use function Reli\Lib\Defer\defer;
 
 use const STDIN;
 
-final class WatchCommand extends Command
+final class WatchCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -21,13 +21,20 @@ use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettingsFromConsoleInput;
 use Reli\Inspector\Settings\PhpSpySettings\PhpSpySettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Lib\PhpSpy\PhpSpyFinder;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PhpSpyDaemonCommand extends Command
+final class PhpSpyDaemonCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpSearcherContextCreator $php_searcher_context_creator,
         private PhpSpyFinder $phpspy_finder,

--- a/src/Command/PhpSpy/PhpSpyInstallCommand.php
+++ b/src/Command/PhpSpy/PhpSpyInstallCommand.php
@@ -15,13 +15,20 @@ namespace Reli\Command\PhpSpy;
 
 use Reli\Lib\PhpSpy\PhpSpyFinder;
 use Reli\Lib\PhpSpy\PhpSpyNotFoundException;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PhpSpyInstallCommand extends Command
+final class PhpSpyInstallCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpSpyFinder $phpspy_finder,
     ) {

--- a/src/Command/PhpSpy/PhpSpyTraceCommand.php
+++ b/src/Command/PhpSpy/PhpSpyTraceCommand.php
@@ -28,13 +28,20 @@ use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\PhpSpy\PhpSpyProcess;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PhpSpyTraceCommand extends Command
+final class PhpSpyTraceCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Full;
+    }
+
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,

--- a/src/Command/Rbt/AnalyzeCommand.php
+++ b/src/Command/Rbt/AnalyzeCommand.php
@@ -19,7 +19,8 @@ use Reli\Rbt\Analyze\FrameFormatter;
 use Reli\Rbt\Analyze\SectionLayout;
 use Reli\Rbt\Analyze\TraceAggregationResult;
 use Reli\Rbt\Analyze\TraceAggregator;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -35,8 +36,14 @@ use Symfony\Component\Console\Terminal;
  * inclusive (total) time, plus optional caller/callee views for finding the
  * call sites that dominate the profile of a given function.
  */
-final class AnalyzeCommand extends Command
+final class AnalyzeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Rbt/ExploreCommand.php
+++ b/src/Command/Rbt/ExploreCommand.php
@@ -17,7 +17,8 @@ use Reli\Rbt\Explore\ExploreTui;
 use Reli\Rbt\Explore\Keymap;
 use Reli\Rbt\Explore\Terminal;
 use Reli\Rbt\Explore\TraceModel;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,8 +32,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  * drill into a frame's call sites without re-running anything. See
  * `--help` and the in-app `?` overlay for keybindings.
  */
-final class ExploreCommand extends Command
+final class ExploreCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Rbt/RecoverCommand.php
+++ b/src/Command/Rbt/RecoverCommand.php
@@ -16,13 +16,20 @@ namespace Reli\Command\Rbt;
 use Reli\Converter\BinaryTrace\BinaryTraceReader;
 use Reli\Converter\BinaryTrace\BinaryTraceWriter;
 use Reli\Converter\StreamDecompressor;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class RecoverCommand extends Command
+final class RecoverCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/ReliCommand.php
+++ b/src/Command/ReliCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class ReliCommand extends Command
+{
+    abstract public static function getDockerProfile(): DockerProfile;
+}

--- a/src/Command/Rmem/RmemExploreCommand.php
+++ b/src/Command/Rmem/RmemExploreCommand.php
@@ -20,7 +20,8 @@ use Reli\Rbt\Explore\Terminal;
 use Reli\Rmem\Serve\RmemQueryService;
 use Reli\Rmem\Explore\RmemExploreTui;
 use Reli\Rmem\Explore\RmemModel;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -29,8 +30,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Interactive TUI for browsing a .rmem memory snapshot.
  */
-final class RmemExploreCommand extends Command
+final class RmemExploreCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Rmem/RmemLiveCommand.php
+++ b/src/Command/Rmem/RmemLiveCommand.php
@@ -18,7 +18,8 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Rmem\Explore\RmemModel;
 use Reli\Rmem\Live\LiveHttpServer;
 use Reli\Rmem\Live\VizHtmlBuilder;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -34,8 +35,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  *   GET  /api/events      SSE stream of focus_node events
  *   POST /api/navigate    JSON {"node_id": int} → broadcast focus_node
  */
-final class RmemLiveCommand extends Command
+final class RmemLiveCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     private const DEFAULT_TOP = 500;
     private const DEFAULT_DEPTH = 1;
     private const DEFAULT_PORT = 8080;

--- a/src/Command/Rmem/RmemMcpCommand.php
+++ b/src/Command/Rmem/RmemMcpCommand.php
@@ -17,7 +17,8 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Rmem\Explore\RmemModel;
 use Reli\Rmem\Serve\RmemQueryService;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,8 +34,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  *   --socket=PATH  connects to an existing rmem:serve or explore --serve
  *                  socket (add --control to enable ui.* tools)
  */
-final class RmemMcpCommand extends Command
+final class RmemMcpCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     private const SERVER_NAME = 'reli-rmem';
     private const SERVER_VERSION = '1.0.0';
     private const PROTOCOL_VERSION = '2024-11-05';

--- a/src/Command/Rmem/RmemQueryCommand.php
+++ b/src/Command/Rmem/RmemQueryCommand.php
@@ -16,7 +16,8 @@ namespace Reli\Command\Rmem;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,8 +26,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Query a .rmem binary file for node details and tree paths.
  */
-final class RmemQueryCommand extends Command
+final class RmemQueryCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Rmem/RmemServeCommand.php
+++ b/src/Command/Rmem/RmemServeCommand.php
@@ -17,7 +17,8 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Rmem\Explore\RmemModel;
 use Reli\Rmem\Serve\RmemQueryService;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,8 +27,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Headless query server for .rmem files over Unix domain socket.
  */
-final class RmemServeCommand extends Command
+final class RmemServeCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     #[\Override]
     public function configure(): void
     {

--- a/src/Command/Rmem/RmemVizCommand.php
+++ b/src/Command/Rmem/RmemVizCommand.php
@@ -17,7 +17,8 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Rmem\Explore\RmemModel;
 use Reli\Rmem\Live\VizHtmlBuilder;
-use Symfony\Component\Console\Command\Command;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,8 +28,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Emit a standalone HTML page that visualizes a .rmem snapshot in
  * multiple ways (3D force graph, circle packing, treemap, sunburst).
  */
-final class RmemVizCommand extends Command
+final class RmemVizCommand extends ReliCommand
 {
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
     private const DEFAULT_TOP = 500;
     private const DEFAULT_DEPTH = 1;
 

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettings.php
@@ -16,13 +16,11 @@ namespace Reli\Inspector\Settings\SidecarSettings;
 /** @psalm-immutable */
 final class SidecarSettings
 {
-    public const DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock';
-
     /**
      * @param array<string, string> $tags session-level tags applied to every snapshot
      */
     public function __construct(
-        public string $socket_path = self::DEFAULT_SOCKET_PATH,
+        public string $socket_path,
         public string $output_dir = '.',
         public int $disk_usage_limit_bytes = 1073741824, // 1GB
         public bool $include_binary = false,

--- a/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInput.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Settings\SidecarSettings;
 
 use PhpCast\NullableCast;
+use Reli\Inspector\Sidecar\SocketPathResolver;
 use Reli\Inspector\Watch\HeapStats;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,8 +30,8 @@ final class SidecarSettingsFromConsoleInput
                 'socket',
                 's',
                 InputOption::VALUE_REQUIRED,
-                'Unix domain socket path',
-                SidecarSettings::DEFAULT_SOCKET_PATH,
+                'Unix domain socket path'
+                . ' (default: $XDG_RUNTIME_DIR/reli/sidecar.sock)',
             )
             ->addOption(
                 'output-dir',
@@ -84,8 +85,13 @@ final class SidecarSettingsFromConsoleInput
             }
         }
 
+        $socket = NullableCast::toString($input->getOption('socket'));
+        if ($socket === null || $socket === '') {
+            $socket = SocketPathResolver::resolveDefault();
+        }
+
         return new SidecarSettings(
-            socket_path: (string)$input->getOption('socket'),
+            socket_path: $socket,
             output_dir: (string)$input->getOption('output-dir'),
             disk_usage_limit_bytes: $disk_limit,
             include_binary: (bool)$input->getOption('include-binary'),

--- a/src/Inspector/Sidecar/SocketPathResolver.php
+++ b/src/Inspector/Sidecar/SocketPathResolver.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar;
+
+use RuntimeException;
+
+/**
+ * Resolves the default path for the sidecar Unix domain socket and validates
+ * that the chosen location has sane per-user permissions before binding.
+ *
+ * Resolution rules for {@see self::resolveDefault()}:
+ *   - `$XDG_RUNTIME_DIR/reli/sidecar.sock` when `$XDG_RUNTIME_DIR` is set
+ *     (systemd exposes `/run/user/$UID` with mode 0700 there).
+ *   - Otherwise, throw with an instructive message. No `/tmp` fallback:
+ *     `/tmp` is world-writable and a concurrent user could pre-create
+ *     the socket path to intercept the sidecar IPC, which has no
+ *     on-the-wire authentication.
+ *
+ * Validation (see {@see self::assertParentSafe()}) strictly rejects a
+ * parent directory that is a symlink, not owned by the current uid, or
+ * not mode 0700. The validator does not inspect the ancestor chain —
+ * relying on the underlying filesystem's per-user permission model for
+ * path components above the parent is sufficient for typical systemd
+ * runtime dirs and conventional home directories.
+ */
+final class SocketPathResolver
+{
+    public const DIR_NAME = 'reli';
+    public const FILE_NAME = 'sidecar.sock';
+
+    public static function resolveDefault(): string
+    {
+        $xdgRuntimeDir = getenv('XDG_RUNTIME_DIR');
+        if (is_string($xdgRuntimeDir) && $xdgRuntimeDir !== '' && is_dir($xdgRuntimeDir)) {
+            return rtrim($xdgRuntimeDir, '/')
+                . '/' . self::DIR_NAME
+                . '/' . self::FILE_NAME;
+        }
+
+        throw new RuntimeException(
+            'Cannot resolve default sidecar socket path: XDG_RUNTIME_DIR is not set or not a directory.'
+            . ' Pass --socket explicitly (or set RELI_SIDECAR_SOCKET) to a user-owned 0700 parent dir.'
+        );
+    }
+
+    /**
+     * Ensures the parent directory of $socketPath exists with mode 0700 and
+     * is owned by the current uid. Creates it (mode 0700) if missing.
+     *
+     * Does NOT traverse symlinks on ancestor path components — see class
+     * docblock for rationale.
+     */
+    public static function assertParentSafe(string $socketPath): void
+    {
+        $parent = dirname($socketPath);
+
+        if (!is_dir($parent)) {
+            if (!@mkdir($parent, 0o700, true) && !is_dir($parent)) {
+                throw new RuntimeException(
+                    "Failed to create sidecar socket parent directory: {$parent}"
+                );
+            }
+        }
+
+        if (is_link($parent)) {
+            throw new RuntimeException(
+                "Sidecar socket parent directory is a symlink (refusing for safety): {$parent}"
+            );
+        }
+
+        $stat = @stat($parent);
+        if ($stat === false) {
+            throw new RuntimeException("Cannot stat sidecar socket parent directory: {$parent}");
+        }
+
+        $currentUid = function_exists('posix_geteuid') ? posix_geteuid() : null;
+        if ($currentUid !== null && $stat['uid'] !== $currentUid) {
+            throw new RuntimeException(sprintf(
+                'Sidecar socket parent directory %s is owned by uid %d, expected %d. '
+                . 'chown the directory or pick a user-owned path via --socket.',
+                $parent,
+                $stat['uid'],
+                $currentUid,
+            ));
+        }
+
+        $mode = $stat['mode'] & 0o777;
+        if ($mode !== 0o700) {
+            throw new RuntimeException(sprintf(
+                'Sidecar socket parent directory %s has mode 0%o, expected 0700. '
+                . "Run: chmod 0700 '%s'",
+                $parent,
+                $mode,
+                $parent,
+            ));
+        }
+    }
+}

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -31,7 +31,7 @@ namespace Reli\Sidecar\Client;
  * Socket path is resolved via:
  *   1. $socket_path argument
  *   2. RELI_SIDECAR_SOCKET environment variable
- *   3. Default: /var/run/reli-sidecar.sock
+ *   3. $XDG_RUNTIME_DIR/reli/sidecar.sock (throws if XDG_RUNTIME_DIR unset)
  *
  * ## Emergency Memory Reserve
  *

--- a/src/Sidecar/Client/SidecarClient.php
+++ b/src/Sidecar/Client/SidecarClient.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Sidecar\Client;
 
+use Reli\Inspector\Sidecar\SocketPathResolver;
+
 /**
  * Lightweight client for communicating with the reli sidecar daemon.
  *
@@ -23,11 +25,10 @@ namespace Reli\Sidecar\Client;
  * Socket path resolution order:
  *   1. Constructor argument ($socket_path)
  *   2. RELI_SIDECAR_SOCKET environment variable
- *   3. Default: /var/run/reli-sidecar.sock
+ *   3. $XDG_RUNTIME_DIR/reli/sidecar.sock (or throws if XDG_RUNTIME_DIR unset)
  */
 final class SidecarClient
 {
-    public const DEFAULT_SOCKET_PATH = '/var/run/reli-sidecar.sock';
     public const ENV_SOCKET_PATH = 'RELI_SIDECAR_SOCKET';
 
     private string $socket_path;
@@ -44,9 +45,11 @@ final class SidecarClient
             $this->socket_path = $socket_path;
         } else {
             $env = getenv(self::ENV_SOCKET_PATH);
-            $this->socket_path = (is_string($env) && $env !== '')
-                ? $env
-                : self::DEFAULT_SOCKET_PATH;
+            if (is_string($env) && $env !== '') {
+                $this->socket_path = $env;
+            } else {
+                $this->socket_path = SocketPathResolver::resolveDefault();
+            }
         }
     }
 

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Docker;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class PrintWrapperCommandTest extends TestCase
+{
+    private function runWrapper(array $options = []): string
+    {
+        $app = new Application();
+        $command = new PrintWrapperCommand();
+        $app->addCommand($command);
+        // Two fake commands to make the allowlist non-trivial.
+        $minimalFake = new class ('fake:viewer') extends ReliCommand {
+            #[\Override]
+            public static function getDockerProfile(): DockerProfile
+            {
+                return DockerProfile::Minimal;
+            }
+        };
+        $fullFake = new class ('fake:attach') extends ReliCommand {
+            #[\Override]
+            public static function getDockerProfile(): DockerProfile
+            {
+                return DockerProfile::Full;
+            }
+        };
+        $app->addCommand($minimalFake);
+        $app->addCommand($fullFake);
+
+        $output = new BufferedOutput();
+        $input = new ArrayInput($options + ['command' => 'docker:print-wrapper']);
+        $input->setInteractive(false);
+        $result = $command->run($input, $output);
+        $this->assertSame(0, $result);
+        return $output->fetch();
+    }
+
+    public function testFullProfileEmitsReliFunction(): void
+    {
+        $out = $this->runWrapper(['--profile' => 'full']);
+        $this->assertStringContainsString('full profile', $out);
+        $this->assertStringContainsString("reli() {", $out);
+        $this->assertStringContainsString('--cap-add=SYS_PTRACE', $out);
+        $this->assertStringContainsString('--pid=host', $out);
+        $this->assertStringContainsString('--network=host', $out);
+        $this->assertStringContainsString('reli_assert_scratch_safe()', $out);
+        $this->assertStringContainsString('reliforp/reli-prof:', $out);
+    }
+
+    public function testFullProfileIsDefault(): void
+    {
+        $out = $this->runWrapper([]);
+        $this->assertStringContainsString("reli() {", $out);
+        $this->assertStringContainsString('--cap-add=SYS_PTRACE', $out);
+    }
+
+    public function testMinimalProfileEmitsReliViewFunction(): void
+    {
+        $out = $this->runWrapper(['--profile' => 'minimal']);
+        $this->assertStringContainsString('minimal profile', $out);
+        $this->assertStringContainsString("reli-view() {", $out);
+        $this->assertStringContainsString('--read-only', $out);
+        $this->assertStringContainsString('--tmpfs /tmp', $out);
+        $this->assertStringNotContainsString('--cap-add=SYS_PTRACE', $out);
+        $this->assertStringNotContainsString('--pid=host', $out);
+        $this->assertStringNotContainsString('reli_assert_scratch_safe', $out);
+    }
+
+    public function testMinimalProfileIncludesAllowlistFromReliCommands(): void
+    {
+        $out = $this->runWrapper(['--profile' => 'minimal']);
+        // Minimal-classified fake should be listed, Full-classified should not.
+        $this->assertStringContainsString('#   fake:viewer', $out);
+        $this->assertStringContainsString('#   docker:print-wrapper', $out);
+        $this->assertStringNotContainsString('#   fake:attach', $out);
+    }
+
+    public function testNameOverrideChangesFunctionName(): void
+    {
+        $out = $this->runWrapper(['--profile' => 'full', '--name' => 'myreli']);
+        $this->assertStringContainsString("myreli() {", $out);
+        $this->assertStringNotContainsString("\nreli() {", $out);
+    }
+
+    public function testImageOverrideChangesImageReference(): void
+    {
+        $out = $this->runWrapper(['--image' => 'myreg/reli:custom']);
+        $this->assertStringContainsString('myreg/reli:custom "$@"', $out);
+    }
+
+    public function testUnknownProfileReturnsNonZero(): void
+    {
+        $app = new Application();
+        $command = new PrintWrapperCommand();
+        $app->addCommand($command);
+
+        $output = new BufferedOutput();
+        $input = new ArrayInput(['--profile' => 'bogus', 'command' => 'docker:print-wrapper']);
+        $input->setInteractive(false);
+        $result = $command->run($input, $output);
+
+        $this->assertSame(2, $result);
+        $this->assertStringContainsString('unknown --profile: bogus', $output->fetch());
+    }
+
+    public function testEmittedShellParsesUnderBash(): void
+    {
+        $out = $this->runWrapper(['--profile' => 'full']);
+        $tmp = tempnam(sys_get_temp_dir(), 'reli-wrapper-');
+        try {
+            file_put_contents($tmp, $out);
+            $exitCode = 0;
+            $output = [];
+            exec('bash -n ' . escapeshellarg($tmp) . ' 2>&1', $output, $exitCode);
+            $this->assertSame(0, $exitCode, "emitted shell failed bash -n: " . implode("\n", $output));
+        } finally {
+            @unlink($tmp);
+        }
+    }
+}
+

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -136,4 +136,3 @@ class PrintWrapperCommandTest extends TestCase
         }
     }
 }
-

--- a/tests/Command/DockerProfileCoverageTest.php
+++ b/tests/Command/DockerProfileCoverageTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Reli\Command;
 
-use DI\ContainerBuilder;
 use GlobIterator;
 use PHPUnit\Framework\TestCase;
 
@@ -70,25 +69,5 @@ class DockerProfileCoverageTest extends TestCase
             DockerProfile::cases(),
             "{$commandClass}::getDockerProfile() must return a DockerProfile enum case."
         );
-    }
-
-    public function testDiContainerCanInstantiateEveryCommand(): void
-    {
-        $container = (new ContainerBuilder())
-            ->addDefinitions(__DIR__ . '/../../config/di.php')
-            ->build();
-
-        $failures = [];
-        foreach (self::allCommandClasses() as [$commandClass]) {
-            try {
-                $instance = $container->make($commandClass);
-                if (!$instance instanceof ReliCommand) {
-                    $failures[] = "{$commandClass} is not a ReliCommand";
-                }
-            } catch (\Throwable $e) {
-                $failures[] = "{$commandClass}: " . $e->getMessage();
-            }
-        }
-        $this->assertSame([], $failures);
     }
 }

--- a/tests/Command/DockerProfileCoverageTest.php
+++ b/tests/Command/DockerProfileCoverageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command;
+
+use DI\ContainerBuilder;
+use GlobIterator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Enforces that every registered Reli command extends ReliCommand and
+ * classifies itself via getDockerProfile(). The abstract method on
+ * ReliCommand already produces a class-load fatal for concrete
+ * subclasses that forget to implement it; this test catches the other
+ * mode — a new command that extends Symfony's Command directly and
+ * therefore sidesteps classification entirely.
+ */
+class DockerProfileCoverageTest extends TestCase
+{
+    /**
+     * @return iterable<array{class-string}>
+     */
+    public static function allCommandClasses(): iterable
+    {
+        $enumerator = new CommandEnumerator(
+            new GlobIterator(__DIR__ . '/../../src/Command/*/*Command.php')
+        );
+        foreach ($enumerator as $commandClass) {
+            yield $commandClass => [$commandClass];
+        }
+    }
+
+    /**
+     * @param class-string $commandClass
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('allCommandClasses')]
+    public function testCommandExtendsReliCommand(string $commandClass): void
+    {
+        $this->assertTrue(
+            is_subclass_of($commandClass, ReliCommand::class),
+            "{$commandClass} must extend Reli\\Command\\ReliCommand"
+            . " so that getDockerProfile() classification is enforced."
+        );
+    }
+
+    /**
+     * @param class-string $commandClass
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('allCommandClasses')]
+    public function testCommandClassificationIsAKnownDockerProfile(string $commandClass): void
+    {
+        $this->assertTrue(
+            is_subclass_of($commandClass, ReliCommand::class),
+            "{$commandClass} must extend ReliCommand (see other test)."
+        );
+        /** @var class-string<ReliCommand> $commandClass */
+        $profile = $commandClass::getDockerProfile();
+        $this->assertContains(
+            $profile,
+            DockerProfile::cases(),
+            "{$commandClass}::getDockerProfile() must return a DockerProfile enum case."
+        );
+    }
+
+    public function testDiContainerCanInstantiateEveryCommand(): void
+    {
+        $container = (new ContainerBuilder())
+            ->addDefinitions(__DIR__ . '/../../config/di.php')
+            ->build();
+
+        $failures = [];
+        foreach (self::allCommandClasses() as [$commandClass]) {
+            try {
+                $instance = $container->make($commandClass);
+                if (!$instance instanceof ReliCommand) {
+                    $failures[] = "{$commandClass} is not a ReliCommand";
+                }
+            } catch (\Throwable $e) {
+                $failures[] = "{$commandClass}: " . $e->getMessage();
+            }
+        }
+        $this->assertSame([], $failures);
+    }
+}

--- a/tests/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/SidecarSettings/SidecarSettingsFromConsoleInputTest.php
@@ -10,10 +10,35 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class SidecarSettingsFromConsoleInputTest extends BaseTestCase
 {
-    public function testCreateSettingsDefaults(): void
+    private ?string $xdgBackup;
+    private string $xdgScratch;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $xdg = getenv('XDG_RUNTIME_DIR');
+        $this->xdgBackup = is_string($xdg) ? $xdg : null;
+        $this->xdgScratch = sys_get_temp_dir() . '/reli-sidecar-default-' . getmypid() . '-' . mt_rand();
+        mkdir($this->xdgScratch, 0o700);
+        putenv('XDG_RUNTIME_DIR=' . $this->xdgScratch);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->xdgBackup !== null) {
+            putenv('XDG_RUNTIME_DIR=' . $this->xdgBackup);
+        } else {
+            putenv('XDG_RUNTIME_DIR');
+        }
+        @rmdir($this->xdgScratch);
+        parent::tearDown();
+    }
+
+    public function testCreateSettingsDefaultsResolveSocketFromXdgRuntimeDir(): void
     {
         $input = Mockery::mock(InputInterface::class);
-        $input->expects()->getOption('socket')->andReturns(SidecarSettings::DEFAULT_SOCKET_PATH);
+        // --socket not specified → null → resolver kicks in.
+        $input->expects()->getOption('socket')->andReturns(null);
         $input->expects()->getOption('output-dir')->andReturns('.');
         $input->expects()->getOption('disk-usage-limit')->andReturns('1G');
         $input->expects()->getOption('include-binary')->andReturns(false);
@@ -22,7 +47,10 @@ class SidecarSettingsFromConsoleInputTest extends BaseTestCase
 
         $settings = (new SidecarSettingsFromConsoleInput())->createSettings($input);
 
-        $this->assertSame(SidecarSettings::DEFAULT_SOCKET_PATH, $settings->socket_path);
+        $this->assertSame(
+            $this->xdgScratch . '/reli/sidecar.sock',
+            $settings->socket_path,
+        );
         $this->assertSame('.', $settings->output_dir);
         $this->assertSame(1073741824, $settings->disk_usage_limit_bytes);
         $this->assertFalse($settings->include_binary);

--- a/tests/Inspector/Sidecar/SocketPathResolverTest.php
+++ b/tests/Inspector/Sidecar/SocketPathResolverTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Sidecar;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SocketPathResolverTest extends TestCase
+{
+    private ?string $xdgBackup;
+    private string $scratch;
+
+    protected function setUp(): void
+    {
+        $xdg = getenv('XDG_RUNTIME_DIR');
+        $this->xdgBackup = is_string($xdg) ? $xdg : null;
+        $this->scratch = sys_get_temp_dir() . '/reli-sockres-' . getmypid() . '-' . mt_rand();
+        mkdir($this->scratch, 0o700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->xdgBackup !== null) {
+            putenv('XDG_RUNTIME_DIR=' . $this->xdgBackup);
+        } else {
+            putenv('XDG_RUNTIME_DIR');
+        }
+        $this->removeTree($this->scratch);
+    }
+
+    private function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) && !is_link($path) ? $this->removeTree($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testResolveDefaultUsesXdgRuntimeDirWhenSet(): void
+    {
+        putenv('XDG_RUNTIME_DIR=' . $this->scratch);
+        $this->assertSame(
+            $this->scratch . '/reli/sidecar.sock',
+            SocketPathResolver::resolveDefault(),
+        );
+    }
+
+    public function testResolveDefaultStripsTrailingSlash(): void
+    {
+        putenv('XDG_RUNTIME_DIR=' . $this->scratch . '/');
+        $this->assertSame(
+            $this->scratch . '/reli/sidecar.sock',
+            SocketPathResolver::resolveDefault(),
+        );
+    }
+
+    public function testResolveDefaultThrowsWhenXdgUnset(): void
+    {
+        putenv('XDG_RUNTIME_DIR');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/XDG_RUNTIME_DIR/');
+        SocketPathResolver::resolveDefault();
+    }
+
+    public function testResolveDefaultThrowsWhenXdgDirMissing(): void
+    {
+        putenv('XDG_RUNTIME_DIR=/nonexistent/path/' . mt_rand());
+        $this->expectException(RuntimeException::class);
+        SocketPathResolver::resolveDefault();
+    }
+
+    public function testAssertParentSafeCreatesMissingParentAt0700(): void
+    {
+        $socketPath = $this->scratch . '/reli/sidecar.sock';
+        SocketPathResolver::assertParentSafe($socketPath);
+        $this->assertDirectoryExists(dirname($socketPath));
+        $this->assertSame(0o700, fileperms(dirname($socketPath)) & 0o777);
+    }
+
+    public function testAssertParentSafeAcceptsExistingCorrectDir(): void
+    {
+        $parent = $this->scratch . '/reli';
+        mkdir($parent, 0o700);
+        SocketPathResolver::assertParentSafe($parent . '/sidecar.sock');
+        // no throw = pass
+        $this->assertTrue(true);
+    }
+
+    public function testAssertParentSafeRejectsWrongMode(): void
+    {
+        $parent = $this->scratch . '/reli';
+        mkdir($parent, 0o755);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/mode 0755.*expected 0700/');
+        SocketPathResolver::assertParentSafe($parent . '/sidecar.sock');
+    }
+
+    public function testAssertParentSafeRejectsSymlinkParent(): void
+    {
+        $real = $this->scratch . '/real';
+        mkdir($real, 0o700);
+        $link = $this->scratch . '/link';
+        symlink($real, $link);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/symlink/');
+        SocketPathResolver::assertParentSafe($link . '/sidecar.sock');
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a Docker wrapper system that allows users to run reli commands transparently through Docker without needing to remember complex docker flags. It includes a new `docker:print-wrapper` CLI command that emits shell functions, a socket path resolver for the sidecar, and updates all commands to declare their Docker profile compatibility.

## Key Changes

- **New `docker:print-wrapper` command** (`src/Command/Docker/PrintWrapperCommand.php`): Generates shell wrapper functions that users can eval into their shell. Supports two profiles:
  - **Full profile** (default): Includes `--cap-add=SYS_PTRACE`, `--pid=host`, `--network=host`, and AppArmor bypass for live process profiling
  - **Minimal profile**: Restricted to read-only operations (viewers/converters) with no ptrace/network capabilities

- **Docker profile classification system**:
  - New `DockerProfile` enum with `Full` and `Minimal` cases
  - New abstract `ReliCommand` base class requiring all commands to implement `getDockerProfile()`
  - Updated all 40+ existing commands to extend `ReliCommand` and declare their profile
  - New `DockerProfileCoverageTest` to enforce classification on all commands

- **Socket path resolver** (`src/Inspector/Sidecar/SocketPathResolver.php`): Replaces hardcoded `/var/run/reli-sidecar.sock` with XDG-compliant path resolution:
  - Prefers `$XDG_RUNTIME_DIR/reli/sidecar.sock` (systemd-managed, 0700 per-user)
  - Validates parent directory ownership and permissions strictly
  - Throws instructive errors rather than silently falling back to world-writable paths

- **Dockerfile enhancement**: Added `libcap2-bin` and file capabilities on the PHP binary to enable `CAP_SYS_PTRACE` under non-root `--user`

- **Documentation**:
  - New `docs/docker-wrapper.md` with comprehensive reference
  - New `docs/internals/design-docker-wrapper.md` with threat model, design rationale, and implementation details
  - Updated `docs/getting-started.md` to feature the wrapper as the primary install method
  - Updated README examples to use `reli` instead of `./reli` and remove `sudo`

## Notable Implementation Details

- The wrapper is a pure POSIX shell function (no host PHP required) for maximum portability across Linux, macOS, and WSL
- Scratch directory validation uses `reli_assert_scratch_safe()` to reject symlinks and non-0700 permissions, with reason-specific error messages
- Image tag is baked into the emitted wrapper at generation time, preventing accidental `:latest` drift
- `RELI_DOCKER_EXTRA_ARGS` environment variable provides an escape hatch for custom mounts/capabilities
- Socket path validation is strict: rejects symlinks on the parent directory itself (though not on ancestor path components, relying on filesystem permissions above)

https://claude.ai/code/session_018e3rQA9bPMpBaJXrFM1EQE