### PR TITLE
rmem:explore: emit source locations as OSC 8 hyperlinks

### DIFF
--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -153,14 +153,11 @@ target still encodes the full path so the jump is unaffected by
 truncation. Terminals without OSC 8 support just see the visible
 text.
 
-PhpStorm/IntelliJ's bundled terminal (JediTerm) parses OSC 8 slowly
-enough that emitting hyperlinks stalls the render pipeline and the
-TUI looks frozen. It's auto-detected via
-`TERMINAL_EMULATOR=JetBrains-JediTerm` and the hyperlink wrapper is
-skipped; the lines fall back to plain `source: file:line` text that
-PhpStorm's own pattern matcher still turns into a clickable link.
-Set `RELI_NO_HYPERLINKS=1` to force the same fallback anywhere
-else you hit a similarly quirky terminal.
+If a terminal turns out to choke on OSC 8 anyway, set
+`RELI_NO_HYPERLINKS=1` to skip the escapes — the source lines then
+fall back to plain `source: file:line` text that most terminals
+(including PhpStorm's built-in one) still pick up as clickable via
+their own file:line pattern matcher.
 
 The URI is derived from the (path-mapped) filename:
 

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -153,6 +153,15 @@ target still encodes the full path so the jump is unaffected by
 truncation. Terminals without OSC 8 support just see the visible
 text.
 
+PhpStorm/IntelliJ's bundled terminal (JediTerm) parses OSC 8 slowly
+enough that emitting hyperlinks stalls the render pipeline and the
+TUI looks frozen. It's auto-detected via
+`TERMINAL_EMULATOR=JetBrains-JediTerm` and the hyperlink wrapper is
+skipped; the lines fall back to plain `source: file:line` text that
+PhpStorm's own pattern matcher still turns into a clickable link.
+Set `RELI_NO_HYPERLINKS=1` to force the same fallback anywhere
+else you hit a similarly quirky terminal.
+
 The URI is derived from the (path-mapped) filename:
 
 - **Plain filesystem path** (`/home/me/project/src/Foo.php`): the

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -153,11 +153,16 @@ target still encodes the full path so the jump is unaffected by
 truncation. Terminals without OSC 8 support just see the visible
 text.
 
-If a terminal turns out to choke on OSC 8 anyway, set
-`RELI_NO_HYPERLINKS=1` to skip the escapes — the source lines then
-fall back to plain `source: file:line` text that most terminals
-(including PhpStorm's built-in one) still pick up as clickable via
-their own file:line pattern matcher.
+PhpStorm/IntelliJ's bundled terminal (JediTerm) silently drops
+OSC 8 hyperlinks — a `printf '\e]8;;…\e\\text\e]8;;\e\\'` test in
+the plain shell already shows no underline — so we auto-detect
+it via `TERMINAL_EMULATOR=JetBrains-JediTerm` and skip the
+hyperlink wrapper. The source lines then fall back to plain
+`source: file:line` text and let JediTerm's own file:line pattern
+matcher turn the full rows into clickable links; middle-truncated
+paths wouldn't have matched its regex. Set `RELI_NO_HYPERLINKS=1`
+to force the same fallback in any other terminal that turns out
+quirky.
 
 The URI is derived from the (path-mapped) filename:
 

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -142,16 +142,34 @@ lines per node, depending on what is available:
 values recorded as `/var/www/html/src/App.php` become
 `/home/me/project/src/App.php` in the pane.
 
-The paths show up in a form terminals such as iTerm2, VS Code's
-integrated terminal, and Kitty recognise as clickable — `Cmd`/`Ctrl`-click
-(or the terminal's keyboard equivalent) opens the file at the
-given line in your editor.
+Each source line is emitted wrapped in an OSC 8 hyperlink, so
+terminals that support it (iTerm2, Kitty, WezTerm, recent VS Code
+integrated terminal, GNOME Terminal, Windows Terminal, …) make the
+whole region clickable regardless of the sidebar width — `Cmd`/`Ctrl`-click
+(or the terminal's keyboard equivalent) opens the file at the given
+line in your editor. The visible `file:line` is middle-truncated
+with a `…` when it would overflow the sidebar, but the hyperlink
+target still encodes the full path so the jump is unaffected by
+truncation. Terminals without OSC 8 support just see the visible
+text.
+
+The URI is derived from the (path-mapped) filename:
+
+- **Plain filesystem path** (`/home/me/project/src/Foo.php`): the
+  link target becomes `file:///home/me/project/src/Foo.php#L17`.
+  Path segments are percent-encoded so spaces and unicode are safe.
+- **User-mapped URL scheme**: point `--path-map` at a scheme-prefixed
+  target to get editor-native links. e.g.
+  `--path-map /var/www/html=vscode://file/Users/me/project` yields
+  `vscode://file/Users/me/project/src/Foo.php:17`; a GitHub blob
+  target (`https://github.com/acme/repo/blob/abc`) yields
+  `…blob/abc/src/Foo.php#L17`.
 
 The first (highest-priority) location is also surfaced as
-`source_location` in `query.node_detail` responses, and the full
-list as `source_locations[]`, so MCP/HTTP bridge clients can turn
-them into `vscode://file/…` or `https://github.com/…` links at
-render time.
+`source_location` (string) in `query.node_detail` responses, and
+the full list as `source_locations[]` with each entry carrying a
+`uri` field, so MCP/HTTP bridge clients can render hyperlinks
+directly without having to reconstruct the URI.
 
 ### HTTP bridge options (`--http-bridge`)
 

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -1647,7 +1647,19 @@ final class RmemExploreTui
             for ($i = 1; $i < count($lines); $i++) {
                 $row = $i + 1; // 1-based terminal row
                 $sLine = $sidebarLines[$i - 1] ?? '';
-                if (strlen($sLine) > $sidebarW - 1) {
+                // Skip byte-based truncation on lines that carry an
+                // OSC 8 hyperlink: the escape embeds a URI which easily
+                // pushes strlen() past $sidebarW even when the visible
+                // text fits. A blind substr here cuts the escape open,
+                // the terminal never sees a closing `\e]8;;\e\\`, and
+                // from that point onward the hyperlink-attributed
+                // region swallows whatever follows (PhpStorm's JediTerm
+                // in particular blocks pty writes while it waits for
+                // the close). buildSidebarLines() has already
+                // middle-truncated the visible text to fit, so the
+                // rendered width is correct without our help.
+                $hasOsc8 = str_contains($sLine, "\e]8;");
+                if (!$hasOsc8 && strlen($sLine) > $sidebarW - 1) {
                     $sLine = substr($sLine, 0, $sidebarW - 4) . '...';
                 }
                 $sidebarBuf .= "\e[{$row};{$sepCol}H\e[2m│\e[22m{$sLine}";
@@ -2166,26 +2178,17 @@ final class RmemExploreTui
     }
 
     /**
-     * Decide whether the current terminal can handle OSC 8 hyperlinks
-     * without stalling on them.
+     * Decide whether the current terminal should get OSC 8 hyperlinks.
      *
-     * Most modern terminals ignore escapes they don't understand, but
-     * a few parse OSC 8 so slowly that pty writes stall the render
-     * pipeline — PHP blocks on `fwrite()` with no CPU use, and the
-     * TUI looks frozen. PhpStorm/IntelliJ's bundled JediTerm is the
-     * known-bad case we can detect cheaply via
-     * `TERMINAL_EMULATOR=JetBrains-JediTerm`. We also honor
-     * `RELI_NO_HYPERLINKS=1` as an escape hatch for anything else we
-     * haven't listed.
+     * Terminals that don't recognise OSC 8 normally just skip the
+     * escape, so we emit by default and leave opting out to the
+     * `RELI_NO_HYPERLINKS=1` env var for the rare case where a
+     * terminal chokes on them.
      */
     private static function supportsOsc8Hyperlinks(): bool
     {
         $optOut = getenv('RELI_NO_HYPERLINKS');
         if ($optOut !== false && $optOut !== '' && $optOut !== '0') {
-            return false;
-        }
-        $emulator = getenv('TERMINAL_EMULATOR');
-        if (is_string($emulator) && stripos($emulator, 'JetBrains') !== false) {
             return false;
         }
         return true;

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -1743,7 +1743,18 @@ final class RmemExploreTui
                 'held_by' => 'held by',
                 default => $loc['kind'],
             };
-            $wrap("{$label}: {$loc['formatted']}");
+            // Don't let $wrap() split the path across sidebar rows:
+            // the resulting `file:line` is no longer a contiguous
+            // clickable token in most terminals. Truncate the visible
+            // text to fit on a single line (keeping the `:line` tail
+            // visible) and wrap the whole thing in an OSC 8 hyperlink
+            // so terminals with OSC 8 support (iTerm2, Kitty, WezTerm,
+            // VS Code's integrated terminal, GNOME Terminal, Windows
+            // Terminal) pick it up regardless of what the ellipsis
+            // ate.
+            $prefix = "{$label}: ";
+            $visible = self::squeezeMiddle($loc['formatted'], max(4, $usable - strlen($prefix)));
+            $lines[] = ' ' . $prefix . self::hyperlink($loc['uri'], $visible);
         }
         foreach ($detail['attributes'] as $key => $val) {
             // filename / line_start / line_end / lineno are already
@@ -2125,5 +2136,39 @@ final class RmemExploreTui
     {
         [, $rows] = $this->term->size();
         return max(1, $rows - 6);
+    }
+
+    /**
+     * Wrap $text in an OSC 8 hyperlink escape pointing at $uri.
+     *
+     * Terminals that understand OSC 8 (iTerm2, Kitty, WezTerm,
+     * recent VS Code integrated terminal, GNOME Terminal, Windows
+     * Terminal, …) make the region clickable irrespective of what
+     * the visible text looks like — which matters in the sidebar
+     * where paths can be long enough to trigger wrapping or
+     * truncation. Terminals that don't grok OSC 8 simply skip the
+     * escapes and see the visible text unchanged.
+     */
+    private static function hyperlink(string $uri, string $text): string
+    {
+        return "\e]8;;" . $uri . "\e\\" . $text . "\e]8;;\e\\";
+    }
+
+    /**
+     * Middle-truncate $text to at most $max chars using a single
+     * ellipsis. Keeps the head and tail visible — useful for
+     * `/long/path/leading/to/Foo.php:42` where both the prefix
+     * context and the trailing `:line` matter.
+     */
+    private static function squeezeMiddle(string $text, int $max): string
+    {
+        $len = strlen($text);
+        if ($len <= $max || $max < 4) {
+            return $text;
+        }
+        $keep = $max - 1; // reserve one char for the ellipsis
+        $head = (int)ceil($keep / 2);
+        $tail = $keep - $head;
+        return substr($text, 0, $head) . '…' . substr($text, $len - $tail);
     }
 }

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -2181,14 +2181,25 @@ final class RmemExploreTui
      * Decide whether the current terminal should get OSC 8 hyperlinks.
      *
      * Terminals that don't recognise OSC 8 normally just skip the
-     * escape, so we emit by default and leave opting out to the
-     * `RELI_NO_HYPERLINKS=1` env var for the rare case where a
-     * terminal chokes on them.
+     * escape, so we emit by default. Two exceptions:
+     *
+     *  - `RELI_NO_HYPERLINKS=1` is a generic escape hatch.
+     *  - PhpStorm/IntelliJ's bundled JediTerm silently drops OSC 8
+     *    entirely — a `printf '\e]8;;…\e\\text\e]8;;\e\\'` test in a
+     *    plain shell yields no underline. In that case we still want
+     *    to fall back to the pre-OSC-8 `$wrap()` layout so JediTerm's
+     *    own `file:line` pattern matcher has a full row to chew on;
+     *    a middle-truncated `…/Foo.php:42` wouldn't match its regex.
+     *    Detected via `TERMINAL_EMULATOR=JetBrains-*`.
      */
     private static function supportsOsc8Hyperlinks(): bool
     {
         $optOut = getenv('RELI_NO_HYPERLINKS');
         if ($optOut !== false && $optOut !== '' && $optOut !== '0') {
+            return false;
+        }
+        $emulator = getenv('TERMINAL_EMULATOR');
+        if (is_string($emulator) && stripos($emulator, 'JetBrains') !== false) {
             return false;
         }
         return true;

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -1736,6 +1736,7 @@ final class RmemExploreTui
             $val = RmemModel::sanitizeForTerminal($detail['string_value']);
             $wrap("val: \"{$val}\"");
         }
+        $hyperlinkable = self::supportsOsc8Hyperlinks();
         foreach ($detail['source_locations'] as $loc) {
             $label = match ($loc['kind']) {
                 'self' => 'source',
@@ -1743,18 +1744,28 @@ final class RmemExploreTui
                 'held_by' => 'held by',
                 default => $loc['kind'],
             };
-            // Don't let $wrap() split the path across sidebar rows:
-            // the resulting `file:line` is no longer a contiguous
-            // clickable token in most terminals. Truncate the visible
-            // text to fit on a single line (keeping the `:line` tail
-            // visible) and wrap the whole thing in an OSC 8 hyperlink
-            // so terminals with OSC 8 support (iTerm2, Kitty, WezTerm,
-            // VS Code's integrated terminal, GNOME Terminal, Windows
-            // Terminal) pick it up regardless of what the ellipsis
-            // ate.
-            $prefix = "{$label}: ";
-            $visible = self::squeezeMiddle($loc['formatted'], max(4, $usable - strlen($prefix)));
-            $lines[] = ' ' . $prefix . self::hyperlink($loc['uri'], $visible);
+            if ($hyperlinkable) {
+                // Don't let $wrap() split the path across sidebar rows:
+                // the resulting `file:line` is no longer a contiguous
+                // clickable token in most terminals. Truncate the
+                // visible text to fit on a single line (keeping the
+                // `:line` tail visible) and wrap the whole thing in an
+                // OSC 8 hyperlink so terminals with OSC 8 support
+                // (iTerm2, Kitty, WezTerm, VS Code's integrated
+                // terminal, GNOME Terminal, Windows Terminal) pick it
+                // up regardless of what the ellipsis ate.
+                $prefix = "{$label}: ";
+                $visible = self::squeezeMiddle($loc['formatted'], max(4, $usable - strlen($prefix)));
+                $lines[] = ' ' . $prefix . self::hyperlink($loc['uri'], $visible);
+            } else {
+                // Fallback: emit plain text and let $wrap() multi-row
+                // it. The terminal's own file:line pattern matcher
+                // (e.g. PhpStorm/IntelliJ JediTerm) still picks up
+                // complete rows as clickable, and more importantly we
+                // avoid OSC 8 escapes that some terminals parse so
+                // slowly that pty writes stall the whole TUI.
+                $wrap("{$label}: {$loc['formatted']}");
+            }
         }
         foreach ($detail['attributes'] as $key => $val) {
             // filename / line_start / line_end / lineno are already
@@ -2152,6 +2163,32 @@ final class RmemExploreTui
     private static function hyperlink(string $uri, string $text): string
     {
         return "\e]8;;" . $uri . "\e\\" . $text . "\e]8;;\e\\";
+    }
+
+    /**
+     * Decide whether the current terminal can handle OSC 8 hyperlinks
+     * without stalling on them.
+     *
+     * Most modern terminals ignore escapes they don't understand, but
+     * a few parse OSC 8 so slowly that pty writes stall the render
+     * pipeline — PHP blocks on `fwrite()` with no CPU use, and the
+     * TUI looks frozen. PhpStorm/IntelliJ's bundled JediTerm is the
+     * known-bad case we can detect cheaply via
+     * `TERMINAL_EMULATOR=JetBrains-JediTerm`. We also honor
+     * `RELI_NO_HYPERLINKS=1` as an escape hatch for anything else we
+     * haven't listed.
+     */
+    private static function supportsOsc8Hyperlinks(): bool
+    {
+        $optOut = getenv('RELI_NO_HYPERLINKS');
+        if ($optOut !== false && $optOut !== '' && $optOut !== '0') {
+            return false;
+        }
+        $emulator = getenv('TERMINAL_EMULATOR');
+        if (is_string($emulator) && stripos($emulator, 'JetBrains') !== false) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/Rmem/Explore/RmemModel.php
+++ b/src/Rmem/Explore/RmemModel.php
@@ -976,6 +976,49 @@ final class RmemModel
     }
 
     /**
+     * Build a URI terminals can honor as an OSC 8 hyperlink.
+     *
+     * Rules:
+     *  - If the filename already carries a URL scheme (because the
+     *    user pointed a --path-map at one), reuse the scheme and pick
+     *    the appropriate line suffix: `#L<n>` for http(s) (GitHub
+     *    blob convention), `:<n>` otherwise (VS Code's
+     *    `vscode://file/<path>:<line>:<col>` convention).
+     *  - Otherwise treat the filename as an absolute POSIX path and
+     *    wrap it in `file://`, with a trailing `#L<n>` fragment so
+     *    terminals that understand fragments (iTerm2, Kitty,
+     *    WezTerm) can jump to the exact line.
+     *
+     * @param array{filename: string, line: ?int, line_start: ?int, line_end: ?int} $loc
+     */
+    public static function buildSourceLocationUri(array $loc): string
+    {
+        $file = $loc['filename'];
+        $line = $loc['line'] ?? $loc['line_start'];
+
+        if (preg_match('#^([a-z][a-z0-9+.-]*)://#i', $file, $m) === 1) {
+            $scheme = strtolower($m[1]);
+            if ($line !== null && $line > 0) {
+                if ($scheme === 'http' || $scheme === 'https') {
+                    return $file . '#L' . $line;
+                }
+                return $file . ':' . $line;
+            }
+            return $file;
+        }
+
+        // Plain filesystem path. Percent-encode the path component
+        // while leaving forward slashes intact so `file://` URIs are
+        // well-formed for spaces / unicode paths.
+        $encoded = implode('/', array_map('rawurlencode', explode('/', $file)));
+        $uri = 'file://' . $encoded;
+        if ($line !== null && $line > 0) {
+            $uri .= '#L' . $line;
+        }
+        return $uri;
+    }
+
+    /**
      * Local filename/line extraction from the node's own attributes,
      * with path-map applied. Shared between the direct-resolver and
      * the multi-kind resolver.
@@ -1247,6 +1290,11 @@ final class RmemModel
     /**
      * Get detailed info for a node (for focus bar / detail view).
      *
+     * source_locations[*].uri is a terminal-friendly URI (see
+     * {@see self::buildSourceLocationUri()}) so clients can render
+     * an OSC 8 hyperlink and bypass file:line auto-detection —
+     * which, in a sidebar, breaks as soon as the path wraps.
+     *
      * @return array{
      *     type: string,
      *     class: ?string,
@@ -1257,7 +1305,15 @@ final class RmemModel
      *     refcount: ?int,
      *     attributes: array<string, string>,
      *     source_location: ?string,
-     *     source_locations: list<array{kind: string, filename: string, line: ?int, line_start: ?int, line_end: ?int, formatted: string}>,
+     *     source_locations: list<array{
+     *         kind: string,
+     *         filename: string,
+     *         line: ?int,
+     *         line_start: ?int,
+     *         line_end: ?int,
+     *         formatted: string,
+     *         uri: string,
+     *     }>,
      * }
      */
     public function nodeDetail(int $nodeId): array
@@ -1266,13 +1322,16 @@ final class RmemModel
 
         $locations = [];
         foreach ($this->resolveSourceLocations($nodeId) as $loc) {
-            $formatted = self::formatLocation([
+            $short = [
                 'filename' => $loc['filename'],
                 'line' => $loc['line'],
                 'line_start' => $loc['line_start'],
                 'line_end' => $loc['line_end'],
-            ]);
-            $locations[] = $loc + ['formatted' => $formatted];
+            ];
+            $locations[] = $loc + [
+                'formatted' => self::formatLocation($short),
+                'uri' => self::buildSourceLocationUri($short),
+            ];
         }
 
         return [

--- a/tests/Rmem/Explore/RmemModelSourceLocationTest.php
+++ b/tests/Rmem/Explore/RmemModelSourceLocationTest.php
@@ -258,6 +258,84 @@ class RmemModelSourceLocationTest extends TestCase
         $this->assertSame('defined_at', $detail['source_locations'][0]['kind']);
     }
 
+    public function testNodeDetailIncludesOsc8ReadyUri(): void
+    {
+        $model = $this->createModel();
+        $detail = $model->nodeDetail(2);
+        $this->assertNotEmpty($detail['source_locations']);
+        $loc = $detail['source_locations'][0];
+        $this->assertArrayHasKey('uri', $loc);
+        $this->assertSame(
+            'file:///var/www/html/src/App.php#L17',
+            $loc['uri'],
+        );
+    }
+
+    public function testBuildUriForPlainFilesystemPath(): void
+    {
+        $uri = RmemModel::buildSourceLocationUri([
+            'filename' => '/home/me/project/src/Foo.php',
+            'line' => 42,
+            'line_start' => 42,
+            'line_end' => 60,
+        ]);
+        $this->assertSame('file:///home/me/project/src/Foo.php#L42', $uri);
+    }
+
+    public function testBuildUriWithoutLineOmitsFragment(): void
+    {
+        $uri = RmemModel::buildSourceLocationUri([
+            'filename' => '/tmp/a.php',
+            'line' => null,
+            'line_start' => null,
+            'line_end' => null,
+        ]);
+        $this->assertSame('file:///tmp/a.php', $uri);
+    }
+
+    public function testBuildUriPercentEncodesSpacesAndUnicode(): void
+    {
+        $uri = RmemModel::buildSourceLocationUri([
+            'filename' => '/home/テスト/My App/Foo.php',
+            'line' => 7,
+            'line_start' => 7,
+            'line_end' => null,
+        ]);
+        // Path segments percent-encoded, separators preserved.
+        $this->assertStringContainsString('/My%20App/', $uri);
+        $this->assertStringStartsWith('file:///', $uri);
+        $this->assertStringEndsWith('#L7', $uri);
+    }
+
+    public function testBuildUriForVscodeSchemePassesThrough(): void
+    {
+        $uri = RmemModel::buildSourceLocationUri([
+            'filename' => 'vscode://file/Users/me/project/src/Foo.php',
+            'line' => 42,
+            'line_start' => 42,
+            'line_end' => null,
+        ]);
+        // VS Code uses `:line` suffix, not a fragment.
+        $this->assertSame(
+            'vscode://file/Users/me/project/src/Foo.php:42',
+            $uri,
+        );
+    }
+
+    public function testBuildUriForHttpsUsesLineFragment(): void
+    {
+        $uri = RmemModel::buildSourceLocationUri([
+            'filename' => 'https://github.com/acme/repo/blob/abc/src/Foo.php',
+            'line' => 42,
+            'line_start' => 42,
+            'line_end' => null,
+        ]);
+        $this->assertSame(
+            'https://github.com/acme/repo/blob/abc/src/Foo.php#L42',
+            $uri,
+        );
+    }
+
     public function testBuildAndPrimeSourceLocationRefsRoundTrip(): void
     {
         $model = $this->createModel();


### PR DESCRIPTION
## Summary

Follow-up to #634. The new `source: file:line` lines in the
`rmem:explore` detail pane were going through the sidebar's
`$wrap()` helper, which happily splits long paths across rows —
and once a `file:line` token is broken across lines, terminals
no longer recognise it as a clickable link. Clicking takes you
to the truncated path, or nowhere at all.

This PR fixes it for real:

- **Middle-truncate** the visible text to a single row (`…` in
  the middle, so both the leading path context and the trailing
  `:line` stay readable).
- Wrap that single row in an **OSC 8 hyperlink** pointing at a
  complete URI. Terminals that understand OSC 8 (iTerm2, Kitty,
  WezTerm, recent VS Code integrated terminal, GNOME Terminal,
  Windows Terminal, …) keep the whole region clickable
  regardless of what the ellipsis ate. Terminals without OSC 8
  support just see the visible text.

URI construction lives on `RmemModel::buildSourceLocationUri()`
so `query.node_detail` clients (MCP / HTTP bridge) get the same
URI for free via a new `uri` field on each `source_locations[]`
entry:

- **Plain path** → `file:///<percent-encoded path>#L<line>`.
  Spaces / unicode in paths are safe.
- **User-mapped URL scheme** (via `--path-map`) passes through:
  `http(s)://` gets `#L<n>` (GitHub blob convention), other
  schemes get `:<n>` (vscode://file/…:line convention).

## Test plan

- [x] `phpcs` (CI-equivalent: `--standard=./phpcs.xml -n -q ./src ./tests`) — exit 0
- [x] `psalm.phar --no-progress --show-info=false` — no errors
- [x] `phpunit tests/Rmem tests/Rbt tests/Lib --exclude-group target-version` — 1128 tests, 53299 assertions, only the existing 3 env-dependent failures (FrankenPHP × 2, mod_php × 1)
- [x] New unit coverage for `buildSourceLocationUri()` — plain path, missing line, percent-encoding for spaces / unicode, vscode:// scheme, https URL.
- [ ] Manually verify in a terminal with OSC 8 support (e.g. iTerm2 / Kitty / VS Code integrated terminal): cursor over a `source:` line still opens the file at the recorded line even when the visible path was truncated.

https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw)_