### PR TITLE
Add SimpleXML memory tracking support (Tier 1)

### DIFF
--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1531,8 +1531,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1506,3 +1506,38 @@ typedef struct _zend_accel_shared_globals {
 	HashTable    interned_strings;
 	uint32_t     uninitialized_bucket[2];
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1533,3 +1533,38 @@ typedef struct _zend_accel_shared_globals {
 	HashTable    interned_strings;
 	uint32_t     uninitialized_bucket[2];
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1558,8 +1558,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1552,8 +1552,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1527,3 +1527,38 @@ typedef struct _zend_accel_shared_globals {
 	HashTable    interned_strings;
 	uint32_t     uninitialized_bucket[2];
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1525,3 +1525,38 @@ typedef struct _zend_accel_shared_globals {
 	uint32_t     uninitialized_bucket[2];
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1550,8 +1550,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1568,3 +1568,38 @@ typedef struct _zend_accel_shared_globals {
 	uint32_t     uninitialized_bucket[2];
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1593,8 +1593,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1596,3 +1596,38 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1621,8 +1621,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1773,8 +1773,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1748,3 +1748,38 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1817,8 +1817,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1792,3 +1792,38 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void *ptr;
+	int   refcount;
+	void *doc_props;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1861,8 +1861,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1835,3 +1835,39 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * Pointer-typed fields are kept as void* since Tier 1 only needs sizes
+ * and offsets, not libxml2 tree traversal. PHP 8.3 added cache_tag. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	int   refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void  *ptr;
+	int    refcount;
+	void  *doc_props;
+	size_t cache_tag_modification_nr;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1955,8 +1955,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1924,3 +1924,44 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * PHP 8.4 restructured php_libxml_ref_obj: added private_data + handlers
+ * pointers and moved refcount to uint32 + two 8-bit bitfields for
+ * class_type / quirks_mode. We represent the two bitfields as one
+ * unsigned int since Tier 1 only needs the total struct size. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	unsigned int refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void        *ptr;
+	void        *doc_props;
+	size_t       cache_tag_modification_nr;
+	void        *private_data;
+	void        *handlers;
+	unsigned int refcount;
+	unsigned int class_and_quirks;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1974,8 +1974,8 @@ typedef struct {
 	HashTable           *properties;
 	void                *xpath;
 	struct {
-		void    *name;
-		void    *nsprefix;
+		char    *name;
+		char    *nsprefix;
 		int      isprefix;
 		int      type;
 		zval     data;

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1943,3 +1943,44 @@ typedef struct _zend_accel_shared_globals {
 	const void **jit_exit_groups;
 	zend_string_table interned_strings;
 } zend_accel_shared_globals;
+
+/* ext/libxml/php_libxml.h — SimpleXML/libxml Tier 1 support.
+ * PHP 8.4 restructured php_libxml_ref_obj: added private_data + handlers
+ * pointers and moved refcount to uint32 + two 8-bit bitfields for
+ * class_type / quirks_mode. We represent the two bitfields as one
+ * unsigned int since Tier 1 only needs the total struct size. */
+typedef struct _php_libxml_node_ptr {
+	void *node;
+	unsigned int refcount;
+	void *_private;
+} php_libxml_node_ptr;
+
+typedef struct _php_libxml_ref_obj {
+	void        *ptr;
+	void        *doc_props;
+	size_t       cache_tag_modification_nr;
+	void        *private_data;
+	void        *handlers;
+	unsigned int refcount;
+	unsigned int class_and_quirks;
+} php_libxml_ref_obj;
+
+/* ext/simplexml/php_simplexml.h — layout is stable from PHP 7.0 through 8.4
+ * for the fields Tier 1 cares about. iter.name/nsprefix switched from
+ * xmlChar* to zend_string* in 8.4 but both are 8-byte pointers. */
+typedef struct {
+	php_libxml_node_ptr *node;
+	php_libxml_ref_obj  *document;
+	HashTable           *properties;
+	void                *xpath;
+	struct {
+		void    *name;
+		void    *nsprefix;
+		int      isprefix;
+		int      type;
+		zval     data;
+	} iter;
+	zval           tmp;
+	zend_function *fptr_count;
+	zend_object    zo;
+} php_sxe_object;

--- a/src/Lib/PhpInternals/Types/Zend/PhpSxeObject.php
+++ b/src/Lib/PhpInternals/Types/Zend/PhpSxeObject.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use Reli\Lib\FFI\FFIHelper;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
+
+/**
+ * php_sxe_object wraps a SimpleXMLElement/SimpleXMLIterator instance.
+ * Layout:
+ *   { php_libxml_node_ptr *node;
+ *     php_libxml_ref_obj  *document;
+ *     HashTable           *properties;
+ *     ... (xpath, iter, tmp, fptr_count)
+ *     zend_object          zo;   // at the end }
+ *
+ * The object-store pointer targets &sxe->zo, so the outer-struct base is
+ * obtained by subtracting the offset of `zo`.
+ *
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
+class PhpSxeObject implements PointedTypeResolverAware
+{
+    use InlineCDataCreatorTrait;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendObject $std;
+
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Pointer<ZendArray>|null
+     */
+    public ?Pointer $properties;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $node_address;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $document_address;
+
+    /**
+     * @param CastedCData<\FFI\PhpInternals\php_sxe_object> $casted_cdata
+     * @param Pointer<PhpSxeObject> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->std);
+        unset($this->properties);
+        unset($this->node_address);
+        unset($this->document_address);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'std' => $this->std = new ZendObject(
+                $this->casted_cdata->createSubView($this->casted_cdata->casted->zo),
+                new Pointer(
+                    ZendObject::class,
+                    $this->pointer->address
+                    +
+                    FFI::typeof($this->casted_cdata->casted)->getStructFieldOffset('zo'),
+                    FFI::typeof($this->casted_cdata->casted->zo)->getSize(),
+                ),
+            ),
+            'properties' => $this->properties =
+                $this->casted_cdata->casted->properties !== null
+                ? Pointer::fromCData(
+                    ZendArray::class,
+                    $this->casted_cdata->casted->properties,
+                )
+                : null
+            ,
+            'node_address' => $this->node_address =
+                FFIHelper::castPointerToInt($this->casted_cdata->casted->node),
+            'document_address' => $this->document_address =
+                FFIHelper::castPointerToInt($this->casted_cdata->casted->document),
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'php_sxe_object';
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        /**
+         * @var CastedCData<\FFI\PhpInternals\php_sxe_object> $casted_cdata
+         * @var Pointer<PhpSxeObject> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
+    }
+
+    /** @return Pointer<PhpSxeObject> */
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+
+    /**
+     * @param Pointer<ZendObject> $pointer
+     * @return Pointer<PhpSxeObject>
+     */
+    public static function getPointerFromZendObjectPointer(
+        Pointer $pointer,
+        ZendTypeReader $zend_type_reader,
+    ): Pointer {
+        $struct_size = $zend_type_reader->sizeOf('php_sxe_object');
+        [$zo_offset] = $zend_type_reader->getOffsetAndSizeOfMember('php_sxe_object', 'zo');
+        return new Pointer(
+            PhpSxeObject::class,
+            $pointer->address - $zo_offset,
+            $struct_size,
+        );
+    }
+}

--- a/src/Lib/PhpInternals/Types/Zend/PhpSxeObject.php
+++ b/src/Lib/PhpInternals/Types/Zend/PhpSxeObject.php
@@ -55,6 +55,12 @@ class PhpSxeObject implements PointedTypeResolverAware
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $document_address;
 
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $iter_name_address;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $iter_nsprefix_address;
+
     /**
      * @param CastedCData<\FFI\PhpInternals\php_sxe_object> $casted_cdata
      * @param Pointer<PhpSxeObject> $pointer
@@ -67,6 +73,8 @@ class PhpSxeObject implements PointedTypeResolverAware
         unset($this->properties);
         unset($this->node_address);
         unset($this->document_address);
+        unset($this->iter_name_address);
+        unset($this->iter_nsprefix_address);
     }
 
     public function __get(string $field_name): mixed
@@ -94,6 +102,10 @@ class PhpSxeObject implements PointedTypeResolverAware
                 FFIHelper::castPointerToInt($this->casted_cdata->casted->node),
             'document_address' => $this->document_address =
                 FFIHelper::castPointerToInt($this->casted_cdata->casted->document),
+            'iter_name_address' => $this->iter_name_address =
+                FFIHelper::castPointerToInt($this->casted_cdata->casted->iter->name),
+            'iter_nsprefix_address' => $this->iter_nsprefix_address =
+                FFIHelper::castPointerToInt($this->casted_cdata->casted->iter->nsprefix),
         };
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitObjectJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitObjectJob.php
@@ -129,6 +129,8 @@ final class EmitObjectJob implements CollectorJob
             || $class_name === \WeakMap::class
             || $class_name === \PDO::class
             || $class_name === \PDOStatement::class
+            || $class_name === 'SimpleXMLElement'
+            || $class_name === 'SimpleXMLIterator'
         ) {
             $object = $ctx->dereferencer->deref($this->pointer);
             $this->processObject($object, $ctx, $queue);
@@ -503,6 +505,17 @@ final class EmitObjectJob implements CollectorJob
         ) {
             try {
                 $queue->push(new EmitClosureJob(
+                    $object,
+                    $object_node_id,
+                    $ctx,
+                ));
+            } catch (\Throwable) {
+            }
+        }
+
+        if ($class_name === 'SimpleXMLElement' || $class_name === 'SimpleXMLIterator') {
+            try {
+                $queue->push(new EmitSimpleXMLJob(
                     $object,
                     $object_node_id,
                     $ctx,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitSimpleXMLJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitSimpleXMLJob.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
 
+use Reli\Lib\PhpInternals\Types\C\RawString;
 use Reli\Lib\PhpInternals\Types\Zend\PhpSxeObject;
 use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
 use Reli\Lib\PhpInternals\Types\Zend\ZendObject;
+use Reli\Lib\PhpInternals\Types\Zend\ZendString;
+use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
@@ -116,5 +119,83 @@ final class EmitSimpleXMLJob implements CollectorJob
                 'simplexml_properties_cache',
             ));
         }
+
+        // iter.name / iter.nsprefix hold the element name / namespace prefix
+        // used when the SimpleXMLElement represents a named child iterator.
+        // Their storage differs by version:
+        //   PHP 7.0-8.3: xmlChar* (estrdup'd null-terminated C string).
+        //   PHP 8.4+:    zend_string* — pick up via the normal string walker.
+        $this->trackIterString(
+            $this->sxe->iter_name_address,
+            'simplexml_iter_name',
+            $ctx,
+            $queue,
+        );
+        $this->trackIterString(
+            $this->sxe->iter_nsprefix_address,
+            'simplexml_iter_nsprefix',
+            $ctx,
+            $queue,
+        );
+    }
+
+    private function trackIterString(
+        int $address,
+        string $link_name,
+        CollectorContext $ctx,
+        JobQueue $queue,
+    ): void {
+        if ($address === 0) {
+            return;
+        }
+
+        if (!$ctx->zend_type_reader->isPhpVersionLowerThan(ZendTypeReader::V84)) {
+            // Already a zend_string; let the standard walker handle
+            // dedup + size accounting.
+            $queue->push(new EmitStringJob(
+                new Pointer(
+                    ZendString::class,
+                    $address,
+                    $ctx->zend_type_reader->sizeOf('zend_string'),
+                ),
+                $this->object_node_id,
+                $link_name,
+            ));
+            return;
+        }
+
+        if ($ctx->memory_locations->has($address)) {
+            $ctx->checkVisitedAndEmitReference(
+                $address,
+                $this->object_node_id,
+                $link_name,
+            );
+            return;
+        }
+
+        // estrdup'd C string: read bounded, then register strlen+1
+        // as its allocation size. 256 is a safe upper bound for
+        // XML element / namespace-prefix names in practice.
+        try {
+            /** @var RawString $raw */
+            $raw = $ctx->dereferencer->deref(
+                new Pointer(RawString::class, $address, 256),
+            );
+            $length = strlen($raw->value) + 1;
+        } catch (\Throwable) {
+            return;
+        }
+
+        $location = new SimpleXmlInternalMemoryLocation(
+            $address,
+            $length,
+            'SimpleXMLElement::iter (estrdup)',
+        );
+        $ctx->memory_locations->add($location);
+        $ctx->emitNode(
+            new SimpleXmlInternalContext($location),
+            $this->object_node_id,
+            $link_name,
+        );
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitSimpleXMLJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitSimpleXMLJob.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
+
+use Reli\Lib\PhpInternals\Types\Zend\PhpSxeObject;
+use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
+use Reli\Lib\PhpInternals\Types\Zend\ZendObject;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\SimpleXmlInternalMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\SimpleXmlInternalContext;
+use Reli\Lib\Process\Pointer\Pointer;
+
+/**
+ * Tier 1 SimpleXML support: attribute the emalloc'd ancillary blocks
+ * (`php_libxml_node_ptr`, `php_libxml_ref_obj`) to their owning
+ * SimpleXMLElement / SimpleXMLIterator, and follow the `properties`
+ * HashTable so its contents are walked normally.
+ *
+ * The outer `php_sxe_object` allocation itself is already covered by the
+ * size correction in {@see ZendObjectMemoryLocation::fromZendObject()}.
+ *
+ * The libxml2 node tree (xmlDoc/xmlNode/xmlAttr) lives in libc malloc,
+ * not zend_mm, so it is intentionally outside the scope of this job.
+ */
+final class EmitSimpleXMLJob implements CollectorJob
+{
+    private PhpSxeObject $sxe;
+
+    public function __construct(
+        ZendObject $object,
+        private ?int $object_node_id,
+        CollectorContext $ctx,
+    ) {
+        $this->sxe = $ctx->dereferencer->deref(
+            PhpSxeObject::getPointerFromZendObjectPointer(
+                $object->getPointer(),
+                $ctx->zend_type_reader,
+            ),
+        );
+    }
+
+    #[\Override]
+    public function execute(CollectorContext $ctx, JobQueue $queue): void
+    {
+        $node_ptr_size = $ctx->zend_type_reader->sizeOf('php_libxml_node_ptr');
+        $ref_obj_size = $ctx->zend_type_reader->sizeOf('php_libxml_ref_obj');
+
+        $node_address = $this->sxe->node_address;
+        if ($node_address !== 0 && !$ctx->memory_locations->has($node_address)) {
+            $location = new SimpleXmlInternalMemoryLocation(
+                $node_address,
+                $node_ptr_size,
+                'SimpleXMLElement::node (php_libxml_node_ptr)',
+            );
+            $ctx->memory_locations->add($location);
+            $ctx->emitNode(
+                new SimpleXmlInternalContext($location),
+                $this->object_node_id,
+                'simplexml_node',
+            );
+        } elseif ($node_address !== 0) {
+            $ctx->checkVisitedAndEmitReference(
+                $node_address,
+                $this->object_node_id,
+                'simplexml_node',
+            );
+        }
+
+        $document_address = $this->sxe->document_address;
+        if ($document_address !== 0 && !$ctx->memory_locations->has($document_address)) {
+            $location = new SimpleXmlInternalMemoryLocation(
+                $document_address,
+                $ref_obj_size,
+                'SimpleXMLElement::document (php_libxml_ref_obj)',
+            );
+            $ctx->memory_locations->add($location);
+            $ctx->emitNode(
+                new SimpleXmlInternalContext($location),
+                $this->object_node_id,
+                'simplexml_document',
+            );
+        } elseif ($document_address !== 0) {
+            $ctx->checkVisitedAndEmitReference(
+                $document_address,
+                $this->object_node_id,
+                'simplexml_document',
+            );
+        }
+
+        // `sxe->properties` is populated on demand by var_dump / (array)
+        // cast / json_encode / get_object_vars. When present it can hold
+        // the whole serialised view of the node, so walking it picks up
+        // the heavy content — child SimpleXMLElements, attribute strings,
+        // and the HashTable itself.
+        if ($this->sxe->properties !== null) {
+            $queue->push(new EmitArrayJob(
+                new Pointer(
+                    ZendArray::class,
+                    $this->sxe->properties->address,
+                    $ctx->zend_type_reader->sizeOf('zend_array'),
+                ),
+                $this->object_node_id,
+                'simplexml_properties_cache',
+            ));
+        }
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/SimpleXmlInternalMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/SimpleXmlInternalMemoryLocation.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+/**
+ * An emalloc'd internal allocation held by a SimpleXMLElement/SimpleXMLIterator
+ * instance — the php_libxml_node_ptr wrapper around an xmlNode, or the
+ * php_libxml_ref_obj wrapper around an xmlDoc. The libxml2 tree itself lives
+ * in libc malloc and is not visible from zend_mm.
+ */
+final class SimpleXmlInternalMemoryLocation extends MemoryLocation
+{
+    public function __construct(
+        int $address,
+        int $size,
+        public readonly string $type_name,
+    ) {
+        parent::__construct($address, $size);
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/ZendObjectMemoryLocation.php
@@ -73,6 +73,10 @@ final class ZendObjectMemoryLocation extends RefcountedMemoryLocation
             [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('pdo_stmt_t', 'std');
             $address -= $std_offset;
             $size = $zend_object->getMemorySize($dereferencer) + $std_offset;
+        } elseif ($class_name === 'SimpleXMLElement' || $class_name === 'SimpleXMLIterator') {
+            [$std_offset] = $zend_type_reader->getOffsetAndSizeOfMember('php_sxe_object', 'zo');
+            $address -= $std_offset;
+            $size = $zend_object->getMemorySize($dereferencer) + $std_offset;
         } else {
             $size = $zend_object->getMemorySize($dereferencer);
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SimpleXmlInternalContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/SimpleXmlInternalContext.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\SimpleXmlInternalMemoryLocation;
+
+final class SimpleXmlInternalContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+
+    public function __construct(
+        public SimpleXmlInternalMemoryLocation $memory_location,
+    ) {
+    }
+
+    #[\Override]
+    public function getLocations(): iterable
+    {
+        return [$this->memory_location];
+    }
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        return [];
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2221,16 +2221,17 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();
 
-        // Parse a small doc and walk a child node so that SimpleXML
-        // allocates both the php_libxml_ref_obj (document) and the
-        // php_libxml_node_ptr (child node) through emalloc.
+        // Parse a small doc and keep a named child SimpleXMLElement alive
+        // so that every tracked emalloc path is exercised:
+        //   - root sxe:   php_sxe_object + php_libxml_ref_obj + node_ptr
+        //   - child sxe:  php_sxe_object + iter.name (estrdup "child")
         $target_script =
             <<<'CODE'
             <?php
             $xml = simplexml_load_string(
                 '<root><child id="1">hello</child></root>'
             );
-            $_ = (string)$xml->child;
+            $keep = $xml->child;
             fputs(STDOUT, "a\n");
             fgets(STDIN);
             CODE
@@ -2340,10 +2341,14 @@ class MemoryLocationsCollectorTest extends BaseTestCase
 
         $found_simplexml_node = false;
         $found_simplexml_document = false;
+        $found_simplexml_iter_name = false;
+        $sxe_object_sizes = [];
         $findSxe = function (array $tree) use (
             &$findSxe,
             &$found_simplexml_node,
             &$found_simplexml_document,
+            &$found_simplexml_iter_name,
+            &$sxe_object_sizes,
         ): void {
             foreach ($tree as $key => $value) {
                 if ($key === 'simplexml_node') {
@@ -2352,7 +2357,22 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 if ($key === 'simplexml_document') {
                     $found_simplexml_document = true;
                 }
-                if (is_array($value) && $key !== '#locations') {
+                if ($key === 'simplexml_iter_name') {
+                    $found_simplexml_iter_name = true;
+                }
+                if ($key === '#locations' && is_array($value)) {
+                    /** @var array<mixed> $value */
+                    foreach ($value as $loc) {
+                        if (
+                            $loc instanceof \Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation
+                            && $loc->class_name === 'SimpleXMLElement'
+                        ) {
+                            $sxe_object_sizes[] = $loc->size;
+                        }
+                    }
+                    continue;
+                }
+                if (is_array($value)) {
                     $findSxe($value);
                 }
             }
@@ -2365,6 +2385,268 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertTrue(
             $found_simplexml_document,
             'SimpleXMLElement should have its php_libxml_ref_obj allocation tracked'
+        );
+        $this->assertTrue(
+            $found_simplexml_iter_name,
+            'A named child SimpleXMLElement should have its iter.name (estrdup/zend_string) tracked'
+        );
+
+        // Object size correction: php_sxe_object is ~152 bytes (incl.
+        // zend_object's baked-in 1-zval slot) vs. sizeof(zend_object)=56
+        // on 64-bit. Without the ZendObjectMemoryLocation fix SimpleXML
+        // would be reported as size=40 (56 - 16 for property_count=0).
+        // We allow some slack in case zend_object shape shifts between
+        // PHP versions, but require > 56 to confirm the correction ran.
+        $this->assertNotEmpty(
+            $sxe_object_sizes,
+            'At least one SimpleXMLElement ZendObjectMemoryLocation should be emitted'
+        );
+        foreach ($sxe_object_sizes as $size) {
+            $this->assertGreaterThan(
+                100,
+                $size,
+                'SimpleXMLElement should report the full php_sxe_object size, not just zend_object'
+            );
+        }
+    }
+
+    /**
+     * Run a target PHP script in a container and drive the memory
+     * locations collector over the resulting process. Returns the
+     * context tree emitted by {@see ArrayContextTreeSink}.
+     *
+     * @return array<string, mixed>
+     */
+    private function runCollectorOnTargetScript(
+        string $php_version,
+        string $docker_image_name,
+        string $target_script,
+        MemoryReader $memory_reader,
+        ZendTypeReaderCreator $type_reader_creator,
+    ): array {
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $sink = new ArrayContextTreeSink();
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        return $sink->getResult();
+    }
+
+    #[DataProvider('provideFromV80')]
+    public function testSimpleXMLPropertiesCacheWalked(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+
+        // Trigger sxe->properties population by casting to array. The
+        // SimpleXML handler populates the HashTable with @attributes +
+        // child zvals and keeps it on the instance.
+        $target_script = <<<'CODE'
+            <?php
+            $xml = simplexml_load_string(
+                '<root><child id="42">hello</child><child>world</child></root>'
+            );
+            /** @var array<mixed> $_ */
+            $_ = (array)$xml;
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE;
+
+        $contexts_analyzed = $this->runCollectorOnTargetScript(
+            $php_version,
+            $docker_image_name,
+            $target_script,
+            new MemoryReader(),
+            new ZendTypeReaderCreator(),
+        );
+
+        $found_properties_cache = false;
+        $find = function (array $tree) use (&$find, &$found_properties_cache): void {
+            foreach ($tree as $key => $value) {
+                if ($key === 'simplexml_properties_cache') {
+                    $found_properties_cache = true;
+                    return;
+                }
+                if (is_array($value) && $key !== '#locations') {
+                    $find($value);
+                    if ($found_properties_cache) {
+                        return;
+                    }
+                }
+            }
+        };
+        $find($contexts_analyzed);
+        $this->assertTrue(
+            $found_properties_cache,
+            'SimpleXMLElement->properties HashTable should be walked after it is populated'
+        );
+    }
+
+    #[DataProvider('provideFromV80')]
+    public function testSimpleXMLIteratorTracked(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+
+        // SimpleXMLIterator uses the same php_sxe_object layout but a
+        // distinct class entry; verify the dispatch picks it up too.
+        $target_script = <<<'CODE'
+            <?php
+            $xml = new SimpleXMLIterator(
+                '<root><child>hello</child></root>'
+            );
+            $keep = $xml->child;
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE;
+
+        $contexts_analyzed = $this->runCollectorOnTargetScript(
+            $php_version,
+            $docker_image_name,
+            $target_script,
+            new MemoryReader(),
+            new ZendTypeReaderCreator(),
+        );
+
+        $found_iterator_class = false;
+        $found_node_edge_under_iterator = false;
+        $find = function (array $tree) use (
+            &$find,
+            &$found_iterator_class,
+            &$found_node_edge_under_iterator,
+        ): void {
+            $is_iterator_here = false;
+            if (isset($tree['#locations']) && is_array($tree['#locations'])) {
+                /** @var array<mixed> $locs */
+                $locs = $tree['#locations'];
+                foreach ($locs as $loc) {
+                    if (
+                        $loc instanceof \Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation
+                        && $loc->class_name === 'SimpleXMLIterator'
+                    ) {
+                        $found_iterator_class = true;
+                        $is_iterator_here = true;
+                    }
+                }
+            }
+            // `simplexml_node` is a direct child link of the object
+            // node (not a grandchild), so check at this same level.
+            if ($is_iterator_here && isset($tree['simplexml_node'])) {
+                $found_node_edge_under_iterator = true;
+            }
+            foreach ($tree as $key => $value) {
+                if (is_array($value) && $key !== '#locations') {
+                    $find($value);
+                }
+            }
+        };
+        $find($contexts_analyzed);
+
+        $this->assertTrue(
+            $found_iterator_class,
+            'SimpleXMLIterator instance should be recognised as a ZendObjectMemoryLocation'
+        );
+        $this->assertTrue(
+            $found_node_edge_under_iterator,
+            'SimpleXMLIterator should also emit a simplexml_node child edge'
         );
     }
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2211,6 +2211,164 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     }
 
     #[DataProvider('provideFromV80')]
+    public function testSimpleXMLInternalAllocationsTracking(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        // Parse a small doc and walk a child node so that SimpleXML
+        // allocates both the php_libxml_ref_obj (document) and the
+        // php_libxml_node_ptr (child node) through emalloc.
+        $target_script =
+            <<<'CODE'
+            <?php
+            $xml = simplexml_load_string(
+                '<root><child id="1">hello</child></root>'
+            );
+            $_ = (string)$xml->child;
+            fputs(STDOUT, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $sink = new ArrayContextTreeSink();
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+
+        $contexts_analyzed = $sink->getResult();
+
+        $found_simplexml_node = false;
+        $found_simplexml_document = false;
+        $findSxe = function (array $tree) use (
+            &$findSxe,
+            &$found_simplexml_node,
+            &$found_simplexml_document,
+        ): void {
+            foreach ($tree as $key => $value) {
+                if ($key === 'simplexml_node') {
+                    $found_simplexml_node = true;
+                }
+                if ($key === 'simplexml_document') {
+                    $found_simplexml_document = true;
+                }
+                if (is_array($value) && $key !== '#locations') {
+                    $findSxe($value);
+                }
+            }
+        };
+        $findSxe($contexts_analyzed);
+        $this->assertTrue(
+            $found_simplexml_node,
+            'SimpleXMLElement should have its php_libxml_node_ptr allocation tracked'
+        );
+        $this->assertTrue(
+            $found_simplexml_document,
+            'SimpleXMLElement should have its php_libxml_ref_obj allocation tracked'
+        );
+    }
+
+    #[DataProvider('provideFromV80')]
     public function testStreamResourceTracking(string $php_version, string $docker_image_name): void
     {
         if ($php_version === 'skip') {

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -78,6 +78,14 @@ class zend_weakmap extends CData
     public zend_object $std;
 }
 
+class php_sxe_object extends CData
+{
+    public ?CPointer $node;
+    public ?CPointer $document;
+    public ?CPointer $properties;
+    public zend_object $zo;
+}
+
 class zend_constants extends CData
 {
     public ?CPointer $name;

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -78,11 +78,21 @@ class zend_weakmap extends CData
     public zend_object $std;
 }
 
+class php_sxe_object_iter extends CData
+{
+    public ?CPointer $name;
+    public ?CPointer $nsprefix;
+    public int $isprefix;
+    public int $type;
+    public zval $data;
+}
+
 class php_sxe_object extends CData
 {
     public ?CPointer $node;
     public ?CPointer $document;
     public ?CPointer $properties;
+    public php_sxe_object_iter $iter;
     public zend_object $zo;
 }
 


### PR DESCRIPTION
## Summary
Implements Tier 1 memory tracking support for SimpleXMLElement and SimpleXMLIterator objects, enabling accurate attribution of internal emalloc'd allocations to their owning SimpleXML instances.

## Key Changes

- **New collector job**: `EmitSimpleXMLJob` handles tracking of SimpleXML-specific internal allocations:
  - `php_libxml_node_ptr` wrapper around xmlNode
  - `php_libxml_ref_obj` wrapper around xmlDoc
  - `properties` HashTable (populated on-demand by var_dump, array cast, etc.)
  - Iterator name/namespace prefix strings (estrdup'd in PHP 7.0-8.3, zend_string in 8.4+)

- **New type definition**: `PhpSxeObject` class provides structured access to the `php_sxe_object` C struct, with proper offset calculations to recover the outer struct from the embedded `zend_object` pointer

- **Memory location types**: 
  - `SimpleXmlInternalMemoryLocation` represents emalloc'd internal blocks
  - `SimpleXmlInternalContext` wraps these locations for the reference tree

- **Object size correction**: Enhanced `ZendObjectMemoryLocation.fromZendObject()` to properly account for the full `php_sxe_object` size (~152 bytes) rather than just the base `zend_object` (~56 bytes), fixing underreporting of SimpleXML memory usage

- **Dispatcher integration**: Updated `EmitObjectJob` to recognize SimpleXMLElement and SimpleXMLIterator classes and dispatch to the new job

- **C struct definitions**: Added `php_libxml_node_ptr`, `php_libxml_ref_obj`, and `php_sxe_object` definitions to all supported PHP version headers (7.0-8.5), accounting for structural changes in PHP 8.3 (cache_tag) and 8.4 (refcount type, private_data/handlers pointers, iter field type changes)

- **Comprehensive tests**: Three new test cases verify:
  - Basic internal allocation tracking (node, document, iter strings)
  - Properties cache walking when populated
  - SimpleXMLIterator support alongside SimpleXMLElement

## Implementation Details

The solution properly handles version-specific differences:
- PHP 7.0-8.3: `iter.name/nsprefix` are estrdup'd C strings (xmlChar*)
- PHP 8.4+: `iter.name/nsprefix` are zend_string pointers
- PHP 8.3+: Added `cache_tag_modification_nr` field to `php_libxml_ref_obj`
- PHP 8.4+: Restructured `php_libxml_ref_obj` with new fields and changed refcount type

The implementation avoids tracking the libxml2 tree itself (xmlDoc/xmlNode/xmlAttr), which lives in libc malloc and is outside zend_mm's scope.

https://claude.ai/code/session_014uBHGtXWmAhAsJzHUxrGnD