### PR TITLE
Add EG(active) liveness check to defer inactive PHP processes

### DIFF
--- a/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorCache.php
+++ b/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorCache.php
@@ -20,19 +20,41 @@ final class ProcessDescriptorCache
     /** @var array<int, TargetProcessDescriptor> */
     private $cache = [];
 
+    /**
+     * Descriptors that have fully resolved EG/SG addresses but whose
+     * EG(active) was 0 at the time of analysis (e.g. mod_php parent
+     * httpd, or a worker still booting). Next cycle only needs to
+     * re-read EG(active) to promote them into $cache.
+     *
+     * @var array<int, TargetProcessDescriptor>
+     */
+    private array $pending_cache = [];
+
     public function set(TargetProcessDescriptor $target_process_descriptor): void
     {
         $this->cache[$target_process_descriptor->pid] = $target_process_descriptor;
+        unset($this->pending_cache[$target_process_descriptor->pid]);
     }
 
     public function setInvalid(int $pid): void
     {
         $this->cache[$pid] = TargetProcessDescriptor::getInvalid();
+        unset($this->pending_cache[$pid]);
+    }
+
+    public function setPending(TargetProcessDescriptor $target_process_descriptor): void
+    {
+        $this->pending_cache[$target_process_descriptor->pid] = $target_process_descriptor;
     }
 
     public function get(int $pid): ?TargetProcessDescriptor
     {
         return $this->cache[$pid] ?? null;
+    }
+
+    public function getPending(int $pid): ?TargetProcessDescriptor
+    {
+        return $this->pending_cache[$pid] ?? null;
     }
 
     public function removeDisappeared(int ...$pids): void
@@ -41,6 +63,11 @@ final class ProcessDescriptorCache
         $diff = array_diff($cached, $pids);
         foreach ($diff as $disappeared) {
             unset($this->cache[$disappeared]);
+        }
+        $pending = array_keys($this->pending_cache);
+        $pending_diff = array_diff($pending, $pids);
+        foreach ($pending_diff as $disappeared) {
+            unset($this->pending_cache[$disappeared]);
         }
     }
 }

--- a/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetriever.php
+++ b/src/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetriever.php
@@ -17,6 +17,7 @@ use Reli\Inspector\Daemon\Dispatcher\TargetProcessDescriptor;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\PhpProcessReader\EgActivityChecker;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessSpecifier;
@@ -27,6 +28,7 @@ class ProcessDescriptorRetriever
     public function __construct(
         private PhpGlobalsFinder $php_globals_finder,
         private PhpVersionDetector $php_version_detector,
+        private EgActivityChecker $eg_activity_checker,
     ) {
     }
 
@@ -47,6 +49,15 @@ class ProcessDescriptorRetriever
         $cache = $process_descriptor_cache->get($pid);
         if (!is_null($cache)) {
             return $cache;
+        }
+
+        $pending = $process_descriptor_cache->getPending($pid);
+        if (!is_null($pending)) {
+            if ($this->eg_activity_checker->isActive($pid, $pending->eg_address, $pending->php_version)) {
+                $process_descriptor_cache->set($pending);
+                return $pending;
+            }
+            return TargetProcessDescriptor::getInvalid();
         }
 
         try {
@@ -94,6 +105,13 @@ class ProcessDescriptorRetriever
             $target_php_settings_decided->php_version,
             $cg_address,
         );
+
+        if (!$this->eg_activity_checker->isActive($pid, $eg_address, $target_php_settings_decided->php_version)) {
+            Log::debug('EG(active) is 0 — deferring as pending (e.g. mod_php parent or booting worker)', ['target_pid' => $pid]);
+            $process_descriptor_cache->setPending($result);
+            return TargetProcessDescriptor::getInvalid();
+        }
+
         $process_descriptor_cache->set($result);
         return $result;
     }

--- a/src/Lib/PhpProcessReader/EgActivityChecker.php
+++ b/src/Lib/PhpProcessReader/EgActivityChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader;
+
+use Reli\Lib\ByteStream\CDataByteReader;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+
+/**
+ * Cheap liveness probe for a candidate PHP process.
+ *
+ * Reads EG(active) with a single-byte process_vm_readv, which does not
+ * require ptrace and so does not SIGSTOP the target. A mod_php parent
+ * httpd (where libphp.so is mapped but the request engine never ran)
+ * leaves EG(active) at 0, so this check lets the searcher avoid picking
+ * up such non-worker processes as valid PHP targets.
+ *
+ * @psalm-suppress ClassMustBeFinal
+ */
+class EgActivityChecker
+{
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+        private ZendTypeReaderCreator $zend_type_reader_creator,
+    ) {
+    }
+
+    /**
+     * @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     */
+    public function isActive(int $pid, int $eg_address, string $php_version): bool
+    {
+        try {
+            $type_reader = $this->zend_type_reader_creator->create($php_version);
+            [$offset, $_size] = $type_reader->getOffsetAndSizeOfMember(
+                'zend_executor_globals',
+                'active',
+            );
+            $cdata = $this->memory_reader->read($pid, $eg_address + $offset, 1);
+            $reader = new CDataByteReader($cdata);
+            return $reader[0] !== 0;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/tests/Inspector/Daemon/Searcher/Worker/ProcessDescriptorCacheTest.php
+++ b/tests/Inspector/Daemon/Searcher/Worker/ProcessDescriptorCacheTest.php
@@ -55,4 +55,51 @@ class ProcessDescriptorCacheTest extends BaseTestCase
         );
         $this->assertNull($process_descriptor_cache->get(2));
     }
+
+    public function testPendingIsIndependentOfValidCache(): void
+    {
+        $cache = new ProcessDescriptorCache();
+        $this->assertNull($cache->get(10));
+        $this->assertNull($cache->getPending(10));
+
+        $pending_desc = new TargetProcessDescriptor(10, 0xdead, 0xbeef, ZendTypeReader::V80);
+        $cache->setPending($pending_desc);
+
+        // Pending must not leak into the valid lookup
+        $this->assertNull($cache->get(10));
+        $this->assertEquals($pending_desc, $cache->getPending(10));
+
+        // Promotion to valid clears the pending entry
+        $cache->set($pending_desc);
+        $this->assertEquals($pending_desc, $cache->get(10));
+        $this->assertNull($cache->getPending(10));
+    }
+
+    public function testSetInvalidClearsPending(): void
+    {
+        $cache = new ProcessDescriptorCache();
+        $cache->setPending(new TargetProcessDescriptor(7, 0x1, 0x2, ZendTypeReader::V80));
+        $cache->setInvalid(7);
+        $this->assertSame(TargetProcessDescriptor::getInvalid(), $cache->get(7));
+        $this->assertNull($cache->getPending(7));
+    }
+
+    public function testRemoveDisappearedClearsBothCaches(): void
+    {
+        $cache = new ProcessDescriptorCache();
+        $cache->set(new TargetProcessDescriptor(1, 0, 0, ZendTypeReader::V80));
+        $cache->setPending(new TargetProcessDescriptor(2, 0, 0, ZendTypeReader::V80));
+        $cache->setPending(new TargetProcessDescriptor(3, 0, 0, ZendTypeReader::V80));
+        $cache->set(new TargetProcessDescriptor(4, 0, 0, ZendTypeReader::V80));
+
+        $cache->removeDisappeared(1, 3);
+
+        $this->assertNotNull($cache->get(1));
+        $this->assertNull($cache->getPending(2));
+        $this->assertEquals(
+            new TargetProcessDescriptor(3, 0, 0, ZendTypeReader::V80),
+            $cache->getPending(3),
+        );
+        $this->assertNull($cache->get(4));
+    }
 }

--- a/tests/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetrieverTest.php
+++ b/tests/Inspector/Daemon/Searcher/Worker/ProcessDescriptorRetrieverTest.php
@@ -18,10 +18,10 @@ use Reli\BaseTestCase;
 use Reli\Inspector\Daemon\Dispatcher\TargetProcessDescriptor;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\PhpProcessReader\EgActivityChecker;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpVersionDetector;
 use Reli\Lib\Process\ProcessSpecifier;
-use PHPUnit\Framework\TestCase;
 
 class ProcessDescriptorRetrieverTest extends BaseTestCase
 {
@@ -29,9 +29,11 @@ class ProcessDescriptorRetrieverTest extends BaseTestCase
     {
         $php_version_detector = \Mockery::mock(PhpVersionDetector::class);
         $php_globals_finder = \Mockery::mock(PhpGlobalsFinder::class);
+        $eg_activity_checker = \Mockery::mock(EgActivityChecker::class);
         $process_descriptor_retriever = new ProcessDescriptorRetriever(
             $php_globals_finder,
             $php_version_detector,
+            $eg_activity_checker,
         );
         $cache = new ProcessDescriptorCache();
         $cache->set(
@@ -76,9 +78,15 @@ class ProcessDescriptorRetrieverTest extends BaseTestCase
             )
             ->andReturns(42)
         ;
+        $eg_activity_checker = \Mockery::mock(EgActivityChecker::class);
+        $eg_activity_checker->expects()
+            ->isActive(1, 42, ZendTypeReader::V80)
+            ->andReturnTrue()
+        ;
         $process_descriptor_retriever = new ProcessDescriptorRetriever(
             $php_globals_finder,
             $php_version_detector,
+            $eg_activity_checker,
         );
         $cache = new ProcessDescriptorCache();
         $result = $process_descriptor_retriever->getProcessDescriptor(
@@ -101,10 +109,12 @@ class ProcessDescriptorRetrieverTest extends BaseTestCase
         $target_php_settings = new TargetPhpSettings(php_version: ZendTypeReader::V80);
         $php_version_detector = \Mockery::mock(PhpVersionDetector::class);
         $php_globals_finder = \Mockery::mock(PhpGlobalsFinder::class);
+        $eg_activity_checker = \Mockery::mock(EgActivityChecker::class);
 
         $process_descriptor_retriever = new ProcessDescriptorRetriever(
             $php_globals_finder,
             $php_version_detector,
+            $eg_activity_checker,
         );
         $php_version_detector->expects()
             ->decidePhpVersion(
@@ -117,5 +127,132 @@ class ProcessDescriptorRetrieverTest extends BaseTestCase
         $result = $process_descriptor_retriever->getProcessDescriptor(1, $target_php_settings, $cache);
         $this->assertSame(TargetProcessDescriptor::getInvalid(), $result);
         $this->assertSame(TargetProcessDescriptor::getInvalid(), $cache->get(1));
+    }
+
+    public function testGetProcessDescriptorDefersWhenEgInactive(): void
+    {
+        $target_php_settings = new TargetPhpSettings(php_version: ZendTypeReader::V80);
+        $php_version_detector = \Mockery::mock(PhpVersionDetector::class);
+        $php_version_detector->expects()
+            ->decidePhpVersion(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns($target_php_settings)
+            ->once()
+        ;
+        $php_globals_finder = \Mockery::mock(PhpGlobalsFinder::class);
+        $php_globals_finder->expects()
+            ->findExecutorGlobals(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns(42)
+            ->once()
+        ;
+        $php_globals_finder->expects()
+            ->findSAPIGlobals(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns(84)
+            ->once()
+        ;
+        $eg_activity_checker = \Mockery::mock(EgActivityChecker::class);
+        $eg_activity_checker->expects()
+            ->isActive(1, 42, ZendTypeReader::V80)
+            ->andReturnFalse()
+            ->once()
+        ;
+
+        $process_descriptor_retriever = new ProcessDescriptorRetriever(
+            $php_globals_finder,
+            $php_version_detector,
+            $eg_activity_checker,
+        );
+        $cache = new ProcessDescriptorCache();
+
+        // First call: inactive -> stored in pending cache, invalid returned
+        $first = $process_descriptor_retriever->getProcessDescriptor(1, $target_php_settings, $cache);
+        $this->assertSame(TargetProcessDescriptor::getInvalid(), $first);
+        $this->assertNull($cache->get(1));
+        $this->assertEquals(
+            new TargetProcessDescriptor(1, 42, 84, ZendTypeReader::V80),
+            $cache->getPending(1),
+        );
+
+        // Second call: active -> pending promoted to valid without
+        // re-running findExecutorGlobals / findSAPIGlobals / decidePhpVersion
+        $eg_activity_checker->expects()
+            ->isActive(1, 42, ZendTypeReader::V80)
+            ->andReturnTrue()
+            ->once()
+        ;
+        $second = $process_descriptor_retriever->getProcessDescriptor(1, $target_php_settings, $cache);
+        $this->assertEquals(
+            new TargetProcessDescriptor(1, 42, 84, ZendTypeReader::V80),
+            $second,
+        );
+        $this->assertEquals(
+            new TargetProcessDescriptor(1, 42, 84, ZendTypeReader::V80),
+            $cache->get(1),
+        );
+        $this->assertNull($cache->getPending(1));
+    }
+
+    public function testGetProcessDescriptorStaysPendingWhenEgStillInactive(): void
+    {
+        $target_php_settings = new TargetPhpSettings(php_version: ZendTypeReader::V80);
+        $php_version_detector = \Mockery::mock(PhpVersionDetector::class);
+        $php_version_detector->expects()
+            ->decidePhpVersion(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns($target_php_settings)
+            ->once()
+        ;
+        $php_globals_finder = \Mockery::mock(PhpGlobalsFinder::class);
+        $php_globals_finder->expects()
+            ->findExecutorGlobals(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns(42)
+            ->once()
+        ;
+        $php_globals_finder->expects()
+            ->findSAPIGlobals(
+                Matchers::equalTo(new ProcessSpecifier(1)),
+                $target_php_settings,
+            )
+            ->andReturns(84)
+            ->once()
+        ;
+        $eg_activity_checker = \Mockery::mock(EgActivityChecker::class);
+        $eg_activity_checker->expects()
+            ->isActive(1, 42, ZendTypeReader::V80)
+            ->andReturnFalse()
+            ->twice()
+        ;
+
+        $process_descriptor_retriever = new ProcessDescriptorRetriever(
+            $php_globals_finder,
+            $php_version_detector,
+            $eg_activity_checker,
+        );
+        $cache = new ProcessDescriptorCache();
+
+        $first = $process_descriptor_retriever->getProcessDescriptor(1, $target_php_settings, $cache);
+        $this->assertSame(TargetProcessDescriptor::getInvalid(), $first);
+
+        // Pending still pending, no re-analysis
+        $second = $process_descriptor_retriever->getProcessDescriptor(1, $target_php_settings, $cache);
+        $this->assertSame(TargetProcessDescriptor::getInvalid(), $second);
+        $this->assertNull($cache->get(1));
+        $this->assertEquals(
+            new TargetProcessDescriptor(1, 42, 84, ZendTypeReader::V80),
+            $cache->getPending(1),
+        );
     }
 }


### PR DESCRIPTION
## Summary
This change introduces a liveness probe for PHP processes by checking the `EG(active)` flag, allowing the process searcher to defer processes that aren't yet active (e.g., mod_php parent httpd processes or workers still booting) rather than marking them as invalid.

## Key Changes

- **New `EgActivityChecker` class**: Implements a cheap liveness probe that reads `EG(active)` with a single-byte `process_vm_readv` call, which doesn't require ptrace and won't SIGSTOP the target process.

- **Pending cache in `ProcessDescriptorCache`**: Added a separate `pending_cache` to store process descriptors that have fully resolved EG/SG addresses but whose `EG(active)` was 0. These can be promoted to valid cache on the next cycle without re-analyzing.

- **Updated `ProcessDescriptorRetriever`**: 
  - Integrated `EgActivityChecker` into the descriptor retrieval flow
  - Checks `EG(active)` after resolving addresses; if inactive, stores in pending cache and returns invalid
  - On subsequent calls, checks pending descriptors first and promotes them if `EG(active)` becomes 1
  - Avoids re-running expensive address resolution for pending descriptors

- **Comprehensive test coverage**: Added tests for the new pending cache behavior, including promotion scenarios and cases where processes remain inactive across multiple checks.

## Implementation Details

The pending cache is independent from the valid cache and is automatically cleared when a descriptor is promoted to valid or marked as invalid. The `removeDisappeared()` method cleans up both caches to prevent stale entries for terminated processes.

https://claude.ai/code/session_01GNaX97t1c4v8R5NqFigxTd