### PR TITLE
rmem:explore: cap sanitize input so big string nodes don't freeze the TUI

### DIFF
--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -1733,7 +1733,13 @@ final class RmemExploreTui
             $wrap("refcount: {$detail['refcount']}");
         }
         if ($detail['string_value'] !== null) {
-            $val = RmemModel::sanitizeForTerminal($detail['string_value']);
+            // Cap the sanitize input: $wrap() shows at most 3 sidebar
+            // rows, so anything past that is discarded anyway. Without
+            // the cap a multi-MB string_value would drag two preg_replace
+            // scans over megabytes on every redraw and turn keypresses
+            // into a visible freeze.
+            $valMax = max(120, $usable * 3 + 32);
+            $val = RmemModel::sanitizeForTerminal($detail['string_value'], $valMax);
             $wrap("val: \"{$val}\"");
         }
         foreach ($detail['source_locations'] as $loc) {

--- a/src/Rmem/Explore/RmemModel.php
+++ b/src/Rmem/Explore/RmemModel.php
@@ -853,11 +853,26 @@ final class RmemModel
     }
 
     /**
-     * Get a short inline preview for string/scalar nodes.
-     * Returns null for non-value nodes.
+     * Replace escape sequences / control chars with visible stand-ins so
+     * the result is safe to splat onto a raw TTY.
+     *
+     * `$maxLen`, when provided, caps the input *before* the pattern
+     * operations run. That cap matters: the TUI calls this from hot
+     * paths like `valuePreview()` (one call per rendered row) and from
+     * the detail pane, and the raw string_value can be multi-MB for
+     * pathological nodes. Running two `preg_replace()` scans over
+     * megabytes of text on every repaint turns keypress response into
+     * a visible freeze. Callers that know how much they will actually
+     * render should pass a generous upper bound (final display length
+     * + some margin for ANSI-strip expansion). A null `$maxLen` keeps
+     * the historical unbounded behavior for places that really do want
+     * the full string.
      */
-    public static function sanitizeForTerminal(string $s): string
+    public static function sanitizeForTerminal(string $s, ?int $maxLen = null): string
     {
+        if ($maxLen !== null && strlen($s) > $maxLen) {
+            $s = substr($s, 0, $maxLen);
+        }
         // Replace common whitespace escapes with visible representations
         $s = str_replace(["\n", "\r", "\t", "\0"], ['\n', '\r', '\t', '\0'], $s);
         // Strip ANSI escape sequences
@@ -871,7 +886,10 @@ final class RmemModel
     {
         $sv = $this->nodeStringValues[$nodeId] ?? null;
         if ($sv !== null) {
-            $preview = self::sanitizeForTerminal($sv);
+            // Bound the sanitize input so a multi-MB string value
+            // doesn't make preg_replace scan megabytes per rendered
+            // row — we only need ~40 chars of preview out.
+            $preview = self::sanitizeForTerminal($sv, 80);
             if (strlen($preview) > 40) {
                 $preview = substr($preview, 0, 37) . '...';
             }

--- a/tests/Rmem/Explore/RmemModelSanitizeForTerminalTest.php
+++ b/tests/Rmem/Explore/RmemModelSanitizeForTerminalTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Rmem\Explore;
+
+use PHPUnit\Framework\TestCase;
+
+class RmemModelSanitizeForTerminalTest extends TestCase
+{
+    public function testReplacesWhitespaceEscapesWithVisibleStandIns(): void
+    {
+        $this->assertSame(
+            'hello\nworld\tend',
+            RmemModel::sanitizeForTerminal("hello\nworld\tend"),
+        );
+    }
+
+    public function testStripsAnsiEscapeSequences(): void
+    {
+        $this->assertSame(
+            'plain text',
+            RmemModel::sanitizeForTerminal("\e[31mplain \e[1;32mtext\e[0m"),
+        );
+    }
+
+    public function testReplacesRemainingControlCharactersWithMiddot(): void
+    {
+        // BEL (0x07) + DEL (0x7f) should both become U+00B7 (·) which is
+        // 0xC2 0xB7 in UTF-8.
+        $out = RmemModel::sanitizeForTerminal("a\x07b\x7fc");
+        $this->assertSame("a\xC2\xB7b\xC2\xB7c", $out);
+    }
+
+    public function testMaxLenCapsInputBeforeRegexScans(): void
+    {
+        // Build a 2 MB string with a few escapes sprinkled in; without the
+        // cap, preg_replace would have to scan the whole thing.
+        $payload = str_repeat("\x1b[31mabc\x1b[0m ", 100_000);
+        $this->assertGreaterThan(1_000_000, strlen($payload));
+
+        $out = RmemModel::sanitizeForTerminal($payload, 80);
+        // Result is bounded (bytes). Exact length depends on where the
+        // 80-byte prefix landed, but it can never exceed the cap + UTF-8
+        // expansion of 0xC2 0xB7 replacements (which can't occur in an
+        // ASCII-only prefix); so 80 bytes is a hard ceiling here.
+        $this->assertLessThanOrEqual(80, strlen($out));
+    }
+
+    public function testMaxLenNullPreservesHistoricalUnboundedBehavior(): void
+    {
+        $payload = str_repeat('abc', 1000);
+        $out = RmemModel::sanitizeForTerminal($payload, null);
+        $this->assertSame($payload, $out);
+    }
+
+    public function testMaxLenLargerThanInputIsNoOp(): void
+    {
+        $payload = 'short string';
+        $this->assertSame(
+            $payload,
+            RmemModel::sanitizeForTerminal($payload, 1_000),
+        );
+    }
+
+    public function testMaxLenDoesNotBreakControlReplacementOnTruncatedTail(): void
+    {
+        // Cap falls mid-string; the surviving prefix should still get its
+        // control characters replaced.
+        $payload = "a\x00bcdef" . str_repeat('x', 100);
+        $out = RmemModel::sanitizeForTerminal($payload, 8);
+        $this->assertStringStartsWith('a\0bcdef', $out);
+    }
+}


### PR DESCRIPTION
## Summary

The `rmem:explore` TUI feels frozen when the snapshot contains
string nodes holding multi-MB values — cached JSON blobs, log
contents, tokenised HTML, that sort of thing. A `reli` trace on the
running TUI shows `RmemModel::sanitizeForTerminal` as the hot frame
every time keypresses trigger a redraw, with `fgetc` idling in
between; pressing `q` eventually works but the screen is left
stuck in whatever the last partial render was.

The root cause is that `sanitizeForTerminal()` runs two
`preg_replace` scans over the **full** input, and two call sites
feed it the raw string value straight from the snapshot and only
truncate afterwards:

- `RmemModel::valuePreview()` — called from every `nodeLabel()`
  during list/sandwich rendering. For a screenful of 50 rows and a
  single 10 MB string value per row, that's a gigabyte of
  `preg_replace` work per repaint.
- `RmemExploreTui::buildSidebarLines()` — renders a `val:` line
  for the focused node, then calls `$wrap()` which caps output at
  three sidebar rows anyway, so the bytes past that are discarded.

Add an optional `$maxLen` parameter that `substr`s the input
before the regex work, and pass a snug bound at both sites:

- `valuePreview()` → 80 bytes (2× the 40-char final preview, so
  there's margin for ANSI-strip shrinkage).
- sidebar `val:` → `max(120, $usable * 3 + 32)` (covers three
  wrapped rows of the actual sidebar width, plus slack).

Callers that deliberately want the historical unbounded behavior
just omit the argument, so this is backwards-compatible for any
downstream use.

## Test plan

- [x] `phpcs --standard=./phpcs.xml -n -q ./src ./tests` — exit 0
- [x] `psalm.phar --no-progress --show-info=false` — no errors
- [x] `phpunit tests/Rmem tests/Rbt tests/Lib --exclude-group target-version` — 1129 tests, 53292 assertions, only the pre-existing 3 env-dependent failures (FrankenPHP × 2, mod_php × 1)
- [x] New unit coverage in `RmemModelSanitizeForTerminalTest` — whitespace substitution, ANSI-strip, control char replacement, `$maxLen` cap over a 2 MB pathological input, `$maxLen = null` preserving old behavior, cap larger than input is a no-op, control replacement still runs on the truncated prefix.
- [ ] Manually verify in `rmem:explore` against a snapshot with a multi-MB string node: navigating rows and opening the detail pane stays responsive, no more sticky last-frame on exit.

https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw)_