### PR TITLE
Add thread name filtering for FrankenPHP and ZTS targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ Tip: **`-f binary` (`.rmem`) is the fastest format** and what the analysers belo
 
 - Alpine / musl libc — [internals/alpine-investigation.md](internals/alpine-investigation.md)
 - AArch64 (ARM64, experimental) — [internals/aarch64-support.md](internals/aarch64-support.md)
+- FrankenPHP (PHP embedded in Caddy) — [tracing/frankenphp.md](tracing/frankenphp.md)
 
 ## Internals / design notes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,9 @@ For the full catalogue of tasks-and-commands, see the
 
 - **AArch64 (ARM64)** — experimental.
 - **Alpine / musl libc** — `--with-native-trace` not supported.
+- **FrankenPHP** — requires three flags up front (`--php-regex`,
+  `--libpthread-regex`, and `--target-thread-regex` when using
+  daemon/top/watch); see [tracing/frankenphp.md](tracing/frankenphp.md).
 
 ## 1. Install
 

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -107,4 +107,5 @@ the EG lookup and the phpspy launch into one command.
 - [binary-trace-format.md](binary-trace-format.md) — `.rbt` format spec, converters, `rbt:recover`
 - [advanced-capture.md](advanced-capture.md) — opcodes, native traces, JIT
 - [phpspy-hybrid.md](phpspy-hybrid.md) — phpspy as the tracer backend, ZTS-aware
+- [frankenphp.md](frankenphp.md) — profiling FrankenPHP (embedded PHP in Caddy)
 - [../inspection/trace-var-command.md](../inspection/trace-var-command.md) — attach variable values to each sample

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -1,0 +1,122 @@
+# Profiling FrankenPHP
+
+[FrankenPHP](https://frankenphp.dev/) embeds PHP inside a Caddy
+(Go) web server. A FrankenPHP process is a single OS process with
+many threads: Caddy's Go runtime threads (the majority) plus a
+handful of PHP worker threads that actually host the Zend VM.
+reli can profile FrankenPHP, but three things differ from a vanilla
+`php` target:
+
+1. PHP is loaded as `libphp.so`, not as the main binary.
+2. Glibc's pthread implementation lives inside `libc.so` rather
+   than a separate `libpthread.so`.
+3. Only the PHP worker threads carry valid executor globals; the
+   Go-runtime TIDs have no PHP state.
+
+The three CLI flags below match those realities.
+
+## Required flags
+
+| Flag | Value | Why |
+|---|---|---|
+| `--php-regex` | `.*/libphp\.so$` | PHP is loaded as a shared library; the default (`/php$`) never matches |
+| `--libpthread-regex` | `.*/libc\.so.*` | pthread functions live in libc, not in a separate libpthread |
+| `--target-thread-regex` (daemon/top/watch) | `^php-[0-9a-f]+$` | Restricts sampling to PHP worker threads; see [Thread filtering](#thread-filtering) |
+
+## Attach by regex (recommended)
+
+`inspector:daemon` — plus the optional per-thread filter —
+discovers FrankenPHP workers automatically and skips Caddy / Go
+runtime threads:
+
+```bash
+sudo php ./reli inspector:daemon \
+    -P frankenphp \
+    --target-thread-regex='^php-[0-9a-f]+$' \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*' \
+    -F rbt -o ./traces/
+```
+
+The same flags work with `inspector:top` for a live view and with
+`inspector:watch --target-regex=...` for triggered captures.
+
+## Attach to a single worker
+
+`inspector:trace -p <pid>` expects the PID/TID of a thread that
+already carries PHP executor globals. For FrankenPHP, pass the
+worker TID, not the Caddy parent PID:
+
+```bash
+# List PHP worker threads by name
+ps -L -p "$(pgrep -o frankenphp)" -o tid,comm | awk '$2 ~ /^php-/'
+#   12345 php-0
+#   12346 php-1
+
+sudo php ./reli inspector:trace -p 12345 \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*'
+```
+
+`--target-thread-regex` is not honoured by `inspector:trace`: the
+single-process mode samples exactly the TID you pass in, so choose
+the worker up front.
+
+## Thread filtering
+
+FrankenPHP names its PHP worker threads via `prctl(PR_SET_NAME)`
+as `php-<hex-index>` (`php-0`, `php-1`, `php-1a`, …). reli reads
+`/proc/<tid>/comm` and, when `--target-thread-regex` is set, only
+considers matching TIDs as trace targets.
+
+Without `--target-thread-regex` the daemon still works — every
+non-PHP TID is tried once and then marked invalid via the binary
+analysis cache — but:
+
+- The first pass over a fresh FrankenPHP process pays a full TLS
+  brute-force scan per Go-runtime thread before giving up.
+- `debug`-level logs fill with "error on analyzing php binary"
+  lines for every non-PHP thread.
+
+`--target-thread-regex='^php-[0-9a-f]+$'` avoids both.
+
+## Memory and watch commands
+
+`inspector:memory`, `inspector:memory:dump`, `inspector:sidecar`,
+and `inspector:watch -p <pid>` also need a PHP worker TID, not the
+parent PID:
+
+```bash
+sudo php ./reli inspector:memory:dump -p "$(
+    ps -L -p "$(pgrep -o frankenphp)" -o tid=,comm= |
+        awk '$2 ~ /^php-/ {print $1; exit}'
+)" \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*' \
+    -o ./frankenphp.rmem
+```
+
+## Caveats
+
+- **Thread name as identifier is an internal FrankenPHP convention,
+  not a stable interface.** `php-%PRIxPTR` is set by
+  `set_thread_name()` in `frankenphp.c`. If upstream changes this,
+  `--target-thread-regex` needs to be adjusted accordingly.
+- **Worker threads come and go.** Idle workers may be torn down;
+  in daemon mode this is fine (they disappear from the next search
+  pass), but a long-running `inspector:trace -p <worker-tid>`
+  will fail once that TID exits. Prefer daemon mode for long
+  sessions.
+- **Target PHP must be 8.x ZTS.** FrankenPHP requires ZTS; reli's
+  ZTS TLS resolution is covered by
+  [internals/binary-analysis-cache.md](../internals/binary-analysis-cache.md).
+
+## See also
+
+- [capturing-traces.md](capturing-traces.md) — `inspector:daemon` /
+  `inspector:top` / `inspector:trace` reference
+- [../troubleshooting.md](../troubleshooting.md) — `--php-regex`
+  and other target-resolution troubleshooting
+- [../internals/binary-analysis-cache.md](../internals/binary-analysis-cache.md)
+  — how TLS offsets are cached across runs (matters for
+  FrankenPHP's first-pass cost)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@
 
 If your PHP binary uses a non-standard binary name that does not end with `/php`, use the `--php-regex` option to specify the name of the executable (or shared object) that contains the PHP interpreter.
 
+For FrankenPHP specifically, PHP is loaded as `libphp.so` and pthread lives in `libc.so`; see [tracing/frankenphp.md](tracing/frankenphp.md) for the full set of flags (`--php-regex`, `--libpthread-regex`, `--target-thread-regex`).
+
 ## I don't think the trace is accurate.
 
 The `-S` option will give you better results. Using this option stops the execution of the target process for a moment at every sampling, but the trace obtained will be more accurate. If you don't stop the VMs from running when profiling CPU-heavy programs such as benchmarking programs, you may misjudge the bottleneck, because you will miss more VM states that transition very quickly and are not detected well.

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -120,6 +120,7 @@ final class DaemonCommand extends Command
             $my_pid,
             $no_cache,
             $get_trace_settings->needsCompilerGlobals(),
+            $daemon_settings->target_thread_regex,
         );
 
         // Pass resolved output dir to workers (not the raw user path)

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -121,6 +121,8 @@ final class TopLikeCommand extends Command
             $target_php_settings,
             $my_pid,
             $no_cache,
+            needs_compiler_globals: false,
+            thread_name_regex: $daemon_settings->target_thread_regex,
         );
 
         $worker_pool = WorkerPool::create(

--- a/src/Command/Inspector/WatchCommand.php
+++ b/src/Command/Inspector/WatchCommand.php
@@ -701,6 +701,8 @@ final class WatchCommand extends Command
             $target_php_settings,
             $my_pid,
             $no_cache,
+            needs_compiler_globals: false,
+            thread_name_regex: $daemon_settings->target_thread_regex,
         );
 
         // Create watch worker pool (WatchTriggerMessage-based)

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -98,6 +98,8 @@ final class PhpSpyDaemonCommand extends Command
             $target_php_settings,
             $my_pid,
             $no_cache,
+            needs_compiler_globals: false,
+            thread_name_regex: $daemon_settings->target_thread_regex,
         );
 
         $interrupted = false;

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherController.php
@@ -46,7 +46,10 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
         $this->auto_context_recovering->getContext()->start();
     }
 
-    /** @param non-empty-string $regex */
+    /**
+     * @param non-empty-string $regex
+     * @param non-empty-string|null $thread_name_regex
+     */
     #[\Override]
     public function sendTarget(
         string $regex,
@@ -54,6 +57,7 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
         int $pid,
         bool $no_cache = false,
         bool $needs_compiler_globals = false,
+        ?string $thread_name_regex = null,
     ): void {
         $message = new TargetPhpSettingsMessage(
             $regex,
@@ -61,6 +65,7 @@ final class PhpSearcherController implements PhpSearcherControllerInterface
             $pid,
             $no_cache,
             $needs_compiler_globals,
+            $thread_name_regex,
         );
         $this->auto_context_recovering->withAutoRecover(
             function (PhpSearcherControllerProtocolInterface $protocol) use ($message) {

--- a/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
+++ b/src/Inspector/Daemon/Searcher/Controller/PhpSearcherControllerInterface.php
@@ -20,13 +20,17 @@ interface PhpSearcherControllerInterface
 {
     public function start(): void;
 
-    /** @param non-empty-string $regex */
+    /**
+     * @param non-empty-string $regex
+     * @param non-empty-string|null $thread_name_regex
+     */
     public function sendTarget(
         string $regex,
         TargetPhpSettings $target_php_settings,
         int $pid,
         bool $no_cache = false,
         bool $needs_compiler_globals = false,
+        ?string $thread_name_regex = null,
     ): void;
 
     public function receivePidList(): UpdateTargetProcessMessage;

--- a/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
+++ b/src/Inspector/Daemon/Searcher/Protocol/Message/TargetPhpSettingsMessage.php
@@ -27,6 +27,8 @@ final class TargetPhpSettingsMessage
      *     static::/func_static:: scopes) requires CG. When false, the
      *     searcher skips the extra lookup and TargetProcessDescriptor's
      *     cg_address stays 0.
+     * @param non-empty-string|null $thread_name_regex optional per-thread
+     *     filter matched against /proc/<tid>/comm; see DaemonSettings.
      */
     public function __construct(
         public string $regex,
@@ -34,6 +36,7 @@ final class TargetPhpSettingsMessage
         public int $parent_pid,
         public bool $no_cache = false,
         public bool $needs_compiler_globals = false,
+        public ?string $thread_name_regex = null,
     ) {
     }
 }

--- a/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
+++ b/src/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPoint.php
@@ -50,7 +50,8 @@ final class PhpSearcherEntryPoint implements WorkerEntryPointInterface
         while ($this->loop_condition->shouldContinue()) {
             $searched_pids = array_diff(
                 $this->process_searcher->searchByRegex(
-                    $target_php_settings_message->regex
+                    $target_php_settings_message->regex,
+                    $target_php_settings_message->thread_name_regex,
                 ),
                 [
                     ...$this->thread_enumerator->getThreadIds(

--- a/src/Inspector/Settings/DaemonSettings/DaemonSettings.php
+++ b/src/Inspector/Settings/DaemonSettings/DaemonSettings.php
@@ -15,10 +15,19 @@ namespace Reli\Inspector\Settings\DaemonSettings;
 
 final class DaemonSettings
 {
-    /** @param non-empty-string $target_regex */
+    /**
+     * @param non-empty-string $target_regex
+     * @param non-empty-string|null $target_thread_regex optional per-thread
+     *     filter, matched against /proc/<tid>/comm of each TID under a
+     *     matching PID. Intended for ZTS targets where only named worker
+     *     threads run the PHP VM (e.g. FrankenPHP names its workers
+     *     `php-<hex>` via prctl(PR_SET_NAME)); setting
+     *     `^php-[0-9a-f]+$` then skips the Caddy/Go runtime threads.
+     */
     public function __construct(
         public string $target_regex,
-        public int $threads
+        public int $threads,
+        public ?string $target_thread_regex = null,
     ) {
     }
 }

--- a/src/Inspector/Settings/DaemonSettings/DaemonSettingsException.php
+++ b/src/Inspector/Settings/DaemonSettings/DaemonSettingsException.php
@@ -20,10 +20,12 @@ final class DaemonSettingsException extends InspectorSettingsException
     public const THREADS_IS_NOT_INTEGER = 1;
     public const TARGET_REGEX_IS_NOT_STRING = 2;
     public const TARGET_REGEX_IS_NOT_SPECIFIED = 3;
+    public const TARGET_THREAD_REGEX_IS_NOT_STRING = 4;
 
     protected const array ERRORS = [
         self::THREADS_IS_NOT_INTEGER => 'threads is not integer',
         self::TARGET_REGEX_IS_NOT_STRING => 'target-regex is not string',
         self::TARGET_REGEX_IS_NOT_SPECIFIED => 'target-regex is not specified',
+        self::TARGET_THREAD_REGEX_IS_NOT_STRING => 'target-thread-regex is not a non-empty string',
     ];
 }

--- a/src/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInput.php
@@ -42,6 +42,13 @@ final class DaemonSettingsFromConsoleInput
                 InputOption::VALUE_OPTIONAL,
                 'number of workers (default: 8)'
             )
+            ->addOption(
+                'target-thread-regex',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'regex matched against /proc/<tid>/comm to restrict which threads of a matching'
+                . ' process get traced (e.g. "^php-[0-9a-f]+$" for FrankenPHP worker threads)'
+            )
         ;
     }
 
@@ -69,6 +76,17 @@ final class DaemonSettingsFromConsoleInput
             );
         }
 
-        return new DaemonSettings('{' . $target_regex . '}', $threads);
+        $target_thread_regex_option = $input->getOption('target-thread-regex');
+        $target_thread_regex = null;
+        if (!is_null($target_thread_regex_option)) {
+            if (!is_string($target_thread_regex_option) || $target_thread_regex_option === '') {
+                throw DaemonSettingsException::create(
+                    DaemonSettingsException::TARGET_THREAD_REGEX_IS_NOT_STRING
+                );
+            }
+            $target_thread_regex = '{' . $target_thread_regex_option . '}';
+        }
+
+        return new DaemonSettings('{' . $target_regex . '}', $threads, $target_thread_regex);
     }
 }

--- a/src/Lib/Process/ProcFileSystem/ThreadNameReader.php
+++ b/src/Lib/Process/ProcFileSystem/ThreadNameReader.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\ProcFileSystem;
+
+final class ThreadNameReader
+{
+    public function read(int $tid): ?string
+    {
+        $raw = @file_get_contents("/proc/{$tid}/comm");
+        if ($raw === false) {
+            return null;
+        }
+        return rtrim($raw, "\n");
+    }
+}

--- a/src/Lib/Process/Search/ProcessSearcher.php
+++ b/src/Lib/Process/Search/ProcessSearcher.php
@@ -16,32 +16,49 @@ namespace Reli\Lib\Process\Search;
 use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\Process\ProcFileSystem\CommandLineEnumerator;
 use Reli\Lib\Process\ProcFileSystem\ThreadEnumerator;
+use Reli\Lib\Process\ProcFileSystem\ThreadNameReader;
 
 final class ProcessSearcher implements ProcessSearcherInterface
 {
     public function __construct(
         private FileReaderInterface $file_reader,
         private ThreadEnumerator $thread_enumerator,
+        private ThreadNameReader $thread_name_reader = new ThreadNameReader(),
     ) {
     }
 
     /**
      * @param non-empty-string $regex
+     * @param non-empty-string|null $thread_name_regex
      * @return int[]
      */
     #[\Override]
-    public function searchByRegex(string $regex): array
+    public function searchByRegex(string $regex, ?string $thread_name_regex = null): array
     {
         $result = [];
 
         foreach (new CommandLineEnumerator($this->file_reader) as $pid => $command_line) {
-            if (preg_match($regex, $command_line)) {
-                $result = \array_merge($result, iterator_to_array(
-                    $this->thread_enumerator->getThreadIds($pid)
-                ));
+            if (!preg_match($regex, $command_line)) {
+                continue;
+            }
+            foreach ($this->thread_enumerator->getThreadIds($pid) as $tid) {
+                if ($thread_name_regex !== null && !$this->threadNameMatches($tid, $thread_name_regex)) {
+                    continue;
+                }
+                $result[] = $tid;
             }
         }
 
         return $result;
+    }
+
+    /** @param non-empty-string $regex */
+    private function threadNameMatches(int $tid, string $regex): bool
+    {
+        $comm = $this->thread_name_reader->read($tid);
+        if ($comm === null) {
+            return false;
+        }
+        return preg_match($regex, $comm) === 1;
     }
 }

--- a/src/Lib/Process/Search/ProcessSearcherInterface.php
+++ b/src/Lib/Process/Search/ProcessSearcherInterface.php
@@ -17,7 +17,12 @@ interface ProcessSearcherInterface
 {
     /**
      * @param non-empty-string $regex
+     * @param non-empty-string|null $thread_name_regex optional per-thread
+     *     filter matched against /proc/<tid>/comm. TIDs whose comm does not
+     *     match are skipped; useful for targets like FrankenPHP where the
+     *     PHP VM only lives on pthread-named worker threads (`php-<hex>`)
+     *     and most other TIDs are Go runtime threads without PHP state.
      * @return int[]
      */
-    public function searchByRegex(string $regex): array;
+    public function searchByRegex(string $regex, ?string $thread_name_regex = null): array;
 }

--- a/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
+++ b/tests/Inspector/Daemon/Searcher/Worker/PhpSearcherEntryPointTest.php
@@ -54,7 +54,7 @@ class PhpSearcherEntryPointTest extends BaseTestCase
             )
             ->once();
         $process_searcher = Mockery::mock(ProcessSearcherInterface::class);
-        $process_searcher->expects()->searchByRegex('regex_to_search_process');
+        $process_searcher->expects()->searchByRegex('regex_to_search_process', null);
         $process_descriptor_retriever = Mockery::mock(ProcessDescriptorRetriever::class);
 
         $entry_point = new PhpSearcherEntryPoint(

--- a/tests/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/DaemonSettings/DaemonSettingsFromConsoleInputTest.php
@@ -24,10 +24,33 @@ class DaemonSettingsFromConsoleInputTest extends BaseTestCase
         $input = Mockery::mock(InputInterface::class);
         $input->expects()->getOption('threads')->andReturns(4);
         $input->expects()->getOption('target-regex')->andReturns('regex');
+        $input->expects()->getOption('target-thread-regex')->andReturns(null);
         $settings = (new DaemonSettingsFromConsoleInput())->createSettings($input);
 
         $this->assertSame('{regex}', $settings->target_regex);
         $this->assertSame(4, $settings->threads);
+        $this->assertNull($settings->target_thread_regex);
+    }
+
+    public function testFromConsoleInputWithTargetThreadRegex(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('threads')->andReturns(4);
+        $input->expects()->getOption('target-regex')->andReturns('regex');
+        $input->expects()->getOption('target-thread-regex')->andReturns('^php-[0-9a-f]+$');
+        $settings = (new DaemonSettingsFromConsoleInput())->createSettings($input);
+
+        $this->assertSame('{^php-[0-9a-f]+$}', $settings->target_thread_regex);
+    }
+
+    public function testFromConsoleInputTargetThreadRegexNotString(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('threads')->andReturns(4);
+        $input->expects()->getOption('target-regex')->andReturns('regex');
+        $input->expects()->getOption('target-thread-regex')->andReturns(1);
+        $this->expectException(DaemonSettingsException::class);
+        (new DaemonSettingsFromConsoleInput())->createSettings($input);
     }
 
     public function testFromConsoleInputTargetRegexNotSpecified(): void

--- a/tests/Lib/Process/ProcFileSystem/ThreadNameReaderTest.php
+++ b/tests/Lib/Process/ProcFileSystem/ThreadNameReaderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Process\ProcFileSystem;
+
+use Reli\BaseTestCase;
+
+class ThreadNameReaderTest extends BaseTestCase
+{
+    public function testReadReturnsCurrentProcessComm(): void
+    {
+        $reader = new ThreadNameReader();
+        $pid = getmypid();
+        $this->assertNotFalse($pid);
+
+        $expected = trim((string)file_get_contents("/proc/{$pid}/comm"));
+        $this->assertSame($expected, $reader->read($pid));
+    }
+
+    public function testReadReturnsNullForNonexistentTid(): void
+    {
+        $reader = new ThreadNameReader();
+        $this->assertNull($reader->read(0));
+    }
+}

--- a/tests/Lib/Process/Search/ProcessSearcherTest.php
+++ b/tests/Lib/Process/Search/ProcessSearcherTest.php
@@ -62,4 +62,68 @@ class ProcessSearcherTest extends BaseTestCase
             $searcher->searchByRegex('/test_ProcessSearcherTest/')
         );
     }
+
+    public function testThreadNameFilterMatches(): void
+    {
+        $this->child = proc_open(
+            [
+                PHP_BINARY,
+                '-r',
+                'fputs(STDOUT, "test_ProcessSearcherTest`\n");fgets(STDIN);'
+            ],
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w'],
+            ],
+            $pipes
+        );
+        fgets($pipes[1]);
+        $child_status = proc_get_status($this->child);
+        $child_pid = $child_status['pid'];
+
+        $comm = trim((string)file_get_contents("/proc/{$child_pid}/comm"));
+
+        $searcher = new ProcessSearcher(
+            new NativeFileReader(),
+            new ThreadEnumerator(),
+        );
+        $this->assertSame(
+            [$child_pid],
+            $searcher->searchByRegex(
+                '/test_ProcessSearcherTest/',
+                '{^' . preg_quote($comm, '}') . '$}'
+            )
+        );
+    }
+
+    public function testThreadNameFilterExcludes(): void
+    {
+        $this->child = proc_open(
+            [
+                PHP_BINARY,
+                '-r',
+                'fputs(STDOUT, "test_ProcessSearcherTest`\n");fgets(STDIN);'
+            ],
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w'],
+            ],
+            $pipes
+        );
+        fgets($pipes[1]);
+
+        $searcher = new ProcessSearcher(
+            new NativeFileReader(),
+            new ThreadEnumerator(),
+        );
+        $this->assertSame(
+            [],
+            $searcher->searchByRegex(
+                '/test_ProcessSearcherTest/',
+                '{^reli-thread-name-should-never-match$}'
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds support for filtering threads by their `/proc/<tid>/comm` name, enabling reli to profile FrankenPHP and other ZTS targets where only named worker threads run the PHP VM while other threads (e.g., Go runtime threads in FrankenPHP) lack PHP state.

## Key Changes

- **New `ThreadNameReader` class** — reads thread names from `/proc/<tid>/comm` to identify PHP worker threads
- **Extended `ProcessSearcher`** — adds optional `thread_name_regex` parameter to filter TIDs by their comm name, skipping non-PHP threads
- **New `--target-thread-regex` CLI option** — allows users to specify a regex pattern (e.g., `^php-[0-9a-f]+$` for FrankenPHP) to restrict sampling to matching threads
- **Updated daemon/searcher infrastructure** — propagates thread name regex through `DaemonSettings`, `PhpSearcherController`, and worker entry points
- **Comprehensive documentation** — new `docs/tracing/frankenphp.md` guide covering FrankenPHP-specific setup, required flags, and caveats
- **Test coverage** — added tests for thread name matching and filtering behavior

## Implementation Details

- Thread name filtering is optional and backward-compatible (defaults to `null`)
- The regex is matched against the full comm string read from `/proc/<tid>/comm`
- Invalid TIDs (where comm cannot be read) are silently skipped
- When `--target-thread-regex` is not specified, the daemon still works but may perform unnecessary TLS brute-force scans on non-PHP threads
- Updated troubleshooting and getting-started documentation with FrankenPHP references

https://claude.ai/code/session_01E2GouNJy6ffoBGypiF4Ngf