### PR TITLE
rmem:explore: expand truncated source path on hover (experimental)

### DIFF
--- a/src/Rbt/Explore/MouseEvent.php
+++ b/src/Rbt/Explore/MouseEvent.php
@@ -18,6 +18,10 @@ namespace Reli\Rbt\Explore;
  *
  * SGR format: \e[<Cb;Cx;CyM  (press) or \e[<Cb;Cx;Cym (release)
  * where Cb = button flags, Cx = 1-based column, Cy = 1-based row.
+ *
+ * With mode 1003 (any-motion tracking) enabled on top, mouse motion
+ * without any button held also arrives here — recognisable by
+ * `drag=true` together with `button=BUTTON_NONE`.
  */
 final class MouseEvent
 {
@@ -35,7 +39,19 @@ final class MouseEvent
         public readonly bool $press,
         public readonly bool $drag,
         public readonly bool $shift = false,
+        public readonly bool $ctrl = false,
     ) {
+    }
+
+    /**
+     * Convenience: the event is "hover" — motion without any button
+     * held down — if the motion bit is set and the button field is
+     * BUTTON_NONE. With mode 1002 only (drag-tracking) we never see
+     * these; mode 1003 (any-motion) emits them on every pixel move.
+     */
+    public function isHover(): bool
+    {
+        return $this->drag && $this->button === self::BUTTON_NONE;
     }
 
     /**
@@ -55,9 +71,10 @@ final class MouseEvent
         $press = $m[4] === 'M';
 
         $shift = ($cb & 4) !== 0;
+        $ctrl = ($cb & 16) !== 0;
         $drag = ($cb & 32) !== 0;
         $button = $cb & ~(4 | 8 | 16 | 32);
 
-        return new self($button, $col, $row, $press, $drag, $shift);
+        return new self($button, $col, $row, $press, $drag, $shift, $ctrl);
     }
 }

--- a/src/Rbt/Explore/Terminal.php
+++ b/src/Rbt/Explore/Terminal.php
@@ -102,8 +102,14 @@ final class Terminal implements TerminalInterface
         // Alt screen on, hide cursor, enable SGR mouse tracking.
         // ?1000h = basic press/release tracking
         // ?1002h = button-motion (drag) tracking
+        // ?1003h = any-motion tracking (hover, motion without button)
         // ?1006h = SGR extended coordinates (no 223-column limit)
-        $this->write("\e[?1049h\e[?25l\e[?1000h\e[?1002h\e[?1006h");
+        //
+        // Consumers that don't care about hover (e.g. rbt:explore) just
+        // ignore motion-only events in their dispatcher — safer than
+        // toggling ?1003h per-TUI and risking leaving it on during an
+        // error exit.
+        $this->write("\e[?1049h\e[?25l\e[?1000h\e[?1002h\e[?1003h\e[?1006h");
 
         $this->entered = true;
     }
@@ -117,7 +123,7 @@ final class Terminal implements TerminalInterface
         $this->entered = false;
 
         // Disable mouse tracking, show cursor, leave alt screen.
-        $this->write("\e[?1006l\e[?1002l\e[?1000l\e[?25h\e[?1049l");
+        $this->write("\e[?1006l\e[?1003l\e[?1002l\e[?1000l\e[?25h\e[?1049l");
 
         if ($this->stty_orig !== null) {
             $this->applyStty($this->stty_orig);

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -149,9 +149,37 @@ final class RmemExploreTui
      *  root step can navigate to it. */
     private array $sidebarPathMap = [];
 
+    /**
+     * Sidebar line index (within `$allSidebarLines`, i.e. before
+     * `$sidebarScroll` is applied) → the full pre-wrap text of the
+     * source/defined/held-by line that occupies that row. Populated
+     * by buildSidebarLines so the hover overlay can redisplay the
+     * full "source: /long/path:line" on a single row when the mouse
+     * lingers on it — long paths normally get $wrap()-ed across
+     * multiple rows which breaks terminals' file:line pattern
+     * matcher.
+     *
+     * @var array<int,string>
+     */
+    private array $sidebarHoverOverlay = [];
+
+    /**
+     * The (pre-scroll) sidebar line index currently being hovered,
+     * or null if the pointer is elsewhere. Kept so the render loop
+     * can fold the overlay into the $body string — changes here
+     * force a repaint automatically.
+     */
+    private ?int $hoveredSidebarIndex = null;
+
     /** Leftmost 1-based terminal column occupied by the sidebar at
      *  the last render (0 if the sidebar is hidden). */
     private int $sidebarStartCol = 0;
+
+    /** Total columns / rows captured by the last render call, used
+     *  by the motion-event hit-test so it doesn't have to re-query
+     *  the terminal for every hover sample. */
+    private int $lastRenderCols = 0;
+    private int $lastRenderRows = 0;
 
     /**
      * Write end of a pipe to a sidecar process (the --http-bridge child).
@@ -679,6 +707,13 @@ final class RmemExploreTui
      */
     private function handleMouseEvent(MouseEvent $mouse): void
     {
+        // Any-motion events (mode 1003) arrive with press=true, drag=true,
+        // and button=BUTTON_NONE. Route them to the hover tracker instead
+        // of falling through to the click handler.
+        if ($mouse->isHover()) {
+            $this->updateHoverFromMotion($mouse);
+            return;
+        }
         if (!$mouse->press || $mouse->drag) {
             return;
         }
@@ -744,6 +779,39 @@ final class RmemExploreTui
         if ($isDouble) {
             $this->lastClickTime = 0.0; // consume, prevent triple-click repeat
             $this->enter();
+        }
+    }
+
+    /**
+     * Translate a motion event into a sidebar hover overlay decision.
+     *
+     * Outside the sidebar column range → clear hover. Over a sidebar
+     * row that carries an overlay entry → set hover to that
+     * (post-scroll-adjusted) all-sidebar index. Elsewhere on the
+     * sidebar → clear hover. We leave it to `render()` to fold the
+     * result into the `$body` string, so the natural diff-against-
+     * last-rendered check triggers a repaint only when the hover
+     * outcome actually changed.
+     */
+    private function updateHoverFromMotion(MouseEvent $mouse): void
+    {
+        $newHover = null;
+        if (
+            $this->sidebarStartCol > 0
+            && $mouse->col >= $this->sidebarStartCol
+        ) {
+            // sidebar rows are painted at terminal row = visibleIdx + 2,
+            // where visibleIdx is 0-based into the post-scroll slice.
+            $visibleIdx = $mouse->row - 2;
+            if ($visibleIdx >= 0) {
+                $allIdx = $visibleIdx + $this->sidebarScroll;
+                if (isset($this->sidebarHoverOverlay[$allIdx])) {
+                    $newHover = $allIdx;
+                }
+            }
+        }
+        if ($newHover !== $this->hoveredSidebarIndex) {
+            $this->hoveredSidebarIndex = $newHover;
         }
     }
 
@@ -1675,7 +1743,14 @@ final class RmemExploreTui
             $lines[$lastIdx] .= "  \e[33m[filter: {$this->filterPattern}]\e[0m";
         }
 
-        $body = implode("\n", array_slice($lines, 1)) . $sidebarBuf;
+        // Stash terminal size so motion-event hit-tests don't have to
+        // reprobe the tty per hover sample.
+        $this->lastRenderCols = $cols;
+        $this->lastRenderRows = $rows;
+
+        $hoverOverlay = $this->buildHoverOverlay($cols);
+
+        $body = implode("\n", array_slice($lines, 1)) . $sidebarBuf . $hoverOverlay;
         $header = $lines[0] ?? '';
 
         if ($body !== $this->lastRendered) {
@@ -1690,6 +1765,45 @@ final class RmemExploreTui
     }
 
     /**
+     * Build the cursor-positioning escape string that paints the
+     * hover overlay (if any) on top of the rest of the frame.
+     *
+     * When the pointer sits on a sidebar row that carries an overlay
+     * entry (source / defined / held-by), we paint the entire terminal
+     * row with the full un-wrapped text and a reverse-video style.
+     * The overlay overruns the main content area for that one row so
+     * terminals' file:line pattern matchers have a contiguous `path:line`
+     * token to recognise. Next repaint clears it naturally — the row
+     * is re-emitted from the main content buffer.
+     */
+    private function buildHoverOverlay(int $cols): string
+    {
+        if ($this->hoveredSidebarIndex === null) {
+            return '';
+        }
+        $text = $this->sidebarHoverOverlay[$this->hoveredSidebarIndex] ?? null;
+        if ($text === null) {
+            return '';
+        }
+        $visibleIdx = $this->hoveredSidebarIndex - $this->sidebarScroll;
+        if ($visibleIdx < 0) {
+            return '';
+        }
+        $row = $visibleIdx + 2; // same mapping buildSidebarLines uses
+        if ($row > $this->lastRenderRows) {
+            return '';
+        }
+        $maxWidth = $cols - 2;
+        if ($maxWidth < 8) {
+            return '';
+        }
+        if (strlen($text) > $maxWidth) {
+            $text = substr($text, 0, $maxWidth - 1) . '…';
+        }
+        return sprintf("\e[%d;1H\e[K\e[7m %s \e[27m", $row, $text);
+    }
+
+    /**
      * Build sidebar lines showing node detail + path-to-root.
      * @return list<string>
      */
@@ -1697,6 +1811,7 @@ final class RmemExploreTui
     {
         $lines = [];
         $this->sidebarPathMap = [];
+        $this->sidebarHoverOverlay = [];
         $detail = $this->model->nodeDetail($nodeId);
         $usable = $width - 2; // 1 space indent + 1 margin
 
@@ -1743,7 +1858,19 @@ final class RmemExploreTui
                 'held_by' => 'held by',
                 default => $loc['kind'],
             };
-            $wrap("{$label}: {$loc['formatted']}");
+            $full = "{$label}: {$loc['formatted']}";
+            // Record every sidebar row this wrapped line ends up
+            // occupying so the hover-overlay hit-test can paint the
+            // full text back over whichever fragment the pointer is
+            // on. Terminals' file:line pattern matchers need the
+            // whole `path:line` on one row to trigger, and the
+            // wrapped fragments alone don't qualify.
+            $firstIdx = count($lines);
+            $wrap($full);
+            $lastIdx = count($lines) - 1;
+            for ($li = $firstIdx; $li <= $lastIdx; $li++) {
+                $this->sidebarHoverOverlay[$li] = $full;
+            }
         }
         foreach ($detail['attributes'] as $key => $val) {
             // filename / line_start / line_end / lineno are already

--- a/tests/Rbt/Explore/MouseEventTest.php
+++ b/tests/Rbt/Explore/MouseEventTest.php
@@ -120,4 +120,57 @@ class MouseEventTest extends BaseTestCase
         $this->assertNull(MouseEvent::tryParse("\e[<0;10M"));
         $this->assertNull(MouseEvent::tryParse("\e[<;10;5M"));
     }
+
+    public function testParseCtrlModifier(): void
+    {
+        // Ctrl adds bit 4 (16). Left click + ctrl = 0 + 16 = 16.
+        $event = MouseEvent::tryParse("\e[<16;10;5M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_LEFT, $event->button);
+        $this->assertTrue($event->ctrl);
+        $this->assertFalse($event->shift);
+        $this->assertFalse($event->drag);
+    }
+
+    public function testNoCtrlByDefault(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;10;5M");
+        $this->assertNotNull($event);
+        $this->assertFalse($event->ctrl);
+    }
+
+    public function testParseHoverMotionWithoutButton(): void
+    {
+        // Any-motion (mode 1003) emits: button=3 (none) + 32 (motion) = 35.
+        $event = MouseEvent::tryParse("\e[<35;42;8M");
+        $this->assertNotNull($event);
+        $this->assertSame(MouseEvent::BUTTON_NONE, $event->button);
+        $this->assertTrue($event->drag);
+        $this->assertTrue($event->isHover());
+    }
+
+    public function testDragWithLeftButtonIsNotHover(): void
+    {
+        // Left button held + motion = 0 + 32 = 32.
+        $event = MouseEvent::tryParse("\e[<32;10;5M");
+        $this->assertNotNull($event);
+        $this->assertTrue($event->drag);
+        $this->assertFalse($event->isHover());
+    }
+
+    public function testPlainClickIsNotHover(): void
+    {
+        $event = MouseEvent::tryParse("\e[<0;10;5M");
+        $this->assertNotNull($event);
+        $this->assertFalse($event->isHover());
+    }
+
+    public function testCtrlPlusHoverMotion(): void
+    {
+        // Button none (3) + motion (32) + ctrl (16) = 51.
+        $event = MouseEvent::tryParse("\e[<51;42;8M");
+        $this->assertNotNull($event);
+        $this->assertTrue($event->isHover());
+        $this->assertTrue($event->ctrl);
+    }
 }


### PR DESCRIPTION
## Summary

Draft / experimental. Trying out option B from the discussion: when
the pointer lingers on one of the wrapped `source:` / `defined:` /
`held by:` rows in the rmem:explore sidebar, paint a single-row
overlay across the full terminal width with the un-wrapped
`source: /full/path:line` text. Terminals' file:line pattern
matchers then see a contiguous token they can latch onto; users on
terminals like PhpStorm's JediTerm can then Shift+Click (or
whatever bypass modifier their terminal uses) to let the terminal
jump to the file.

## Mechanics

- `Terminal::enter()` now also emits `\e[?1003h` so the TUI sees
  motion events, not just drag. `leave()` emits the matching `?1003l`.
  `rbt:explore` ignores motion events already (dispatcher acts only
  on press + `BUTTON_LEFT`), so the extra traffic is inert there.
- `MouseEvent` gains a `$ctrl` flag and an `isHover()` shorthand —
  `drag && button == BUTTON_NONE`, which is the mode-1003 signature
  for bare motion.
- `RmemExploreTui::buildSidebarLines()` records, per wrapped
  source-location fragment row, the full un-wrapped text. A motion
  event landing on one of those rows stashes the row index in
  `$hoveredSidebarIndex`.
- `render()` folds the overlay into the `$body` diff key, so the
  existing "body unchanged → no repaint" short-circuit naturally
  coalesces rapid intra-row motion; only crossings into / out of a
  hoverable row trigger a redraw.

## Test plan

- [x] `phpcs --standard=./phpcs.xml -n -q ./src ./tests` — exit 0
- [x] `psalm.phar --no-progress --show-info=false` — no errors
- [x] `phpunit tests/Rmem tests/Rbt tests/Lib --exclude-group target-version` — 1128 tests, 53302 assertions, only the pre-existing 3 env-dependent failures (FrankenPHP × 2, mod_php × 1)
- [x] New `MouseEvent` unit coverage: Ctrl modifier parsing, hover motion (`button=none + drag`), hover with Ctrl, drag-with-button is *not* hover, plain click is *not* hover.
- [ ] Manual TUI sanity — hover a wrapped `source:` row in rmem:explore:
  - overlay appears with the full path + line on a single reverse-video row
  - moving off returns to the normal wrapped layout
  - rapid motion within the same hover row does not repaint the frame
  - Shift+Click on the overlay lets PhpStorm / GNOME Terminal's own jump-to-file fire
  - `rbt:explore` is unchanged despite the new `?1003h` traffic

## Known quirks / follow-ups

- Mode 1003 makes the terminal stream motion events continuously
  while the TUI runs. The render-diff short-circuit absorbs
  most of them, but on a very slow pty with a large snapshot the
  extra events could still be felt. Easy follow-up: drain motion
  events from the input queue before calling `render()` so only
  the latest position is used.
- The overlay always paints full-width, including over the main
  content pane; next natural repaint restores it. If future work
  wants a less intrusive surface (e.g. a floating "tooltip row"
  that doesn't cover list content), the hook is `buildHoverOverlay()`.

https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw)_