### PR TITLE
rmem:explore: resolve defined_at on definition wrappers via their class_entry / op_array child

### DIFF
--- a/src/Rmem/Explore/RmemModel.php
+++ b/src/Rmem/Explore/RmemModel.php
@@ -1005,11 +1005,47 @@ final class RmemModel
     }
 
     /**
+     * Tree-link names whose target child carries the canonical
+     * "this thing was defined at" filename. ClassDefinitionContext
+     * has a `class_entry` child (a ClassEntryContext that knows
+     * the user-defined class's filename); UserFunctionDefinitionContext
+     * has an `op_array` child (a OpArrayContext with the function's
+     * file:line range). Picking these by link-name keeps the
+     * heuristic from leaking into unrelated structural children
+     * (function_table, properties_info, …) that happen to share
+     * the same parent.
+     */
+    private const DEFINING_CHILD_LINKS = ['class_entry', 'op_array'];
+
+    /**
+     * Find a child of $nodeId whose tree-link is one of the
+     * known definition-bearing names AND whose own attributes
+     * carry a filename. Returns the child node_id or null.
+     */
+    private function findDefiningChildNodeId(int $nodeId): ?int
+    {
+        foreach ($this->substrate->getChildren($nodeId) as $childId) {
+            if (!isset($this->nodeAttributes[$childId]['filename'])) {
+                continue;
+            }
+            $linkName = $this->substrate->getTreeLinkName($childId);
+            if ($linkName === null) {
+                continue;
+            }
+            if (in_array($linkName, self::DEFINING_CHILD_LINKS, true)) {
+                return $childId;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return array{filename: string, line_start: ?int, line_end: ?int, line: ?int}|null
      */
     private function resolveDefinedAt(int $nodeId): ?array
     {
-        // Cached refs short-circuit the class_entry index scan.
+        // Cached refs short-circuit both the class_entry index scan
+        // and the child-link lookup.
         if ($this->sourceLocationRefs !== null) {
             $refs = $this->sourceLocationRefs[$nodeId] ?? null;
             if ($refs !== null && $refs['defined_at'] >= 0) {
@@ -1019,16 +1055,32 @@ final class RmemModel
                 return null;
             }
         }
+
+        // Path 1: object zvals carry a class name in nodeClasses;
+        // hop through the class_entry index to the matching class
+        // definition's filename.
         $class = $this->resolveClass($nodeId);
-        if ($class === null || $class === '') {
-            return null;
+        if ($class !== null && $class !== '') {
+            $index = $this->classEntryIndex();
+            $ceNodeId = $index[$class] ?? null;
+            if ($ceNodeId !== null && $ceNodeId !== $nodeId) {
+                $loc = $this->rawSourceLocation($ceNodeId);
+                if ($loc !== null) {
+                    return $loc;
+                }
+            }
         }
-        $index = $this->classEntryIndex();
-        $ceNodeId = $index[$class] ?? null;
-        if ($ceNodeId === null || $ceNodeId === $nodeId) {
-            return null;
+
+        // Path 2: definition wrappers (ClassDefinitionContext,
+        // UserFunctionDefinitionContext) own a class_entry / op_array
+        // child that carries the filename. Surface that as
+        // defined_at so navigating onto a class_table entry shows
+        // its source line directly.
+        $childId = $this->findDefiningChildNodeId($nodeId);
+        if ($childId !== null) {
+            return $this->rawSourceLocation($childId);
         }
-        return $this->rawSourceLocation($ceNodeId);
+        return null;
     }
 
     /**
@@ -1088,14 +1140,26 @@ final class RmemModel
             }
 
             $definedAt = -1;
+            // Path 1: object zvals → class_entry via class name.
             $class = $this->resolveClass($nid);
             if ($class !== null && $class !== '') {
                 $cand = $classIndex[$class] ?? null;
-                if ($cand !== null && $cand !== $nid) {
-                    // Only record if that class_entry has a filename.
-                    if (isset($this->nodeAttributes[$cand]['filename'])) {
-                        $definedAt = $cand;
-                    }
+                if (
+                    $cand !== null
+                    && $cand !== $nid
+                    && isset($this->nodeAttributes[$cand]['filename'])
+                ) {
+                    $definedAt = $cand;
+                }
+            }
+            // Path 2: definition wrappers (ClassDefinitionContext,
+            // UserFunctionDefinitionContext) → their `class_entry`
+            // / `op_array` child carrying the filename. Mirrors the
+            // live resolveDefinedAt() fallback.
+            if ($definedAt === -1) {
+                $cand = $this->findDefiningChildNodeId($nid);
+                if ($cand !== null) {
+                    $definedAt = $cand;
                 }
             }
 

--- a/tests/Rmem/Explore/RmemModelSourceLocationTest.php
+++ b/tests/Rmem/Explore/RmemModelSourceLocationTest.php
@@ -205,6 +205,158 @@ class RmemModelSourceLocationTest extends TestCase
         $this->assertSame(5, $definedAt['line_start']);
     }
 
+    public function testDefinedAtForDefinitionWrapperWithClassEntryChild(): void
+    {
+        // Build a small graph mimicking a ClassDefinitionContext: a
+        // wrapper node with no own filename whose `class_entry`
+        // tree-link points at a ClassEntryContext that does carry one.
+        $path = tempnam(sys_get_temp_dir(), 'reli_srcloc_wrap_');
+        $rmemPath = $path . '.rmem';
+        $sink = new BinaryContextTreeSink(batch_size: 10);
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: null,
+            link_name: 'class_def',
+            type: 'ClassDefinitionContext',
+            locations: [new ZendArrayMemoryLocation(
+                address: 0x1000,
+                size: 16,
+                refcount: 1,
+                type_info: 7,
+            )],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 2,
+            parent_node_id: 1,
+            link_name: 'class_entry',
+            type: 'ClassEntryContext',
+            locations: [new ZendArrayMemoryLocation(
+                address: 0x2000,
+                size: 400,
+                refcount: 1,
+                type_info: 7,
+            )],
+            attributes: [
+                'class_name' => 'App\\Foo',
+                'filename' => '/var/www/html/src/Foo.php',
+                'line_start' => 7,
+                'line_end' => 33,
+            ],
+        );
+        $sink->emitNode(
+            node_id: 3,
+            parent_node_id: 1,
+            link_name: 'name',
+            type: 'ZendStringContext',
+            locations: [new ZendArrayMemoryLocation(
+                address: 0x3000,
+                size: 32,
+                refcount: 1,
+                type_info: 6,
+            )],
+            attributes: [],
+        );
+        $binary_output = new BinaryMemoryOutput($rmemPath);
+        $binary_output->finalizeStreaming($sink, [
+            ['zend_mm_heap_usage' => '500', 'php_version' => '8.2.0'],
+        ]);
+
+        try {
+            $reader = BinaryReader::open($rmemPath);
+            $substrate = GraphSubstrate::createFromBinary($reader, forceFfiCsr: false, skipScc: true);
+            $model = RmemModel::fromSubstrate($substrate, $reader);
+
+            $locs = $model->resolveSourceLocations(1);
+            $definedAt = null;
+            foreach ($locs as $loc) {
+                if ($loc['kind'] === 'defined_at') {
+                    $definedAt = $loc;
+                    break;
+                }
+            }
+            $this->assertNotNull(
+                $definedAt,
+                'ClassDefinitionContext should resolve defined_at via its class_entry child',
+            );
+            $this->assertSame('/var/www/html/src/Foo.php', $definedAt['filename']);
+            $this->assertSame(7, $definedAt['line_start']);
+
+            // The `name` ZendStringContext sibling has no filename
+            // and isn't on the DEFINING_CHILD_LINKS list, so the
+            // resolver must not pick it up as a defined_at hit.
+            $this->assertNull($model->resolveSourceLocation(3));
+        } finally {
+            @unlink($rmemPath);
+        }
+    }
+
+    public function testDefinedAtForDefinitionWrapperWithOpArrayChild(): void
+    {
+        // UserFunctionDefinitionContext mirrors ClassDefinitionContext
+        // but with an `op_array` child carrying the filename.
+        $path = tempnam(sys_get_temp_dir(), 'reli_srcloc_func_');
+        $rmemPath = $path . '.rmem';
+        $sink = new BinaryContextTreeSink(batch_size: 10);
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: null,
+            link_name: 'function_def',
+            type: 'UserFunctionDefinitionContext',
+            locations: [new ZendArrayMemoryLocation(
+                address: 0x1000,
+                size: 16,
+                refcount: 1,
+                type_info: 7,
+            )],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 2,
+            parent_node_id: 1,
+            link_name: 'op_array',
+            type: 'OpArrayContext',
+            locations: [new ZendArrayMemoryLocation(
+                address: 0x2000,
+                size: 100,
+                refcount: 1,
+                type_info: 7,
+            )],
+            attributes: [
+                'filename' => '/var/www/html/src/funcs.php',
+                'line_start' => 12,
+                'line_end' => 28,
+            ],
+        );
+        $binary_output = new BinaryMemoryOutput($rmemPath);
+        $binary_output->finalizeStreaming($sink, [
+            ['zend_mm_heap_usage' => '116', 'php_version' => '8.2.0'],
+        ]);
+
+        try {
+            $reader = BinaryReader::open($rmemPath);
+            $substrate = GraphSubstrate::createFromBinary($reader, forceFfiCsr: false, skipScc: true);
+            $model = RmemModel::fromSubstrate($substrate, $reader);
+
+            $locs = $model->resolveSourceLocations(1);
+            $definedAt = null;
+            foreach ($locs as $loc) {
+                if ($loc['kind'] === 'defined_at') {
+                    $definedAt = $loc;
+                    break;
+                }
+            }
+            $this->assertNotNull(
+                $definedAt,
+                'UserFunctionDefinitionContext should resolve defined_at via op_array',
+            );
+            $this->assertSame('/var/www/html/src/funcs.php', $definedAt['filename']);
+            $this->assertSame(12, $definedAt['line_start']);
+        } finally {
+            @unlink($rmemPath);
+        }
+    }
+
     public function testNodesThatOwnLocationDoNotEmitHeldBy(): void
     {
         $model = $this->createModel();


### PR DESCRIPTION
## Summary

ClassDefinitionContext and UserFunctionDefinitionContext nodes
are the wrappers in the dump that *are* the class / function
definitions, but the existing `defined_at` resolver missed them
entirely. It was tuned to hop from object zvals → class_name →
`classEntryIndex` → matching ClassEntryContext, so for the wrappers
themselves (which don't have a class_name of their own) we walked
off the end of that path and showed nothing — even though the
wrapper's `class_entry` / `op_array` child carries the filename.

After this PR a class_table entry shows its source line directly
when you focus on it, instead of leaving `defined:` blank and
forcing you to drill one level into `class_entry` to read it.

## Mechanics

Add a child-based fallback to `resolveDefinedAt()`: after the
class-name-lookup path misses, scan `getChildren($nodeId)` for a
tree-link whose name is one of `class_entry` / `op_array` and whose
attributes already carry a filename. The two link names are an
explicit allow-list so we don't pick up unrelated structural
children (function_table, properties_info, ZendString name
children, …) that happen to share the same parent.

Mirror the same logic in `buildSourceLocationRefs()` so the
derived cache (`srcloc_refs`) preserves the resolution and
subsequent sessions skip the live child scan.

## Out of scope

The reported asymmetry where some `ObjectContext` instances surface
a `→ class →` link to `ClassDefinitionContext` and others don't is
a separate phenomenon (it's the synthetic `addDefinitionLinks()` /
`findClassDef()` lookup against the class_table walk index, not the
real `defined_at` resolver). This PR doesn't change that path.

## Test plan

- [x] `phpcs --standard=./phpcs.xml -n -q ./src ./tests` — exit 0
- [x] `psalm.phar --no-progress --show-info=false` — no errors
- [x] `phpunit tests/Rmem tests/Rbt tests/Lib --exclude-group target-version` — 1130 tests, 53303 assertions, only the pre-existing 3 env-dependent failures (FrankenPHP × 2, mod_php × 1)
- [x] New unit coverage in `RmemModelSourceLocationTest`:
  - `testDefinedAtForDefinitionWrapperWithClassEntryChild` — fakes a ClassDefinitionContext with a `class_entry` child carrying a filename; asserts `defined_at` surfaces the child's source. Sibling `name` ZendStringContext is *not* picked up (link not on the allow-list).
  - `testDefinedAtForDefinitionWrapperWithOpArrayChild` — same shape but for UserFunctionDefinitionContext / `op_array`.
- [ ] Manual sanity: navigate to a class_table entry in `rmem:explore`, confirm the `defined:` line in the sidebar / banner shows the class's `file:line` directly without drilling into `class_entry`.

https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXo4QACibyKMdC8CvbBijw)_