### PR TITLE
inspector:trace: auto-select rbt format from -o *.rbt extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ A taste of what reli looks like in use. For the full walkthroughs, follow each s
 Capture to `.rbt` in one terminal while running `rbt:analyze` through `watch(1)` in another for a live-refreshing "top of the hot frames" view — the data streams in as samples are taken.
 
 ```bash
-# Terminal A — capture
-$ reli inspector:trace -p <pid> -F rbt -o trace.rbt
+# Terminal A — capture (`-F rbt` is implied by the .rbt extension)
+$ reli inspector:trace -p <pid> -o trace.rbt
 
 # Terminal B — live analysis, refreshed every 0.2 seconds
 $ watch -n0.2 'reli rbt:analyze --last --last-depth=10 --top=10 --sections="tail,self+total" --crop-anchor=right --path=short --crop=auto < trace.rbt'
@@ -35,6 +35,8 @@ $ watch -n0.2 'reli rbt:analyze --last --last-depth=10 --top=10 --sections="tail
 
 **What you're looking at.** reli is a *sampling* profiler — every ~10 ms it takes a snapshot of the target's PHP call stack. The top pane is the most recent snapshot (what the target is running *right now*). The self / total tables below rank frames by how many accumulated snapshots they've appeared in: more appearances = more wall time spent there. *Self* is time directly in the frame; *Total* is time in the frame **plus** anything it called.
 
+**Compact enough to leave running.** At default 10 ms sampling, an hour of trace is typically only a few MB of `.rbt` — interning and run-length encoding bring it down to a handful of bytes per sample, so `.rbt` files are easy to keep around, ship to a colleague, or analyse later. Capture now, dig in when you have time.
+
 Analyser reference: [docs/tracing/rbt-analyze-and-explore.md](docs/tracing/rbt-analyze-and-explore.md).
 
 ### Interactive trace browsing — `rbt:explore`
@@ -42,7 +44,7 @@ Analyser reference: [docs/tracing/rbt-analyze-and-explore.md](docs/tracing/rbt-a
 Capture to `.rbt`, open the sandwich / flamegraph / tree TUI.
 
 ```bash
-$ reli inspector:trace -p <pid> -F rbt -o trace.rbt
+$ reli inspector:trace -p <pid> -o trace.rbt
 $ reli rbt:explore trace.rbt
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | I want to... | Use | More |
 |---|---|---|
 | Attach to a running process | `inspector:trace -p <pid>` | [tracing/capturing-traces.md](tracing/capturing-traces.md) |
-| Capture to a compact binary file for later analysis **(recommended)** | `inspector:trace -p <pid> -F rbt -o trace.rbt` | [tracing/binary-trace-format.md](tracing/binary-trace-format.md) |
+| Capture to a compact binary file for later analysis **(recommended)** | `inspector:trace -p <pid> -o trace.rbt` | [tracing/binary-trace-format.md](tracing/binary-trace-format.md) |
 | Trace many processes at once (e.g. a php-fpm pool) | `inspector:daemon -P <regex>` | [tracing/capturing-traces.md](tracing/capturing-traces.md) |
 | Live `top`-style aggregation | `inspector:top -P <regex>` | [tracing/capturing-traces.md](tracing/capturing-traces.md) |
 | Include C-level frames | add `--with-native-trace` | [tracing/advanced-capture.md](tracing/advanced-capture.md) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,8 +147,8 @@ Run your workload in one terminal, attach reli from another:
 php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
-reli inspector:trace -p "$(pgrep -f your-script.php)" \
-                     -F rbt -o trace.rbt
+# (-F rbt is implied by the .rbt extension on -o)
+reli inspector:trace -p "$(pgrep -f your-script.php)" -o trace.rbt
 ```
 
 The target process must be reachable with `ptrace(2)`. Under the

--- a/docs/inspection/trace-var-command.md
+++ b/docs/inspection/trace-var-command.md
@@ -36,7 +36,8 @@ reli inspector:trace -p <pid> \
   --trace-var='memory::memory_get_peak_usage'
 
 # Binary (rbt) output — annotations ride on SAMPLE_ANNOTATION events
-reli inspector:trace -p <pid> -F rbt -o trace.rbt \
+# (-F rbt is implied by the .rbt extension on -o)
+reli inspector:trace -p <pid> -o trace.rbt \
   --trace-var='global::$counter'
 ```
 
@@ -79,7 +80,7 @@ equivalents. Available names: `memory_get_usage`, `memory_get_peak_usage`,
 For `local::` and `func_static::`, the function name is **required**; use
 `<main>` for the top-level script scope.
 
-## Output Formats
+## Annotations in each output format
 
 ### phpspy text (`-F template:phpspy`, default)
 

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -75,7 +75,7 @@ VM's opcode dispatcher.
 Capture to `.rbt` and analyse interactively:
 
 ```bash
-$ sudo php ./reli i:trace --with-native-trace -p <pid> -F rbt -o trace.rbt
+$ sudo php ./reli i:trace --with-native-trace -p <pid> -o trace.rbt
 $ ./reli rbt:explore trace.rbt
 # ...or convert to a flamegraph:
 $ ./reli converter:flamegraph <trace.rbt >flame_native.svg

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -37,7 +37,7 @@ sudo php ./reli inspector:trace -p <pid>
 
 # Capture to the compact .rbt binary format (recommended for later
 # analysis with rbt:explore / rbt:analyze / converter:*)
-sudo php ./reli inspector:trace -p <pid> -F rbt -o trace.rbt
+sudo php ./reli inspector:trace -p <pid> -o trace.rbt
 ```
 
 Useful flags:
@@ -49,6 +49,69 @@ Useful flags:
 - `-S/--stop-process` — `SIGSTOP` the target for the duration of each sample (more accurate at a higher cost)
 - `--with-native-trace`, `--native-trace-anytime` — see [advanced-capture.md](advanced-capture.md)
 - `--trace-var=…` — see [../inspection/trace-var-command.md](../inspection/trace-var-command.md)
+
+### What the output looks like
+
+Pick the format with `-F`. If `-F` is omitted, the format is chosen
+from the output destination: writing to a `.rbt` file picks the
+binary format, anything else (including stdout) falls back to the
+configured default template — phpspy text out of the box.
+
+#### Text (default: `-F template:phpspy`)
+
+One block per sample, blank-line separated. Each line is
+`<idx> <fqn> <file>:<line>`, deepest frame on top:
+
+```
+0 App\Controller::handle /app/src/Controller.php:17
+1 App\Http\Router::dispatch /app/src/Router.php:42
+2 <main> /app/public/index.php:9
+
+0 PDO::query /app/src/Db.php:142
+1 App\UserRepo::find /app/src/UserRepo.php:28
+2 App\Controller::handle /app/src/Controller.php:18
+3 App\Http\Router::dispatch /app/src/Router.php:42
+4 <main> /app/public/index.php:9
+
+```
+
+Convenient for eyeballing live and for piping into any
+phpspy-compatible tool. Note that the phpspy text format is **much
+larger** than `.rbt` for the same trace — for anything beyond a
+quick look, capture to `.rbt` instead.
+
+#### Binary (`-F rbt`, auto-selected for `-o *.rbt`)
+
+Compact append-only binary — typically a few bytes per sample after
+string interning and run-length encoding. Not human-readable;
+inspect or convert it with:
+
+```bash
+./reli rbt:explore   trace.rbt          # interactive TUI
+./reli rbt:analyze < trace.rbt          # one-shot text report
+./reli converter:phpspy < trace.rbt     # decode back to phpspy text
+./reli converter:speedscope < trace.rbt # speedscope JSON
+./reli converter:pprof < trace.rbt      # pprof
+./reli converter:flamegraph < trace.rbt # flamegraph SVG (via Brendan Gregg's tool)
+```
+
+Recommended for any capture beyond a few seconds: `.rbt` files stay
+small enough to keep around, the analysers above all expect this
+format, and every other text/visualisation format reli supports is
+reachable via `converter:*`. See [binary-trace-format.md](binary-trace-format.md)
+for the format spec.
+
+#### Choosing
+
+| Criterion | `template:phpspy` (default on stdout) | `rbt` (auto-selected for `-o *.rbt`) |
+|---|---|---|
+| File size | large (text per sample) | small (interned, RLE) |
+| Human-readable | yes | no — use `rbt:analyze` / `rbt:explore` |
+| Live tail (`tail -f`, `less`) | yes | no |
+| Works with `rbt:analyze` / `rbt:explore` | no — convert with `converter:rbt` first | yes |
+| Per-sample annotations (`--trace-var`) | yes (`#` comment lines) | yes |
+| Per-sample timestamps, segment markers | no | yes |
+| Long captures (minutes+) | not recommended | recommended |
 
 ## `inspector:daemon`
 

--- a/docs/tracing/rbt-analyze-and-explore.md
+++ b/docs/tracing/rbt-analyze-and-explore.md
@@ -24,8 +24,8 @@ Any of reli's `.rbt`-emitting modes produce input these commands can
 read:
 
 ```bash
-# inspector:trace, single .rbt file
-sudo ./reli inspector:trace -p <pid> --output-format=rbt -o trace.rbt
+# inspector:trace, single .rbt file (rbt format is auto-selected from the .rbt extension)
+sudo ./reli inspector:trace -p <pid> -o trace.rbt
 
 # inspector:daemon, one .rbt per worker
 sudo ./reli inspector:daemon -P "^php-fpm" --output-format=rbt -o /tmp/traces/

--- a/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
@@ -34,7 +34,8 @@ final class OutputSettingsFromConsoleInput
                 'output-format',
                 'F',
                 InputOption::VALUE_OPTIONAL,
-                'output format (template:phpspy|template:phpspy_with_opcode|template:json_lines|rbt|rbt-bundled)'
+                'output format (template:phpspy|template:phpspy_with_opcode|template:json_lines|rbt|rbt-bundled).'
+                . ' Default: when -o ends with .rbt, rbt is selected; otherwise the configured template (phpspy).'
             )
             ->addOption(
                 'template',
@@ -76,6 +77,19 @@ final class OutputSettingsFromConsoleInput
             }
         }
 
+        $output_path = $input->getOption('output');
+        if (!is_null($output_path) and !is_string($output_path)) {
+            throw OutputSettingsException::create(
+                OutputSettingsException::OUTPUT_IS_NOT_STRING
+            );
+        }
+
+        if ($output_format === null && is_string($output_path)) {
+            if (str_ends_with(strtolower($output_path), '.rbt')) {
+                $output_format = 'rbt';
+            }
+        }
+
         if ($output_format === null) {
             $default_template = NullableCast::toString($this->config->get('output.template.default'));
             if ($default_template !== null) {
@@ -85,13 +99,6 @@ final class OutputSettingsFromConsoleInput
                     OutputSettingsException::TEMPLATE_NOT_SPECIFIED
                 );
             }
-        }
-
-        $output_path = $input->getOption('output');
-        if (!is_null($output_path) and !is_string($output_path)) {
-            throw OutputSettingsException::create(
-                OutputSettingsException::OUTPUT_IS_NOT_STRING
-            );
         }
 
         /** @var string $rbt_timestamps */

--- a/tests/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInputTest.php
@@ -120,4 +120,82 @@ class OutputSettingsFromConsoleInputTest extends BaseTestCase
         $this->assertTrue($settings->isBinaryTraceBundled());
         $this->assertFalse($settings->isTemplate());
     }
+
+    public function testCreateSettingsAutoDetectsRbtFromOutputExtension(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('output-format')->andReturns(null);
+        $input->expects()->getOption('template')->andReturns(null);
+        $input->expects()->getOption('output')->andReturns('/tmp/trace.rbt');
+        $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
+        $config = Mockery::mock(Config::class);
+
+        $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
+        $this->assertSame('rbt', $settings->output_format);
+        $this->assertTrue($settings->isBinaryTrace());
+        $this->assertFalse($settings->isTemplate());
+        $this->assertSame('/tmp/trace.rbt', $settings->output_path);
+    }
+
+    public function testCreateSettingsAutoDetectsRbtExtensionCaseInsensitive(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('output-format')->andReturns(null);
+        $input->expects()->getOption('template')->andReturns(null);
+        $input->expects()->getOption('output')->andReturns('/tmp/Trace.RBT');
+        $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
+        $config = Mockery::mock(Config::class);
+
+        $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
+        $this->assertTrue($settings->isBinaryTrace());
+    }
+
+    public function testCreateSettingsExplicitFormatWinsOverRbtExtension(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('output-format')->andReturns('template:phpspy');
+        $input->allows()->getOption('template')->andReturns(null);
+        $input->expects()->getOption('output')->andReturns('/tmp/trace.rbt');
+        $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
+        $config = Mockery::mock(Config::class);
+
+        $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
+        $this->assertSame('template:phpspy', $settings->output_format);
+        $this->assertFalse($settings->isBinaryTrace());
+    }
+
+    public function testCreateSettingsRbtGzExtensionDoesNotAutoDetect(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('output-format')->andReturns(null);
+        $input->expects()->getOption('template')->andReturns(null);
+        $input->expects()->getOption('output')->andReturns('/tmp/trace.rbt.gz');
+        $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
+        $config = Mockery::mock(Config::class);
+        $config->expects()->get('output.template.default')->andReturns('phpspy');
+
+        $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
+        $this->assertSame('template:phpspy', $settings->output_format);
+        $this->assertFalse($settings->isBinaryTrace());
+    }
+
+    public function testCreateSettingsNonRbtExtensionFallsThroughToConfigDefault(): void
+    {
+        $input = Mockery::mock(InputInterface::class);
+        $input->expects()->getOption('output-format')->andReturns(null);
+        $input->expects()->getOption('template')->andReturns(null);
+        $input->expects()->getOption('output')->andReturns('/tmp/trace.txt');
+        $input->allows()->getOption('rbt-timestamps')->andReturns('none');
+        $input->allows()->getOption('rbt-compress')->andReturns(false);
+        $config = Mockery::mock(Config::class);
+        $config->expects()->get('output.template.default')->andReturns('phpspy');
+
+        $settings = (new OutputSettingsFromConsoleInput($config))->createSettings($input);
+        $this->assertSame('template:phpspy', $settings->output_format);
+        $this->assertFalse($settings->isBinaryTrace());
+    }
 }


### PR DESCRIPTION
## Summary

Doc-cleanup pass for 0.12.0 with one small ergonomic addition that makes the docs read more naturally:

- **`inspector:trace`/`inspector:daemon`: auto-select `rbt` when `-o` ends with `.rbt`.**
  `reli inspector:trace -p <pid> -o trace.rbt` now picks the rbt format without needing `-F rbt`. Explicit `-F` still wins; non-`.rbt` paths (and `.rbt.gz`) fall through to the configured default template (phpspy text). Help text updated.
- **`docs/tracing/capturing-traces.md`: new "What the output looks like" section.** Shows the default phpspy text shape, points the binary path through `rbt:explore` / `rbt:analyze` / `converter:*`, and gives a side-by-side "Choosing" table.
- **`docs/inspection/trace-var-command.md`: rename "Output Formats" → "Annotations in each output format".** The section content is annotation-specific; the previous title oversold what it covered.
- **`README.md`: "Compact enough to leave running" callout in the showcase.** The `.rbt` file size advantage was nowhere on the README before, even though it's a real reason to capture to `.rbt` over the phpspy text default.
- **Existing `-F rbt -o trace.rbt` examples updated to use the new shorthand** in `README.md`, `docs/README.md`, `docs/getting-started.md`, `docs/inspection/trace-var-command.md`, `docs/tracing/advanced-capture.md`, `docs/tracing/rbt-analyze-and-explore.md`. Daemon `-o <dir>/` examples are kept explicit since dir paths don't trigger the extension sniff.

## Why

Came out of a doc-organisation review for 0.12.0. The default phpspy text output is great for "what is this thing doing right now" but it's a poor match for the rest of the toolchain (`rbt:explore`, `rbt:analyze`, `converter:*` all want `.rbt`), and `capturing-traces.md` had no visible output sample at all — readers had to extrapolate. Filling that gap surfaced two related ergonomics:

1. Telling people "capture to `.rbt`" is annoying when it requires both `-F rbt` and `-o trace.rbt`. Sniffing the extension drops the `-F` redundancy without breaking any existing invocation (the path is purely additive).
2. Without a size pitch on the README, the `.rbt` story reads as "yet another format" instead of "smaller, so capture freely."

Bigger structural cleanup of the trace output pipeline (event-stream + serialiser model, `rbt-` flag prefix, etc.) is intentionally deferred to after 0.12.0.

## Test plan

- [x] `OutputSettingsFromConsoleInputTest`: 5 new cases (auto-detect, case-insensitive, explicit `-F` wins, `.rbt.gz` does **not** auto-detect, non-`.rbt` extension falls through). 12/12 pass.
- [x] All `OutputSettings` / `TraceFormatterFactory` / `TraceOutputFactory` / `TraceOutputPathResolver` tests: 21/21 pass.
- [x] `psalm` on `src/Inspector/Settings/OutputSettings/`: clean.
- [x] `phpcs --standard=PSR12` on changed source + tests: clean.
- [x] Unit suite (`--exclude-group target-version`): only pre-existing environmental failures remain (FrankenPHP / mod_php / native trace), all unrelated to this change.
- [x] Manual smoke test: `./reli inspector:trace -p <pid> -o /tmp/trace.rbt` produces a valid `.rbt` (no `-F` needed) and `./reli rbt:explore /tmp/trace.rbt` opens it.

https://claude.ai/code/session_011RZpG8hWrRCZyhnwYXxBwR

---
_Generated by [Claude Code](https://claude.ai/code/session_011RZpG8hWrRCZyhnwYXxBwR)_