### PR TITLE
Render canonical class/method/function names in report path labels (display-time)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -613,6 +613,174 @@ final class BinaryReportDataProvider
     }
 
     /**
+     * Build the `node_id => canonical class/method/function name` map for
+     * the binary path. Mirrors NodeLabeler's SQL fetch, but reads sections
+     * directly so the binary report renders the same case-preserved
+     * identifiers as the SQLite report (the
+     * `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings` parity
+     * check requires it).
+     *
+     * Walks three sections:
+     *  - `nodes` — restrict to ClassDefinitionContext /
+     *    UserFunctionDefinitionContext / InternalFunctionDefinitionContext.
+     *  - `edges` — find the `name` tree-edge from each definition node.
+     *  - `locations` — pull the `string_value_id` of the name child and
+     *    resolve via the string dict.
+     *
+     * @return array<int, string>
+     * @psalm-suppress InaccessibleMethod
+     * @psalm-suppress PossiblyNullPropertyFetch
+     * @psalm-suppress UndefinedPropertyFetch
+     * @psalm-suppress InvalidPropertyFetch
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress PossiblyInvalidArrayAccess
+     */
+    public static function loadCanonicalNames(BinaryReader $reader): array
+    {
+        if (
+            !$reader->hasSection(Format::SECTION_NODES)
+            || !$reader->hasSection(Format::SECTION_EDGES)
+            || !$reader->hasSection(Format::SECTION_LOCATIONS)
+        ) {
+            return [];
+        }
+
+        $dict = $reader->getStringDict();
+
+        $target_types = [
+            'ClassDefinitionContext' => true,
+            'UserFunctionDefinitionContext' => true,
+            'InternalFunctionDefinitionContext' => true,
+        ];
+
+        // Step 1: collect node_ids whose type is a class/function definition
+        /** @var array<int, true> $is_def_node */
+        $is_def_node = [];
+        $node_count = $reader->getSectionElementCount(Format::SECTION_NODES);
+        $nodeRows = $reader->castSection(Format::SECTION_NODES, 'NodeRow');
+        if ($nodeRows !== null) {
+            for ($i = 0; $i < $node_count; $i++) {
+                $type = $dict->lookup((int)$nodeRows[$i]->type_id);
+                if ($type !== null && isset($target_types[$type])) {
+                    $is_def_node[(int)$nodeRows[$i]->node_id] = true;
+                }
+            }
+        } else {
+            $data = $reader->getSectionData(Format::SECTION_NODES);
+            for ($i = 0; $i < $node_count; $i++) {
+                $off = $i * Format::NODE_ROW_SIZE;
+                $row = unpack('Vnode_id/Vcanonical_id/Vtype_id/Vclass_id', $data, $off);
+                $type = $dict->lookup((int)$row['type_id']);
+                if ($type !== null && isset($target_types[$type])) {
+                    $is_def_node[(int)$row['node_id']] = true;
+                }
+            }
+        }
+
+        if ($is_def_node === []) {
+            return [];
+        }
+
+        // Step 2: find 'name' tree-edges from definition nodes
+        /** @var array<int, int> def_node_id => name_child_node_id */
+        $name_child_of = [];
+        $edge_count = $reader->getSectionElementCount(Format::SECTION_EDGES);
+        $edgeRows = $reader->castSection(Format::SECTION_EDGES, 'EdgeRow');
+        if ($edgeRows !== null) {
+            for ($i = 0; $i < $edge_count; $i++) {
+                if ((int)$edgeRows[$i]->is_tree !== 1) {
+                    continue;
+                }
+                $parent = (int)$edgeRows[$i]->parent_node_id;
+                if (!isset($is_def_node[$parent])) {
+                    continue;
+                }
+                $link = $dict->lookup((int)$edgeRows[$i]->link_name_id);
+                if ($link === 'name') {
+                    $name_child_of[$parent] = (int)$edgeRows[$i]->child_node_id;
+                }
+            }
+        } else {
+            $data = $reader->getSectionData(Format::SECTION_EDGES);
+            for ($i = 0; $i < $edge_count; $i++) {
+                $off = $i * Format::EDGE_ROW_SIZE;
+                $row = unpack('Vparent/Vchild/Vlid/Cis_tree/Cstrength', $data, $off);
+                if ((int)$row['is_tree'] !== 1) {
+                    continue;
+                }
+                $parent = (int)$row['parent'];
+                if (!isset($is_def_node[$parent])) {
+                    continue;
+                }
+                $link = $dict->lookup((int)$row['lid']);
+                if ($link === 'name') {
+                    $name_child_of[$parent] = (int)$row['child'];
+                }
+            }
+        }
+
+        if ($name_child_of === []) {
+            return [];
+        }
+
+        // Reverse mapping for the location-pass lookup below.
+        /** @var array<int, list<int>> name_child_node_id => def node ids */
+        $defs_for_child = [];
+        foreach ($name_child_of as $def_id => $child_id) {
+            $defs_for_child[$child_id][] = $def_id;
+        }
+
+        // Step 3: resolve string_value of each name child via locations
+        /** @var array<int, string> $canonical_names */
+        $canonical_names = [];
+        $loc_count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
+        $locRows = $reader->castSection(Format::SECTION_LOCATIONS, 'LocationRow');
+        if ($locRows !== null) {
+            for ($i = 0; $i < $loc_count; $i++) {
+                $node_id = (int)$locRows[$i]->node_id;
+                if (!isset($defs_for_child[$node_id])) {
+                    continue;
+                }
+                $sv_id = (int)$locRows[$i]->string_value_id;
+                if ($sv_id === Format::NULL_STRING_ID) {
+                    continue;
+                }
+                $name = $dict->lookup($sv_id);
+                if ($name === null || $name === '') {
+                    continue;
+                }
+                foreach ($defs_for_child[$node_id] as $def_id) {
+                    $canonical_names[$def_id] = $name;
+                }
+            }
+        } else {
+            $data = $reader->getSectionData(Format::SECTION_LOCATIONS);
+            for ($i = 0; $i < $loc_count; $i++) {
+                $off = $i * Format::LOCATION_ROW_SIZE;
+                $node_id = unpack('V', $data, $off)[1];
+                if (!isset($defs_for_child[(int)$node_id])) {
+                    continue;
+                }
+                // string_value_id offset: node_id u32 + type_id u32 +
+                // class_id u32 + address u64 + size u64 = 28
+                $sv_id = unpack('V', $data, $off + 28)[1];
+                if ((int)$sv_id === Format::NULL_STRING_ID) {
+                    continue;
+                }
+                $name = $dict->lookup((int)$sv_id);
+                if ($name === null || $name === '') {
+                    continue;
+                }
+                foreach ($defs_for_child[(int)$node_id] as $def_id) {
+                    $canonical_names[$def_id] = $name;
+                }
+            }
+        }
+
+        return $canonical_names;
+    }
+
+    /**
      * Load frame labels (function_name:lineno) from the binary attributes section.
      *
      * Replaces NodeLabeler's SQL query on context_node_attributes.

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -24,12 +24,17 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
  */
 final class CallStackPass implements PassInterface
 {
-    /** @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path) */
+    /**
+     * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
+     * @param array<int, string>|null $canonical_names Pre-loaded class/
+     *     method/function canonical names (binary path)
+     */
     public function __construct(
         private \PDO $db,
         private int $run_id,
         private ?GraphSubstrate $substrate = null,
         private ?array $frame_labels = null,
+        private ?array $canonical_names = null,
     ) {
     }
 
@@ -72,7 +77,12 @@ final class CallStackPass implements PassInterface
             return [];
         }
 
-        $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
+        $labeler = new NodeLabeler(
+            $this->db,
+            $this->run_id,
+            $this->frame_labels,
+            $this->canonical_names,
+        );
         $framesByNo = [];
         foreach ($this->substrate->getChildren($callFramesNodeId) as $child_id) {
             $link_name = $this->substrate->getTreeLinkName($child_id) ?? '?';

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/ChokePointPass.php
@@ -26,6 +26,8 @@ final class ChokePointPass implements PassInterface
     /**
      * @param array<int, true>|null $objects_store_nodes Pre-computed set (binary path)
      * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
+     * @param array<int, string>|null $canonical_names Pre-loaded class/
+     *     method/function canonical names (binary path)
      */
     public function __construct(
         private GraphSubstrate $substrate,
@@ -34,6 +36,7 @@ final class ChokePointPass implements PassInterface
         private int $heap_usage = 0,
         private ?array $objects_store_nodes = null,
         private ?array $frame_labels = null,
+        private ?array $canonical_names = null,
     ) {
     }
 
@@ -119,7 +122,12 @@ final class ChokePointPass implements PassInterface
         // substrate's in-memory indexes (loadEdgesFfi / loadNodeTypesFfi),
         // so the only prepared statement left here is the loc_stmt
         // class+location_type lookup, which is called at most 10 times.
-        $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
+        $labeler = new NodeLabeler(
+            $this->db,
+            $this->run_id,
+            $this->frame_labels,
+            $this->canonical_names,
+        );
 
         $loc_stmt = null;
         if ($this->objects_store_nodes === null) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CycleClusterPass.php
@@ -24,13 +24,18 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class CycleClusterPass implements PassInterface
 {
-    /** @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path) */
+    /**
+     * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
+     * @param array<int, string>|null $canonical_names Pre-loaded class/
+     *     method/function canonical names (binary path)
+     */
     public function __construct(
         private GraphSubstrate $substrate,
         private \PDO $db,
         private int $run_id,
         private ?LinkNameResolver $link_resolver = null,
         private ?array $frame_labels = null,
+        private ?array $canonical_names = null,
     ) {
     }
 
@@ -73,7 +78,12 @@ final class CycleClusterPass implements PassInterface
         // We now look them up on demand from the shared LinkNameResolver
         // inside findBackReference itself.
         $top_groups = array_slice($groups_sorted, 0, 10);
-        $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
+        $labeler = new NodeLabeler(
+            $this->db,
+            $this->run_id,
+            $this->frame_labels,
+            $this->canonical_names,
+        );
 
         $findings = [];
         foreach ($top_groups as $g) {

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -23,12 +23,17 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class DrillDownPass implements PassInterface
 {
-    /** @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path) */
+    /**
+     * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
+     * @param array<int, string>|null $canonical_names Pre-loaded class/
+     *     method/function canonical names (binary path)
+     */
     public function __construct(
         private GraphSubstrate $substrate,
         private \PDO $db,
         private int $run_id,
         private ?array $frame_labels = null,
+        private ?array $canonical_names = null,
     ) {
     }
 
@@ -46,7 +51,12 @@ final class DrillDownPass implements PassInterface
         // issued one prepared-statement execute per depth level for
         // each, which on big dumps showed up as a small but real
         // hot spot in the trace.
-        $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
+        $labeler = new NodeLabeler(
+            $this->db,
+            $this->run_id,
+            $this->frame_labels,
+            $this->canonical_names,
+        );
 
         $path_parts = [];
         $path_types = [];

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -29,6 +29,8 @@ final class TopStringsPass implements PassInterface
     /**
      * @param list<array{node_id: int, size: int, preview: string}>|null $top_strings_data Pre-computed (binary path)
      * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
+     * @param array<int, string>|null $canonical_names Pre-loaded class/
+     *     method/function canonical names (binary path)
      */
     public function __construct(
         private \PDO $db,
@@ -36,6 +38,7 @@ final class TopStringsPass implements PassInterface
         private ?GraphSubstrate $substrate = null,
         private ?array $top_strings_data = null,
         private ?array $frame_labels = null,
+        private ?array $canonical_names = null,
     ) {
     }
 
@@ -80,7 +83,12 @@ final class TopStringsPass implements PassInterface
             ")->fetchAll(\PDO::FETCH_ASSOC);
         }
 
-        $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
+        $labeler = new NodeLabeler(
+            $this->db,
+            $this->run_id,
+            $this->frame_labels,
+            $this->canonical_names,
+        );
         $findings = [];
         foreach ($rows as $row) {
             $size = (int)$row['size'];

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -365,6 +365,7 @@ final class ReportGenerator
             // Done before forking so child workers inherit the results
             // via copy-on-write.
             $frame_labels = BinaryReportDataProvider::loadFrameLabels($reader);
+            $canonical_names = BinaryReportDataProvider::loadCanonicalNames($reader);
             $objects_store_nodes = BinaryReportDataProvider::getNodesByLocationType(
                 $reader,
                 'ObjectsStoreMemoryLocation',
@@ -381,7 +382,7 @@ final class ReportGenerator
             $dummy_db = new \PDO('sqlite::memory:');
             $dummy_db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $findings = array_merge($findings, $this->runPass(
-                new CallStackPass($dummy_db, 0, $substrate, $frame_labels)
+                new CallStackPass($dummy_db, 0, $substrate, $frame_labels, $canonical_names)
             ));
 
             // Binary passes don't share a SQLite fd, so each factory
@@ -400,7 +401,14 @@ final class ReportGenerator
                 new DynamicPropertiesPass($dummy_factory(), 0, $substrate)
             );
             $pass_factories['CycleClusterPass'] = fn (): array => $this->runPass(
-                new CycleClusterPass($substrate, $dummy_factory(), 0, $resolver_factory(), $frame_labels)
+                new CycleClusterPass(
+                    $substrate,
+                    $dummy_factory(),
+                    0,
+                    $resolver_factory(),
+                    $frame_labels,
+                    $canonical_names,
+                )
             );
             $pass_factories['PropertyScalingPass'] = fn (): array => $this->runPass(
                 new PropertyScalingPass(
@@ -422,7 +430,14 @@ final class ReportGenerator
                 new TopArraysPass($dummy_factory(), 0, $substrate, $frame_labels)
             );
             $pass_factories['TopStringsPass'] = fn (): array => $this->runPass(
-                new TopStringsPass($dummy_factory(), 0, $substrate, $top_strings, $frame_labels)
+                new TopStringsPass(
+                    $dummy_factory(),
+                    0,
+                    $substrate,
+                    $top_strings,
+                    $frame_labels,
+                    $canonical_names,
+                )
             );
             $pass_factories['NonTreeEdgePass'] = fn (): array => $this->runPass(
                 new NonTreeEdgePass($dummy_factory(), 0, $substrate, $non_tree_edge_stats)
@@ -440,7 +455,13 @@ final class ReportGenerator
                 new StructuralDedupPass($dummy_factory(), 0, $substrate, $resolver_factory())
             );
             $pass_factories['DrillDownPass'] = fn (): array => $this->runPass(
-                new DrillDownPass($substrate, $dummy_factory(), 0, $frame_labels)
+                new DrillDownPass(
+                    $substrate,
+                    $dummy_factory(),
+                    0,
+                    $frame_labels,
+                    $canonical_names,
+                )
             );
             $pass_factories['ChokePointPass'] = fn (): array => $this->runPass(
                 new ChokePointPass(
@@ -450,6 +471,7 @@ final class ReportGenerator
                     $heap_usage,
                     $objects_store_nodes,
                     $frame_labels,
+                    $canonical_names,
                 )
             );
             $pass_factories['BlameAllocationPass'] = fn (): array => $this->runPass(

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
@@ -16,28 +16,56 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
 /**
  * Resolves node IDs to human-readable labels for report output.
  *
- * Call frame numbers become "function_name:lineno",
- * objects become their short class name, etc.
+ * Handles two label sources:
+ *
+ *  1. **Call-frame labels** — `function_name:lineno` for `CallFrameContext`
+ *     nodes, derived from `context_node_attributes`.
+ *
+ *  2. **Canonical class / method / function names** — the `name` child of
+ *     `ClassDefinitionContext` / `UserFunctionDefinitionContext` /
+ *     `InternalFunctionDefinitionContext` nodes. The HashTable bucket key
+ *     that the collector emits as the link_name is case-folded
+ *     ("twig\extension\coreextension"); the canonical name lives in a
+ *     `name` child string node ("Twig\Extension\CoreExtension"). This
+ *     labeler returns the canonical form at display time without
+ *     touching the underlying substrate.
  */
 final class NodeLabeler
 {
     /** @var array<int, string> node_id => "function_name:lineno" */
     private array $frame_labels = [];
 
+    /**
+     * node_id => canonical class / method / function name. Populated for
+     * `ClassDefinitionContext` and `*FunctionDefinitionContext` nodes
+     * from their `name` string child.
+     *
+     * @var array<int, string>
+     */
+    private array $canonical_names = [];
+
     /** @var bool */
     private bool $loaded = false;
 
+    /**
+     * @param array<int, string>|null $preloaded_frame_labels Pre-loaded
+     *     frame labels (binary path).
+     * @param array<int, string>|null $preloaded_canonical_names Pre-loaded
+     *     canonical class/method/function names (binary path). When
+     *     provided, the SQL fetch is skipped.
+     */
     public function __construct(
         private ?\PDO $db,
         private int $run_id,
-        /** @var array<int, string>|null Pre-loaded frame labels (binary path) */
         private ?array $preloaded_frame_labels = null,
+        private ?array $preloaded_canonical_names = null,
     ) {
     }
 
     /**
-     * Resolve a link_name like "1" into "functionName:42" if the
-     * target node is a CallFrameContext with function_name attribute.
+     * Resolve a link_name like "1" into "functionName:42" (call frame),
+     * or a case-folded class/method/function key into its canonical name.
+     * Falls back to the raw link_name when no override is available.
      *
      * @psalm-suppress MixedArrayAccess, MixedAssignment
      */
@@ -51,6 +79,10 @@ final class NodeLabeler
             return $this->frame_labels[$child_node_id];
         }
 
+        if (isset($this->canonical_names[$child_node_id])) {
+            return $this->canonical_names[$child_node_id];
+        }
+
         return $link_name;
     }
 
@@ -62,6 +94,13 @@ final class NodeLabeler
         }
         $this->loaded = true;
 
+        $this->loadFrameLabels();
+        $this->loadCanonicalNames();
+    }
+
+    /** @psalm-suppress MixedArrayAccess, MixedAssignment */
+    private function loadFrameLabels(): void
+    {
         // Binary path: use pre-loaded frame labels
         if ($this->preloaded_frame_labels !== null) {
             $this->frame_labels = $this->preloaded_frame_labels;
@@ -100,6 +139,64 @@ final class NodeLabeler
             }
             $ln = $kvs['lineno'] ?? '';
             $this->frame_labels[$node_id] = $ln !== '' ? "{$fn}:{$ln}" : $fn;
+        }
+    }
+
+    /**
+     * Build the `node_id => canonical_name` map for class definitions and
+     * function/method definitions. The collector emits a `name` child
+     * string node alongside each definition; that string is the canonical
+     * (case-preserved) identifier the source declared.
+     *
+     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     */
+    private function loadCanonicalNames(): void
+    {
+        if ($this->preloaded_canonical_names !== null) {
+            $this->canonical_names = $this->preloaded_canonical_names;
+            return;
+        }
+
+        if ($this->db === null) {
+            return;
+        }
+
+        // The binary report path reuses NodeLabeler with a dummy
+        // in-memory PDO (no schema) and is expected to preload
+        // canonical_names instead. If preload was skipped *and* the db
+        // happens to lack the schema, fall through silently so the
+        // labeler still answers raw link_names rather than blowing up
+        // the surrounding pass.
+        try {
+            $rows = $this->db->query("
+                SELECT cn.node_id, cnl.string_value
+                FROM context_nodes cn
+                JOIN context_edges name_edge
+                    ON name_edge.parent_node_id = cn.node_id
+                    AND name_edge.run_id = cn.run_id
+                    AND name_edge.link_name = 'name'
+                    AND name_edge.is_tree = 1
+                JOIN context_node_locations cnl
+                    ON cnl.node_id = name_edge.child_node_id
+                    AND cnl.run_id = name_edge.run_id
+                    AND cnl.location_type = 'ZendStringMemoryLocation'
+                WHERE cn.run_id = {$this->run_id}
+                    AND cn.type IN (
+                        'ClassDefinitionContext',
+                        'UserFunctionDefinitionContext',
+                        'InternalFunctionDefinitionContext'
+                    )
+                    AND cnl.string_value IS NOT NULL
+                    AND cnl.string_value <> ''
+            ")->fetchAll(\PDO::FETCH_NUM);
+        } catch (\PDOException) {
+            return;
+        }
+
+        foreach ($rows as $row) {
+            $node_id = (int)$row[0];
+            $name = (string)$row[1];
+            $this->canonical_names[$node_id] = $name;
         }
     }
 }


### PR DESCRIPTION
## Summary

Re-takes B1 + G1 from PR #644 (canonical class / method / function names in path labels) using the **display-time** approach the original `memory-report-ux-improvements.md` doc proposed as fix shape (ii). The earlier emit-time attempt rewrote `link_name` at `emitNode()` — which broke PHP 8.x target-version CI in ways I could never diagnose from logs — and was reverted. This PR doesn't touch the collector or substrate at all; the case-folded HashTable bucket key still goes into the graph as before, and the canonical name only appears when a path is rendered.

## What changes

- `NodeLabeler` learns a second resolution mode. Beyond the existing `frame_labels` (call-frame → `function_name:lineno`), it now keeps a `canonical_names` map that overrides `link_name` at display time when the target node is a `ClassDefinitionContext` / `UserFunctionDefinitionContext` / `InternalFunctionDefinitionContext`. The collector already emits a `name` child string node for every such definition (long predates this PR); we just weren't reading it.
  - SQL path: a single query joining `context_nodes` (filtered by `type IN (...)`), `context_edges` (the `'name'` tree-edge), and `context_node_locations` (the string_value of the name child). Wrapped in `try/catch(\PDOException)` — the binary-report parallel runner reuses NodeLabeler with a dummy in-memory PDO with no schema, and the labeler should fall through silently in that shape rather than blow up the surrounding pass.
- `BinaryReportDataProvider::loadCanonicalNames` walks the binary `nodes` / `edges` / `locations` sections to build the same map for the binary path. This is required for parity — `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings` compares `facts.summary_path` between SQLite and binary reports, so they have to render the same identifiers.
- The five passes that build a `NodeLabeler` (`DrillDownPass`, `CallStackPass`, `CycleClusterPass`, `ChokePointPass`, `TopStringsPass`) gained a `?array $canonical_names = null` constructor parameter that they thread through. SQL paths leave it null and let the labeler do its own SQL fetch; the binary block in `ReportGenerator` calls `loadCanonicalNames` once and shares the array across the parallel workers via copy-on-write, the same way `$frame_labels` is shared.

## What's deliberately out of scope

- **No collector / substrate changes.** What the dump and analyzer write to `context_nodes` / `context_edges` is unchanged — bucket keys still go in case-folded as the structural representation. (PR #644's emit-time attempt is what broke CI; this branch avoids that surface.)
- **No `impact_bytes` semantics changes.** The `dedup_candidate` and `property_scaling` `min(total, heap_total)` clamps that landed in PR #644 are still there as a "stops the >heap-total embarrassment" safety net but as the design team noted aren't a real saving estimate. That refactor is its own follow-up.
- **`function_table` non-definition entries.** Some entries in the global function_table don't correspond to a `*FunctionDefinitionContext` node (internal builtins registered via different paths). For those, the path still shows the bucket key. The fix here covers the user-visible cases: methods inside `class_table->Class->methods->...` and user-defined functions in `function_table->`.

## Local verification

- Unit suite (`DedupCandidatePass | TextReportFormatter | StructuralDedupPass | PropertyScalingPass | NodeLabeler`): 32 tests pass.
- `testReportContainsRankingSections@v84`: passes.
- `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84`: passes. This one was the smoking gun before the binary loader landed — the SQLite report rendered `class_table->PDO->...` and the binary side rendered `class_table->pdo->...`, the assertion diff'd them.
- Full v84 target-version suite: 71 tests / 517 assertions / 1 failure / 1 warning / 1 skipped. The single failure is `testLightweightDumpSmallerThanFullShm` which also fails on `0.12.x` head in my local docker environment (139 MB > 128 MB threshold — env-specific opcache memory layout mismatch with stock `php:8.4-cli` vs CI's `reli-test-for-ci` image). Not caused by this PR.
- `psalm` + `phpcs`: clean on touched files.

## How to test

```bash
RELI_TEST_PHP_TARGETS=v84 php vendor/bin/phpunit --group target-version --filter 'MemoryReportCommandIntegrationTest'
```

Should produce 3 / 3 OK locally. Full CI matrix will exercise PHP 7.x (where canonical_names load returns nothing harmlessly because there are no class entries with the same case-folding behaviour the test expects) and PHP 8.0+ (where the previous PR #644 caught fire).

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_