### PR TITLE
Add RSS bytes capture to memory dump format (v2)

### DIFF
--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -76,13 +76,18 @@ final class MemoryDumpInspectCommand extends ReliCommand
             throw new \RuntimeException("invalid dump file: bad magic");
         }
         $format_version = $this->readUint32($fp);
-        if ($format_version !== 1) {
+        if ($format_version !== 1 && $format_version !== 2) {
             throw new \RuntimeException("unsupported dump format version: {$format_version}");
         }
         $php_version = $this->readString($fp);
         $pid = $this->readInt64($fp);
         $eg_address = $this->readInt64($fp);
         $cg_address = $this->readInt64($fp);
+        $rss_bytes = null;
+        if ($format_version >= 2) {
+            $raw = $this->readInt64($fp);
+            $rss_bytes = $raw === -1 ? null : $raw;
+        }
         $memory_map_count = $this->readUint32($fp);
         $region_count = $this->readUint32($fp);
 
@@ -93,6 +98,10 @@ final class MemoryDumpInspectCommand extends ReliCommand
         $output->writeln("  PID:              {$pid}");
         $output->writeln("  EG Address:       0x" . dechex($eg_address));
         $output->writeln("  CG Address:       0x" . dechex($cg_address));
+        $output->writeln(
+            "  RSS at dump:      "
+            . ($rss_bytes === null ? '(unavailable)' : (string)$rss_bytes . ' bytes')
+        );
         $output->writeln("  Memory Map Count: {$memory_map_count}");
         $output->writeln("  Region Count:     {$region_count}");
         $output->writeln('');

--- a/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
+++ b/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
@@ -71,6 +71,7 @@ final class MemoryDumpNormalizer
                 $header['cg_address'],
                 $memory_areas,
                 $merged,
+                $header['rss_bytes'],
             );
             rename($temp_path, $output_path);
         } catch (\Throwable $e) {
@@ -153,7 +154,8 @@ final class MemoryDumpNormalizer
     /**
      * @param resource $fp
      * @return array{pid: int, php_version: string, eg_address: int,
-     *     cg_address: int, memory_map_count: int, region_count: int}
+     *     cg_address: int, rss_bytes: int|null,
+     *     memory_map_count: int, region_count: int}
      */
     private function readHeader($fp): array
     {
@@ -162,14 +164,24 @@ final class MemoryDumpNormalizer
             throw new \RuntimeException('Invalid dump file: bad magic');
         }
         $version = $this->readUint32($fp);
-        if ($version !== 1) {
+        if ($version !== 1 && $version !== 2) {
             throw new \RuntimeException("Unsupported format version: {$version}");
         }
+        $php_version = $this->readString($fp);
+        $pid = $this->readInt64($fp);
+        $eg_address = $this->readInt64($fp);
+        $cg_address = $this->readInt64($fp);
+        $rss_bytes = null;
+        if ($version >= 2) {
+            $raw = $this->readInt64($fp);
+            $rss_bytes = $raw === -1 ? null : $raw;
+        }
         return [
-            'php_version' => $this->readString($fp),
-            'pid' => $this->readInt64($fp),
-            'eg_address' => $this->readInt64($fp),
-            'cg_address' => $this->readInt64($fp),
+            'php_version' => $php_version,
+            'pid' => $pid,
+            'eg_address' => $eg_address,
+            'cg_address' => $cg_address,
+            'rss_bytes' => $rss_bytes,
             'memory_map_count' => $this->readUint32($fp),
             'region_count' => $this->readUint32($fp),
         ];

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -21,7 +21,6 @@ use Reli\Inspector\MemoryDump\FastPath\FastPathReader;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
-use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\Result\RegionsSummary;
@@ -38,6 +37,7 @@ final class MemoryDumpReader
         private int $eg_address,
         private int $cg_address,
         private ?int $bg_address = null,
+        private ?int $rss_bytes = null,
         private ?FastPathReader $fast_path = null,
     ) {
     }
@@ -97,9 +97,6 @@ final class MemoryDumpReader
                 $collected_memories->memory_locations,
             );
 
-            $rss_reader = new RssReader();
-            $rss_bytes = $rss_reader->read($this->pid);
-
             $sink->flush();
             $region_boundaries->backfillRegions($db, $run_id);
             $_region_result = RegionsSummary::queryRegionSums($db, $run_id);
@@ -111,7 +108,7 @@ final class MemoryDumpReader
             $summary = $this->buildSummary(
                 $summary_base,
                 $collected_memories,
-                $rss_bytes,
+                $this->rss_bytes,
                 $target_php_settings,
             );
 
@@ -187,9 +184,6 @@ final class MemoryDumpReader
             $collected_memories->memory_locations,
         );
 
-        $rss_reader = new RssReader();
-        $rss_bytes = $rss_reader->read($this->pid);
-
         // Use corrected summary if region sums are available from the
         // backfilled locations. Compute region sums directly from the
         // location temp file since we don't have a SQL DB.
@@ -200,7 +194,7 @@ final class MemoryDumpReader
         $summary = $this->buildSummary(
             $summary_base,
             $collected_memories,
-            $rss_bytes,
+            $this->rss_bytes,
             $target_php_settings,
         );
 

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -116,6 +116,7 @@ final class MemoryDumpReaderFactory
             $php_version,
             $parsed['eg_address'],
             $parsed['cg_address'],
+            rss_bytes: $parsed['rss_bytes'],
             fast_path: $fast_path,
         );
     }
@@ -130,6 +131,7 @@ final class MemoryDumpReaderFactory
      *     php_version: string,
      *     eg_address: int,
      *     cg_address: int,
+     *     rss_bytes: int|null,
      *     memory_areas: ProcessMemoryArea[],
      *     region_index: list<array{address: int, size: int, file_offset: int}>,
      * }
@@ -142,13 +144,20 @@ final class MemoryDumpReaderFactory
             throw new \RuntimeException("invalid dump file: bad magic");
         }
         $format_version = $this->readUint32($fp);
-        if ($format_version !== 1) {
+        if ($format_version !== 1 && $format_version !== 2) {
             throw new \RuntimeException("unsupported dump format version: {$format_version}");
         }
         $php_version = $this->readString($fp);
         $pid = $this->readInt64($fp);
         $eg_address = $this->readInt64($fp);
         $cg_address = $this->readInt64($fp);
+        // v2 added rss_bytes (signed int64; -1 = unavailable) right
+        // after cg_address. v1 dumps don't carry it.
+        $rss_bytes = null;
+        if ($format_version >= 2) {
+            $raw = $this->readInt64($fp);
+            $rss_bytes = $raw === -1 ? null : $raw;
+        }
         $memory_map_count = $this->readUint32($fp);
         $region_count = $this->readUint32($fp);
 
@@ -206,6 +215,7 @@ final class MemoryDumpReaderFactory
             'php_version' => $php_version,
             'eg_address' => $eg_address,
             'cg_address' => $cg_address,
+            'rss_bytes' => $rss_bytes,
             'memory_areas' => $memory_areas,
             'region_index' => $region_index,
         ];

--- a/src/Inspector/MemoryDump/MemoryDumpWriter.php
+++ b/src/Inspector/MemoryDump/MemoryDumpWriter.php
@@ -18,11 +18,13 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 final class MemoryDumpWriter
 {
     private const MAGIC = "RELIMEM\0";
-    private const FORMAT_VERSION = 1;
+    private const FORMAT_VERSION = 2;
 
     /**
      * @param array<array{address: int, size: int, data: string}> $regions
      * @param ProcessMemoryArea[] $memory_areas
+     * @param int|null $rss_bytes RSS in bytes captured at dump time, or
+     *     null when /proc/<pid>/statm was unreadable.
      */
     public function write(
         string $output_path,
@@ -32,6 +34,7 @@ final class MemoryDumpWriter
         int $cg_address,
         array $memory_areas,
         array $regions,
+        ?int $rss_bytes = null,
     ): void {
         // Delegate to the streaming path so there is a single code path.
         $this->writeStreaming(
@@ -47,6 +50,7 @@ final class MemoryDumpWriter
                     yield $region;
                 }
             })(),
+            $rss_bytes,
         );
     }
 
@@ -63,6 +67,8 @@ final class MemoryDumpWriter
      *
      * @param ProcessMemoryArea[] $memory_areas
      * @param iterable<array{address: int, size: int, data: string}> $regions
+     * @param int|null $rss_bytes RSS in bytes captured at dump time, or
+     *     null when /proc/<pid>/statm was unreadable.
      * @return array{region_count: int, total_bytes: int}
      */
     public function writeStreaming(
@@ -74,6 +80,7 @@ final class MemoryDumpWriter
         array $memory_areas,
         int $estimated_region_count,
         iterable $regions,
+        ?int $rss_bytes = null,
     ): array {
         $fp = fopen($output_path, 'wb');
         if ($fp === false) {
@@ -88,6 +95,7 @@ final class MemoryDumpWriter
                 $cg_address,
                 count($memory_areas),
                 $estimated_region_count,
+                $rss_bytes,
             );
             $this->writeMemoryMap($fp, $memory_areas);
 
@@ -133,6 +141,7 @@ final class MemoryDumpWriter
         int $cg_address,
         int $memory_map_count,
         int $region_count,
+        ?int $rss_bytes,
     ): int {
         $buf = self::MAGIC;
         $buf .= pack('V', self::FORMAT_VERSION);
@@ -140,6 +149,8 @@ final class MemoryDumpWriter
         $buf .= pack('P', $pid);
         $buf .= pack('P', $eg_address);
         $buf .= pack('P', $cg_address);
+        // v2: rss_bytes (int64, signed). -1 = unavailable.
+        $buf .= pack('q', $rss_bytes ?? -1);
         $buf .= pack('V', $memory_map_count);
         $region_count_offset = strlen($buf);
         $buf .= pack('V', $region_count);

--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\MemoryDump;
 
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Inspector\Watch\RssReader;
 use Reli\Lib\Log\Log;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCastedTypeProvider;
 use Reli\Lib\PhpInternals\Types\Zend\ZendCompilerGlobals;
@@ -73,6 +74,10 @@ final class MemoryDumper
         );
 
         $pid = $process_specifier->pid;
+        // Capture RSS up-front so the figure embedded in the dump
+        // reflects the target's footprint at snapshot time, not whatever
+        // the PID happens to point at when the dump is replayed later.
+        $rss_bytes = (new RssReader())->read($pid);
         $memory_map = $this->process_memory_map_creator
             ->getProcessMemoryMap($pid);
 
@@ -615,6 +620,7 @@ final class MemoryDumper
             $cg_address,
             $all_areas,
             $regions_data,
+            $rss_bytes,
         );
 
         $total_size = 0;

--- a/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
@@ -80,11 +80,12 @@ class MemoryDumpInspectCommandTest extends TestCase
 
         $display = $output->fetch();
         $this->assertStringContainsString('=== Header ===', $display);
-        $this->assertStringContainsString('Format Version:   1', $display);
+        $this->assertStringContainsString('Format Version:   2', $display);
         $this->assertStringContainsString('PHP Version:      v84', $display);
         $this->assertStringContainsString('PID:              9999', $display);
         $this->assertStringContainsString('EG Address:       0x7f0000001000', $display);
         $this->assertStringContainsString('CG Address:       0x7f0000002000', $display);
+        $this->assertStringContainsString('RSS at dump:      (unavailable)', $display);
         $this->assertStringContainsString('Memory Map Count: 0', $display);
         $this->assertStringContainsString('Region Count:     0', $display);
     }

--- a/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
+++ b/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
@@ -66,12 +66,13 @@ class DumpFileMemoryReaderTest extends TestCase
         $fp = fopen($this->tmp_file, 'rb') ?: $this->fail('open failed');
         $magic = fread($fp, 8);
         $this->assertSame("RELIMEM\0", $magic);
-        // format version (4) + php_version (4 len + 3 body) + pid (8) +
-        // eg (8) + cg (8) + memory_map_count (4) + region_count (4)
+        // format version (4) + php_version (4 len + body) + pid (8) +
+        // eg (8) + cg (8) + rss_bytes (8, v2) + memory_map_count (4) +
+        // region_count (4)
         fread($fp, 4);
         $len = unpack('V', fread($fp, 4))[1];
         fread($fp, $len);
-        fread($fp, 8 + 8 + 8 + 4 + 4);
+        fread($fp, 8 + 8 + 8 + 8 + 4 + 4);
         // Skip the memory map entries.
         foreach ($memory_areas as $area) {
             // begin + end + file_offset strings
@@ -165,7 +166,9 @@ class DumpFileMemoryReaderTest extends TestCase
         fread($fp, 4); // format version
         $len = unpack('V', fread($fp, 4))[1];
         fread($fp, $len);
-        fread($fp, 8 + 8 + 8 + 4 + 4);
+        // pid (8) + eg (8) + cg (8) + rss_bytes (8, v2)
+        // + memory_map_count (4) + region_count (4)
+        fread($fp, 8 + 8 + 8 + 8 + 4 + 4);
 
         $region_index = [];
         foreach ($regions as $region) {

--- a/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
@@ -131,7 +131,7 @@ class MemoryDumpRoundtripTest extends TestCase
 
         // version
         $ver = unpack('Vval', fread($fp, 4));
-        $this->assertSame(1, $ver['val']);
+        $this->assertSame(2, $ver['val']);
 
         // php_version
         $len = unpack('Vval', fread($fp, 4))['val'];
@@ -147,6 +147,10 @@ class MemoryDumpRoundtripTest extends TestCase
         $this->assertSame(0x5000, $eg);
         $cg = unpack('Pval', fread($fp, 8))['val'];
         $this->assertSame(0x6000, $cg);
+
+        // rss_bytes (v2): caller passed default null → -1 sentinel
+        $rss = unpack('qval', fread($fp, 8))['val'];
+        $this->assertSame(-1, $rss);
 
         // counts
         $map_count = unpack('Vval', fread($fp, 4))['val'];

--- a/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
@@ -79,6 +79,7 @@ class MemoryDumpWriterTest extends TestCase
             0x7f00cafebabe,
             $memory_areas,
             $regions,
+            107798528,
         );
 
         $this->assertFileExists($this->tmp_file);
@@ -95,7 +96,7 @@ class MemoryDumpWriterTest extends TestCase
 
         // Format version
         $result = unpack('Vval', fread($fp, 4));
-        $this->assertSame(1, $result['val']);
+        $this->assertSame(2, $result['val']);
 
         // PHP version
         $len = unpack('Vval', fread($fp, 4))['val'];
@@ -113,6 +114,10 @@ class MemoryDumpWriterTest extends TestCase
         // CG address
         $cg_address = unpack('Pval', fread($fp, 8))['val'];
         $this->assertSame(0x7f00cafebabe, $cg_address);
+
+        // RSS bytes (v2)
+        $rss_bytes = unpack('Pval', fread($fp, 8))['val'];
+        $this->assertSame(107798528, $rss_bytes);
 
         // Memory map count
         $memory_map_count = unpack('Vval', fread($fp, 4))['val'];
@@ -216,6 +221,33 @@ class MemoryDumpWriterTest extends TestCase
         $fp = fopen($this->tmp_file, 'rb');
         $magic = fread($fp, 8);
         $this->assertSame("RELIMEM\0", $magic);
+        fclose($fp);
+    }
+
+    #[Test]
+    public function testRssBytesNullSerializedAsMinusOne(): void
+    {
+        $writer = new MemoryDumpWriter();
+        $writer->write(
+            $this->tmp_file,
+            42,
+            'v83',
+            0x1000,
+            0x2000,
+            [],
+            [],
+            null,
+        );
+
+        $fp = fopen($this->tmp_file, 'rb');
+        // Skip magic(8) + version(4) + php_version(string) + pid(8) + eg(8) + cg(8)
+        fread($fp, 8 + 4);
+        $len = unpack('Vval', fread($fp, 4))['val'];
+        fread($fp, $len);
+        fread($fp, 8 + 8 + 8);
+        // rss_bytes
+        $rss_raw = unpack('qval', fread($fp, 8))['val'];
+        $this->assertSame(-1, $rss_raw);
         fclose($fp);
     }
 }


### PR DESCRIPTION
## Summary
Upgrade the memory dump file format from v1 to v2 to capture and persist the process RSS (Resident Set Size) at the time of dump creation. This ensures the RSS figure embedded in the dump reflects the target's actual memory footprint at snapshot time, rather than being read later when the dump is replayed.

## Key Changes

- **Format Version Upgrade**: Incremented dump format version from 1 to 2
- **RSS Bytes Field**: Added an 8-byte signed integer field (`rss_bytes`) to the dump header immediately after `cg_address`, using -1 as a sentinel value when RSS is unavailable
- **Capture at Dump Time**: Modified `MemoryDumper` to capture RSS via `RssReader` upfront and pass it through the dump pipeline, ensuring the value reflects the target process state at snapshot time
- **Reader Compatibility**: Updated all dump readers (`MemoryDumpReader`, `MemoryDumpReaderFactory`, `MemoryDumpNormalizer`, `MemoryDumpInspectCommand`) to handle both v1 (no RSS field) and v2 (with RSS field) formats
- **Removed Redundant Reads**: Eliminated duplicate RSS reads in `MemoryDumpReader` that occurred during PDO and binary read paths, now relying on the captured value instead
- **CLI Output**: Enhanced `MemoryDumpInspectCommand` to display RSS at dump time in the header output, showing "(unavailable)" when null
- **Test Coverage**: Added comprehensive tests including roundtrip validation, null RSS serialization as -1, and format version assertions

## Implementation Details

- RSS is stored as a signed 64-bit integer; -1 indicates the value was unavailable at dump time
- The format change is backward compatible for reading: v1 dumps are still readable (RSS will be null), and v2 readers gracefully handle both versions
- The RSS capture happens early in the dump process before memory collection begins, ensuring it reflects the process state at the start of the snapshot

https://claude.ai/code/session_01VNc829xK55PQCRLwmomPGh