### PR TITLE
Resolve canonical class/function names through non-tree `name` edges too (G4)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -686,11 +686,19 @@ final class BinaryReportDataProvider
         $name_child_of = [];
         $edge_count = $reader->getSectionElementCount(Format::SECTION_EDGES);
         $edgeRows = $reader->castSection(Format::SECTION_EDGES, 'EdgeRow');
+        // No `is_tree` filter on the `name` edge: when a class registers
+        // after its name string has already been collected by some other
+        // path (autoload, opcache-loaded interned strings, etc.), the
+        // resulting edge is recorded as `is_tree = 0` (back-reference to
+        // an existing node). Filtering by `is_tree = 1` would drop ~half
+        // of the user-defined ClassDefinitionContexts in real captures
+        // while keeping the internal classes that happened to be
+        // discovered first via the class table walk. Each
+        // ClassDefinitionContext / *FunctionDefinitionContext has at
+        // most one `name`-link edge by construction, so dropping the
+        // filter doesn't introduce duplicates.
         if ($edgeRows !== null) {
             for ($i = 0; $i < $edge_count; $i++) {
-                if ((int)$edgeRows[$i]->is_tree !== 1) {
-                    continue;
-                }
                 $parent = (int)$edgeRows[$i]->parent_node_id;
                 if (!isset($is_def_node[$parent])) {
                     continue;
@@ -705,9 +713,6 @@ final class BinaryReportDataProvider
             for ($i = 0; $i < $edge_count; $i++) {
                 $off = $i * Format::EDGE_ROW_SIZE;
                 $row = unpack('Vparent/Vchild/Vlid/Cis_tree/Cstrength', $data, $off);
-                if ((int)$row['is_tree'] !== 1) {
-                    continue;
-                }
                 $parent = (int)$row['parent'];
                 if (!isset($is_def_node[$parent])) {
                     continue;

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
@@ -167,6 +167,18 @@ final class NodeLabeler
         // happens to lack the schema, fall through silently so the
         // labeler still answers raw link_names rather than blowing up
         // the surrounding pass.
+        //
+        // No `is_tree` filter on the `name` edge: when a class
+        // registers after its name string has already been collected
+        // (autoload, opcache-loaded interned strings, etc.), the
+        // resulting edge is recorded as `is_tree = 0` (back-reference
+        // to an existing node). Filtering by `is_tree = 1` would drop
+        // ~half of the user-defined ClassDefinitionContexts in real
+        // captures while keeping the internal classes that happened
+        // to be discovered first via the class table walk. Each
+        // ClassDefinitionContext / *FunctionDefinitionContext has at
+        // most one `name`-link edge by construction, so dropping the
+        // filter doesn't introduce duplicates.
         try {
             $rows = $this->db->query("
                 SELECT cn.node_id, cnl.string_value
@@ -175,7 +187,6 @@ final class NodeLabeler
                     ON name_edge.parent_node_id = cn.node_id
                     AND name_edge.run_id = cn.run_id
                     AND name_edge.link_name = 'name'
-                    AND name_edge.is_tree = 1
                 JOIN context_node_locations cnl
                     ON cnl.node_id = name_edge.child_node_id
                     AND cnl.run_id = name_edge.run_id

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabelerTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabelerTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+use Reli\BaseTestCase;
+
+class NodeLabelerTest extends BaseTestCase
+{
+    private string $db_path = '';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $path = tempnam(sys_get_temp_dir(), 'reli_node_labeler_test_');
+        self::assertNotFalse($path);
+        $this->db_path = $path . '.db';
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        @unlink($this->db_path);
+        parent::tearDown();
+    }
+
+    public function testResolvesCanonicalNameRegardlessOfNameEdgeTreeFlag(): void
+    {
+        // Regression for G4: when a class is registered after its name
+        // string has already been collected by another path (autoload,
+        // opcache-loaded interned strings), the resulting `name` edge
+        // is recorded as `is_tree = 0` (back-reference to an existing
+        // node). The canonical-name lookup must accept those too — in
+        // real captures that's roughly half of all user-defined
+        // ClassDefinitionContexts, including the ones a reader cares
+        // about (Composer\Autoload\..., framework classes, the test's
+        // own classes, etc.).
+        $db = $this->createDirectDb();
+
+        $tree_class_node_id = 100;
+        $tree_name_node_id = 101;
+        $back_ref_class_node_id = 200;
+        $back_ref_name_node_id = 201;
+
+        // Two ClassDefinitionContext nodes: one whose `name` edge
+        // happens to be `is_tree = 1` (the internal class case), and
+        // one whose `name` edge is `is_tree = 0` (the back-reference
+        // case G4 used to drop). Same `link_name = 'name'`, same
+        // string-location target shape — only the flag differs.
+        $this->insertContextNode($db, $tree_class_node_id, 'ClassDefinitionContext');
+        $this->insertContextNode($db, $back_ref_class_node_id, 'ClassDefinitionContext');
+
+        $this->insertStringLocation($db, $tree_name_node_id, 'Internal\\Class');
+        $this->insertStringLocation($db, $back_ref_name_node_id, 'App\\UserClass');
+
+        // is_tree = 1
+        $this->insertEdge(
+            $db,
+            $tree_class_node_id,
+            $tree_name_node_id,
+            'name',
+            is_tree: 1,
+        );
+        // is_tree = 0 — back-reference to an already-collected string
+        $this->insertEdge(
+            $db,
+            $back_ref_class_node_id,
+            $back_ref_name_node_id,
+            'name',
+            is_tree: 0,
+        );
+
+        $labeler = new NodeLabeler($db, 1);
+
+        $this->assertSame(
+            'Internal\\Class',
+            $labeler->resolvePathLabel('original_label', $tree_class_node_id),
+            'is_tree = 1 (internal-first) case still resolved',
+        );
+        $this->assertSame(
+            'App\\UserClass',
+            $labeler->resolvePathLabel('original_label', $back_ref_class_node_id),
+            'is_tree = 0 (back-reference) case is now resolved (G4 fix)',
+        );
+    }
+
+    public function testResolvesCanonicalNameForFunctionDefinitions(): void
+    {
+        $db = $this->createDirectDb();
+
+        $func_node_id = 300;
+        $name_node_id = 301;
+        $internal_func_node_id = 400;
+        $internal_name_node_id = 401;
+
+        $this->insertContextNode($db, $func_node_id, 'UserFunctionDefinitionContext');
+        $this->insertContextNode($db, $internal_func_node_id, 'InternalFunctionDefinitionContext');
+
+        $this->insertStringLocation($db, $name_node_id, 'doSomething');
+        $this->insertStringLocation($db, $internal_name_node_id, 'strlen');
+
+        $this->insertEdge(
+            $db,
+            $func_node_id,
+            $name_node_id,
+            'name',
+            is_tree: 0,
+        );
+        $this->insertEdge(
+            $db,
+            $internal_func_node_id,
+            $internal_name_node_id,
+            'name',
+            is_tree: 1,
+        );
+
+        $labeler = new NodeLabeler($db, 1);
+
+        $this->assertSame(
+            'doSomething',
+            $labeler->resolvePathLabel('?', $func_node_id),
+        );
+        $this->assertSame(
+            'strlen',
+            $labeler->resolvePathLabel('?', $internal_func_node_id),
+        );
+    }
+
+    public function testFallsBackToRawLinkNameWhenNoCanonicalName(): void
+    {
+        $db = $this->createDirectDb();
+
+        $labeler = new NodeLabeler($db, 1);
+        $this->assertSame(
+            'unmapped_link',
+            $labeler->resolvePathLabel('unmapped_link', 9999),
+        );
+    }
+
+    private function insertContextNode(\PDO $db, int $node_id, string $type): void
+    {
+        $stmt = $db->prepare(
+            'INSERT INTO context_nodes (run_id, node_id, type) VALUES (?, ?, ?)'
+        );
+        $stmt->execute([1, $node_id, $type]);
+    }
+
+    private function insertStringLocation(\PDO $db, int $node_id, string $value): void
+    {
+        $stmt = $db->prepare(
+            'INSERT INTO context_node_locations'
+            . ' (run_id, node_id, address, size, location_type, class_name, string_value)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            1,
+            $node_id,
+            0x1000 + $node_id,
+            strlen($value),
+            'ZendStringMemoryLocation',
+            null,
+            $value,
+        ]);
+    }
+
+    private function insertEdge(
+        \PDO $db,
+        int $parent_node_id,
+        int $child_node_id,
+        string $link_name,
+        int $is_tree,
+    ): void {
+        $stmt = $db->prepare(
+            'INSERT INTO context_edges'
+            . ' (run_id, parent_node_id, child_node_id, link_name, is_tree, strength)'
+            . ' VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([1, $parent_node_id, $child_node_id, $link_name, $is_tree, 'strong']);
+    }
+
+    private function createDirectDb(): \PDO
+    {
+        $db = new \PDO('sqlite:' . $this->db_path);
+        $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $db->exec('CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY, created_at TEXT NOT NULL)');
+        $db->exec("INSERT INTO runs (run_id, created_at) VALUES (1, '2024-01-01T00:00:00Z')");
+
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_nodes (
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS context_edges (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL,
+                link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL,
+                strength TEXT NOT NULL DEFAULT 'strong'
+            )
+        ");
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                address BIGINT,
+                size BIGINT,
+                location_type TEXT NOT NULL,
+                class_name TEXT,
+                string_value TEXT,
+                refcount BIGINT,
+                type_info BIGINT,
+                region TEXT
+            )
+        ');
+        $db->exec('
+            CREATE TABLE IF NOT EXISTS context_node_attributes (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            )
+        ');
+
+        return $db;
+    }
+}


### PR DESCRIPTION
Bug fix follow-up to PR #648 (display-time canonical names). Reported by the verification team in `docs/internals/memory-report-implementation-handoff.md` § G4.

## What was wrong

PR #648's canonical-name lookup gated the `name` edge by `is_tree = 1` in both the SQL query and the binary-section walk. That filter drops ~half of all user-defined `ClassDefinitionContext` rows in real captures.

`rw_phpunit.db` (one of the saved corpus reports) has 448 `ClassDefinitionContext` rows. The pre-fix labeler resolved canonical names for only 240 (54%). The 208 missed entries are the user-defined classes — `Composer\Autoload\ClassLoader`, `PHPUnit\Framework\TestCase`, `GeneratedTest0`, etc. — exactly the classes a reader of the report cares about.

## Why

When a class is registered after its name string has already been collected by another path (autoload, opcache-loaded interned strings, …), the `$class_definition_context->add('name', $existing_string)` call records a back-reference rather than emitting a fresh tree edge — so the edge ends up with `is_tree = 0`. Internal classes loaded first via the class-table walk get `is_tree = 1` and were the only ones the previous code resolved canonically.

The target string node and its `string_value` are identical regardless of edge tree-ness — `is_tree` here just records who discovered the node first, not anything about data validity.

## Fix

Drop the `is_tree` filter from three sites:

  - `src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php` (the SQL `JOIN` clause)
  - `src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php` (the FFI `castSection` branch + raw-bytes fallback branch — both edge walks inside `loadCanonicalNames`)

Each `ClassDefinitionContext` / `*FunctionDefinitionContext` has at most one `name`-link edge by construction, so dropping the filter doesn't introduce duplicate entries in the resulting map.

## Verification

Same corpus methodology the handoff specifies. After this lands, the verification team's corpus-wide check should produce:

```
grep -E 'class_table->[a-z][a-z0-9_\\\\]+\b' /tmp/memreport-out/rw*_*.report.txt
```

— only genuinely-lowercase class names (`stdclass`, etc.) remaining; everything else rendered with declared casing.

Spot-check report expectations:

| Report | Before | After |
|---|---|---|
| `rw_phpunit` | `class_table->generatedtest0` | `class_table->GeneratedTest0` |
| `rw_phpunit` | `class_table->phpunit\framework\testcase` | `class_table->PHPUnit\Framework\TestCase` |
| `rw_phpunit` | `class_table->composer\autoload\composerstaticinit32e1def...` | `class_table->Composer\Autoload\ComposerStaticInit32e1def...` |
| `rw_twig` | `class_table->twig\extension\coreextension` | `class_table->Twig\Extension\CoreExtension` |
| `rw_symfony-console` | `class_table->symfony\component\dependencyinjection\containerbuilder` | `class_table->Symfony\Component\DependencyInjection\ContainerBuilder` |

The 240/448 ratio in `rw_phpunit.db` should become close to 448/448 (modulo the small set of class entries that genuinely lack a `name` child for unrelated reasons).

## Tests

Adds `NodeLabelerTest` with 3 cases:

  - **G4 regression guard** — two `ClassDefinitionContext` rows, one with `is_tree = 1` (internal-first) and one with `is_tree = 0` (back-reference). Both must resolve to their canonical name string.
  - Same shape for `UserFunctionDefinitionContext` and `InternalFunctionDefinitionContext`.
  - Unmapped fallback — a `link_name` for a node that has no canonical-name override returns the raw label.

## Local verification

  - psalm + phpcs clean
  - `NodeLabelerTest`: 3 / 3 pass
  - `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84`: passes (binary and SQL paths still match — the fix applies symmetrically to both)

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_