### PR TITLE
Render bottleneck-path spine drop by path component name (T2.2)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Formatter;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportResult;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TextReportFormatter implements ReportFormatterInterface
@@ -427,14 +428,33 @@ final class TextReportFormatter implements ReportFormatterInterface
 
         $pre_drop_size = $sizes[$drop_index];
         $post_drop_size = $sizes[$drop_index + 1];
-        $line = sprintf(
-            'Spine: heaviest-child mass drops at depth %d'
-            . ' (%s → %s); leaf retains only %s',
-            $drop_index + 1,
-            SizeFormatter::format($pre_drop_size),
-            SizeFormatter::format($post_drop_size),
-            SizeFormatter::format($leaf_size),
-        );
+
+        // Name the drop position by the path component the descent
+        // landed on, not the depth integer ("at depth 5" forced the
+        // reader to count segments in `facts.path[]` to learn what was
+        // there). Format the path prefix up to and including the
+        // pre-drop component via PathFormatter so it matches the
+        // syntax used by `summary_path` ("$sink->addressMinNode" etc.).
+        $drop_label = self::formatSpineDropLabel($finding, $drop_index);
+        $line = $drop_label !== null
+            ? sprintf(
+                'Spine: heaviest-child mass drops after %s'
+                . ' (%s → %s); leaf retains only %s',
+                $drop_label,
+                SizeFormatter::format($pre_drop_size),
+                SizeFormatter::format($post_drop_size),
+                SizeFormatter::format($leaf_size),
+            )
+            : sprintf(
+                // Legacy path: facts predate path_types — fall back to
+                // the depth integer rather than emit nothing.
+                'Spine: heaviest-child mass drops at depth %d'
+                . ' (%s → %s); leaf retains only %s',
+                $drop_index + 1,
+                SizeFormatter::format($pre_drop_size),
+                SizeFormatter::format($post_drop_size),
+                SizeFormatter::format($leaf_size),
+            );
 
         $out = [$line];
 
@@ -483,5 +503,63 @@ final class TextReportFormatter implements ReportFormatterInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Resolve the spine-drop position to a user-facing PHP-syntax label
+     * like `$sink->addressMinNode` (matching the format of
+     * `facts.summary_path`). Returns null when the finding doesn't carry
+     * `path` + `path_types` — the caller falls back to a depth integer
+     * in that case.
+     *
+     * Long prefixes are truncated to the trailing portion so the line
+     * stays inside terminal width: a path like
+     * `$container->config->servers[0]->endpoints[3]` becomes
+     * `...->endpoints[3]` past 50 chars.
+     *
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArgumentTypeCoercion
+     */
+    private static function formatSpineDropLabel(
+        Finding $finding,
+        int $drop_index,
+    ): ?string {
+        /** @var mixed $raw_path */
+        $raw_path = $finding->facts['path'] ?? null;
+        /** @var mixed $raw_types */
+        $raw_types = $finding->facts['path_types'] ?? null;
+        if (!is_array($raw_path) || !is_array($raw_types)) {
+            return null;
+        }
+        if ($drop_index < 0 || $drop_index >= count($raw_path)) {
+            return null;
+        }
+
+        /** @var list<string> $path_parts */
+        $path_parts = [];
+        foreach (array_slice($raw_path, 0, $drop_index + 1) as $p) {
+            if (!is_string($p)) {
+                return null;
+            }
+            $path_parts[] = $p;
+        }
+        /** @var list<string> $path_types */
+        $path_types = [];
+        foreach (array_slice($raw_types, 0, $drop_index + 1) as $t) {
+            $path_types[] = is_string($t) ? $t : '';
+        }
+
+        $label = PathFormatter::toPhpSyntax($path_parts, $path_types);
+        if ($label === '' || $label === '(root)') {
+            return null;
+        }
+
+        // Truncate from the right when the prefix grows long. 50 chars
+        // keeps the full Spine line under ~110 chars, comfortable for
+        // most terminals.
+        $max = 50;
+        if (strlen($label) > $max) {
+            $label = '...' . substr($label, -($max - 3));
+        }
+        return $label;
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DrillDownPass.php
@@ -146,6 +146,7 @@ final class DrillDownPass implements PassInterface
                 ),
                 facts: [
                     'path' => $path_parts,
+                    'path_types' => $path_types,
                     'sizes' => $path_sizes,
                     'depth' => count($path_parts),
                     'summary_path' => $path_str,

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -310,14 +310,62 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringNotContainsString("first line\nsecond line", $output);
     }
 
-    public function testFormatRendersBottleneckSpineDropLine(): void
+    public function testFormatRendersBottleneckSpineDropLineWithPathComponent(): void
     {
-        // bottleneck_path uses sizes[0] (spine root) as impact_bytes while
-        // showing the leaf path as summary. When the descent crosses into a
-        // uniform-sibling region the displayed size and path describe
-        // opposite ends of the chain. The formatter should emit a "Spine"
-        // explanatory line that names where mass drops and reports the
-        // leaf's actual retained size.
+        // T2.2: the spine line should name the path component the
+        // descent landed on ("drops after $decoded[data]"), not a
+        // depth integer that forces the reader to count segments in
+        // facts.path manually. PathFormatter renders the prefix in
+        // the same syntax as facts.summary_path so the two read
+        // consistently.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bottleneck_path',
+                severity: FindingSeverity::High,
+                confidence: FindingConfidence::High,
+                summary: '$decoded[data][10100][profile] (171.45 MB)',
+                facts: [
+                    // global_variables → array_elements → 'decoded' →
+                    // array_header → array_elements → 'data' → ...
+                    // PathFormatter strips the structural intermediaries
+                    // and renders ['$decoded', '[data]', ...].
+                    'path' => [
+                        'global_variables', 'array_elements', 'decoded',
+                        'array_header', 'array_elements', 'data',
+                        'array_header', 'array_elements', '10100', 'profile',
+                        'value', 'value',
+                    ],
+                    'path_types' => [
+                        '', '', '',
+                        '', '', '',
+                        '', '', 'ArrayElementContext', '',
+                        '', '',
+                    ],
+                    'sizes' => [
+                        325480905, 325479089, 325475106, 325475106, 324977898,
+                        3336, 3336, 3184, 2520, 2240, 2144, 2144,
+                    ],
+                ],
+                impact_bytes: 325480905,
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        // Names the drop position as a path component, not "depth 5".
+        $this->assertStringContainsString('Spine: heaviest-child mass drops after ', $output);
+        $this->assertStringNotContainsString('drops at depth', $output);
+        // After the drop, sizes flatline within ~10% — formatter should
+        // mark the leaf as one-of-many uniform siblings.
+        $this->assertStringContainsString('one of many similar-sized siblings', $output);
+    }
+
+    public function testFormatFallsBackToDepthIntegerWhenPathTypesMissing(): void
+    {
+        // Legacy / minimal facts (path / path_types absent — older
+        // captures and unit-test fixtures that pre-date T2.2). The
+        // spine line should still appear, falling back to the depth
+        // integer rather than skipping the line entirely.
         $result = new ReportResult([], [
             new Finding(
                 kind: 'bottleneck_path',
@@ -337,9 +385,41 @@ class TextReportFormatterTest extends BaseTestCase
         $output = $formatter->format($result);
 
         $this->assertStringContainsString('Spine: heaviest-child mass drops at depth 5', $output);
-        // After the drop, sizes flatline within ~10% — formatter should
-        // mark the leaf as one-of-many uniform siblings.
-        $this->assertStringContainsString('one of many similar-sized siblings', $output);
+    }
+
+    public function testFormatTruncatesLongSpineDropLabel(): void
+    {
+        // Very deep paths get truncated from the right so the Spine
+        // line stays inside terminal width. The pre-truncation prefix
+        // here is ~110 chars; the rendered label should start with
+        // "..." and keep the trailing ~47 chars.
+        $deep_path = [];
+        $deep_types = [];
+        for ($i = 0; $i < 30; $i++) {
+            $deep_path[] = 'verbose_property_name_' . $i;
+            $deep_types[] = '';
+        }
+        $sizes = array_fill(0, 31, 1_000_000);
+        $sizes[10] = 1000; // sharp drop at depth 10
+
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bottleneck_path',
+                severity: FindingSeverity::High,
+                confidence: FindingConfidence::High,
+                summary: 'long path summary',
+                facts: [
+                    'path' => $deep_path,
+                    'path_types' => $deep_types,
+                    'sizes' => $sizes,
+                ],
+                impact_bytes: $sizes[0],
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        $this->assertStringContainsString('drops after ...', $output);
     }
 
     public function testFormatOmitsBottleneckSpineLineForUniformDescent(): void


### PR DESCRIPTION
Implements **T2.2** from `docs/internals/memory-report-implementation-handoff.md`.

## Why

`bottleneck_path` findings emitted

```
Spine: heaviest-child mass drops at depth 5 (30.24 MB → 10.00 MB);
       leaf retains only 0 B
```

`depth 5` is engineering-internal: a reader has to count segments in `facts.path[]` to learn what's at depth 5, then map that back to the rendered `summary_path`. There's no context that would make "5" meaningful by itself — it's just an index into an array the reader doesn't see. For a real path like `Reli\…\MemoryLocationsCollector::collectAll:297::$sink->addressMinNode[0]`, "drops at depth 5" forces mental segment-counting just to identify *where* in the user's own variables the dominance breaks.

## What changes

- **`DrillDownPass`** — adds `path_types` to the `bottleneck_path` finding's facts (one-line addition; the pass was already collecting per-step context types, it just hadn't been exposing them in the facts).

- **`TextReportFormatter::renderBottleneckSpine`** — reads `facts.path` + `facts.path_types`, slices both to `[0..drop_index]` inclusive, and feeds them to `PathFormatter::toPhpSyntax` — same formatter `DrillDownPass` uses to build `summary_path`, so the new label and `summary_path` read consistently.

After this PR:

```
Spine: heaviest-child mass drops after $sink->addressMinNode
       (30.24 MB → 10.00 MB); leaf retains only 0 B
```

### Edge cases

- **Long prefixes** are truncated from the right with a `...` prefix when they exceed 50 chars, keeping the full spine line under ~110 chars (one comfortable terminal width).

- **Legacy fallback** — when a finding lacks `path` or `path_types` (older capture data, lightweight unit-test fixtures, JSON consumers that didn't refresh), the line falls back to the original `at depth N` form rather than skipping the spine line entirely. Same diagnostic information, less polished phrasing.

- **No-drop case** unchanged — `renderBottleneckSpine` still returns `[]` when there's no >2× drop.

## Tests

- `testFormatRendersBottleneckSpineDropLineWithPathComponent` — the json-decode-huge-shape fixture (12-element sizes array, drop at depth 5) gets the new "drops after " prefix; asserts no "at depth" substring.
- `testFormatFallsBackToDepthIntegerWhenPathTypesMissing` — same sizes fixture without `path` / `path_types` keeps the legacy `at depth 5` output (regression guard for older data).
- `testFormatTruncatesLongSpineDropLabel` — 30-component prefix triggers the `...` truncation.
- `testFormatOmitsBottleneckSpineLineForUniformDescent` (pre-existing) — no-drop branch still returns `[]`.

## Local verification

- psalm + phpcs clean
- `TextReportFormatter` unit tests: 17 / 17
- `testReportContainsRankingSections@v84` and `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84` pass

## Verification per the handoff doc

Re-run `inspector:memory:report` against the 25 saved `.db` files in `/tmp/memreport-out/` and check:

- All existing `Spine:` lines still appear
- `at depth N` substring is gone (modulo legacy fixtures without `path_types`)
- The drop component reads as a recognisable user-side identifier (`$sink`, `$decoded[data]`, etc.) rather than an internal label like `array_elements` or `value`

Spot-check reports flagged in the handoff: `rw2_json-decode-huge`, `rw2_csv-mega`, `rw4_pdo-result-hoarding`, `rw4_eloquent-hydration`, plus any "reli profiling itself" captures with the spine descending into `MemoryLocationsCollector::collectAll`.

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_