### PR TITLE
Strip call-frame line number from non-stack path labels (T2.4)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -86,7 +86,11 @@ final class CallStackPass implements PassInterface
         $framesByNo = [];
         foreach ($this->substrate->getChildren($callFramesNodeId) as $child_id) {
             $link_name = $this->substrate->getTreeLinkName($child_id) ?? '?';
-            $label = $labeler->resolvePathLabel($link_name, $child_id);
+            // Call Stack is the one rendering site that benefits from
+            // the line-number suffix ("paused at line N of fn"); every
+            // other consumer of NodeLabeler treats `:lineno` as noise
+            // and gets the path form ("fn()") by default.
+            $label = $labeler->resolvePathLabel($link_name, $child_id, include_call_site: true);
             // resolvePathLabel returns the link_name unchanged when
             // the child has no function_name attribute. That can't
             // happen for a real CallFrameContext but we handle it

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabeler.php
@@ -18,8 +18,18 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
  *
  * Handles two label sources:
  *
- *  1. **Call-frame labels** — `function_name:lineno` for `CallFrameContext`
- *     nodes, derived from `context_node_attributes`.
+ *  1. **Call-frame labels** — for `CallFrameContext` nodes. The
+ *     underlying data is `function_name` + `lineno`. The labeler
+ *     renders them in two forms:
+ *      - `function_name:lineno` (e.g. `collectAll:297`) — used by the
+ *        Call Stack section, where the line number disambiguates
+ *        which point in the function the snapshot caught.
+ *      - `function_name()` (e.g. `collectAll()`) — used everywhere
+ *        else (`bottleneck_path`, `Spine:`, Top Arrays paths, etc.),
+ *        where the line number is incidental noise (`$sink` doesn't
+ *        depend on which line `collectAll` happens to be paused at).
+ *        The `()` makes the call-frame nature unambiguous against
+ *        PHP's `Class::staticMethod::$staticProp` syntax.
  *
  *  2. **Canonical class / method / function names** — the `name` child of
  *     `ClassDefinitionContext` / `UserFunctionDefinitionContext` /
@@ -32,8 +42,11 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
  */
 final class NodeLabeler
 {
-    /** @var array<int, string> node_id => "function_name:lineno" */
-    private array $frame_labels = [];
+    /** @var array<int, string> node_id => "function_name:lineno" (Call Stack form) */
+    private array $frame_labels_with_line = [];
+
+    /** @var array<int, string> node_id => "function_name()" (path form) */
+    private array $frame_labels_path_form = [];
 
     /**
      * node_id => canonical class / method / function name. Populated for
@@ -49,7 +62,9 @@ final class NodeLabeler
 
     /**
      * @param array<int, string>|null $preloaded_frame_labels Pre-loaded
-     *     frame labels (binary path).
+     *     frame labels (binary path), in `"function_name:lineno"` form
+     *     (or just `"function_name"` when no lineno is recorded). The
+     *     labeler splits each entry into the two display forms it uses.
      * @param array<int, string>|null $preloaded_canonical_names Pre-loaded
      *     canonical class/method/function names (binary path). When
      *     provided, the SQL fetch is skipped.
@@ -63,20 +78,39 @@ final class NodeLabeler
     }
 
     /**
-     * Resolve a link_name like "1" into "functionName:42" (call frame),
-     * or a case-folded class/method/function key into its canonical name.
-     * Falls back to the raw link_name when no override is available.
+     * Resolve a link_name for a child node into a human-readable label.
+     *
+     * For `CallFrameContext` nodes:
+     *  - `$include_call_site = true`: returns `"functionName:lineno"`
+     *    (the Call Stack form).
+     *  - `$include_call_site = false` (default): returns
+     *    `"functionName()"` (the path form). All path-rendering passes
+     *    use this default.
+     *
+     * For `ClassDefinitionContext` / `*FunctionDefinitionContext` nodes
+     * the canonical-name form is returned regardless of the flag (the
+     * line number doesn't apply).
+     *
+     * Falls back to the raw `$link_name` when no override is available
+     * for the node.
      *
      * @psalm-suppress MixedArrayAccess, MixedAssignment
      */
     public function resolvePathLabel(
         string $link_name,
         int $child_node_id,
+        bool $include_call_site = false,
     ): string {
         $this->ensureLoaded();
 
-        if (isset($this->frame_labels[$child_node_id])) {
-            return $this->frame_labels[$child_node_id];
+        if ($include_call_site) {
+            if (isset($this->frame_labels_with_line[$child_node_id])) {
+                return $this->frame_labels_with_line[$child_node_id];
+            }
+        } else {
+            if (isset($this->frame_labels_path_form[$child_node_id])) {
+                return $this->frame_labels_path_form[$child_node_id];
+            }
         }
 
         if (isset($this->canonical_names[$child_node_id])) {
@@ -101,9 +135,19 @@ final class NodeLabeler
     /** @psalm-suppress MixedArrayAccess, MixedAssignment */
     private function loadFrameLabels(): void
     {
-        // Binary path: use pre-loaded frame labels
+        // Binary path: split the pre-baked "function_name:lineno"
+        // strings into the two display forms.
         if ($this->preloaded_frame_labels !== null) {
-            $this->frame_labels = $this->preloaded_frame_labels;
+            foreach ($this->preloaded_frame_labels as $node_id => $combined) {
+                [$fn, $ln] = self::splitFunctionNameAndLineno($combined);
+                if ($fn === '') {
+                    continue;
+                }
+                $this->frame_labels_with_line[$node_id] = $ln !== null
+                    ? "{$fn}:{$ln}"
+                    : $fn;
+                $this->frame_labels_path_form[$node_id] = self::pathFormForFunction($fn);
+            }
             return;
         }
 
@@ -138,8 +182,51 @@ final class NodeLabeler
                 continue;
             }
             $ln = $kvs['lineno'] ?? '';
-            $this->frame_labels[$node_id] = $ln !== '' ? "{$fn}:{$ln}" : $fn;
+            $this->frame_labels_with_line[$node_id] = $ln !== ''
+                ? "{$fn}:{$ln}"
+                : $fn;
+            $this->frame_labels_path_form[$node_id] = self::pathFormForFunction($fn);
         }
+    }
+
+    /**
+     * Split a `"function_name:lineno"` combined label back into its parts.
+     * Handles `Class::method:42` correctly (the last `:` precedes the
+     * lineno; `::` separators inside the function name are preserved).
+     * Returns `[name, null]` when no numeric lineno suffix is present.
+     *
+     * @return array{0: string, 1: ?int}
+     */
+    private static function splitFunctionNameAndLineno(string $combined): array
+    {
+        $colon = strrpos($combined, ':');
+        if ($colon === false) {
+            return [$combined, null];
+        }
+        $tail = substr($combined, $colon + 1);
+        if ($tail === '' || !ctype_digit($tail)) {
+            // Last colon isn't a lineno separator (e.g. `Class::method`
+            // with no lineno suffix). Keep the full string as the
+            // function name.
+            return [$combined, null];
+        }
+        return [substr($combined, 0, $colon), (int)$tail];
+    }
+
+    /**
+     * Path-form rendering for a call-frame function name. Wraps the
+     * name in `()` so `collectAll()::$sink` reads unambiguously as a
+     * call-frame scope rather than aliasing PHP's
+     * `Class::staticMethod::$staticProp` syntax. Idempotent on names
+     * that already end with `)` (synthetic closure names, future
+     * decorations).
+     */
+    private static function pathFormForFunction(string $function_name): string
+    {
+        if (str_ends_with($function_name, ')')) {
+            return $function_name;
+        }
+        return $function_name . '()';
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabelerTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/NodeLabelerTest.php
@@ -148,6 +148,133 @@ class NodeLabelerTest extends BaseTestCase
         );
     }
 
+    public function testCallFrameDefaultPathFormStripsLineNumberAndAppendsParens(): void
+    {
+        // T2.4: by default, NodeLabeler returns the path-form for
+        // call-frame nodes — `function_name()`, no `:lineno`. The
+        // line number is noise outside the Call Stack section
+        // ("$sink doesn't depend on which line collectAll happens
+        // to be paused at"); the parens disambiguate the
+        // call-frame scope from PHP's `Class::staticMethod`.
+        $db = $this->createDirectDb();
+
+        $frame_node_id = 500;
+        $this->insertContextNode($db, $frame_node_id, 'CallFrameContext');
+        $this->insertAttribute($db, $frame_node_id, 'function_name', 'collectAll');
+        $this->insertAttribute($db, $frame_node_id, 'lineno', '297');
+
+        $labeler = new NodeLabeler($db, 1);
+
+        $this->assertSame(
+            'collectAll()',
+            $labeler->resolvePathLabel('?', $frame_node_id),
+            'default mode strips :lineno and adds ()',
+        );
+    }
+
+    public function testCallFrameWithIncludeCallSiteKeepsLineNumber(): void
+    {
+        // The Call Stack render site opts into `include_call_site:
+        // true` because the line number is exactly what disambiguates
+        // "where in this function did the snapshot catch us".
+        $db = $this->createDirectDb();
+
+        $frame_node_id = 600;
+        $this->insertContextNode($db, $frame_node_id, 'CallFrameContext');
+        $this->insertAttribute($db, $frame_node_id, 'function_name', 'collectAll');
+        $this->insertAttribute($db, $frame_node_id, 'lineno', '297');
+
+        $labeler = new NodeLabeler($db, 1);
+
+        $this->assertSame(
+            'collectAll:297',
+            $labeler->resolvePathLabel('?', $frame_node_id, include_call_site: true),
+        );
+    }
+
+    public function testCallFrameWithoutLinenoIsHandledIdempotently(): void
+    {
+        // No `lineno` attribute. The path form is still
+        // `function_name()`, the Call Stack form is just
+        // `function_name`.
+        $db = $this->createDirectDb();
+
+        $frame_node_id = 700;
+        $this->insertContextNode($db, $frame_node_id, 'CallFrameContext');
+        $this->insertAttribute($db, $frame_node_id, 'function_name', '{closure}');
+
+        $labeler = new NodeLabeler($db, 1);
+
+        $this->assertSame(
+            '{closure}()',
+            $labeler->resolvePathLabel('?', $frame_node_id),
+        );
+        $this->assertSame(
+            '{closure}',
+            $labeler->resolvePathLabel('?', $frame_node_id, include_call_site: true),
+        );
+    }
+
+    public function testBinaryPathFrameLabelIsSplitCorrectly(): void
+    {
+        // The binary report path passes pre-baked
+        // "function_name:lineno" strings via $preloaded_frame_labels.
+        // The labeler must split them back into the two display forms
+        // even when the function name itself contains "::" (a static
+        // method's `Class::method` shape).
+        $preloaded_frame_labels = [
+            10 => 'plain_function:42',
+            11 => 'App\\Service\\Worker::run:123',
+            12 => 'no_lineno_function',
+            13 => 'App\\Util\\X::lookup', // no numeric suffix — keep whole
+        ];
+
+        $labeler = new NodeLabeler(null, 0, $preloaded_frame_labels);
+
+        // Default path form
+        $this->assertSame('plain_function()', $labeler->resolvePathLabel('?', 10));
+        $this->assertSame(
+            'App\\Service\\Worker::run()',
+            $labeler->resolvePathLabel('?', 11),
+        );
+        $this->assertSame('no_lineno_function()', $labeler->resolvePathLabel('?', 12));
+        $this->assertSame(
+            'App\\Util\\X::lookup()',
+            $labeler->resolvePathLabel('?', 13),
+        );
+
+        // Call Stack form
+        $this->assertSame(
+            'plain_function:42',
+            $labeler->resolvePathLabel('?', 10, include_call_site: true),
+        );
+        $this->assertSame(
+            'App\\Service\\Worker::run:123',
+            $labeler->resolvePathLabel('?', 11, include_call_site: true),
+        );
+        $this->assertSame(
+            'no_lineno_function',
+            $labeler->resolvePathLabel('?', 12, include_call_site: true),
+        );
+        $this->assertSame(
+            'App\\Util\\X::lookup',
+            $labeler->resolvePathLabel('?', 13, include_call_site: true),
+        );
+    }
+
+    private function insertAttribute(
+        \PDO $db,
+        int $node_id,
+        string $key,
+        string $value,
+    ): void {
+        $stmt = $db->prepare(
+            'INSERT INTO context_node_attributes'
+            . ' (run_id, node_id, key, value) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([1, $node_id, $key, $value]);
+    }
+
     private function insertContextNode(\PDO $db, int $node_id, string $type): void
     {
         $stmt = $db->prepare(


### PR DESCRIPTION
Implements **T2.4** from `docs/internals/memory-report-implementation-handoff.md`.

## Why

Paths like

```
Reli\…\MemoryLocationsCollector::collectAll:297::$sink->addressMinNode[0]
                                      ^^^^
                                   noise — $sink doesn't depend on
                                   which line the frame is paused at
```

leaked the call-frame `:lineno` suffix into every report section that traverses a `CallFrameContext` on the way to user-land state. The line number is genuinely informative in the **Call Stack** section ("we paused at line 297 of `collectAll`"), but distracting noise everywhere else (`bottleneck_path`, `Spine:` drop annotation, `Top Arrays` paths, `Top Strings` paths, `choke_point` path).

## What changes

- **`NodeLabeler`** now stores two display forms per call-frame node:
  - `frame_labels_with_line` — `"functionName:lineno"`, the Call Stack form.
  - `frame_labels_path_form` — `"functionName()"`, used by every other rendering site. The `()` makes the call-frame nature unambiguous against PHP's `Class::staticMethod::$staticProp` syntax.

- `resolvePathLabel($link_name, $child_node_id, bool $include_call_site = false)` picks the form via the new flag. Default is `false` (path form), so the four path-rendering passes (`DrillDownPass`, `CycleClusterPass`, `ChokePointPass`, `TopStringsPass`, `TopArraysPass`) get the `function()` form without any change at the call site.

- **`CallStackPass`** opts into `include_call_site: true` — the only call site that needs the `:lineno` form.

## Final form by section

| Where rendered                  | Format                                                  |
|---------------------------------|---------------------------------------------------------|
| Call Stack                      | `#0 …::collectAll:297` (unchanged)                      |
| `bottleneck_path` etc.          | `…::collectAll()::$sink->addressMinNode[0]` (new)       |
| `Spine:` drop label (T2.2)      | `Spine: drops after collectAll()::$sink` (new)          |

## Implementation notes

- Splitting binary-path preloaded labels back into the two forms is handled in NodeLabeler (`splitFunctionNameAndLineno`). Splits on the last `:` only when the suffix is all digits, so `App\Service\Worker::run:123` correctly produces `(App\Service\Worker::run, 123)` and `App\Util\X::lookup` (no lineno suffix) is kept whole.

- `pathFormForFunction` is idempotent — already-parens-suffixed names (synthetic closure names, future decorations) skip the second `()`. `{closure}:42` becomes `{closure}()`, `internalFunc` becomes `internalFunc()`.

## Tests

  - `testCallFrameDefaultPathFormStripsLineNumberAndAppendsParens` — `function_name="collectAll"`, `lineno="297"` → default mode returns `collectAll()`.
  - `testCallFrameWithIncludeCallSiteKeepsLineNumber` — same node, `include_call_site: true` → `collectAll:297`.
  - `testCallFrameWithoutLinenoIsHandledIdempotently` — `{closure}` with no lineno: path form `{closure}()`, call-site form `{closure}`.
  - `testBinaryPathFrameLabelIsSplitCorrectly` — exercises the binary-path preload split for plain function, `Class::method:123`, no-lineno, and `Class::method` (no numeric suffix → kept whole).

## Local verification

  - psalm + phpcs clean
  - NodeLabelerTest: 8 / 8 (4 new T2.4 cases on top of the G4 cases)
  - CallStackPassTest: 7 / 7
  - `testReportContainsRankingSections@v84` and `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84` pass

## Verification per the handoff doc

```
grep -hE '::[a-zA-Z_][a-zA-Z0-9_]*:[0-9]+::' \
  /tmp/memreport-out/rw*_*.report.txt
```

After this lands, the only matches should be Call Stack lines.

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_