### PR TITLE
Record per-node class IDs through the binary writer (T2.3 root cause)

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -490,7 +490,15 @@ final class BinaryContextTreeSink implements ContextTreeSink
             $new_cap *= 2;
         }
         $new_sizes = \Reli\Lib\FFI\FFIHelper::new("int64_t[{$new_cap}]");
-        $new_classes = \Reli\Lib\FFI\FFIHelper::new("int32_t[{$new_cap}]");
+        // Class slots hold string-dict IDs (unsigned 32-bit, with
+        // Format::NULL_STRING_ID = 0xFFFFFFFF reserved for "unset").
+        // `uint32_t` is the right type for that representation: a
+        // signed `int32_t` reads NULL_STRING_ID back as `-1`, which
+        // makes `=== Format::NULL_STRING_ID` (the natural guard) never
+        // match and silently leaves every per-node class id as NULL on
+        // disk — see `docs/internals/memory-report-t2-3-investigation.md`
+        // for the failure trail this caused on the binary report path.
+        $new_classes = \Reli\Lib\FFI\FFIHelper::new("uint32_t[{$new_cap}]");
         // Initialize new class slots to NULL_STRING_ID
         for ($i = 0; $i < $new_cap; $i++) {
             $new_classes[$i] = Format::NULL_STRING_ID;
@@ -515,7 +523,7 @@ final class BinaryContextTreeSink implements ContextTreeSink
     }
 
     /**
-     * Get per-node class IDs as FFI int32 array (string dict IDs).
+     * Get per-node class IDs as FFI uint32 array (string dict IDs).
      */
     public function getPerNodeClasses(): ?\FFI\CData
     {

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
@@ -171,6 +171,74 @@ class BinaryFormatRoundTripTest extends TestCase
         $this->assertNotNull($dict->lookup(0)); // at least one string interned
     }
 
+    public function testNodeClassesSectionIsPopulatedForObjectLocations(): void
+    {
+        // Regression for T2.3: BinaryContextTreeSink::$perNodeClasses was
+        // an FFI `int32_t[]`. NULL_STRING_ID = 0xFFFFFFFF round-tripped
+        // through int32_t reads back as `-1`, never `4294967295`, so
+        // `(int)$arr[i] === Format::NULL_STRING_ID` was always false and
+        // the per-node accumulator never recorded a class for any
+        // object location. Result: the on-disk `node_classes` section
+        // came out all-NULL and the FFI-CSR substrate's binary loader
+        // returned null for every `getNodeClass()` — the SQL path was
+        // unaffected because it reads class_name straight from
+        // LocationRow. See
+        // docs/internals/memory-report-t2-3-investigation.md for the
+        // full trace.
+        $sink = new BinaryContextTreeSink(batch_size: 10);
+
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: null,
+            link_name: 'root_entry',
+            type: 'ObjectContext',
+            locations: [
+                new ZendObjectMemoryLocation(
+                    address: 0x1000,
+                    size: 64,
+                    refcount: 1,
+                    type_info: 7,
+                    class_name: 'App\\MyClass',
+                ),
+            ],
+            attributes: [],
+        );
+
+        $binary_output = new BinaryMemoryOutput($this->rmem_path);
+        $binary_output->finalizeStreaming(
+            $sink,
+            [['zend_mm_heap_usage' => '64']],
+        );
+
+        $reader = Reader::open($this->rmem_path);
+        $this->assertTrue(
+            $reader->hasSection('node_classes'),
+            'finalize wrote a node_classes section',
+        );
+
+        $classesData = $reader->getSectionData('node_classes');
+        $slots = (int)(strlen($classesData) / 4);
+        $this->assertGreaterThan(0, $slots);
+
+        // At least one slot must be a real string-dict id, not the
+        // NULL_STRING_ID sentinel that signals "no class known". Pre-
+        // T2.3, every slot in this scenario was NULL_STRING_ID.
+        $non_null_slots = 0;
+        for ($i = 0; $i < $slots; $i++) {
+            /** @var array{1: int} $u */
+            $u = unpack('V', $classesData, $i * 4);
+            if ((int)$u[1] !== Format::NULL_STRING_ID) {
+                $non_null_slots++;
+            }
+        }
+        $this->assertGreaterThan(
+            0,
+            $non_null_slots,
+            'node_classes section must record at least one class id'
+            . ' for the emitted ZendObjectMemoryLocation',
+        );
+    }
+
     public function testSubstrateLoadFromBinary(): void
     {
         // Build a .rmem with a small graph


### PR DESCRIPTION
Fixes the T2.3 root cause identified by the verification team's investigation on `claude/investigate-memory-t2-3-SDYVA` (commit `3adbdac`, doc at `docs/internals/memory-report-t2-3-investigation.md`).

## What was wrong

`BinaryContextTreeSink::$perNodeClasses` was an FFI `int32_t[]` accumulator with `Format::NULL_STRING_ID` (= `0xFFFFFFFF` = `4294967295`) as the "unset" sentinel. The update guard in `emitNode`:

```php
if (
    $class_id !== Format::NULL_STRING_ID
    && (int)$this->perNodeClasses[$node_id] === (int)Format::NULL_STRING_ID
) {
    $this->perNodeClasses[$node_id] = $class_id;
}
```

never fired. A slot initialised with `Format::NULL_STRING_ID` and read back through `int32_t` evaluates as `-1` in PHP, never as `4294967295`. The right-hand `===` was therefore always false, the slot was never updated, and the on-disk `node_classes` section came out all NULL — for every object location, in every binary report.

Downstream, `FfiCsrGraphSubstrate::loadFromBinary` reads `node_classes` first and treats it as authoritative (its locations scan only fills classes when the section is missing), so `getNodeClass()` returned null for every object node on the binary path. The user-visible symptom was `dedup_candidate` findings on the binary report path collapsing to the bare `link_name:` form (`raw:`, `value:`, …) even when the SQLite report path on the same dump rendered the full `Owner::$prop -> TargetClass` label — the SQL side reads `class_name` straight from `LocationRow` and isn't affected.

`PHP-array GraphSubstrate::loadFromBinary` (the small-graph fallback) also reads `class_name` from LocationRow rather than the section, so its existing regression test `testSubstrateLoadFromBinary` happily kept passing — the bug only triggered on the FFI-CSR variant that real captures use.

## Fix

Switch `perNodeClasses` from `int32_t[]` to `uint32_t[]`. The values it stores are unsigned 32-bit string-dict IDs; the signed type was the source of the round-trip mismatch and using the matching unsigned type makes `=== Format::NULL_STRING_ID` evaluate as written.

Output bytes on the wire are unchanged — both types are 4 bytes; `FFI::string($perNodeClasses, $slots * 4)` emits the same `FF FF FF FF` for unset slots and the same packed LE u32 for set ones. No format-version bump.

Doc comment on `getPerNodeClasses` updated from "FFI int32 array" to "FFI uint32 array" to match.

## Regression test

`BinaryFormatRoundTripTest::testNodeClassesSectionIsPopulatedForObjectLocations`:

- Emit a single node with a `ZendObjectMemoryLocation` carrying `class_name`.
- Finalize to `.rmem`.
- Assert the on-disk `node_classes` section has at least one slot != `NULL_STRING_ID`.

Pre-fix this test fails with `Failed asserting that 0 is greater than 0` (every slot null); post-fix it passes. Direct guard for the failure mode the investigation pinpointed — verified locally by stash-pop'ing the source change and re-running.

## What's deliberately not in this PR

The original T2.3 doc proposed a `?::$link_name -> TargetClass` display fallback in `DedupCandidatePass::buildDedupLabel` as a second line of defence. After root-causing the actual writer bug, the only observed bare-label case (`raw:`) goes away with this fix; the fallback would purely guard against speculative future failures with no concrete data behind them. Skipped per CLAUDE.md's no-hypothetical-features guidance — if a different code path produces bare labels later, the fail-loud `link_name:` form is also more likely to get reported and fixed than a softened `?::$raw -> ?` that hides it.

The investigation also recommended (3) auditing other `int32_t[]` FFI accumulators for the same `=== NULL_STRING_ID` pattern and (4) sweeping substrate consumers other than `DedupCandidatePass` for silent binary-path degradation. Those are codebase-wide grep tasks better handled separately by the verification team.

## Local verification

  - psalm + phpcs clean
  - `BinaryFormatRoundTripTest`: 24 / 24 (1 new T2.3 case)
  - `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84` passes

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_