### PR TITLE
Extend bottleneck-Spine drop label past structural intermediaries (T2.5)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -534,19 +534,51 @@ final class TextReportFormatter implements ReportFormatterInterface
             return null;
         }
 
-        /** @var list<string> $path_parts */
-        $path_parts = [];
-        foreach (array_slice($raw_path, 0, $drop_index + 1) as $p) {
+        /** @var list<string> $all_parts */
+        $all_parts = [];
+        foreach ($raw_path as $p) {
             if (!is_string($p)) {
                 return null;
             }
-            $path_parts[] = $p;
+            $all_parts[] = $p;
         }
-        /** @var list<string> $path_types */
-        $path_types = [];
-        foreach (array_slice($raw_types, 0, $drop_index + 1) as $t) {
-            $path_types[] = is_string($t) ? $t : '';
+        /** @var list<string> $all_types */
+        $all_types = [];
+        foreach ($raw_types as $t) {
+            $all_types[] = is_string($t) ? $t : '';
         }
+
+        // Walk past trailing structural intermediaries (`global_variables`,
+        // `array_elements`, `object_properties`, ...) so the rendered
+        // prefix lands on a user-named identifier (`$decoded`, `$bus`,
+        // a class name, ...). Without this, a depth-1 drop into
+        // `array_elements` of `global_variables` rendered as the literal
+        // `global_variables -> array_elements` because PathFormatter's
+        // structural elision had nothing to anchor on, while the
+        // bottleneck_path summary line on the same finding showed the
+        // user-side `$decoded[...]`. T2.5 — the two lines now share
+        // vocabulary.
+        //
+        // Stop conditions:
+        //  - Hit a non-structural component (the user-named slot that
+        //    PathFormatter can render as `$var`, `Class::name`, etc.).
+        //  - Run off the end of the path. In that rare case the descent
+        //    is entirely structural (e.g. pure class_table internals);
+        //    we fall back to the depth integer rather than emit a
+        //    longer string of structural noise.
+        $end = $drop_index + 1;
+        while (
+            $end < count($all_parts)
+            && PathFormatter::isStructuralLink($all_parts[$end - 1])
+        ) {
+            $end++;
+        }
+        if (PathFormatter::isStructuralLink($all_parts[$end - 1])) {
+            return null;
+        }
+
+        $path_parts = array_slice($all_parts, 0, $end);
+        $path_types = array_slice($all_types, 0, $end);
 
         $label = PathFormatter::toPhpSyntax($path_parts, $path_types);
         if ($label === '' || $label === '(root)') {

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
@@ -45,6 +45,19 @@ final class PathFormatter
     ];
 
     /**
+     * Whether the given link name is a structural intermediary that
+     * `toPhpSyntax` would otherwise elide. Exposed so callers that
+     * render a partial path slice (e.g. the bottleneck-spine drop
+     * label) can extend the slice past structural components until
+     * a user-named segment appears, keeping the rendered vocabulary
+     * consistent with the full-path `summary_path`. T2.5.
+     */
+    public static function isStructuralLink(string $link_name): bool
+    {
+        return in_array($link_name, self::STRUCTURAL, true);
+    }
+
+    /**
      * Format a raw path (from link_names) into PHP-style syntax.
      *
      * @param list<string> $parts resolved link_names (frame names already resolved)

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -422,6 +422,86 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringContainsString('drops after ...', $output);
     }
 
+    public function testFormatExtendsSpineSliceToUserIdentifierForShallowStructuralDrop(): void
+    {
+        // T2.5: when the drop lands on a structural intermediary
+        // (`global_variables` → `array_elements`), PathFormatter has no
+        // user-named segment to anchor on and falls back to a literal
+        // `global_variables -> array_elements` join. The bottleneck_path
+        // summary line on the same finding speaks the user-side
+        // vocabulary (`$decoded[...]`); the Spine line should match.
+        // The formatter walks the slice forward past trailing
+        // structural components until a user-named identifier appears.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bottleneck_path',
+                severity: FindingSeverity::High,
+                confidence: FindingConfidence::High,
+                summary: '$decoded[data] (171.45 MB)',
+                facts: [
+                    'path' => [
+                        'global_variables', 'array_elements', 'decoded',
+                        'array_header', 'array_elements', 'data',
+                    ],
+                    'path_types' => [
+                        '', '', '',
+                        '', '', '',
+                    ],
+                    // ~2× drop at depth 1 (between sizes[0] and sizes[1]).
+                    // Without T2.5, the slice [0..1] is
+                    // [global_variables, array_elements] — both
+                    // structural — and PathFormatter renders
+                    // `global_variables -> array_elements`. With T2.5,
+                    // the slice extends to include `decoded` and renders
+                    // `$decoded`.
+                    'sizes' => [171_000_000, 84_000_000, 84_000_000, 84_000_000, 84_000_000, 84_000_000],
+                ],
+                impact_bytes: 171_000_000,
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        $this->assertStringContainsString('drops after $decoded', $output);
+        $this->assertStringNotContainsString('global_variables -> array_elements', $output);
+    }
+
+    public function testFormatFallsBackToDepthIntegerWhenDescentEntirelyStructural(): void
+    {
+        // Pathological case: every component on the descent is a
+        // structural intermediary. The extension loop runs off the
+        // end without finding a user-named segment; the formatter
+        // falls back to the depth integer rather than emit a longer
+        // string of structural noise.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bottleneck_path',
+                severity: FindingSeverity::High,
+                confidence: FindingConfidence::High,
+                summary: 'pathological structural-only descent',
+                facts: [
+                    'path' => [
+                        'global_variables', 'array_elements',
+                        'object_properties', 'value',
+                    ],
+                    'path_types' => ['', '', '', ''],
+                    // Drop at depth 1.
+                    'sizes' => [10_000_000, 1_000_000, 500_000, 100_000],
+                ],
+                impact_bytes: 10_000_000,
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        // No user-named identifier ever appears, so the new label
+        // can't be built. The legacy "at depth N" form takes over.
+        // (depth = drop_index + 1; drop_index = 0 here because the
+        // first comparison sizes[1]*2 < sizes[0] satisfies on i=0.)
+        $this->assertStringContainsString('drops at depth 1', $output);
+        $this->assertStringNotContainsString('global_variables', $output);
+    }
+
     public function testFormatOmitsBottleneckSpineLineForUniformDescent(): void
     {
         // When the spine stays dominant from root to leaf (no >2× drop


### PR DESCRIPTION
Implements **T2.5** from `docs/internals/memory-report-implementation-handoff.md` (commit `df69d91` on the research branch).

## Why

For shallow drops the two lines under a `bottleneck_path` finding spoke different vocabularies:

```
bottleneck_path: $decoded[data][10100][profile] (171.45 MB)
Spine: heaviest-child mass drops after global_variables -> array_elements
       (171.44 MB → 84.33 MB); leaf retains only 1.94 KB
```

`bottleneck_path` already elides structural roots (`global_variables`, `array_elements`) and starts the user-visible path at `$decoded`. After T2.2 (PR #652), `Spine:` rendered the raw path prefix from the structural root through the drop index — so a depth-1 drop into `array_elements` surfaced engine vocabulary the bottleneck_path line consciously hides, and the two reads as if they describe different paths.

The mismatch is inside `PathFormatter::toPhpSyntax`: when every component in a slice is in the `STRUCTURAL` list (`global_variables`, `array_elements`, `object_properties`, `value`, …) the function falls back to `implode(' -> ', $parts)` because there's no user-named segment to anchor on. For a full path this is never hit (the tail always names something user-side); for a bottleneck-spine slice that ends at the drop_index it can be hit on shallow drops.

## Fix — shape (B) from the handoff: extend the slice

  - New `PathFormatter::isStructuralLink(string $link_name)` exposes the `STRUCTURAL` list to outside callers without duplicating it. The formatter is the only caller for now.
  - In `formatSpineDropLabel`, walk forward from `drop_index + 1` while the trailing component is structural; stop on the first user-named identifier (`$decoded`, a class name, etc.).
  - If the entire descent is structural (rare — pure class_table internals or similar), fall back to the legacy `at depth N` form rather than emit a longer string of structural noise. (The handoff explicitly called out this cap.)

Drop-detection semantics are unchanged: the displayed label is just a slightly longer prefix that reaches a recognisable identifier; the size pair (`pre_drop_size → post_drop_size`) and the "leaf retains only X" trailer are unaffected.

The other fix shape considered in the handoff — (A) sharing elision logic between `selectSummaryPath` / `PathFormatter` and the Spine renderer — is more principled but pulls more refactor than the visible benefit warrants. Skipped per the handoff's "either works; (B) is simpler" recommendation.

## Tests

  - `testFormatExtendsSpineSliceToUserIdentifierForShallowStructuralDrop` — json-decode-shape fixture with depth-1 drop into `[global_variables, array_elements]`. Asserts the line reads `drops after $decoded` (extension landed on the user identifier) and not `global_variables -> array_elements` (the pre-T2.5 raw join).

  - `testFormatFallsBackToDepthIntegerWhenDescentEntirelyStructural` — pathological all-structural path `[global_variables, array_elements, object_properties, value]`. Asserts the legacy `drops at depth N` form takes over rather than the formatter emitting structural noise.

  - The pre-existing T2.2 spine tests (drop on user-named tail, truncation, no-drop, legacy facts-without-`path_types` fallback) keep their existing assertions — none of them exercise the all-structural slice case.

## Local verification

  - psalm + phpcs clean
  - TextReportFormatter unit tests: 19 / 19 (2 new T2.5 cases)
  - `testReportContainsRankingSections@v84` and `testBinaryAnalyzeReportMatchesSqliteReportForKeyFindings@v84` pass

## Verification per the handoff doc

```
grep -hE 'bottleneck_path|Spine: ' /tmp/memreport-out/rw*_*.report.txt \
  | paste - -
```

After this lands, no Spine line should show `global_variables -> array_elements` while its paired `bottleneck_path` line shows `$decoded`. Expected affected reports:

- `rw2_json-decode-huge` (drop into `global_variables -> array_elements`)
- `rw4_graph-recursion` (same shape)

Reports with mid-userland drops (`$bus->listeners[request.completed]`) stay unchanged.

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_