### PR TITLE
feat(memory-report): T2.6 — quote string array keys in path display

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatter.php
@@ -112,12 +112,16 @@ final class PathFormatter
                 continue;
             }
             if ($in_array_elements && $part !== 'value') {
-                // Array index — append [key] to previous segment
+                // Array index — append [key] to previous segment.
+                // String keys are quoted to match what PHP source code
+                // looks like (`$arr['data']` rather than `$arr[data]`,
+                // which would parse as a constant reference). T2.6.
+                $rendered = self::formatArrayKey($part);
                 if ($segments !== []) {
                     $last = count($segments) - 1;
-                    $segments[$last] .= "[{$part}]";
+                    $segments[$last] .= $rendered;
                 } else {
-                    $segments[] = "[{$part}]";
+                    $segments[] = $rendered;
                 }
                 $in_array_elements = false;
                 $prev_type = $type;
@@ -188,5 +192,31 @@ final class PathFormatter
         }
 
         return $result;
+    }
+
+    /**
+     * Render an array-key segment in PHP-source style: numeric keys
+     * stay bare (`[42]`), string keys are wrapped in single quotes
+     * (`['data']`). T2.6 — the path output reads as the PHP source
+     * a developer would write, so a bareword inside `[ ]` doesn't
+     * get mis-read as a constant reference.
+     *
+     * Numeric detection is the simple `/^-?\d+$/` test the handoff
+     * spec calls for. PHP arrays auto-cast numeric-string keys to
+     * ints at runtime, so quoting `['0']` would be incorrect; the
+     * common-case heuristic does miss strings like `'01'` and
+     * `'0e123'` (which PHP keeps as strings) but those are rare in
+     * captured paths and the divergence is cosmetic, not semantic.
+     */
+    private static function formatArrayKey(string $key): string
+    {
+        if ($key !== '' && preg_match('/^-?\d+$/', $key) === 1) {
+            return "[{$key}]";
+        }
+        // Single-quoted PHP literals only need `\` and `'` escaped.
+        // Replace `\` first so we don't double-escape the backslash
+        // we just added when escaping `'`.
+        $escaped = strtr($key, ['\\' => '\\\\', "'" => "\\'"]);
+        return "['{$escaped}']";
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/PathFormatterTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+use Reli\BaseTestCase;
+
+class PathFormatterTest extends BaseTestCase
+{
+    public function testNumericArrayKeysRenderBare(): void
+    {
+        // `$rows[0]` — numeric keys stay unquoted because PHP arrays
+        // auto-cast numeric-string keys to int slots.
+        $parts = ['global_variables', 'array_elements', 'rows', 'array_elements', '0'];
+        $types = ['', '', '', '', ''];
+
+        $this->assertSame(
+            '$rows[0]',
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testNegativeNumericArrayKeysRenderBare(): void
+    {
+        // PHP allows negative int keys (`$arr[-1] = "x"` works).
+        $parts = ['global_variables', 'array_elements', 'cache', 'array_elements', '-1'];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame('$cache[-1]', PathFormatter::toPhpSyntax($parts, $types));
+    }
+
+    public function testStringArrayKeysAreSingleQuoted(): void
+    {
+        // T2.6: bareword inside `[ ]` reads as a constant reference
+        // in PHP source. Path output should match what a developer
+        // would actually type — `$decoded['data']`, not `$decoded[data]`.
+        $parts = ['global_variables', 'array_elements', 'decoded', 'array_elements', 'data'];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame(
+            "\$decoded['data']",
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testMixedNumericAndStringKeysQuoteOnlyTheStringOnes(): void
+    {
+        // `$rows[0]['metadata']['ref']` — the 0 stays bare, the two
+        // string keys get quoted.
+        $parts = [
+            'global_variables', 'array_elements', 'rows',
+            'array_elements', '0',
+            'array_elements', 'metadata',
+            'array_elements', 'ref',
+        ];
+        $types = array_fill(0, 9, '');
+
+        $this->assertSame(
+            "\$rows[0]['metadata']['ref']",
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testKeysWithDotsOrSpecialCharsGetQuoted(): void
+    {
+        // Keys like `request.completed` look enough like constants to
+        // confuse a reader if rendered bare.
+        $parts = [
+            'global_variables', 'array_elements', 'listeners',
+            'array_elements', 'request.completed',
+        ];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame(
+            "\$listeners['request.completed']",
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testKeyWithEmbeddedSingleQuoteIsEscaped(): void
+    {
+        // Single-quoted PHP literals escape `'` as `\'`. Rare in real
+        // captures but the formatter shouldn't produce malformed
+        // pseudo-PHP.
+        $parts = [
+            'global_variables', 'array_elements', 'msgs',
+            'array_elements', "it's",
+        ];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame(
+            "\$msgs['it\\'s']",
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testKeyWithEmbeddedBackslashIsEscaped(): void
+    {
+        // `\` is the only other character a single-quoted PHP literal
+        // needs to escape. Order of escape (`\` before `'`) matters:
+        // a naive `'` → `\'` then `\` → `\\` would double-escape the
+        // newly-added `\`.
+        $parts = [
+            'global_variables', 'array_elements', 'paths',
+            'array_elements', 'a\\b',
+        ];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame(
+            "\$paths['a\\\\b']",
+            PathFormatter::toPhpSyntax($parts, $types),
+        );
+    }
+
+    public function testNumericLookingStringKeyIsTreatedAsNumeric(): void
+    {
+        // Documented edge case from the T2.6 spec: keys like '01' or
+        // '0e123' are stored as PHP strings at runtime (PHP doesn't
+        // canonicalise these), but the formatter's simple `^-?\d+$`
+        // check treats them as numeric. Common-case heuristic;
+        // strings of all-digits in real captures are almost always
+        // semantically integer.
+        $parts = [
+            'global_variables', 'array_elements', 'arr',
+            'array_elements', '01',
+        ];
+        $types = array_fill(0, 5, '');
+
+        $this->assertSame('$arr[01]', PathFormatter::toPhpSyntax($parts, $types));
+    }
+}


### PR DESCRIPTION
## Summary

T2.6 from the memory-report UX handoff. Render array-key path segments as the
PHP source a developer would actually type:

- Numeric keys stay bare — `$rows[0]`, `$cache[-1]`
- String keys get single-quoted — `$decoded['data']`, `$listeners['request.completed']`
- Embedded `'` and `\` in keys are escaped (`$msgs['it\'s']`, `$paths['a\\b']`)

Without quoting, a bareword inside `[ ]` reads as a constant reference in PHP
source — `$arr[data]` parses as "the constant named `data`," which isn't what
was actually captured.

## Behaviour notes

- Numeric detection uses the `^-?\d+$` heuristic from the spec. PHP auto-casts
  numeric-string keys to int at runtime, so `['0']` would be wrong for the
  common case. The heuristic diverges for keys like `'01'` or `'0e123'`
  (which PHP keeps as strings); those render bare. Documented as an explicit
  test case — common-case heuristic, divergence is cosmetic only.
- Escape order in `formatArrayKey` is `\` first, then `'`. Reversed order
  would double-escape the backslash that was just added when quoting the
  apostrophe.

## Test plan

- [x] New `PathFormatterTest` (8 cases: numeric / negative numeric / string /
      mixed / dots & specials / embedded `'` / embedded `\` / numeric-looking
      string)
- [x] Full unit suite: 3176 / 3176 passing
- [x] `BinaryFormatRoundTrip` (9/9) — path encoding unchanged
- [x] `MemoryReportCommandIntegrationTest` v84 (3/3, 53 assertions)
- [x] psalm + phpcs clean on both touched files

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_