### PR TITLE
feat(memory-report): N4 — collapse uniform-sibling rows in Top Arrays/Strings

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportResult;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\PathFormatter;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\UniformSiblingDetector;
 
 final class TextReportFormatter implements ReportFormatterInterface
 {
@@ -211,8 +212,37 @@ final class TextReportFormatter implements ReportFormatterInterface
             $lines[] = sprintf('  %3s  %12s %12s %8s  %8s  %s', '#', 'Retained', 'Table', 'Elems', 'Node', 'Path');
             $lines[] = '  ' . str_repeat('-', 90);
 
-            $array_rank = 0;
+            // Detect runs of "+N similar siblings" so the table doesn't
+            // dump 25 near-identical $rows[0]…$rows[N] rows when one
+            // representative line + a count is what a reader actually
+            // wants. N4. Run only across same-kind findings — collapsing a
+            // dense array into a sparse-array's run would lose the
+            // [sparse] tag.
+            $sizes = [];
+            $extras = [];
+            $paths = [];
             foreach ($top_arrays as $finding) {
+                $facts = $finding->facts;
+                /** @var int $r */
+                $r = $facts['retained_size'] ?? $facts['table_size'] ?? 0;
+                /** @var int $e */
+                $e = $facts['element_count'] ?? $facts['capacity'] ?? 0;
+                /** @var string $p */
+                $p = $facts['owner_path'] ?? '';
+                $sizes[] = $r;
+                // Encode kind into the extras vector so dense vs sparse
+                // never collapse together (different table-density tags
+                // on the same row would confuse a reader).
+                $extras[] = $e * 2 + ($finding->kind === 'sparse_array' ? 1 : 0);
+                $paths[] = $p;
+            }
+            $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+            $array_rank = 0;
+            foreach ($top_arrays as $i => $finding) {
+                if ($decisions[$i]['kind'] === 'member') {
+                    continue;
+                }
                 $facts = $finding->facts;
                 /** @var int $retained */
                 $retained = $facts['retained_size'] ?? $facts['table_size'] ?? 0;
@@ -236,6 +266,9 @@ final class TextReportFormatter implements ReportFormatterInterface
                     $path ?: '(root)',
                     $tag,
                 );
+                if ($decisions[$i]['kind'] === 'head' && isset($decisions[$i]['annotation'])) {
+                    $lines[] = '       ' . $decisions[$i]['annotation'];
+                }
             }
             $lines[] = '';
         }
@@ -247,8 +280,30 @@ final class TextReportFormatter implements ReportFormatterInterface
             $lines[] = sprintf('  %3s  %12s  %8s  %-30s  %s', '#', 'Size', 'Node', 'Path', 'Preview');
             $lines[] = '  ' . str_repeat('-', 100);
 
-            $string_rank = 0;
+            // Same uniform-sibling collapse as Top Arrays. Run detection
+            // uses the *full* path (not the truncated `$display_path`) so
+            // segment differences past the leading `...` aren't masked.
+            // Strings have no element_count, so pass 0 uniformly. N4.
+            $sizes = [];
+            $extras = [];
+            $paths = [];
             foreach ($top_strings as $finding) {
+                $facts = $finding->facts;
+                /** @var int $s */
+                $s = $facts['size'] ?? 0;
+                /** @var string $p */
+                $p = $facts['owner_path'] ?? '';
+                $sizes[] = $s;
+                $extras[] = 0;
+                $paths[] = $p;
+            }
+            $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+            $string_rank = 0;
+            foreach ($top_strings as $i => $finding) {
+                if ($decisions[$i]['kind'] === 'member') {
+                    continue;
+                }
                 $facts = $finding->facts;
                 /** @var int $size */
                 $size = $facts['size'] ?? 0;
@@ -282,6 +337,9 @@ final class TextReportFormatter implements ReportFormatterInterface
                     $display_path ?: '(root)',
                     $display_preview ?: '(binary)',
                 );
+                if ($decisions[$i]['kind'] === 'head' && isset($decisions[$i]['annotation'])) {
+                    $lines[] = '       ' . $decisions[$i]['annotation'];
+                }
             }
             $lines[] = '';
         }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/UniformSiblingDetector.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/UniformSiblingDetector.php
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+/**
+ * Detect runs of consecutive rows that look like "the same thing N times":
+ * same size (±tolerance), same auxiliary count (element_count for arrays),
+ * and PHP-syntax paths that differ in exactly one token.
+ *
+ * Top Arrays / Top Strings tables in real captures often dump 6–25
+ * sibling rows that read as one phenomenon — `$rows[0]`, `$rows[1]`,
+ * ... or `class_table->Carbon\X->doc_comment` for several X. Collapsing
+ * the run to one representative + annotation keeps the table scannable
+ * without losing the count or the spread of varying values.
+ *
+ * Tokenization splits on the natural PHP path boundaries: `$var`, `[K]`,
+ * `->prop`. A run is extended only while the *same* token position is the
+ * differing one — so `$a[0]` / `$a[1]` collapses, but `$a[0]` / `$b[0]`
+ * doesn't (different first token), and `$a[0]->x` / `$a[0]->y` collapses
+ * (third token varies). Tolerance is on retained size only; auxiliary
+ * counts (element_count) must match exactly.
+ *
+ * The detector only finds *consecutive* runs. The Top Arrays / Top
+ * Strings tables come pre-sorted by retained size descending, so similar
+ * siblings naturally sit adjacent — non-adjacent matches are rare and
+ * deliberately not collapsed (sorting them under one heading would
+ * scramble the rank order).
+ */
+final class UniformSiblingDetector
+{
+    /**
+     * Scan parallel arrays of rows and decide, per row, whether to render
+     * normally, render as the head of a collapsed run, or skip (collapsed
+     * into the previous head).
+     *
+     * `$extras` lets the caller require an exact match on a secondary
+     * field (Top Arrays passes element_count; Top Strings passes 0
+     * uniformly so the field is a no-op). Pass `0.05` for the default
+     * 5% size tolerance.
+     *
+     * @param list<int>    $sizes
+     * @param list<int>    $extras  must be the same length as `$sizes`
+     * @param list<string> $paths   PHP-syntax paths (already formatted)
+     * @return array<int, array{
+     *   kind: 'normal'|'head'|'member',
+     *   annotation?: string,
+     * }>
+     */
+    public static function findRuns(
+        array $sizes,
+        array $extras,
+        array $paths,
+        float $size_tolerance = 0.05,
+    ): array {
+        $n = count($sizes);
+        if ($n !== count($extras) || $n !== count($paths)) {
+            // Defensive: callers in this codebase always pass equal-length
+            // arrays, but a length mismatch is ambiguous (which row is
+            // which?) so degrade to "render everything normally".
+            $out = [];
+            for ($i = 0; $i < $n; $i++) {
+                $out[] = ['kind' => 'normal'];
+            }
+            return $out;
+        }
+
+        /** @var array<int, array{kind: 'normal'|'head'|'member', annotation?: string}> $decisions */
+        $decisions = [];
+        for ($i = 0; $i < $n; $i++) {
+            $decisions[$i] = ['kind' => 'normal'];
+        }
+
+        $i = 0;
+        while ($i < $n) {
+            $head_tokens = self::tokenize($paths[$i]);
+            $varying_idx = null;
+            $run_values = [$head_tokens];
+            $j = $i + 1;
+            while ($j < $n) {
+                if ($extras[$j] !== $extras[$i]) {
+                    break;
+                }
+                if (!self::sizesMatch($sizes[$i], $sizes[$j], $size_tolerance)) {
+                    break;
+                }
+                $cur_tokens = self::tokenize($paths[$j]);
+                if (count($cur_tokens) !== count($head_tokens)) {
+                    break;
+                }
+                $diff_idx = self::singleDiffPosition($head_tokens, $cur_tokens);
+                if ($diff_idx === null) {
+                    break;
+                }
+                if ($varying_idx === null) {
+                    $varying_idx = $diff_idx;
+                } elseif ($varying_idx !== $diff_idx) {
+                    break;
+                }
+                $run_values[] = $cur_tokens;
+                $j++;
+            }
+
+            $extension = $j - $i - 1;
+            if ($extension >= 1 && $varying_idx !== null) {
+                $values = [];
+                foreach ($run_values as $tokens) {
+                    $values[] = $tokens[$varying_idx];
+                }
+                $annotation = self::buildAnnotation(
+                    $extension,
+                    $sizes[$i],
+                    $values,
+                    $head_tokens[$varying_idx],
+                );
+                $decisions[$i] = ['kind' => 'head', 'annotation' => $annotation];
+                for ($k = $i + 1; $k < $j; $k++) {
+                    $decisions[$k] = ['kind' => 'member'];
+                }
+            }
+            $i = $j;
+        }
+
+        return $decisions;
+    }
+
+    /**
+     * Split a PHP-syntax path into the tokens that bound a "segment":
+     * `$var`, `[K]`, `->prop`. Falls back to a single token when the
+     * path doesn't match the expected shape (e.g. `(root)`); that
+     * still works correctly with the run detector — a single-token
+     * path can only collapse against another single-token path that
+     * differs entirely, which is the right behaviour.
+     *
+     * @return list<string>
+     */
+    private static function tokenize(string $path): array
+    {
+        if ($path === '') {
+            return [''];
+        }
+        if (preg_match_all('/\$[^\->\[]+|->[^\->\[]+|\[[^\]]*\]/', $path, $matches) === false) {
+            return [$path];
+        }
+        $tokens = $matches[0];
+        if ($tokens === [] || implode('', $tokens) !== $path) {
+            // Tokenizer didn't cover the whole string — paths with `::`
+            // (call frames) or `<main>:line` prefixes fall here. Treat
+            // the whole path as one token; runs only collapse when two
+            // such paths happen to be identical, which won't trigger.
+            return [$path];
+        }
+        return $tokens;
+    }
+
+    /**
+     * Position of the single differing token, or null when the two
+     * token lists differ at zero positions or more than one position.
+     *
+     * @param list<string> $a
+     * @param list<string> $b
+     */
+    private static function singleDiffPosition(array $a, array $b): ?int
+    {
+        if (count($a) !== count($b)) {
+            return null;
+        }
+        $diff = -1;
+        for ($i = 0; $i < count($a); $i++) {
+            if ($a[$i] !== $b[$i]) {
+                if ($diff !== -1) {
+                    return null;
+                }
+                $diff = $i;
+            }
+        }
+        return $diff === -1 ? null : $diff;
+    }
+
+    private static function sizesMatch(int $a, int $b, float $tolerance): bool
+    {
+        if ($a === $b) {
+            return true;
+        }
+        $reference = max(1, max($a, $b));
+        return abs($a - $b) <= (int)floor((float)$reference * $tolerance);
+    }
+
+    /**
+     * Build the "+N more similar siblings ..." line that follows the
+     * representative row. When all varying values are integer keys
+     * (`[123]`), render as a numeric range (`indices [0..6]`); otherwise
+     * list the bare values, capped at 4 examples.
+     *
+     * @param list<string> $varying_token_values
+     */
+    private static function buildAnnotation(
+        int $extension_count,
+        int $representative_size,
+        array $varying_token_values,
+        string $head_varying_token,
+    ): string {
+        $size_repr = SizeFormatter::format($representative_size);
+        $total = $extension_count + 1;
+
+        $numerics = self::extractIntegerKeys($varying_token_values);
+        if ($numerics !== null && $numerics !== []) {
+            $min = min($numerics);
+            $max = max($numerics);
+            return sprintf(
+                '(+%d more similar siblings, ~%s each across %d rows; indices [%d..%d])',
+                $extension_count,
+                $size_repr,
+                $total,
+                $min,
+                $max,
+            );
+        }
+
+        $bare = [];
+        foreach ($varying_token_values as $token) {
+            $bare[] = self::bareTokenValue($token);
+        }
+        $sample = array_slice($bare, 0, 4);
+        $more = count($bare) > 4 ? sprintf(', ...+%d more', count($bare) - 4) : '';
+        $kind = self::tokenKindLabel($head_varying_token);
+        return sprintf(
+            '(+%d more similar siblings, ~%s each across %d rows; varying %s: %s%s)',
+            $extension_count,
+            $size_repr,
+            $total,
+            $kind,
+            implode(', ', $sample),
+            $more,
+        );
+    }
+
+    /**
+     * If every token is a bracketed integer key (`[42]`, `[-1]`),
+     * return the integer list. Returns null when any token is not
+     * a pure integer key, so the caller falls back to enumerating
+     * values verbatim.
+     *
+     * @param list<string> $tokens
+     * @return list<int>|null
+     */
+    private static function extractIntegerKeys(array $tokens): ?array
+    {
+        $out = [];
+        foreach ($tokens as $token) {
+            if (preg_match('/^\[(-?\d+)\]$/', $token, $m) !== 1) {
+                return null;
+            }
+            $out[] = (int)$m[1];
+        }
+        return $out;
+    }
+
+    private static function bareTokenValue(string $token): string
+    {
+        if (str_starts_with($token, '->')) {
+            return substr($token, 2);
+        }
+        if (str_starts_with($token, '[') && str_ends_with($token, ']')) {
+            return substr($token, 1, -1);
+        }
+        return $token;
+    }
+
+    private static function tokenKindLabel(string $token): string
+    {
+        if (str_starts_with($token, '->')) {
+            return 'property';
+        }
+        if (str_starts_with($token, '[')) {
+            return 'key';
+        }
+        return 'name';
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -310,6 +310,79 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringNotContainsString("first line\nsecond line", $output);
     }
 
+    public function testTopArraysCollapseUniformIndexSiblings(): void
+    {
+        // N4: when several Top Arrays rows describe what is clearly the
+        // same shape — same retained size, same element_count, paths
+        // differing only in `[N]` — collapse into one representative
+        // line plus a "+N more" annotation. Without this, captures from
+        // workloads like rw3_graphql-shape spend half a screen on
+        // identical $queryResult[viewer][recentActivity][0..N] rows.
+        $facts_template = [
+            'table_size' => 1228800,
+            'retained_size' => 6553600,
+            'element_count' => 100,
+        ];
+        $findings = [];
+        for ($i = 0; $i < 5; $i++) {
+            $findings[] = new Finding(
+                kind: 'large_array',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::High,
+                summary: 'sibling',
+                facts: $facts_template + [
+                    'node_id' => 1000 + $i,
+                    'owner_path' => "\$queryResult[viewer][recentActivity][{$i}]",
+                ],
+                impact_bytes: 6553600,
+            );
+        }
+        $output = (new TextReportFormatter())->format(new ReportResult([], $findings));
+
+        // First row renders normally.
+        $this->assertStringContainsString('$queryResult[viewer][recentActivity][0]', $output);
+        // Annotation appears on the row after the first.
+        $this->assertStringContainsString('+4 more similar siblings', $output);
+        $this->assertStringContainsString('indices [0..4]', $output);
+        // Members are skipped — the trailing siblings shouldn't print.
+        $this->assertStringNotContainsString('$queryResult[viewer][recentActivity][3]', $output);
+        $this->assertStringNotContainsString('$queryResult[viewer][recentActivity][4]', $output);
+    }
+
+    public function testTopStringsCollapseUniformVaryingProperty(): void
+    {
+        // N4 for Top Strings — same shape as Top Arrays: rw_logger-stack
+        // dumps several Carbon doc_comments with the same ~156 KB size,
+        // path differing on the class-name segment.
+        $facts_template = [
+            'preview' => '/**\n * A simple API extension for DateT...',
+        ];
+        $sizes_bytes = [159907, 159870, 159860, 159855];
+        $classes = ['CarbonInterface', 'CarbonImmutable', 'Carbon', 'Traits\\Date'];
+        $findings = [];
+        foreach ($classes as $i => $cls) {
+            $findings[] = new Finding(
+                kind: 'large_string',
+                severity: FindingSeverity::Medium,
+                confidence: FindingConfidence::High,
+                summary: 'doc_comment',
+                facts: $facts_template + [
+                    'node_id' => 2000 + $i,
+                    'size' => $sizes_bytes[$i],
+                    'owner_path' => "\$class_table->Carbon\\{$cls}->doc_comment",
+                ],
+                impact_bytes: $sizes_bytes[$i],
+            );
+        }
+        $output = (new TextReportFormatter())->format(new ReportResult([], $findings));
+
+        $this->assertStringContainsString('Carbon\\CarbonInterface', $output);
+        // The non-numeric-key form: enumerated values, kind-labelled
+        // as `property` because the varying segment is `->Class`.
+        $this->assertStringContainsString('+3 more similar siblings', $output);
+        $this->assertStringContainsString('varying property:', $output);
+    }
+
     public function testFormatRendersBottleneckSpineDropLineWithPathComponent(): void
     {
         // T2.2: the spine line should name the path component the

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/UniformSiblingDetectorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/UniformSiblingDetectorTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
+
+use Reli\BaseTestCase;
+
+class UniformSiblingDetectorTest extends BaseTestCase
+{
+    /**
+     * @param array{kind: 'normal'|'head'|'member', annotation?: string} $decision
+     */
+    private function annotationOf(array $decision): string
+    {
+        $this->assertArrayHasKey('annotation', $decision);
+        return $decision['annotation'];
+    }
+
+    public function testRunOfNumericIndexSiblingsCollapses(): void
+    {
+        // Real-world shape from rw3_graphql-shape: three rows of the
+        // exact same retained size, paths differing only in `[N]`. The
+        // first row should become the head; the others marked member.
+        $sizes = [688128, 688128, 688128];
+        $extras = [42, 42, 42];
+        $paths = [
+            '$queryResult[viewer][recentActivity][0]',
+            '$queryResult[viewer][recentActivity][1]',
+            '$queryResult[viewer][recentActivity][2]',
+        ];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('head', $decisions[0]['kind']);
+        $this->assertSame('member', $decisions[1]['kind']);
+        $this->assertSame('member', $decisions[2]['kind']);
+        $annotation = $this->annotationOf($decisions[0]);
+        $this->assertStringContainsString('+2 more similar siblings', $annotation);
+        // Numeric range form is the cleaner annotation when every
+        // varying token is a `[N]` integer key.
+        $this->assertStringContainsString('indices [0..2]', $annotation);
+    }
+
+    public function testNonNumericVaryingSegmentEnumeratesValues(): void
+    {
+        // rw_logger-stack — Carbon doc_comments under different class
+        // entries. Same size band, varying token is `->Carbon\X`.
+        $sizes = [159907, 159870, 159860];
+        $extras = [0, 0, 0];
+        $paths = [
+            '$class_table->Carbon\\CarbonInterface->doc_comment',
+            '$class_table->Carbon\\CarbonImmutable->doc_comment',
+            '$class_table->Carbon\\Carbon->doc_comment',
+        ];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('head', $decisions[0]['kind']);
+        $this->assertSame('member', $decisions[1]['kind']);
+        $this->assertSame('member', $decisions[2]['kind']);
+        // Non-numeric varying tokens fall back to enumerating bare values
+        // — `property` because the differing token starts with `->`.
+        $annotation = $this->annotationOf($decisions[0]);
+        $this->assertStringContainsString('varying property:', $annotation);
+        $this->assertStringContainsString('Carbon\\CarbonInterface', $annotation);
+    }
+
+    public function testRunBreaksOnSizeOutOfTolerance(): void
+    {
+        // 5% default tolerance. 1000 → 1100 is 10% — must NOT collapse.
+        $sizes = [1000, 1100, 1100];
+        $extras = [0, 0, 0];
+        $paths = ['$arr[0]', '$arr[1]', '$arr[2]'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        // Row 0 stays alone (size diff to row 1 is 10%). Rows 1+2 form
+        // their own collapsed run because they're identical size.
+        $this->assertSame('normal', $decisions[0]['kind']);
+        $this->assertSame('head', $decisions[1]['kind']);
+        $this->assertSame('member', $decisions[2]['kind']);
+    }
+
+    public function testRunBreaksOnElementCountMismatch(): void
+    {
+        // Same size, paths differ only in `[N]`, but element_count
+        // differs — the rows describe arrays of different shape, so
+        // they shouldn't collapse even though the surface looks similar.
+        $sizes = [1000, 1000, 1000];
+        $extras = [10, 20, 10];
+        $paths = ['$arr[0]', '$arr[1]', '$arr[2]'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('normal', $decisions[0]['kind']);
+        $this->assertSame('normal', $decisions[1]['kind']);
+        $this->assertSame('normal', $decisions[2]['kind']);
+    }
+
+    public function testRunBreaksWhenDifferingPositionShifts(): void
+    {
+        // Row 0 vs row 1: differing position is segment 1 (`[0]` vs `[1]`).
+        // Row 1 vs row 2: differing position is segment 3 (`->x` vs `->y`).
+        // The varying-position constraint forbids extending across the
+        // shift — a run must keep the same single varying token slot.
+        $sizes = [1000, 1000, 1000];
+        $extras = [0, 0, 0];
+        $paths = ['$arr[0]->x', '$arr[1]->x', '$arr[1]->y'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        // Rows 0+1 collapse on the index.
+        $this->assertSame('head', $decisions[0]['kind']);
+        $this->assertSame('member', $decisions[1]['kind']);
+        // Row 2's varying position is different from rows 0+1, so it
+        // doesn't extend the run; it stands on its own.
+        $this->assertSame('normal', $decisions[2]['kind']);
+    }
+
+    public function testRunBreaksWhenTwoSegmentsDiffer(): void
+    {
+        // Both `$a` vs `$b` AND `[0]` vs `[1]` differ — that's two
+        // changes, which means these aren't the same shape with one
+        // varying coordinate, so don't collapse.
+        $sizes = [1000, 1000];
+        $extras = [0, 0];
+        $paths = ['$a[0]', '$b[1]'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('normal', $decisions[0]['kind']);
+        $this->assertSame('normal', $decisions[1]['kind']);
+    }
+
+    public function testIdenticalPathsDoNotCollapse(): void
+    {
+        // Zero differing tokens between rows 0 and 1: not a varying
+        // sibling pattern (would mean the same node twice). The
+        // detector treats "no differing position" as "no run".
+        $sizes = [1000, 1000];
+        $extras = [0, 0];
+        $paths = ['$a[0]', '$a[0]'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('normal', $decisions[0]['kind']);
+        $this->assertSame('normal', $decisions[1]['kind']);
+    }
+
+    public function testNegativeIndicesAreStillIntegerRange(): void
+    {
+        // Negative integer keys are valid in PHP; the integer-range
+        // annotation form should accept them.
+        $sizes = [1000, 1000, 1000];
+        $extras = [0, 0, 0];
+        $paths = ['$arr[-1]', '$arr[0]', '$arr[1]'];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('head', $decisions[0]['kind']);
+        $this->assertStringContainsString('indices [-1..1]', $this->annotationOf($decisions[0]));
+    }
+
+    public function testQuotedStringKeysRenderAsEnumeratedValues(): void
+    {
+        // String keys like `['data']` aren't pure integer tokens, so
+        // the annotation falls back to listing values rather than a
+        // numeric range.
+        $sizes = [1000, 1000];
+        $extras = [0, 0];
+        $paths = ["\$arr['alpha']", "\$arr['beta']"];
+
+        $decisions = UniformSiblingDetector::findRuns($sizes, $extras, $paths);
+
+        $this->assertSame('head', $decisions[0]['kind']);
+        $annotation = $this->annotationOf($decisions[0]);
+        $this->assertStringContainsString('varying key:', $annotation);
+        $this->assertStringContainsString("'alpha'", $annotation);
+    }
+
+    public function testEmptyInputProducesEmptyOutput(): void
+    {
+        $this->assertSame([], UniformSiblingDetector::findRuns([], [], []));
+    }
+
+    public function testMismatchedInputLengthsDegradeToAllNormal(): void
+    {
+        // Defensive path: callers in this codebase pass equal-length
+        // arrays, but if they didn't (length mismatch), we don't know
+        // which row maps to which fact, so render everything normally
+        // rather than risk a crash or a mis-collapse.
+        $decisions = UniformSiblingDetector::findRuns([1, 2, 3], [0, 0], ['a', 'b', 'c']);
+
+        $this->assertCount(3, $decisions);
+        foreach ($decisions as $d) {
+            $this->assertSame('normal', $d['kind']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

T3 / N4 from the memory-report UX handoff. Captures from real workloads
frequently dump several Top Arrays / Top Strings rows that are clearly the
same phenomenon — same retained size, same element_count, paths that differ
only in `[N]` index or one class-name segment. Before this change, those ate
half a screen.

Now consecutive runs with same size (±5%), same element_count, and exactly
one differing tokenized path segment collapse to one representative line
plus a `(+N more similar siblings...)` annotation. Integer-key runs render
as numeric ranges; non-numeric runs list bare values.

```text
Before:                                   After:
3   54.50 KB   $errors[0]->frames         3   54.50 KB   $errors[0]->frames
4   53.99 KB   $errors[1000]->frames          (+6 more similar siblings, ~54 KB
5   53.99 KB   $errors[1001]->frames           each across 7 rows; indices [0..1006])
6   53.99 KB   $errors[1002]->frames     4   ... (next finding)
... (7 rows total)
```

## Behaviour notes

- **Run detection lives in `Substrate\UniformSiblingDetector`** so the same
  logic drives Top Arrays and Top Strings; strings just pass 0 for the
  element_count vector.
- **Full path is used for tokenization**, not the truncated display path —
  segment differences past the leading `...` aren't masked.
- **Dense and sparse arrays are kept apart** by encoding the finding kind
  into the extras vector — collapsing a `[sparse]` row into a dense run
  would silently drop the tag.
- **Only adjacent rows collapse.** The tables come pre-sorted by retained
  size desc, so genuine sibling runs sit adjacent. Non-adjacent matches are
  deliberately not re-sorted; that would scramble the rank order.
- **JSON output is unchanged.** This is purely a text-formatter
  presentation change, in line with the Finding-centric/Narrative-centric
  split we agreed on.

## Test plan

- [x] `UniformSiblingDetectorTest` — 11 cases covering numeric range
      annotation, non-numeric enumeration, size tolerance, element-count
      mismatch, varying-position shift, two-segment diff, identical paths,
      negative integer keys, quoted string keys, empty input,
      length-mismatch defensive path
- [x] `TextReportFormatterTest` — 2 new end-to-end cases (Top Arrays index
      run, Top Strings property run); all 21 existing cases still pass
- [x] Full unit suite: 3190 / 3191 passing — the one failure is an
      unrelated flaky `LiveHttpServerTest::testGzipWhen...` (passes in
      isolation, no relation to this change)
- [x] psalm + phpcs clean on all four touched files

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_