### PR TITLE
feat(memory-report): N2 — split Additional Info into Observations + Minor findings

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -376,7 +376,12 @@ final class TextReportFormatter implements ReportFormatterInterface
             $lines[] = '';
         }
 
-        // Info findings (non-table)
+        // Info findings (non-table). N2: split into "Observations" (this
+        // is the system working as intended — CoW sharing, string
+        // interning) vs "Minor findings" (small dedup opportunities or
+        // diagnostics worth a glance). Without the split, a working
+        // singleton or interning pattern reads identical to a real
+        // problem because both render with the same `[shared_*]` tag.
         $other_info = array_filter(
             $info,
             fn(Finding $f) => !in_array($f->kind, [
@@ -388,9 +393,26 @@ final class TextReportFormatter implements ReportFormatterInterface
                 'large_string',
             ], true)
         );
-        if ($other_info !== []) {
-            $lines[] = '=== Additional Info ===';
-            foreach ($other_info as $finding) {
+        $observations = [];
+        $minor_findings = [];
+        foreach ($other_info as $finding) {
+            if (self::isObservation($finding)) {
+                $observations[] = $finding;
+            } else {
+                $minor_findings[] = $finding;
+            }
+        }
+        if ($observations !== []) {
+            $lines[] = '=== Observations (no action needed) ===';
+            foreach ($observations as $finding) {
+                $label = self::observationLabel($finding);
+                $lines[] = "  [{$label}] {$finding->summary}";
+            }
+            $lines[] = '';
+        }
+        if ($minor_findings !== []) {
+            $lines[] = '=== Minor findings ===';
+            foreach ($minor_findings as $finding) {
                 $lines[] = "  [{$finding->kind}] {$finding->summary}";
             }
             $lines[] = '';
@@ -423,6 +445,54 @@ final class TextReportFormatter implements ReportFormatterInterface
             FindingSeverity::Medium => 2,
             FindingSeverity::Low => 3,
             FindingSeverity::Info => 4,
+        };
+    }
+
+    /**
+     * Bucket selection for the Additional Info split (N2).
+     *
+     * - `shared_singleton` is always an observation: by definition it
+     *   means many references collapsed onto one target, which is the
+     *   CoW share working as intended.
+     * - `shared_fanin` becomes an observation only when the refs/targets
+     *   ratio is >= 100. Real-world examples: PDO HashTable keys at
+     *   4.5M refs → 39 interned strings (~115k each). Below that
+     *   threshold, the ratio represents a small-pool dedup opportunity
+     *   worth surfacing as a minor finding rather than hiding as an
+     *   "all good" observation. The [10, 100) middle band defaults to
+     *   Minor — borderline patterns are worth a glance.
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    private static function isObservation(Finding $finding): bool
+    {
+        if ($finding->kind === 'shared_singleton') {
+            return true;
+        }
+        if ($finding->kind === 'shared_fanin') {
+            $refs = $finding->facts['ref_count'] ?? 0;
+            $targets = $finding->facts['target_count'] ?? 0;
+            if (!is_int($refs) || !is_int($targets) || $targets <= 0) {
+                return false;
+            }
+            return $refs / $targets >= 100;
+        }
+        return false;
+    }
+
+    /**
+     * Reader-facing tag for the Observations bucket. The raw kinds
+     * (`shared_singleton`, `shared_fanin`) document what the detector
+     * looked for; the observation tag documents what it *means* — CoW
+     * share, string interning. Both forms remain accessible on JSON
+     * output via `Finding::$kind`; this is text-only narrative.
+     */
+    private static function observationLabel(Finding $finding): string
+    {
+        return match ($finding->kind) {
+            'shared_singleton' => 'CoW share',
+            'shared_fanin' => 'interning',
+            default => $finding->kind,
         };
     }
 

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -625,4 +625,162 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringContainsString('...', $output);
         $this->assertStringContainsString('ClassName', $output);
     }
+
+    public function testSharedSingletonRendersUnderObservations(): void
+    {
+        // N2: a shared_singleton (1 target, many refs) means CoW share
+        // is working — always an observation, never a "finding to fix".
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'shared_singleton',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'AttributeMetadata::$ignoredAttributes (4,499 refs -> 1 target) [singleton]',
+                facts: [
+                    'ref_count' => 4499,
+                    'target_count' => 1,
+                ],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Observations (no action needed) ===', $output);
+        // Reader-facing label rather than the internal kind tag.
+        $this->assertStringContainsString('[CoW share] AttributeMetadata', $output);
+        // Must NOT appear under Minor findings, and the legacy combined
+        // section header must not appear either.
+        $this->assertStringNotContainsString('=== Minor findings ===', $output);
+        $this->assertStringNotContainsString('=== Additional Info ===', $output);
+    }
+
+    public function testSharedFaninWithHighRatioRendersAsInterning(): void
+    {
+        // refs/targets = 4,500,030 / 39 ≈ 115k each — classic interning
+        // (PDO HashTable keys, real corpus example). Above the 100x
+        // threshold so it lands in Observations with the [interning] tag.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'shared_fanin',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: 'key -> ? (4,500,030 refs -> 39 targets, 115385.4 each)',
+                facts: [
+                    'ref_count' => 4500030,
+                    'target_count' => 39,
+                ],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Observations (no action needed) ===', $output);
+        $this->assertStringContainsString('[interning] key', $output);
+        $this->assertStringNotContainsString('=== Minor findings ===', $output);
+    }
+
+    public function testSharedFaninWithLowRatioRendersUnderMinorFindings(): void
+    {
+        // refs/targets = 4391 / 686 ≈ 6.4 each — well below 100x. This
+        // is a small dedup opportunity, not a working interning pattern,
+        // so it lands in Minor findings with the raw kind tag.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'shared_fanin',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: 'config -> Setting (4,391 refs -> 686 targets, 6.4 each)',
+                facts: [
+                    'ref_count' => 4391,
+                    'target_count' => 686,
+                ],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Minor findings ===', $output);
+        $this->assertStringContainsString('[shared_fanin] config', $output);
+        $this->assertStringNotContainsString('=== Observations', $output);
+    }
+
+    public function testSharedFaninWithMidRatioStaysInMinorFindings(): void
+    {
+        // refs/targets = 4501 / 300 ≈ 15 each — sits in the [10, 100)
+        // middle band. Per the bucketing rules, mid-ratio cases stay
+        // in Minor findings: a 15x ratio is borderline enough to be
+        // worth a glance, not loud enough to call "everything's fine".
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'shared_fanin',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: 'PropertyInfoCacheEntry::$className -> ? (4,501 refs -> 300 targets, 15 each)',
+                facts: [
+                    'ref_count' => 4501,
+                    'target_count' => 300,
+                ],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Minor findings ===', $output);
+        $this->assertStringContainsString('[shared_fanin] PropertyInfoCacheEntry', $output);
+        $this->assertStringNotContainsString('=== Observations', $output);
+    }
+
+    public function testObservationsAndMinorFindingsCoexist(): void
+    {
+        // Both buckets populated — make sure both section headers print
+        // and findings sort into the right one. Verifies the buckets
+        // are independently emitted, not mutually exclusive.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'shared_singleton',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'Singleton::$instance (200 refs -> 1 target)',
+                facts: ['ref_count' => 200, 'target_count' => 1],
+            ),
+            new Finding(
+                kind: 'shared_fanin',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: 'cfg -> Setting (40 refs -> 8 targets, 5.0 each)',
+                facts: ['ref_count' => 40, 'target_count' => 8],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Observations (no action needed) ===', $output);
+        $this->assertStringContainsString('=== Minor findings ===', $output);
+        $this->assertStringContainsString('[CoW share] Singleton', $output);
+        $this->assertStringContainsString('[shared_fanin] cfg', $output);
+        // Observations should come before Minor findings — section order
+        // is part of the narrative ("here's what's working, here's the
+        // smaller stuff"). pos comparison guarantees the order.
+        $obs_pos = strpos($output, '=== Observations');
+        $min_pos = strpos($output, '=== Minor findings');
+        $this->assertNotFalse($obs_pos);
+        $this->assertNotFalse($min_pos);
+        $this->assertLessThan($min_pos, $obs_pos);
+    }
+
+    public function testNonSharedInfoFindingFallsIntoMinorFindings(): void
+    {
+        // Generic Info-severity finding kinds (anything outside the
+        // shared_* family) are not "everything's fine" signals, so they
+        // belong in Minor findings rather than Observations.
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'retained_approximate',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: 'approximate retained size note',
+                facts: [],
+            ),
+        ]);
+        $output = (new TextReportFormatter())->format($result);
+
+        $this->assertStringContainsString('=== Minor findings ===', $output);
+        $this->assertStringContainsString('[retained_approximate]', $output);
+        $this->assertStringNotContainsString('=== Observations', $output);
+    }
 }


### PR DESCRIPTION
## Summary

T3 / N2 from the memory-report UX handoff. Working CoW-share / interning
patterns currently render in the same `[shared_*]` format as actual problems,
so a 4.5M-refs / 39-targets HashTable (clean interning at ~115k each) reads
identical to a 4,391-refs / 686-targets case (small dedup opportunity).
The reader has no way to tell "this is the system working" from "this might
be worth a glance".

Split the section in two:

```text
=== Observations (no action needed) ===
  [CoW share] AttributeMetadata::$ignoredAttributes (4,499 refs -> 1 target)
  [interning] key -> ? (4,500,030 refs -> 39 targets, 115385.4 each)

=== Minor findings ===
  [shared_fanin] cfg -> Setting (40 refs -> 8 targets, 5.0 each)
```

## Bucketing rules

- `shared_singleton` → **always Observations** (1 target with many refs is
  CoW share by definition).
- `shared_fanin` with refs/targets **≥ 100** → Observations (interning
  threshold; PDO HashTable / enum / DateTimeZone-style sharing).
- `shared_fanin` with refs/targets **< 100** → Minor findings. The middle
  band `[10, 100)` defaults to Minor — borderline ratios are worth a glance,
  not strong enough to call "everything's fine".
- All other Info-severity findings (e.g. `retained_approximate`) → Minor
  findings.

## Behaviour notes

- **Reader-facing tags**: in Observations, `[shared_singleton]` becomes
  `[CoW share]` and high-ratio `[shared_fanin]` becomes `[interning]` — the
  tag names *what the pattern means* rather than what the detector looked
  for. Raw `Finding::$kind` is unchanged on JSON output.
- **JSON output is unchanged.** Purely text-formatter narrative, in line
  with the Finding-centric / Narrative-centric split.
- Both section headers are conditional — empty buckets don't print, so
  reports with only one of the two render cleanly.

## Test plan

- [x] 6 new `TextReportFormatterTest` cases: shared_singleton →
      Observations, high-ratio shared_fanin → interning, low-ratio
      shared_fanin → Minor, mid-ratio (15x) → Minor, both buckets coexist
      with correct order, non-shared Info → Minor
- [x] Full unit suite: 3197 / 3197 passing
- [x] psalm + phpcs clean on both touched files

https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhRtxQ1dsBfUeAkNcngtd7)_