### PR TITLE
Docs: Add recipes guide and consolidate requirements/installation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ this file links out to a dedicated doc or a section of the top-level
 ## Getting started
 
 - **New here?** [getting-started.md](getting-started.md) walks you from install to your first trace in 5 minutes.
+- **Just want copy-paste commands for a common task?** [recipes.md](recipes.md) — profile a php-fpm pool, investigate memory growth, capture `memory_limit` crashes, profile FrankenPHP.
 - Docker wrapper (`reli` / `reli-view` installed via `eval "$(... docker:print-wrapper)"`) — [docker-wrapper.md](docker-wrapper.md)
 - How it works (architecture overview) — [README § How it works](../README.md#how-it-works)
 - Supported PHP versions and platforms — [getting-started.md § Requirements](getting-started.md#requirements)

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Reli samples the call stack on a timer, so each trace reflects what the VM is do
 | I want to... | Use | More |
 |---|---|---|
 | Browse interactively in the terminal **(recommended)** | `rbt:explore trace.rbt` | [tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md) |
-| One-shot text report (hot frames, callers/callees, live tail) | `rbt:analyze trace.rbt` | [tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md) |
+| One-shot text report (hot frames, callers/callees, live tail) | `rbt:analyze < trace.rbt` | [tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md) |
 | Show the opcode at each frame | `rbt:analyze --with-opcode`, or press `c` in `rbt:explore` | [tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md) |
 | Convert to speedscope / pprof / flamegraph / callgrind / folded | `converter:<format>` | [tracing/binary-trace-format.md](tracing/binary-trace-format.md) |
 | Decode `.rbt` back to phpspy text | `converter:phpspy` | [tracing/binary-trace-format.md](tracing/binary-trace-format.md) |

--- a/docs/bench/RESULTS.md
+++ b/docs/bench/RESULTS.md
@@ -1,13 +1,18 @@
 # Profiler benchmark results
 
+> [!NOTE]
+> **Most users do not need this page.** If you're picking a profiler
+> for an operational decision, start with
+> [`docs/comparison.md`](../comparison.md) and only come back here
+> when you need raw numbers, methodology, or one-off findings to back
+> up a specific call.
+
 Numerical comparison data for the PHP profilers covered in
 [`docs/comparison.md`](../comparison.md). The doc you're
 reading is the heavy version — full tables, methodology notes, and
 one-off findings encountered during the runs.
 [`docs/comparison.md`](../comparison.md) is the lighter,
-selection-oriented companion. If you're picking a profiler for an
-operational decision, start there and come back here for "but how
-much does it actually cost in numbers?"
+selection-oriented companion.
 
 > Numbers are from the suite in [`bench/`](.). PHP 8.4 NTS on a
 > single Linux host, Docker not used (the sandbox couldn't reach

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -178,9 +178,10 @@ From here you can:
 
 Full walkthrough: [tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md).
 
-If you prefer a one-shot text report, `rbt:analyze trace.rbt` prints
-hot frames, callers/callees of a regex, and a live tail — see the
-same doc.
+If you prefer a one-shot text report, `rbt:analyze < trace.rbt`
+prints hot frames, callers/callees of a regex, and a live tail —
+see the same doc. (`rbt:analyze` reads from stdin so it pipes well
+into shell scripts and AI assistants.)
 
 To feed the trace into an existing visualiser (speedscope,
 Flamegraph SVG, pprof, callgrind, …) use the converters:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,12 +111,16 @@ composer install
 ./reli
 ```
 
+> The rest of this page uses **`reli`** as the command name, matching
+> the Docker-wrapper install above. On a native checkout (Composer or
+> Git) the equivalent command is `./reli` — substitute as you read.
+
 ## 2. Smoke test
 
 Trace a throwaway PHP command to confirm reli can see inside the VM:
 
 ```bash
-$ ./reli inspector:trace -- php -r "for(;;){usleep(10000);}"
+$ reli inspector:trace -- php -r "for(;;){usleep(10000);}"
 0 usleep <internal>:-1
 1 <main> Command line code:1
 
@@ -162,7 +166,7 @@ use to run reli.
 Drop into the interactive TUI:
 
 ```bash
-./reli rbt:explore trace.rbt
+reli rbt:explore trace.rbt
 ```
 
 From here you can:
@@ -182,16 +186,17 @@ To feed the trace into an existing visualiser (speedscope,
 Flamegraph SVG, pprof, callgrind, …) use the converters:
 
 ```bash
-./reli converter:speedscope <trace.rbt >profile.speedscope.json
-./reli converter:flamegraph <trace.rbt >flame.svg
+reli converter:speedscope <trace.rbt >profile.speedscope.json
+reli converter:flamegraph <trace.rbt >flame.svg
 ```
 
 Full list and `.rbt` format details: [tracing/binary-trace-format.md](tracing/binary-trace-format.md).
 
 ## 5. Where to go next
 
-The [documentation index](README.md) maps tasks to commands and
-docs. Suggested entry points:
+For copy-paste shortcuts on the most common tasks, jump to
+[recipes.md](recipes.md). For the full tasks-to-commands map, see the
+[documentation index](README.md). Suggested entry points:
 
 - **Memory leaks / heap analysis**: dump now, analyse later
   → [memory/memory-dump.md](memory/memory-dump.md) →

--- a/docs/inspection/peek-var-command.md
+++ b/docs/inspection/peek-var-command.md
@@ -35,11 +35,8 @@ reli inspector:peek-var -p <pid> --var='global::$counter' --format=json
 
 ## Requirements
 
-Same as other `inspector:*` commands:
-
-- PHP 8.1+ (for execution), targets PHP 7.0+
-- FFI extension
-- `CAP_SYS_PTRACE` capability (usually root)
+See [Getting started § Requirements](../getting-started.md#requirements) for the
+common runtime and target requirements. No command-specific overrides apply.
 
 ## Variable Specification
 

--- a/docs/inspection/trace-var-command.md
+++ b/docs/inspection/trace-var-command.md
@@ -43,11 +43,8 @@ reli inspector:trace -p <pid> -o trace.rbt \
 
 ## Requirements
 
-Same as other `inspector:*` commands:
-
-- PHP 8.1+ (for execution), targets PHP 7.0+
-- FFI extension
-- `CAP_SYS_PTRACE` capability (usually root)
+See [Getting started § Requirements](../getting-started.md#requirements) for the
+common runtime and target requirements. No command-specific overrides apply.
 
 ## Variable Specification
 

--- a/docs/memory/coredump.md
+++ b/docs/memory/coredump.md
@@ -36,14 +36,20 @@ output across tools, use the SQLite pipeline described in
 $ sudo gcore -o /tmp/myapp 12345
 # → /tmp/myapp.12345
 
-# Run the memory analyzer against the core file
+# Run the memory analyzer against the core file (.rmem is the fastest
+# format and is what every analyser reads natively)
 $ php ./reli inspector:coredump /tmp/myapp.12345 --pid 12345 \
-    -f sqlite3 -o snapshot.db
+    -f binary -o snapshot.rmem
 
 # Feed the output into the normal analysis pipeline
-$ php ./reli inspector:memory:report snapshot.db
-$ php ./reli rmem:explore snapshot.db
+$ php ./reli inspector:memory:report snapshot.rmem
+$ php ./reli rmem:explore snapshot.rmem
 ```
+
+`-f sqlite3` is also supported if you want to query the same snapshot
+with SQL tools — `inspector:memory:report` / `inspector:memory:compare`
+accept either format. `rmem:explore`, `rmem:serve`, and `rmem:mcp`
+read `.rmem` only.
 
 The output of `inspector:coredump` uses the same
 [`MemoryProfilerSettings`](../../src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php)
@@ -158,6 +164,6 @@ See `man 5 core` for the full bitmask.
 - [`inspector:memory:report`](memory-report.md) — generate an
   automated analysis report from the output.
 - [`rmem:explore`](rmem-explore-and-serve.md) — interactive
-  TUI over the SQLite output.
+  TUI over the `.rmem` output.
 - [`gcore` comparison](../internals/memory-dump-vs-gcore.md) — internals
   note on trade-offs between reli's native dump and ELF core files.

--- a/docs/memory/coredump.md
+++ b/docs/memory/coredump.md
@@ -26,7 +26,7 @@ when live dumping cannot be used.
 For live analysis of a still-running process, use
 [`inspector:memory`](memory-profiler.md) or
 [`inspector:memory:dump`](memory-dump.md). For reuse of an analyzer
-output across tools, use the SQLite pipeline described in
+output across tools, use the captured-snapshot pipeline described in
 [memory-report.md](memory-report.md) and [rmem-explore-and-serve.md](rmem-explore-and-serve.md).
 
 ## Quick start
@@ -54,9 +54,12 @@ read `.rmem` only.
 The output of `inspector:coredump` uses the same
 [`MemoryProfilerSettings`](../../src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php)
 as `inspector:memory`, so every output format (`json`, `sqlite3`,
-`binary`, `mysql`, `postgresql`, `report`, `report-json`) and every
-downstream tool (`inspector:memory:report`, `inspector:memory:compare`, `rmem:explore`,
-`rmem:serve`) works the same way.
+`binary`, `mysql`, `postgresql`, `report`, `report-json`) is supported.
+Which downstream tool you can feed depends on the format:
+
+- `inspector:memory:report` and `inspector:memory:compare` accept
+  `.rmem` (binary) or SQLite (`.db` / `.sqlite`).
+- `rmem:explore`, `rmem:serve`, and `rmem:mcp` require `.rmem`.
 
 ## Arguments and options
 

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -11,8 +11,8 @@
 
 This page documents `inspector:memory`'s default JSON output — the original memory-profiling entry point in reli — and the `jq`-based analysis style that grew up around it. `inspector:memory` itself still works exactly as described below; what has changed since its first iteration is the *recommended* way to use its output:
 
-- For interactive exploration and prioritised findings, reach for the SQLite-based pipeline ([memory-dump.md](memory-dump.md) → [rmem-explore-and-serve.md](rmem-explore-and-serve.md) / [memory-report.md](memory-report.md)). It stops the target for much less time and ships with purpose-built analysers.
-- Read *this* page when you need to hand-query snapshots with `jq`, understand the on-disk JSON structure, integrate with other tooling that expects JSON, or maintain pipelines that predate the SQLite format.
+- For interactive exploration and prioritised findings, reach for the captured-snapshot pipeline ([memory-dump.md](memory-dump.md) → [rmem-explore-and-serve.md](rmem-explore-and-serve.md) / [memory-report.md](memory-report.md)). It stops the target for much less time and ships with purpose-built analysers, all built around the `.rmem` format.
+- Read *this* page when you need to hand-query snapshots with `jq`, understand the on-disk JSON structure, integrate with other tooling that expects JSON, or maintain pipelines that predate the `.rmem` / report workflow.
 
 The canonical invocation:
 

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -413,14 +413,18 @@ The example of the output is like below.
 
 ### Automatic analysis instead of manual jq
 
-If you prefer actionable findings over manual `jq` exploration, use the automatic report feature. Save to SQLite and generate a report:
+If you prefer actionable findings over manual `jq` exploration, use the automatic report feature. Capture once to `.rmem` (the fastest format and what every analyser reads natively), then run the report:
 
 ```bash
-sudo ./reli inspector:memory -p <pid> -f sqlite3 -o snapshot.db
-./reli inspector:memory:report snapshot.db
+sudo ./reli inspector:memory -p <pid> -f binary -o snapshot.rmem
+./reli inspector:memory:report snapshot.rmem
 ```
 
-Or generate directly:
+`-f sqlite3 -o snapshot.db` is also supported — useful when you want
+SQL access to the same snapshot. `inspector:memory:report` and
+`inspector:memory:compare` accept either format.
+
+Or generate the report directly from a live process, without going through a snapshot file:
 
 ```bash
 sudo ./reli inspector:memory -p <pid> -f report

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -27,34 +27,15 @@ You can use this mode to analyze the memory usage of the target process — for 
 The functionality of this mode is similar to [php-meminfo](https://github.com/BitOne/php-meminfo), but works in the [phpspy](https://github.com/adsr/phpspy)-ish way: it captures the memory contents of the target from outside the process, analyses them with knowledge of the PHP VM's internal structures, then dumps the whole analysis. Target programs don't need any modifications and don't need to load a specific extension.
 
 # Requirements
-- FFI and PCNTL
-- PHP 8.1 or above for execution
-- PHP 7.0+ for targets
-- Only NTS targets are tested currently
-- The capability to stab the target process with ptrace (CAP_SYS_PTRACE)
-  - Usually running as root is enough
+
+See [Getting started § Requirements](../getting-started.md#requirements) for the
+canonical runtime / target requirements (PHP version, NTS/ZTS support,
+platform notes). No command-specific overrides apply to `inspector:memory`.
 
 # Installation
-## From Composer
-```bash
-composer create-project reliforp/reli-prof
-cd reli-prof
-./reli
-```
 
-## From Git
-```bash
-git clone git@github.com:reliforp/reli-prof.git
-cd reli-prof
-composer install
-./reli
-```
-
-## From Docker
-```bash
-docker pull reliforp/reli-prof
-docker run -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof
-```
+See [Getting started § Install](../getting-started.md#1-install) for the
+recommended install paths (Docker wrapper, Composer, Git).
 
 # Options
 ```bash

--- a/docs/memory/memory-report.md
+++ b/docs/memory/memory-report.md
@@ -34,7 +34,7 @@ sudo ./reli inspector:memory -p <pid> -f report
 ### Human-readable text (`report`)
 
 ```bash
-./reli inspector:memory:report snapshot.db
+./reli inspector:memory:report snapshot.rmem
 # or
 sudo ./reli inspector:memory -p <pid> -f report
 ```
@@ -138,7 +138,7 @@ Example output:
 For programmatic consumption or AI-assisted analysis:
 
 ```bash
-./reli inspector:memory:report snapshot.db -f report-json
+./reli inspector:memory:report snapshot.rmem -f report-json
 # or
 sudo ./reli inspector:memory -p <pid> -f report-json
 ```
@@ -182,14 +182,15 @@ Each finding includes machine-readable fields:
 
 ### `inspector:memory:report`
 
-Generate a report from an existing SQLite database:
+Generate a report from an existing snapshot file (binary `.rmem` or
+SQLite `.db`/`.sqlite`):
 
 ```
 Usage:
-  inspector:memory:report [options] <db-file>
+  inspector:memory:report [options] <snapshot-file>
 
 Arguments:
-  db-file                                Path to the SQLite database file
+  snapshot-file                          Path to the analysis file (binary .rmem or SQLite .db/.sqlite)
 
 Options:
   -f, --output-format=FORMAT             Output format: report (text) or report-json [default: report]
@@ -337,7 +338,7 @@ Memory usage for graph load: ~300 MB for 1M edges, ~2 GB for 6M edges.
 
 ## Tips
 
-- **Start with the SQLite workflow**: Capture once, analyze many times. The `inspector:memory:report` command is fast on an existing database.
+- **Start with the captured-snapshot workflow**: Capture once, analyze many times. The `inspector:memory:report` command is fast on an existing `.rmem` (or `.db`) file.
 - **Use `--memory-limit=2G`** for large snapshots instead of `php -d memory_limit=2G`.
 - **Use JSON for CI/automation**: The `report-json` format is designed for programmatic consumption — pipe it to `jq`, feed it to an LLM, or integrate into monitoring.
 - **Findings are sorted**: HIGH severity and largest impact appear first. Focus on the top findings.
@@ -350,23 +351,25 @@ Memory usage for graph load: ~300 MB for 1M edges, ~2 GB for 6M edges.
 
 ## Comparing Two Snapshots
 
-The `inspector:memory:compare` command diffs two SQLite memory snapshot databases and highlights what changed.
+The `inspector:memory:compare` command diffs two memory snapshot files
+(binary `.rmem` or SQLite `.db`/`.sqlite`) and highlights what changed.
 
 ### Quick Start
 
 ```bash
-# Capture baseline
-sudo ./reli inspector:memory -p <pid> -f sqlite3 -o before.db
+# Capture baseline (.rmem is the fastest format and is what every analyser reads natively)
+sudo ./reli inspector:memory -p <pid> -f binary -o before.rmem
 
 # ... deploy code change, trigger workload, etc.
 
 # Capture target
-sudo ./reli inspector:memory -p <pid> -f sqlite3 -o after.db
+sudo ./reli inspector:memory -p <pid> -f binary -o after.rmem
 
 # Compare two files
-./reli inspector:memory:compare before.db after.db
+./reli inspector:memory:compare before.rmem after.rmem
 
-# Compare run IDs within the same file
+# Compare run IDs within the same file (SQLite only — multi-run support
+# requires the relational schema)
 ./reli inspector:memory:compare snapshot.db --run-id-baseline 1 --run-id-target 2
 ```
 
@@ -431,9 +434,9 @@ Usage:
   inspector:memory:compare [options] <baseline> [<target>]
 
 Arguments:
-  baseline                               Path to the baseline SQLite database file
-  target                                 Path to the target SQLite database file
-                                         (omit to compare run IDs within the same file)
+  baseline                               Path to the baseline snapshot (binary .rmem or SQLite .db/.sqlite)
+  target                                 Path to the target snapshot (binary .rmem or SQLite .db/.sqlite)
+                                         (omit to compare run IDs within the same SQLite file)
 
 Options:
   -f, --output-format=FORMAT             Output format: report (text) or report-json [default: report]
@@ -449,7 +452,7 @@ Options:
 ### JSON Output
 
 ```bash
-./reli inspector:memory:compare before.db after.db -f report-json -o diff.json
+./reli inspector:memory:compare before.rmem after.rmem -f report-json -o diff.json
 ```
 
 ```json
@@ -485,7 +488,7 @@ Use `--threshold` to suppress small changes (useful for noisy environments):
 
 ```bash
 # Only show changes >= 5%
-./reli inspector:memory:compare before.db after.db --threshold 5
+./reli inspector:memory:compare before.rmem after.rmem --threshold 5
 ```
 
 This filters summary metric deltas, type breakdown deltas, and class memory changes below the given percentage.

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -24,9 +24,13 @@ When your application hits `memory_limit`, the handler automatically requests a 
 
 ## Requirements
 
-- Same as other `inspector:*` commands (FFI, PCNTL, PHP 8.1+ for execution, PHP 7.0+ for targets)
-- `CAP_SYS_PTRACE` capability (usually root)
-- The sidecar process must share the PID namespace with target processes (important for Docker setups)
+See [Getting started § Requirements](../getting-started.md#requirements) for the
+common runtime and target requirements.
+
+Command-specific notes:
+
+- The sidecar process must share the PID namespace with target processes
+  (important for Docker / Kubernetes — see [§ Docker / Kubernetes Setup](#docker--kubernetes-setup)).
 
 ## Why Use a Sidecar?
 
@@ -47,6 +51,26 @@ The sidecar approach:
 ## Client Library
 
 The client library requires **no FFI** and has **no heavy dependencies**. It's designed to work in shutdown handlers with minimal memory overhead.
+
+### Installing the client code in your application
+
+The classes under `Reli\Sidecar\Client\` (`MemoryLimitHandler`, `SidecarClient`, `SidecarClientResponse`) must be available in the target application's autoloader. There are two practical options today:
+
+- **Composer dependency** — add `reliforp/reli-prof` as a dependency
+  in the application (`composer require reliforp/reli-prof`). The
+  client classes are pulled in along with the rest of the package.
+  The client side has no FFI / PCNTL requirement, so this works on
+  any modern PHP runtime that hosts your application.
+- **Vendoring the three files** — for applications that don't want
+  the full dependency, copy `src/Sidecar/Client/MemoryLimitHandler.php`,
+  `src/Sidecar/Client/SidecarClient.php`, and
+  `src/Sidecar/Client/SidecarClientResponse.php` into your project
+  and wire them into your autoloader (PSR-4 under the
+  `Reli\Sidecar\Client\` namespace, or any namespace as long as you
+  update the `use` statements).
+
+Either way, only the `Reli\Sidecar\Client\` namespace is needed
+application-side; the rest of reli runs in the sidecar process.
 
 ### Emergency Memory Reserve
 

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -400,13 +400,19 @@ jobs:
               -o "/tmp/analyzed/$(basename "$f" .dump).rmem"
           done
 
-      # Compare with baseline (if available)
+      # Compare with baseline (if available). inspector:memory:compare
+      # takes one baseline + one target snapshot, so iterate over the
+      # labels (baseline, after-fixtures, …) and pair each one up.
       - name: Compare with baseline
         if: hashFiles('baseline/*.rmem') != ''
         run: |
-          reli inspector:memory:compare \
-            baseline/*.rmem /tmp/analyzed/*.rmem \
-            --threshold 5%
+          for target in /tmp/analyzed/sidecar-*.rmem; do
+            label="$(basename "$target" .rmem | sed -E 's/^sidecar-[0-9]+-[0-9-]+(-(.+))?$/\2/')"
+            baseline="$(ls baseline/sidecar-*-"${label:-baseline}".rmem 2>/dev/null | head -n1)"
+            [ -n "$baseline" ] || { echo "no baseline for ${label:-baseline}"; continue; }
+            echo "=== ${label:-baseline} ==="
+            reli inspector:memory:compare "$baseline" "$target" --threshold 5
+          done
 
       # Save current results as new baseline
       - uses: actions/upload-artifact@v4

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -209,8 +209,12 @@ Binary memory dump in the same format as `inspector:memory:dump`. Can be analyze
 
 ```bash
 reli inspector:memory:analyze /tmp/dumps/sidecar-1234-20260403-120000-after-fixtures.dump \
-  --output-format sqlite3 --output result.db
+  -f binary -o result.rmem
 ```
+
+`-f sqlite3 -o result.db` is also supported (`inspector:memory:report`
+and `inspector:memory:compare` accept either format); `rmem:explore`
+and friends require `.rmem`.
 
 ### Metadata File (`.meta.json`)
 
@@ -383,21 +387,25 @@ jobs:
           RELI_SIDECAR_SOCKET: /tmp/reli.sock
         run: php bench/memory_trend.php
 
-      # Analyze dumps
+      # Analyze dumps. Either .rmem or SQLite is fine — both are
+      # accepted by inspector:memory:compare. .rmem is the fastest
+      # default and is what the rest of the docs use; switch to
+      # `-f sqlite3 -o ....db` if your CI also runs ad-hoc SQL queries
+      # against the snapshots.
       - name: Analyze snapshots
         run: |
           for f in /tmp/dumps/sidecar-*.dump; do
             reli inspector:memory:analyze "$f" \
-              --output-format sqlite3 \
-              --output "/tmp/analyzed/$(basename "$f" .dump).db"
+              -f binary \
+              -o "/tmp/analyzed/$(basename "$f" .dump).rmem"
           done
 
       # Compare with baseline (if available)
       - name: Compare with baseline
-        if: hashFiles('baseline/*.db') != ''
+        if: hashFiles('baseline/*.rmem') != ''
         run: |
           reli inspector:memory:compare \
-            baseline/*.db /tmp/analyzed/*.db \
+            baseline/*.rmem /tmp/analyzed/*.rmem \
             --threshold 5%
 
       # Save current results as new baseline
@@ -469,4 +477,4 @@ Clients can check `$response->isCompatible()` to detect whether the server's ver
 | `inspector:watch` | Passive monitoring with threshold triggers | Polling (automatic) |
 | **`inspector:sidecar`** | **Application-initiated dump on error/at specific points** | **On-demand (IPC)** |
 | `inspector:memory:analyze` | Offline analysis of dump files | Post-hoc (CLI) |
-| `inspector:memory:compare` | Diff two analysis databases | Post-hoc (CLI) |
+| `inspector:memory:compare` | Diff two analysis snapshots | Post-hoc (CLI) |

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -347,8 +347,8 @@ v2.3.0 release                         v2.4.0 PR
 │ sidecar + benchmark  │                │ sidecar + benchmark  │
 │ → snapshot(baseline) │                │ → snapshot(baseline) │
 │ → snapshot(loaded)   │                │ → snapshot(loaded)   │
-│ → analyze → v2.3.db  │                │ → analyze → v2.4.db  │
-│ → upload artifact    │                │ → download v2.3.db   │
+│ → analyze → v2.3.rmem│                │ → analyze → v2.4.rmem│
+│ → upload artifact    │                │ → download v2.3.rmem │
 └─────────────────────┘                │ → compare → pass/fail│
                                         └─────────────────────┘
 ```
@@ -394,6 +394,7 @@ jobs:
       # against the snapshots.
       - name: Analyze snapshots
         run: |
+          mkdir -p /tmp/analyzed
           for f in /tmp/dumps/sidecar-*.dump; do
             reli inspector:memory:analyze "$f" \
               -f binary \

--- a/docs/monitoring/watch-command.md
+++ b/docs/monitoring/watch-command.md
@@ -22,9 +22,12 @@ reli inspector:watch -p <pid> --memory-usage=128M --oneshot=3
 
 ## Requirements
 
-- Same as other `inspector:*` commands (FFI, PCNTL, PHP 8.1+ for execution, PHP 7.0+ for targets)
-- `CAP_SYS_PTRACE` capability (usually root)
-- For `--target-regex` (daemon mode): same as `inspector:daemon`
+See [Getting started § Requirements](../getting-started.md#requirements) for the
+common runtime and target requirements.
+
+Command-specific notes:
+
+- For `--target-regex` (daemon mode): same as `inspector:daemon`.
 
 ## Triggers
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,127 @@
+# Recipes
+
+Copy-paste shortcuts for the most common reli workflows. Each recipe
+links out to the full reference doc when you want to understand the
+options.
+
+If a recipe assumes the Docker wrapper (`reli ...`), the equivalent
+on a native checkout is `./reli ...`. See
+[getting-started.md](getting-started.md) for installation.
+
+## Profile a php-fpm pool for 60 seconds
+
+Capture all worker processes at once, write a single `.rbt` per worker,
+and stop after a minute:
+
+```bash
+mkdir -p ./traces
+
+# Attach to every worker matching the regex for ~60s, one .rbt per PID
+sudo timeout 60 reli inspector:daemon \
+    -P "^php-fpm" \
+    -F rbt -o ./traces/
+
+# Browse one worker's trace
+reli rbt:explore ./traces/<pid>.rbt
+
+# Or get a one-shot text "hot frames" report
+reli rbt:analyze ./traces/<pid>.rbt
+```
+
+References: [tracing/capturing-traces.md](tracing/capturing-traces.md),
+[tracing/rbt-analyze-and-explore.md](tracing/rbt-analyze-and-explore.md).
+
+## Investigate memory growth in a worker
+
+Dump now (short stop), analyse offline, look at the prioritised report:
+
+```bash
+# 1. Take a fast binary dump (target stopped only briefly)
+sudo reli inspector:memory:dump --pid=<pid> --output=worker.relimem
+
+# 2. Analyse the dump into a .rmem snapshot
+reli inspector:memory:analyze worker.relimem -f binary -o worker.rmem
+
+# 3. Read the prioritised findings (dominant classes, cycles, choke points, …)
+reli inspector:memory:report worker.rmem
+
+# 4. (optional) Drop into the TUI to chase paths interactively
+reli rmem:explore worker.rmem
+```
+
+To check whether a suspected leak is actually growing, capture a second
+snapshot after letting the workload run, then diff:
+
+```bash
+reli inspector:memory:compare worker.rmem worker-later.rmem
+```
+
+References: [memory/memory-dump.md](memory/memory-dump.md),
+[memory/memory-report.md](memory/memory-report.md),
+[memory/rmem-explore-and-serve.md](memory/rmem-explore-and-serve.md).
+
+## Capture `memory_limit` crashes with the sidecar
+
+Run the sidecar as a separate process / container, register one line
+in your application bootstrap, and reli will dump from outside at the
+exact moment the application reports it's dying:
+
+```bash
+# Start the sidecar (foreground; wrap in systemd / supervisor / a
+# Kubernetes sidecar container in real deployments)
+reli inspector:sidecar \
+    --socket=/tmp/reli-sidecar.sock \
+    --output-dir=/tmp/reli-dumps
+```
+
+```php
+// In your application bootstrap (index.php / bin/console / …)
+\Reli\Sidecar\Client\MemoryLimitHandler::register();
+```
+
+When the application hits `memory_limit`, you get a `.dump` file plus a
+`.meta.json` with the call trace and memory stats in `--output-dir`.
+
+Analyse the dump like any other reli memory snapshot:
+
+```bash
+reli inspector:memory:analyze /tmp/reli-dumps/sidecar-<pid>-<ts>.dump \
+    -f binary -o crash.rmem
+reli inspector:memory:report crash.rmem
+```
+
+References: [monitoring/sidecar.md](monitoring/sidecar.md) (including
+client install, Docker / Kubernetes setup, and CI cross-release
+comparison).
+
+## Profile FrankenPHP workers
+
+FrankenPHP loads PHP as `libphp.so` and runs many threads inside one
+process — only the PHP worker threads carry executor globals. Three
+flags do the work:
+
+```bash
+# Daemon mode: discover workers automatically, skip Caddy / Go threads
+sudo reli inspector:daemon \
+    -P frankenphp \
+    --target-thread-regex='^php-[0-9a-f]+$' \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*' \
+    -F rbt -o ./traces/
+```
+
+For attaching to a single worker (`inspector:trace`), pass the PHP
+worker **TID** rather than the FrankenPHP parent PID:
+
+```bash
+ps -L -p "$(pgrep -o frankenphp)" -o tid,comm | awk '$2 ~ /^php-/'
+#   12345 php-0
+#   12346 php-1
+
+sudo reli inspector:trace -p 12345 \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*' \
+    -o trace.rbt
+```
+
+Reference: [tracing/frankenphp.md](tracing/frankenphp.md).

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -16,16 +16,18 @@ and stop after a minute:
 ```bash
 mkdir -p ./traces
 
-# Attach to every worker matching the regex for ~60s, one .rbt per PID
+# Attach to every worker matching the regex for ~60s.
+# The daemon writes one .rbt per *reli worker* (-T, default 8) into
+# ./traces/, named worker_<reli-worker-pid>.rbt — not one per target PID.
 sudo timeout 60 reli inspector:daemon \
     -P "^php-fpm" \
     -F rbt -o ./traces/
 
-# Browse one worker's trace
-reli rbt:explore ./traces/<pid>.rbt
-
-# Or get a one-shot text "hot frames" report
-reli rbt:analyze ./traces/<pid>.rbt
+# List what was written, then browse / report on one of them
+ls ./traces/
+# worker_12345.rbt  worker_12346.rbt  ...
+reli rbt:explore ./traces/worker_12345.rbt
+reli rbt:analyze < ./traces/worker_12345.rbt
 ```
 
 References: [tracing/capturing-traces.md](tracing/capturing-traces.md),

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -19,7 +19,7 @@ it differently:
 
 - **Capturing to `.rbt`**: the opcode is recorded on every PHP frame
   unconditionally — no flag needed at capture time. Reveal it during
-  analysis with `./reli rbt:analyze --with-opcode trace.rbt`, or
+  analysis with `./reli rbt:analyze --with-opcode < trace.rbt`, or
   press `c` inside `rbt:explore` to toggle the opcode column.
 - **phpspy text output**: opt in at capture time with
   `--template=phpspy_with_opcode`:

--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -3,6 +3,15 @@
 **Version:** 1
 **Status:** Draft
 
+> [!NOTE]
+> **Most users do not need this format specification.**
+> To capture and read traces, start with
+> [capturing-traces.md](capturing-traces.md) and
+> [rbt-analyze-and-explore.md](rbt-analyze-and-explore.md). Read this
+> page if you are writing a converter, debugging a corrupted file with
+> `rbt:recover`, or integrating with the binary format from another
+> language.
+
 ## Overview
 
 The reli Binary Trace Format is an append-only binary stream format for efficient storage of PHP profiling traces. A `.rbt` file consists of one or more **self-contained segments**, each carrying its own header and definition events.

--- a/docs/tracing/phpspy-hybrid.md
+++ b/docs/tracing/phpspy-hybrid.md
@@ -6,6 +6,13 @@ resolution — including for ZTS targets, which phpspy alone cannot
 resolve. The result is phpspy's sampling throughput with reli's
 ZTS support.
 
+> **Note:** The official `reliforp/reli-prof` Docker image does **not**
+> bundle phpspy. If you installed reli via the Docker wrapper, the
+> `phpspy:*` commands won't work out of the box — install phpspy
+> natively (e.g. via `phpspy:install` on a host install of reli) or
+> build a custom image that runs `phpspy:install` at build time. See
+> [docker-wrapper.md § Limitations](../docker-wrapper.md#limitations).
+
 ## Commands
 
 | Command | Purpose |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,48 @@ The `-S` option will give you better results. Using this option stops the execut
 
 First, try `cat /proc/<pid>/maps` to check the memory map of the target PHP process. If the first module does not indicate the location of the PHP binary and looks like an anonymous region, try to specify `--php-regex="^$"` as an option.
 
+## "Operation not permitted" / ptrace denied when attaching
+
+`inspector:trace`, `inspector:memory`, `inspector:peek-var`, `inspector:watch`, `inspector:sidecar` and friends all rely on `ptrace(2)` / `process_vm_readv(2)`. If attach fails with `EPERM`, walk the checklist:
+
+- **Permission**. Run reli as `root`, or grant `CAP_SYS_PTRACE` to the `php` binary you use to run reli (`sudo setcap cap_sys_ptrace=eip $(readlink -f $(which php))`).
+- **Docker wrapper**. Make sure you installed the **full** profile (`docker:print-wrapper`, not `--profile=minimal`). The minimal profile drops `CAP_SYS_PTRACE`, `--pid=host`, `--security-opt=apparmor=unconfined`, and `--network=host` on purpose — re-install with `--profile=full` for live attach. See [docker-wrapper.md](docker-wrapper.md).
+- **Yama / `ptrace_scope`**. On hardened hosts, `cat /proc/sys/kernel/yama/ptrace_scope` returning `2` or `3` blocks ptrace even for root. Temporarily lower it (`echo 1 | sudo tee /proc/sys/kernel/yama/ptrace_scope`), or use a native install.
+- **AppArmor / SELinux**. Some distros confine `docker` and similar tools with profiles that block ptrace. Pass `--security-opt=apparmor=unconfined` (already set by the full Docker wrapper).
+- **PID namespace**. In containers, the target process must be visible inside reli's PID namespace. The Docker wrapper passes `--pid=host`. For Kubernetes / docker-compose, set `shareProcessNamespace: true` / `pid: "service:app"`. The sidecar specifically requires this — see [monitoring/sidecar.md](monitoring/sidecar.md).
+
+## I installed `reli-view` and live-attach commands fail
+
+`reli-view` is the **minimal** Docker wrapper profile — viewers / converters only (`rbt:explore`, `rmem:explore`, `converter:*`, `inspector:memory:report`, `inspector:memory:compare`, …). It deliberately omits `CAP_SYS_PTRACE`, `--pid=host`, and `--network=host`, so any command that attaches to a live process or binds to a host port will fail.
+
+Re-install with the full profile and retry:
+
+```bash
+eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+```
+
+The two profiles can coexist — see [docker-wrapper.md](docker-wrapper.md) for the side-by-side install pattern (`--name=reli` / `--name=reliv`).
+
+## "FFI extension not loaded" / "PCNTL not available"
+
+reli relies on FFI for VM struct layout and PCNTL for daemon mode. The two extensions are bundled in the official Docker image (use the wrapper — see [getting-started.md § 1. Install](getting-started.md#1-install)). For native installs, build PHP with `--with-ffi` and `--enable-pcntl`, or install your distro's `php-ffi` / `php-pcntl` packages.
+
+The sidecar **client** (the application-side library) does not require FFI — only the sidecar server / reli binary itself does. See [monitoring/sidecar.md § Client Library](monitoring/sidecar.md#client-library).
+
+## `rmem:explore` won't open my file
+
+`rmem:explore`, `rmem:serve`, and `rmem:mcp` read **`.rmem` only** (binary memory snapshots produced by `inspector:memory -f binary`, `inspector:memory:dump` + `inspector:memory:analyze -f binary`, or `inspector:coredump -f binary`).
+
+If your snapshot is a SQLite `.db` / `.sqlite` file, either re-capture with `-f binary -o snapshot.rmem`, or use the SQL-aware analysers instead (`inspector:memory:report`, `inspector:memory:compare`, raw `sqlite3` / `duckdb`). To convert an existing dump, run `inspector:memory:analyze <dump> -f binary -o snapshot.rmem`.
+
+See [memory/memory-dump.md](memory/memory-dump.md) and [memory/rmem-explore-and-serve.md](memory/rmem-explore-and-serve.md).
+
+## FrankenPHP: "no such PID" or empty trace when targeting the parent
+
+A FrankenPHP process is one OS process with many threads, but only the PHP worker threads carry valid executor globals. Targeting the Caddy parent PID gives no PHP state.
+
+Pass a **PHP worker TID** to `inspector:trace -p`, and add the three FrankenPHP flags (`--php-regex='.*/libphp\.so$'`, `--libpthread-regex='.*/libc\.so.*'`, plus `--target-thread-regex='^php-[0-9a-f]+$'` for `inspector:daemon` / `inspector:top` / `inspector:watch`). Full walkthrough: [tracing/frankenphp.md](tracing/frankenphp.md).
+
 ## Something seems stale after a PHP upgrade or container rebuild.
 
 reli caches expensive binary-analysis results (ELF symbol resolution, ZTS TLS offsets, PHP version detection) under `~/.cache/reli/binary-analysis/`. If you suspect a stale entry is being served — after upgrading the target PHP, rebuilding a container image, or any other "shouldn't that have worked?" moment — drop or bypass the cache:


### PR DESCRIPTION
## Summary

This PR adds a new `recipes.md` guide with copy-paste shortcuts for common reli workflows, and refactors documentation to consolidate duplicated requirements and installation information into a single source of truth in `getting-started.md`.

## Key Changes

- **New recipes guide** (`docs/recipes.md`): Provides quick-start examples for:
  - Profiling php-fpm pools
  - Investigating memory growth
  - Capturing memory_limit crashes with the sidecar
  - Profiling FrankenPHP workers
  - Each recipe links to full reference documentation

- **Consolidated requirements**: Replaced scattered, command-specific requirements sections across multiple docs with a single reference to `getting-started.md#requirements`, reducing duplication and maintenance burden

- **Consolidated installation**: Removed redundant installation instructions from `memory-profiler.md` and pointed to `getting-started.md#1-install` instead

- **Updated format references**: Changed documentation to consistently refer to `.rmem` (binary snapshot format) as the primary/fastest format, with SQLite as an alternative where applicable:
  - Updated `memory-report.md`, `memory-dump.md`, `coredump.md` examples
  - Clarified which tools accept which formats (e.g., `rmem:explore` requires `.rmem` only)
  - Updated CI/CD example in `sidecar.md` to use `.rmem` with improved comparison logic

- **Enhanced troubleshooting**: Added new troubleshooting sections for:
  - ptrace permission issues and Docker wrapper profiles
  - FFI/PCNTL extension requirements
  - `.rmem` vs SQLite format confusion
  - FrankenPHP targeting issues

- **Improved navigation**: Updated `README.md` and `getting-started.md` to point users to `recipes.md` for common tasks before diving into full reference docs

- **Clarified Docker wrapper profiles**: Added notes distinguishing between full (`reli`) and minimal (`reli-view`) Docker wrapper profiles and their capabilities

- **Minor format improvements**: Added note boxes to `bench/RESULTS.md` and `binary-trace-format.md` to clarify audience and when to read those pages

https://claude.ai/code/session_019LNm4FQQs1N58ct9S7j11m