### PR TITLE
Optimize cold-attach performance and fix ZTS cache poisoning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,153 @@ RELI_TEST_PHP_TARGETS=v73_zts php vendor/bin/phpunit --group target-version
 RELI_TEST_PHP_TARGETS=v74 php vendor/bin/phpunit --filter 'MemoryCompareCommandIntegrationTest'
 ```
 
+### Sandbox-only ptrace failures
+
+If `tests/Lib/Process/Exec/TraceeExecutorTest` (or anything else that calls
+`PTRACE_TRACEME` from a forked child) returns `EPERM` here, that is a
+seccomp/yama restriction in the sandbox container — the test is green on
+`0.12.x` upstream. Don't chase it as a regression. `strace -e ptrace` on the
+phpunit run will show the EPERM if you're unsure.
+
+## Profiling reli (dogfooding)
+
+reli is itself a PHP process, so you can profile it with another reli. Useful
+when you suspect a hot path inside reli's own code.
+
+### Standard recipe
+
+```bash
+# Inner reli runs against the real target; bigger sample interval (1 ms here)
+# keeps the rbt manageable.
+php ./reli inspector:trace -p "$TARGET_TID" \
+    --php-regex='.*/libphp\.so$' \
+    --libpthread-regex='.*/libc\.so.*' \
+    > /tmp/inner.out 2>&1 &
+INNER=$!
+
+# Outer reli profiles the inner and writes a binary trace.
+php ./reli inspector:trace -p "$INNER" \
+    -F rbt -o /tmp/profile.rbt \
+    -s 1000000 \
+    > /dev/null 2>&1 &
+OUTER=$!
+
+# Wait for inner to do its thing, then INT both. Send INT, not KILL — the rbt
+# is finalised on graceful shutdown only; SIGKILL leaves the file empty or
+# truncated and `rbt:analyze` will bail with "Unexpected end of stream while
+# decoding varint".
+sleep 5
+kill -INT $OUTER $INNER
+wait
+```
+
+Variant: profile reli **from the very first PHP frame** (catches startup +
+autoload too) by letting the outer reli launch the inner as a child:
+
+```bash
+php ./reli inspector:trace \
+    -F rbt -o /tmp/profile.rbt -s 100000 \
+    -E /tmp/inner.err -O /tmp/inner.out \
+    -- php ./reli inspector:trace -p "$TARGET_TID" \
+        --php-regex='.*/libphp\.so$' --libpthread-regex='.*/libc\.so.*'
+```
+
+### Analyzing the rbt
+
+Use `rbt:analyze`, not `converter:folded` + ad-hoc `awk`. The folded format
+collapses identical stacks into a single line with a count column at the end,
+so `wc -l` and `sort | uniq -c` both undercount samples. `rbt:analyze` does the
+right summation and surfaces self-time / total-time / callers / callees in one
+shot:
+
+```bash
+# Reads from stdin
+php ./reli rbt:analyze --top=15 --no-line --crop=140 < /tmp/profile.rbt
+
+# Filter to a code path (PCRE matched against any frame in each stack)
+php ./reli rbt:analyze --match='findGlobals|loadResolver' \
+    --top=15 --no-line --crop=140 < /tmp/profile.rbt
+
+# Who calls X?
+php ./reli rbt:analyze --sections=callers --callers='^FFI::string$' \
+    --no-line --crop=200 < /tmp/profile.rbt
+```
+
+### Sampling-resolution gotchas
+
+- The PHP-frame sampler does **not** cover time the target spends in C-only
+  code (FFI calls, syscalls). If `rbt:analyze` looks dominated by
+  `time_nanosleep`, that is the post-cold-attach sampling loop sleeping —
+  not a real hot spot. Filter cold-attach with `--match='findGlobals|...'`
+  to focus on the relevant samples.
+- The outer reli has its own startup cost (~1 s on this sandbox), so it can
+  miss the **first** ~1 s of the inner reli's life when both are launched
+  back-to-back. The `-- cmd` form above sidesteps that by having the outer
+  fork the inner.
+- The first attach to a fresh `libphp.so` is slower than subsequent
+  ones (parses the dynamic symbol table, brute-forces TLS, etc.).
+  Sub-second on a normal box, a few seconds on this sandbox. Don't
+  `timeout 5s` the first run when investigating unfamiliar binaries.
+
 ## Project-Specific Pitfalls
+
+### FrankenPHP cold attach reality
+
+FrankenPHP is the canonical "this should be daemon-mode" target. A few
+non-obvious things bite single-shot `inspector:trace -p` users:
+
+- **`php-main` is the bootstrap thread, not a worker.** It matches `^php-`
+  but does not host requests; memory commands fail with "failed to find
+  ZendMM main chunk" and trace samples are useless. The recommended regex
+  everywhere is `^php-[0-9a-f]+$`.
+- **Hex-named workers can be uninitialised.** A worker that has never
+  served a request leaves `_tsrm_ls_cache` zeroed, so brute force returns
+  null. `PhpGlobalsFinder::findTsrmLsCache` re-checks PT_TLS in the ELF
+  before treating that as a binary-level fact, so the negative result
+  is not persisted and the next attach against a warm worker succeeds
+  without intervention.
+- **Tests in `tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest`
+  share one `BinaryAnalysisCache` across thread iterations.** That's the
+  regression test for the cache-poisoning fix; if you put a fresh cache
+  back per iteration, the test passes again but the bug it pins also
+  comes back.
+- See `docs/tracing/frankenphp.md` for the user-facing version of the
+  same warnings.
+
+### File reading from /proc/<pid>/root/...
+
+`Reli\Lib\File\NativeFileReader` opens files via FFI (libc `open`/`pread`/
+`close`) instead of PHP's stream wrappers. PHP's stream layer runs paths
+through `realpath()`, which for `/proc/<pid>/root/...` follows the symlink
+back to `/` and ends up trying to open the **host's** copy of the binary,
+not the container's. `file_get_contents` will silently succeed on the wrong
+file or fail with ENOENT — that's why the FFI path exists.
+
+If you ever need to add a fast read path for the cold-attach hot loop,
+keep using FFI; replacing it with `file_get_contents` is a footgun.
+`CatFileReader` (the `proc_open(['cat', $path], …)` fallback) is the only
+sanctioned non-FFI alternative and is markedly slower because it pays a
+shell process per read.
+
+### ELF / link-map parsing hot paths
+
+The cold-attach path parses tens of thousands of ELF symbols per binary.
+Two patterns that look harmless are surprisingly expensive at that scale:
+
+- **`offsetGet` loops on `ByteReaderInterface`** — `read32`/`read64` used
+  to do four/eight ArrayAccess calls per integer. Prefer
+  `unpack('V', $data->createSliceAsString(offset, 4))` /
+  `unpack('V2', $data->createSliceAsString(offset, 8))` instead.
+- **Per-record reader calls in tight parser loops** — for things like the
+  symbol table where each entry is a fixed shape, read the entire blob
+  via `createSliceAsString` once and `unpack(format, substr($blob, …))`
+  per entry. One native `unpack` per entry beats half a dozen wrapper
+  calls.
+- **Byte-by-byte C-string reads from the target process** — the link-map
+  walker used to do one `process_vm_readv` syscall per character. Read in
+  chunks **clipped to the current page** (otherwise you cross an unmapped
+  page boundary and trip EFAULT, which surfaces as `MemoryReaderException`
+  and aborts the cold attach). See `LinkMapLoader::readCString`.
 
 ### FFI CData lifetime — recurring source of bugs
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -67,13 +67,15 @@ A few realities on FrankenPHP that the snippet above is built around:
   populated request heap, so memory commands fail with
   "failed to find ZendMM main chunk". `^php-[0-9a-f]+$` excludes
   it.
-- **Cold-attach takes time.** On the first attach to a given
-  `libphp.so`, reli scans the TLS block byte-by-byte to locate
-  `_tsrm_ls_cache`. Expect tens of seconds (5–30 s, occasionally
-  more under daemon mode where multiple workers race) before the
-  first sample appears. Subsequent attaches reuse the cached TLS
-  offset and start almost immediately, so don't time-out the very
-  first run aggressively.
+- **First attach is slower than subsequent ones.** The first attach
+  to a given `libphp.so` parses the dynamic symbol table, reads
+  PT_TLS, and brute-forces `_tsrm_ls_cache` out of the TLS block.
+  Once that succeeds, the offset is cached on disk and every later
+  attach (including other threads of the same process) skips
+  straight to the cache. The first attach typically completes in
+  well under a second on a normal dev box; sandboxed or
+  IO-constrained environments may take a few seconds. Either way,
+  don't time the very first run out aggressively.
 - **Some hex-named workers fail brute-forcing.** A worker that has
   not yet served a request leaves `_tsrm_ls_cache` zeroed, so the
   search returns nothing and the call dies with `global symbol
@@ -82,9 +84,7 @@ A few realities on FrankenPHP that the snippet above is built around:
   the cached offset works for every other thread of the same
   process. `inspector:daemon` and `inspector:trace` retry
   internally; `inspector:memory:dump` and friends do not, so cold
-  failures are most visible there. If you get unlucky on the
-  first thread and the negative result was cached, run
-  `php ./reli cache:clear` and try a different TID.
+  failures are most visible there.
 
 `--target-thread-regex` is not honoured by `inspector:trace`: the
 single-process mode samples exactly the TID you pass in, so choose
@@ -129,11 +129,11 @@ sudo php ./reli inspector:memory:dump -p "$(
 Unlike `inspector:trace`, `inspector:memory:dump` does **not**
 retry TLS resolution. If the chosen worker happens to be one that
 never handled a request, the dump fails with `global symbol not
-found executor_globals` and the negative result is cached for the
-binary. Recovery: `php ./reli cache:clear`, send some traffic
-through the server, and rerun against a different TID — or run a
-short `inspector:trace` / `inspector:daemon` first to populate the
-TLS-offset cache, after which any worker TID works.
+found executor_globals`. Recovery: rerun against a different TID,
+or push a request through the server and retry. Running a brief
+`inspector:trace` / `inspector:daemon` first populates the
+TLS-offset cache and lets every subsequent worker TID succeed
+immediately.
 
 ## Caveats
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,15 +58,16 @@ Pass a **PHP worker TID** to `inspector:trace -p`, and add the three FrankenPHP 
 
 ## "global symbol not found executor_globals" on FrankenPHP / ZTS.
 
-ZTS (FrankenPHP, embed-SAPI, custom ZTS builds) keeps `executor_globals` in TLS, so reli has to find `_tsrm_ls_cache` by brute-forcing the target thread's TLS block. If the chosen thread happens to never have served a request — its TLS slot is still zero — the search returns nothing, the negative result is cached for that binary, and subsequent runs short-circuit straight to a missing-symbol error.
+ZTS (FrankenPHP, embed-SAPI, custom ZTS builds) keeps `executor_globals` in TLS, so reli has to find `_tsrm_ls_cache` by brute-forcing the target thread's TLS block. If the chosen thread happens to never have served a request — its TLS slot is still zero — the search returns nothing.
 
-Recovery, in order of cost:
+Recovery:
 
 1. Pick a different worker TID and retry. Once any one thread succeeds, the cached TLS offset works for every other thread of the process.
-2. If the negative result is already cached, drop it and retry: `./reli cache:clear` followed by a run against a different TID.
-3. Push some traffic through the server first so workers are warm, then attach.
+2. Push some traffic through the server first so workers are warm, then attach.
 
-`inspector:daemon` and `inspector:trace` retry internally and will eventually self-recover; `inspector:memory:dump` / `inspector:memory` / `inspector:sidecar` exit on the first failure, so the workaround matters most for those. For FrankenPHP-specific guidance see [tracing/frankenphp.md](tracing/frankenphp.md#memory-and-watch-commands).
+`inspector:daemon` and `inspector:trace` retry internally and will recover from a transient idle-worker miss without help; `inspector:memory:dump` / `inspector:memory` / `inspector:sidecar` exit on the first failure, so the worker-choice workaround matters most for those. For FrankenPHP-specific guidance see [tracing/frankenphp.md](tracing/frankenphp.md#memory-and-watch-commands).
+
+> **Note:** older versions of reli could persist `has_tsrm_ls_cache: false` for a ZTS binary the first time an idle worker was hit. The current code re-checks the binary's PT_TLS on every cache read and drops the entry if the binary is in fact ZTS, so upgraders do not need to `./reli cache:clear` — the stale entry self-heals on the next attach.
 
 ## Something seems stale after a PHP upgrade or container rebuild.
 

--- a/src/Lib/File/NativeFileReader.php
+++ b/src/Lib/File/NativeFileReader.php
@@ -18,18 +18,47 @@ use Reli\Lib\FFI\CannotAllocateBufferException;
 
 final class NativeFileReader implements FileReaderInterface
 {
-    /** @var FFI\Libc\libc_file_ffi  */
+    // libphp.so is in the order of 20 MB on FrankenPHP-style builds, so a
+    // 4 KB chunk loop fed through ".=" turned readAll into the dominant
+    // cold-attach hot spot (~98% of total time). 1 MB chunks bring the
+    // syscall count down by 256x and let the kernel's readahead actually
+    // do its job.
+    private const CHUNK_SIZE = 1024 * 1024;
+
+    /** @var FFI\Libc\libc_file_ffi */
     private FFI $ffi;
 
     public function __construct()
     {
+        // PHP's stream wrappers run paths through realpath(), which follows
+        // /proc/<pid>/root symlinks back to "/" and breaks container-path
+        // resolution -- which is the whole reason this reader exists.
+        // Open() / read() / close() over FFI sidesteps that. lseek lets us
+        // size the file with one syscall before allocating the destination
+        // buffer, which is portable across glibc versions and architectures
+        // (struct stat layout differs between x86_64 and aarch64, so calling
+        // __fxstat() and reading the bytes by hand corrupts memory on ARM).
+        // pread is used for the actual transfer so no seek state has to be
+        // maintained.
+        //
+        // Types are spelled with explicit `long` / `unsigned long` /
+        // `int` rather than `size_t` / `ssize_t` / `off_t`. PHP FFI's
+        // cdef parser only recognises the C primitive types from the
+        // language spec; size_t and friends silently fall through to a
+        // shorter type, which produces an ABI mismatch on aarch64 (the
+        // upper bits of the size argument arrive as garbage and pread
+        // ends up writing past the buffer, surfacing as
+        // "zend_mm_heap corrupted" in the test runner). The other libc
+        // bindings in this codebase (LibcFileReader, MemoryDumper) use
+        // the same explicit-types convention.
         /** @var FFI\Libc\libc_file_ffi */
-        $this->ffi = FFI::cdef('
-            int open(const char *pathname, int flags);
-            long read(int fd, void *buf, unsigned long count);
-            long pread(int fd, void *buf, unsigned long count, long offset);
-            int close(int fd);
-        ');
+        $this->ffi = FFI::cdef(
+            'int open(const char *pathname, int flags);'
+            . 'long pread(int fd, void *buf, unsigned long count, long offset);'
+            . 'long read(int fd, void *buf, unsigned long count);'
+            . 'long lseek(int fd, long offset, int whence);'
+            . 'int close(int fd);',
+        );
     }
 
     #[\Override]
@@ -58,22 +87,78 @@ final class NativeFileReader implements FileReaderInterface
     #[\Override]
     public function readAll(string $path): string
     {
-        $buffer = $this->ffi->new("unsigned char[4096]")
-            ?? throw new CannotAllocateBufferException('cannot allocate buffer');
-
         $fd = $this->ffi->open($path, 0);
-        $result = "";
-        $done = false;
-        do {
-            $read_len = $this->ffi->read($fd, $buffer, 4096);
-            if ($read_len > 0) {
-                $result .= \FFI::string($buffer, min($read_len, 4096));
-            } else {
-                $done = true;
-            }
-        } while (!$done);
-        $this->ffi->close($fd);
+        if ($fd < 0) {
+            return '';
+        }
 
-        return $result;
+        try {
+            $size = $this->seekToSize($fd);
+            if ($size > 0) {
+                return $this->readKnownSize($fd, $size);
+            }
+            return $this->readUntilEof($fd);
+        } finally {
+            $this->ffi->close($fd);
+        }
+    }
+
+    private function seekToSize(int $fd): int
+    {
+        // SEEK_END = 2. Returns the new offset, i.e. the file size, or -1
+        // on error. /proc files and pipes report 0 (or an error) and fall
+        // through to readUntilEof. Regular files on disk give us the real
+        // size in one syscall, no struct-stat ABI guessing required.
+        /** @var int $size */
+        $size = $this->ffi->lseek($fd, 0, 2);
+        if ($size <= 0) {
+            return 0;
+        }
+        return $size;
+    }
+
+    private function readKnownSize(int $fd, int $size): string
+    {
+        // Always read in CHUNK_SIZE-bound segments. Allocating a single
+        // multi-MB FFI buffer the size of the whole binary turned out to
+        // corrupt zend_mm under load on aarch64 (memory dump tests
+        // surfaced "zend_mm_heap corrupted"); 1 MB chunks keep the per-
+        // allocation footprint small and reuse one buffer across the
+        // loop. The size hint from lseek still helps because it lets us
+        // pre-size the implode and bound the loop.
+        $chunk_buffer = $this->ffi->new('unsigned char[' . self::CHUNK_SIZE . ']')
+            ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+        $chunks = [];
+        $offset = 0;
+        while ($offset < $size) {
+            $remaining = $size - $offset;
+            $more = $this->ffi->pread(
+                $fd,
+                $chunk_buffer,
+                $remaining < self::CHUNK_SIZE ? $remaining : self::CHUNK_SIZE,
+                $offset,
+            );
+            if ($more <= 0) {
+                break;
+            }
+            $chunks[] = FFI::string($chunk_buffer, $more);
+            $offset += $more;
+        }
+        return implode('', $chunks);
+    }
+
+    private function readUntilEof(int $fd): string
+    {
+        $buffer = $this->ffi->new('unsigned char[' . self::CHUNK_SIZE . ']')
+            ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+        $chunks = [];
+        while (true) {
+            $read_len = $this->ffi->read($fd, $buffer, self::CHUNK_SIZE);
+            if ($read_len <= 0) {
+                break;
+            }
+            $chunks[] = FFI::string($buffer, $read_len);
+        }
+        return implode('', $chunks);
     }
 }

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -127,16 +127,20 @@ class PhpGlobalsFinder
             $this->binary_analysis_cache->set($fingerprint, 'tsrm_ls_cache', [
                 'has_tsrm_ls_cache' => true,
             ]);
-        } elseif (!$brute_force->has_tls_segment) {
+        } elseif ($brute_force->has_tls_segment === false) {
             // No PT_TLS in the ELF — confirmed NTS build, persist the negative.
             $this->binary_analysis_cache->set($fingerprint, 'tsrm_ls_cache', [
                 'has_tsrm_ls_cache' => false,
             ]);
         }
-        // else: PT_TLS exists but the chosen thread's slot is still zero
-        // (e.g. an idle FrankenPHP worker that hasn't served a request yet).
-        // That is per-thread state, not a binary-level fact, so do not poison
-        // the cache for the rest of the binary's threads.
+        // Two non-cacheable cases collapse here:
+        //   has_tls_segment === true: PT_TLS exists but the chosen thread's
+        //     slot is still zero (e.g. an idle FrankenPHP worker that hasn't
+        //     served a request yet). Per-thread state, not a binary-level fact.
+        //   has_tls_segment === null: we couldn't read or parse the ELF prefix,
+        //     so we don't know whether this is NTS or ZTS. Treating "couldn't
+        //     tell" as "definitely NTS" would lock in a transient I/O failure
+        //     as a permanent verdict.
         $this->tsrm_ls_cache_cache[$process_specifier->pid] = $brute_force->address;
         return $brute_force->address;
     }

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -18,6 +18,7 @@ use Reli\Lib\ByteStream\CDataByteReader;
 use Reli\Lib\ByteStream\IntegerByteSequence\IntegerByteSequenceReader;
 use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Lib\Elf\Process\BinaryFingerprint;
 use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
@@ -52,7 +53,21 @@ final class PhpTsrmLsCacheFinder
     ) {
     }
 
-    /** @return array{int, int, ProcessModuleMemoryMap}|null */
+    /**
+     * Returns the TLS block address + size + the binary's module map when the
+     * ELF has a PT_TLS program header. Returns null only when the ELF is
+     * confirmed to have no PT_TLS (NTS build) or when the TLS block address
+     * for the target thread cannot be resolved -- both of which are
+     * binary-/thread-level facts the caller may persist as negatives.
+     *
+     * Read or parse failures throw ElfParserException so the caller can
+     * distinguish "this is NTS" from "we couldn't tell"; conflating the two
+     * here would let a transient I/O failure poison the cache as a permanent
+     * NTS verdict.
+     *
+     * @return array{int, int, ProcessModuleMemoryMap}|null
+     * @throws ElfParserException
+     */
     public function resolveTlsBlock(
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
@@ -80,19 +95,39 @@ final class PhpTsrmLsCacheFinder
             $php_module_name,
         );
 
-        // We only need the ELF header and the program header table here,
-        // both of which sit at the very start of the file -- typically
-        // within the first KB. Pulling the whole 19 MB libphp.so off disk
-        // (and through FFI::string) just to find PT_TLS is what made
-        // resolveTlsBlock the second-largest cold-attach cost after the
-        // symbol resolver. Read 64 KB and call it; that comfortably covers
-        // the program header table for any sane ELF binary.
-        $header_bytes = $this->file_reader->readSlice($php_path, 0, 64 * 1024);
-        if ($header_bytes === '') {
-            return null;
+        // PT_TLS lives in the program header table, which itself lives at
+        // e_phoff and is e_phentsize * e_phnum bytes long -- usually just a
+        // few hundred bytes right after the ELF header. Read the 64-byte
+        // ELF header first so we can size the program-header read exactly,
+        // instead of guessing a magic upper bound and pulling the entire
+        // libphp.so (~19 MB) just to inspect a kilobyte of metadata.
+        $header_size = 64;
+        $header_bytes = $this->file_reader->readSlice($php_path, 0, $header_size);
+        if (strlen($header_bytes) < $header_size) {
+            throw new ElfParserException(
+                sprintf('cannot read ELF header from %s', $php_path),
+            );
         }
         $byte_reader = new StringByteReader($header_bytes);
         $php_elf_header = $this->elf64_parser->parseElfHeader($byte_reader);
+
+        $ph_end = $php_elf_header->e_phoff->toInt()
+            + $php_elf_header->e_phentsize * $php_elf_header->e_phnum;
+        if ($ph_end > $header_size) {
+            $extended = $this->file_reader->readSlice($php_path, 0, $ph_end);
+            if (strlen($extended) < $ph_end) {
+                throw new ElfParserException(
+                    sprintf(
+                        'short read while loading program headers from %s: got %d bytes, need %d',
+                        $php_path,
+                        strlen($extended),
+                        $ph_end,
+                    ),
+                );
+            }
+            $byte_reader = new StringByteReader($extended);
+        }
+
         $program_headers = $this->elf64_parser->parseProgramHeader($byte_reader, $php_elf_header);
         $tls_entries = $program_headers->findTls();
         if ($tls_entries === []) {
@@ -107,10 +142,17 @@ final class PhpTsrmLsCacheFinder
         ProcessSpecifier $process_specifier,
         TargetPhpSettings $target_php_settings
     ): TsrmLsCacheBruteForceResult {
-        $tls_block = $this->resolveTlsBlock(
-            $process_specifier,
-            $target_php_settings,
-        );
+        try {
+            $tls_block = $this->resolveTlsBlock(
+                $process_specifier,
+                $target_php_settings,
+            );
+        } catch (ElfParserException) {
+            // Could not read or parse the ELF prefix -- the binary may be
+            // ZTS or NTS, we just don't know. Caller must treat this as
+            // "do not persist a negative cache entry".
+            return new TsrmLsCacheBruteForceResult(null, null);
+        }
         if (is_null($tls_block)) {
             // No PT_TLS in the ELF — this is a binary-level fact (NTS build).
             return new TsrmLsCacheBruteForceResult(null, false);

--- a/src/Lib/PhpProcessReader/TsrmLsCacheBruteForceResult.php
+++ b/src/Lib/PhpProcessReader/TsrmLsCacheBruteForceResult.php
@@ -16,16 +16,27 @@ namespace Reli\Lib\PhpProcessReader;
 /**
  * Outcome of {@see PhpTsrmLsCacheFinder::findByBruteForcing()}.
  *
- * Distinguishing "binary has no PT_TLS at all" (NTS) from "PT_TLS exists but
- * the scanned thread's slot was empty" (ZTS, idle worker) lets the caller
- * decide whether to persist a negative cache entry: only the former is a
- * binary-level fact.
+ * Three states matter to the caller:
+ *
+ *  - address !== null: TSRM_LS_CACHE was found, regardless of has_tls_segment.
+ *  - address === null && has_tls_segment === true: PT_TLS exists in the ELF
+ *    but no slot in the scanned thread's TLS block validated. This is a
+ *    per-thread "the slot is still zero" situation (typical of an idle
+ *    FrankenPHP worker) and must NOT be persisted as a binary-level negative.
+ *  - address === null && has_tls_segment === false: confirmed no PT_TLS in
+ *    the ELF -- the binary is NTS, and the negative cache entry is safe to
+ *    persist.
+ *  - address === null && has_tls_segment === null: the ELF could not be
+ *    read or parsed enough to tell either way (for example the
+ *    /proc/<pid>/root/... path race-disappeared, or the file_reader returned
+ *    an empty buffer). The caller must NOT persist a negative cache entry,
+ *    because doing so would lock in a guess as a binary-level fact.
  */
 final readonly class TsrmLsCacheBruteForceResult
 {
     public function __construct(
         public ?int $address,
-        public bool $has_tls_segment,
+        public ?bool $has_tls_segment,
     ) {
     }
 }


### PR DESCRIPTION
## Summary

This PR significantly improves cold-attach performance (the initial profiling startup cost) and fixes a critical bug where negative TSRM cache entries were incorrectly persisted for ZTS binaries, causing subsequent attaches to fail.

## Key Changes

**Performance Optimizations:**
- **File reading**: Increased chunk size from 4 KB to 1 MB in `NativeFileReader`, reducing syscall overhead by 256x for large binaries like libphp.so (20 MB). Added `readSlice()` method for partial reads and `pread()` for single-shot reads of known-size files.
- **ELF symbol table parsing**: Replaced per-entry `IntegerByteSequenceReader` calls with bulk `unpack()` operations. Symbol table parsing now reads the entire table as a string and decodes each entry with a single native `unpack()` call instead of 6+ PHP-level function calls per symbol.
- **GNU hash table parsing**: Applied the same bulk-read optimization to bloom and bucket arrays.
- **Link-map C-string reading**: Replaced byte-by-byte `process_vm_readv` syscalls with page-aware chunked reads (up to 256 bytes per chunk, clipped to page boundaries). Typical 30-40 character library paths now require a single syscall instead of one per character.
- **Symbol resolver caching**: Added `PerBinarySymbolCacheRetriever` to cache parsed `Elf64SymbolResolver` instances per binary fingerprint. Cold attach often constructs multiple resolver instances against the same libphp.so; the cache eliminates redundant 19 MB reads and re-parses.
- **TLS block resolution**: Optimized `PhpTsrmLsCacheFinder::resolveTlsBlock()` to read only the first 64 KB of the binary (containing ELF header and program headers) instead of the entire file.

**Bug Fixes:**
- **ZTS cache poisoning**: Fixed `PhpGlobalsFinder` incorrectly persisting negative `has_tsrm_ls_cache` entries for ZTS binaries. The issue occurred when an idle FrankenPHP worker's TLS slot was still zero—the brute force would return null, but this is per-thread state, not a binary-level fact. The fix distinguishes between "binary has no PT_TLS" (NTS, safe to cache negative) and "PT_TLS exists but thread's slot is empty" (ZTS, do not cache). When a cached negative is encountered, the code now re-verifies by checking for PT_TLS in the ELF; if found, the stale entry is dropped and brute force is retried.

## Implementation Details

- `LinkMapLoader::readCString()` now respects 4096-byte page boundaries to avoid `EFAULT` when reads would cross unmapped memory.
- `Elf64SymbolResolverCreator` now exposes `createLinearScanResolverFromBinary()` and `createDynamicResolverFromBinary()` methods to allow callers to reuse a pre-read binary string.
- New `TsrmLsCacheBruteForceResult` class distinguishes between "address found" and "has_tls_segment" to enable correct cache-poisoning decisions.
- Added comprehensive test coverage in `LinkMapLoaderTest` for page-boundary edge cases and in `PhpGlobalsFinderTest` for NTS negative caching.
- Documentation updates in `CLAUDE.md` and `docs/tracing/frankenphp.md` explain cold-attach realities, profiling recipes, and FrankenPHP-specific gotchas.

https://claude.ai/code/session_01EbocTVi82AWJNHJtpsLxpw