### PR TITLE
[bisect] + resolver sharing + readSlice infrastructure (no NativeFileReader::readAll rewrite)

### DIFF
--- a/src/Lib/ByteStream/IntegerByteSequence/LittleEndianReader.php
+++ b/src/Lib/ByteStream/IntegerByteSequence/LittleEndianReader.php
@@ -16,6 +16,8 @@ namespace Reli\Lib\ByteStream\IntegerByteSequence;
 use Reli\Lib\ByteStream\ByteReaderInterface;
 use Reli\Lib\Integer\UInt64;
 
+use function unpack;
+
 final class LittleEndianReader implements IntegerByteSequenceReader
 {
     #[\Override]
@@ -33,18 +35,22 @@ final class LittleEndianReader implements IntegerByteSequenceReader
     #[\Override]
     public function read32(ByteReaderInterface $data, int $offset): int
     {
-        return ($data[$offset + 3] << 24)
-            | ($data[$offset + 2] << 16)
-            | ($data[$offset + 1] << 8)
-            | $data[$offset];
+        // Hot path on cold attach (ELF symbol/hash-table parsing). Going
+        // through ArrayAccess::offsetGet four times per read32 means four
+        // PHP function calls + four ord() calls per uint32; for libphp.so
+        // with tens of thousands of symbols that adds up to millions of
+        // PHP-level calls. unpack('V', $bytes) collapses each read32 to two
+        // native calls.
+        /** @var array{1: int} $unpacked */
+        $unpacked = unpack('V', $data->createSliceAsString($offset, 4));
+        return $unpacked[1];
     }
 
     #[\Override]
     public function read64(ByteReaderInterface $data, int $offset): UInt64
     {
-        return new UInt64(
-            $this->read32($data, $offset + 4),
-            $this->read32($data, $offset),
-        );
+        /** @var array{1: int, 2: int} $unpacked */
+        $unpacked = unpack('V2', $data->createSliceAsString($offset, 8));
+        return new UInt64($unpacked[2], $unpacked[1]);
     }
 }

--- a/src/Lib/Elf/Parser/Elf64Parser.php
+++ b/src/Lib/Elf/Parser/Elf64Parser.php
@@ -205,22 +205,43 @@ final class Elf64Parser
         int $number_of_symbols,
         int $entry_size
     ): Elf64SymbolTable {
+        // Cold-attach hot loop: libphp.so has tens of thousands of dynamic
+        // symbols, and the previous implementation went through six
+        // IntegerByteSequenceReader calls per entry, each of which fanned
+        // out into per-byte ArrayAccess fetches. Reading the whole symbol
+        // table into a single string up front and decoding each entry with
+        // one native unpack() per record cuts the parse cost dramatically.
+        if ($number_of_symbols === 0) {
+            return new Elf64SymbolTable();
+        }
+        $blob = $data->createSliceAsString(
+            $start_offset,
+            $number_of_symbols * $entry_size,
+        );
         $symbol_table_array = [];
+        $entry_format = 'Vst_name/Cst_info/Cst_other/vst_shndx/V2st_value/V2st_size';
         for ($i = 0; $i < $number_of_symbols; $i++) {
-            $offset = $start_offset + $i * $entry_size;
-            $st_name = $this->integer_reader->read32($data, $offset);
-            $st_info = $this->integer_reader->read8($data, $offset + 4);
-            $st_other = $this->integer_reader->read8($data, $offset + 5);
-            $st_shndx = $this->integer_reader->read16($data, $offset + 6);
-            $st_value = $this->integer_reader->read64($data, $offset + 8);
-            $st_size = $this->integer_reader->read64($data, $offset + 16);
+            $entry = substr($blob, $i * $entry_size, 24);
+            /**
+             * @var array{
+             *     st_name: int,
+             *     st_info: int,
+             *     st_other: int,
+             *     st_shndx: int,
+             *     st_value1: int,
+             *     st_value2: int,
+             *     st_size1: int,
+             *     st_size2: int,
+             * } $fields
+             */
+            $fields = unpack($entry_format, $entry);
             $symbol_table_array[] = new Elf64SymbolTableEntry(
-                $st_name,
-                $st_info,
-                $st_other,
-                $st_shndx,
-                $st_value,
-                $st_size
+                $fields['st_name'],
+                $fields['st_info'],
+                $fields['st_other'],
+                $fields['st_shndx'],
+                new UInt64($fields['st_value2'], $fields['st_value1']),
+                new UInt64($fields['st_size2'], $fields['st_size1']),
             );
         }
         return new Elf64SymbolTable(...$symbol_table_array);
@@ -246,14 +267,32 @@ final class Elf64Parser
         $bloom_size = $this->integer_reader->read32($data, $offset + 8);
         $bloom_shift = $this->integer_reader->read32($data, $offset + 12);
         $bloom_offset = $offset + 16;
+        // Decode the bloom array in one unpack instead of 2*bloom_size
+        // ArrayAccess fetches; same trick for the buckets table below.
         $bloom = [];
-        for ($i = 0; $i < $bloom_size; $i++) {
-            $bloom[] = $this->integer_reader->read64($data, $bloom_offset + $i * 8);
+        if ($bloom_size > 0) {
+            $bloom_blob = $data->createSliceAsString($bloom_offset, $bloom_size * 8);
+            $bloom_unpacked = unpack('V*', $bloom_blob);
+            if ($bloom_unpacked === false) {
+                throw new ElfParserException('failed to unpack gnu hash bloom array');
+            }
+            /** @var int[] $bloom_words */
+            $bloom_words = array_values($bloom_unpacked);
+            for ($i = 0; $i < $bloom_size; $i++) {
+                $bloom[] = new UInt64($bloom_words[$i * 2 + 1], $bloom_words[$i * 2]);
+            }
         }
         $buckets_offset = $offset + 16 + $bloom_size * 8;
         $buckets = [];
-        for ($i = 0; $i < $nbuckets; $i++) {
-            $buckets[] = $this->integer_reader->read32($data, $buckets_offset + $i * 4);
+        if ($nbuckets > 0) {
+            $buckets_blob = $data->createSliceAsString($buckets_offset, $nbuckets * 4);
+            $buckets_unpacked = unpack('V*', $buckets_blob);
+            if ($buckets_unpacked === false) {
+                throw new ElfParserException('failed to unpack gnu hash buckets');
+            }
+            /** @var int[] $bucket_words */
+            $bucket_words = array_values($buckets_unpacked);
+            $buckets = $bucket_words;
         }
 
         $chain_offset = $offset + 16 + $bloom_size * 8 + $nbuckets * 4;

--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
+use Reli\Lib\ByteStream\StringByteReader;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
 use Reli\Lib\Elf\SymbolResolver\SymbolResolverCreatorInterface;
+use Reli\Lib\File\FileReaderInterface;
 use Reli\Lib\Integer\UInt64;
 use Reli\Lib\Process\MemoryMap\ProcessModuleMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -36,12 +39,36 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
 
     private function loadResolver(): Elf64SymbolResolver
     {
+        // Both the linear-scan and the dynamic-symbol resolver want the
+        // libphp.so contents as a string. Reading the binary once and
+        // letting the fallback chain reuse it shaves roughly half the
+        // cold-attach disk-read cost on stripped builds (FrankenPHP), where
+        // the linear-scan path is guaranteed to fail and we always have to
+        // try the dynamic-symbol path next.
+        if ($this->symbol_resolver_creator instanceof Elf64SymbolResolverCreator) {
+            $binary = $this->readBinaryOnce();
+            if ($binary !== null) {
+                try {
+                    return $this->symbol_resolver_creator->createLinearScanResolverFromBinary($binary);
+                } catch (ElfParserException) {
+                    try {
+                        return $this->symbol_resolver_creator->createDynamicResolverFromBinary($binary);
+                    } catch (ElfParserException) {
+                        return $this->symbol_resolver_creator->createDynamicResolverFromProcessMemory(
+                            $this->memory_reader,
+                            $this->pid,
+                            $this->module_memory_map
+                        );
+                    }
+                }
+            }
+        }
         try {
             return $this->symbol_resolver_creator->createLinearScanResolverFromPath($this->path);
-        } catch (ElfParserException $e) {
+        } catch (ElfParserException) {
             try {
                 return $this->symbol_resolver_creator->createDynamicResolverFromPath($this->path);
-            } catch (ElfParserException $e) {
+            } catch (ElfParserException) {
                 return $this->symbol_resolver_creator->createDynamicResolverFromProcessMemory(
                     $this->memory_reader,
                     $this->pid,
@@ -49,6 +76,23 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
                 );
             }
         }
+    }
+
+    private function readBinaryOnce(): ?StringByteReader
+    {
+        if (!($this->symbol_resolver_creator instanceof Elf64SymbolResolverCreator)) {
+            return null;
+        }
+        $reader = $this->symbol_resolver_creator->getFileReader();
+        try {
+            $raw = $reader->readAll($this->path);
+        } catch (\Throwable) {
+            return null;
+        }
+        if ($raw === '') {
+            return null;
+        }
+        return new StringByteReader($raw);
     }
 
     #[\Override]

--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -34,10 +34,34 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
         private int $pid,
         private ProcessModuleMemoryMap $module_memory_map,
         private SymbolResolverCreatorInterface $symbol_resolver_creator,
+        private ?PerBinarySymbolCacheRetriever $shared_resolver_cache = null,
+        private ?BinaryFingerprint $fingerprint = null,
     ) {
     }
 
     private function loadResolver(): Elf64SymbolResolver
+    {
+        // Cold attach often constructs several Elf64LazyParseSymbolResolver
+        // instances against the same libphp.so (PhpGlobalsFinder,
+        // resolveTlsBlock, TsrmGlobalsResolver each create their own symbol
+        // reader), and each instance would otherwise re-read and re-parse
+        // the 19 MB binary. The shared resolver cache, keyed on the binary
+        // fingerprint, lets the second-and-later instances skip straight
+        // to the parsed inner resolver.
+        if ($this->shared_resolver_cache !== null && $this->fingerprint !== null) {
+            $shared = $this->shared_resolver_cache->getResolver($this->fingerprint);
+            if ($shared !== null) {
+                return $shared;
+            }
+        }
+        $resolver = $this->loadResolverUncached();
+        if ($this->shared_resolver_cache !== null && $this->fingerprint !== null) {
+            $this->shared_resolver_cache->setResolver($this->fingerprint, $resolver);
+        }
+        return $resolver;
+    }
+
+    private function loadResolverUncached(): Elf64SymbolResolver
     {
         // Both the linear-scan and the dynamic-symbol resolver want the
         // libphp.so contents as a string. Reading the binary once and

--- a/src/Lib/Elf/Process/LinkMapLoader.php
+++ b/src/Lib/Elf/Process/LinkMapLoader.php
@@ -69,17 +69,29 @@ final class LinkMapLoader
 
     private function readCString(int $pid, int $address): string
     {
-        $bytes = $this->memory_reader->read($pid, $address, 1);
+        // Cold-attach hot path: link-map traversal during cold-attach has
+        // to read every loaded library's path (DT_NEEDED-style), and naive
+        // byte-by-byte reads cost one process_vm_readv syscall per
+        // character. Reading in 256-byte chunks turns each typical 30-40
+        // character path into a single syscall.
+        $chunk_size = 256;
         $str = '';
         while (true) {
-            /** @var int $c */
-            $c = $bytes[0];
-            if ($c === 0) {
+            $chunk = $this->memory_reader->read($pid, $address, $chunk_size);
+            $found_terminator = false;
+            for ($i = 0; $i < $chunk_size; $i++) {
+                /** @var int $c */
+                $c = $chunk[$i];
+                if ($c === 0) {
+                    $found_terminator = true;
+                    break;
+                }
+                $str .= chr($c);
+            }
+            if ($found_terminator) {
                 break;
             }
-            $str .= chr($c);
-            $address += 1;
-            $bytes = $this->memory_reader->read($pid, $address, 1);
+            $address += $chunk_size;
         }
         return $str;
     }

--- a/src/Lib/Elf/Process/LinkMapLoader.php
+++ b/src/Lib/Elf/Process/LinkMapLoader.php
@@ -72,27 +72,44 @@ final class LinkMapLoader
         // Cold-attach hot path: link-map traversal during cold-attach has
         // to read every loaded library's path (DT_NEEDED-style), and naive
         // byte-by-byte reads cost one process_vm_readv syscall per
-        // character. Reading in 256-byte chunks turns each typical 30-40
+        // character. Reading in larger chunks turns each typical 30-40
         // character path into a single syscall.
-        $chunk_size = 256;
+        //
+        // The string sits inside ld-linux's / the binary's .dynstr table,
+        // which is usually mapped contiguously, but the very last string
+        // in that table can land so close to the page boundary that a
+        // greedy read would cross into unmapped memory and trip EFAULT
+        // (process_vm_readv refuses partial transfers). To stay safe,
+        // never let a single read cross a page boundary -- that is the
+        // granularity at which mappings start and end. We always clip the
+        // chunk to the rest of the current page; if the string spans
+        // pages, the next iteration starts page-aligned and reads exactly
+        // one page. If we still have not found the terminator after a
+        // generous PATH_MAX-style budget, give up rather than walking
+        // into unrelated mappings.
+        $page_size = 4096;
+        $max_chunk = 256;
+        $max_total = 4 * $page_size;
+        $total = 0;
         $str = '';
-        while (true) {
+        while ($total < $max_total) {
+            $remaining_in_page = $page_size - ($address & ($page_size - 1));
+            $chunk_size = $remaining_in_page < $max_chunk ? $remaining_in_page : $max_chunk;
             $chunk = $this->memory_reader->read($pid, $address, $chunk_size);
-            $found_terminator = false;
             for ($i = 0; $i < $chunk_size; $i++) {
                 /** @var int $c */
                 $c = $chunk[$i];
                 if ($c === 0) {
-                    $found_terminator = true;
-                    break;
+                    return $str;
                 }
                 $str .= chr($c);
             }
-            if ($found_terminator) {
-                break;
-            }
             $address += $chunk_size;
+            $total += $chunk_size;
         }
+        // No terminator within the safety budget. Returning the prefix
+        // keeps searchByName() honest -- the result simply will not match
+        // any expected library path -- without exploding the cold attach.
         return $str;
     }
 }

--- a/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
+++ b/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolCache;
 
 final class PerBinarySymbolCacheRetriever
@@ -20,11 +21,33 @@ final class PerBinarySymbolCacheRetriever
     /** @var array<string, Elf64SymbolCache> */
     private array $cache = [];
 
+    /**
+     * Holds the parsed inner resolver per binary fingerprint so that a
+     * cold attach which constructs several Elf64LazyParseSymbolResolver
+     * instances against the same libphp.so reuses one parse instead of
+     * re-reading 19 MB off disk per instance.
+     *
+     * @var array<string, Elf64SymbolResolver>
+     */
+    private array $resolver_cache = [];
+
     public function get(BinaryFingerprint $binary_fingerprint): Elf64SymbolCache
     {
         if (!isset($this->cache[(string)$binary_fingerprint])) {
             $this->cache[(string)$binary_fingerprint] = new Elf64SymbolCache();
         }
         return $this->cache[(string)$binary_fingerprint];
+    }
+
+    public function getResolver(BinaryFingerprint $binary_fingerprint): ?Elf64SymbolResolver
+    {
+        return $this->resolver_cache[(string)$binary_fingerprint] ?? null;
+    }
+
+    public function setResolver(
+        BinaryFingerprint $binary_fingerprint,
+        Elf64SymbolResolver $resolver,
+    ): void {
+        $this->resolver_cache[(string)$binary_fingerprint] = $resolver;
     }
 }

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -69,6 +69,8 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                 $pid,
                 $module_memory_map,
                 $this->symbol_resolver_creator,
+                $this->per_binary_symbol_cache_retriever,
+                $binary_fingerprint,
             ),
             $this->per_binary_symbol_cache_retriever->get($binary_fingerprint),
             $this->binary_analysis_cache,

--- a/src/Lib/Elf/SymbolResolver/Elf64SymbolResolverCreator.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64SymbolResolverCreator.php
@@ -30,17 +30,35 @@ final class Elf64SymbolResolverCreator implements SymbolResolverCreatorInterface
     ) {
     }
 
+    public function getFileReader(): FileReaderInterface
+    {
+        return $this->file_reader;
+    }
+
     /**
      * @throws ElfParserException
      */
     #[\Override]
     public function createLinearScanResolverFromPath(string $path): Elf64LinearScanSymbolResolver
     {
-        $binary_raw = $this->file_reader->readAll($path);
-        if ($binary_raw === '') {
-            throw new ElfParserException('cannot read ELF binary');
-        }
-        $binary = new StringByteReader($binary_raw);
+        return $this->createLinearScanResolverFromBinary($this->readBinary($path));
+    }
+
+    /**
+     * @throws ElfParserException
+     */
+    #[\Override]
+    public function createDynamicResolverFromPath(string $path): Elf64DynamicSymbolResolver
+    {
+        return $this->createDynamicResolverFromBinary($this->readBinary($path));
+    }
+
+    /**
+     * @throws ElfParserException
+     */
+    public function createLinearScanResolverFromBinary(
+        StringByteReader $binary,
+    ): Elf64LinearScanSymbolResolver {
         $elf_header = $this->elf_parser->parseElfHeader($binary);
         $program_header = $this->elf_parser->parseProgramHeader($binary, $elf_header);
         $base_address = $program_header->findBaseAddress();
@@ -87,15 +105,22 @@ final class Elf64SymbolResolverCreator implements SymbolResolverCreatorInterface
     /**
      * @throws ElfParserException
      */
-    #[\Override]
-    public function createDynamicResolverFromPath(string $path): Elf64DynamicSymbolResolver
+    public function createDynamicResolverFromBinary(
+        StringByteReader $binary,
+    ): Elf64DynamicSymbolResolver {
+        return Elf64DynamicSymbolResolver::load($this->elf_parser, $binary);
+    }
+
+    /**
+     * @throws ElfParserException
+     */
+    private function readBinary(string $path): StringByteReader
     {
         $binary_raw = $this->file_reader->readAll($path);
         if ($binary_raw === '') {
             throw new ElfParserException('cannot read ELF binary');
         }
-        $binary = new StringByteReader($binary_raw);
-        return Elf64DynamicSymbolResolver::load($this->elf_parser, $binary);
+        return new StringByteReader($binary_raw);
     }
 
     /**

--- a/src/Lib/File/CatFileReader.php
+++ b/src/Lib/File/CatFileReader.php
@@ -46,4 +46,17 @@ final class CatFileReader implements FileReaderInterface
 
         return $contents;
     }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        // CatFileReader is the proc_open(cat) fallback; we don't shell out
+        // to dd here, so just slice the full read. Callers in the cold-attach
+        // hot path use NativeFileReader anyway.
+        $all = $this->readAll($path);
+        if ($offset < 0 || $offset >= strlen($all)) {
+            return '';
+        }
+        return substr($all, $offset, $size);
+    }
 }

--- a/src/Lib/File/FileReaderInterface.php
+++ b/src/Lib/File/FileReaderInterface.php
@@ -16,4 +16,12 @@ namespace Reli\Lib\File;
 interface FileReaderInterface
 {
     public function readAll(string $path): string;
+
+    /**
+     * Read up to $size bytes starting at $offset. Implementations may return
+     * fewer bytes than requested if the file ends before $offset + $size.
+     * Returns an empty string when the file cannot be opened or the offset
+     * is past EOF.
+     */
+    public function readSlice(string $path, int $offset, int $size): string;
 }

--- a/src/Lib/File/NativeFileReader.php
+++ b/src/Lib/File/NativeFileReader.php
@@ -26,9 +26,33 @@ final class NativeFileReader implements FileReaderInterface
         /** @var FFI\Libc\libc_file_ffi */
         $this->ffi = FFI::cdef('
             int open(const char *pathname, int flags);
-            ssize_t read(int fd, void *buf, size_t count);
+            long read(int fd, void *buf, unsigned long count);
+            long pread(int fd, void *buf, unsigned long count, long offset);
             int close(int fd);
         ');
+    }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        if ($size <= 0) {
+            return '';
+        }
+        $fd = $this->ffi->open($path, 0);
+        if ($fd < 0) {
+            return '';
+        }
+        try {
+            $buffer = $this->ffi->new("unsigned char[{$size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $read_len = $this->ffi->pread($fd, $buffer, $size, $offset);
+            if ($read_len <= 0) {
+                return '';
+            }
+            return FFI::string($buffer, $read_len);
+        } finally {
+            $this->ffi->close($fd);
+        }
     }
 
     #[\Override]

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -80,7 +80,18 @@ final class PhpTsrmLsCacheFinder
             $php_module_name,
         );
 
-        $byte_reader = new StringByteReader($this->file_reader->readAll($php_path));
+        // We only need the ELF header and the program header table here,
+        // both of which sit at the very start of the file -- typically
+        // within the first KB. Pulling the whole 19 MB libphp.so off disk
+        // (and through FFI::string) just to find PT_TLS is what made
+        // resolveTlsBlock the second-largest cold-attach cost after the
+        // symbol resolver. Read 64 KB and call it; that comfortably covers
+        // the program header table for any sane ELF binary.
+        $header_bytes = $this->file_reader->readSlice($php_path, 0, 64 * 1024);
+        if ($header_bytes === '') {
+            return null;
+        }
+        $byte_reader = new StringByteReader($header_bytes);
         $php_elf_header = $this->elf64_parser->parseElfHeader($byte_reader);
         $program_headers = $this->elf64_parser->parseProgramHeader($byte_reader, $php_elf_header);
         $tls_entries = $program_headers->findTls();

--- a/tests/Lib/Elf/Process/LinkMapLoaderTest.php
+++ b/tests/Lib/Elf/Process/LinkMapLoaderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Elf\Process;
+
+use FFI;
+use FFI\CData;
+use Reli\BaseTestCase;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Process\MemoryReader\MemoryReaderException;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+
+class LinkMapLoaderTest extends BaseTestCase
+{
+    public function testReadsCStringWithoutCrossingPageBoundaries(): void
+    {
+        // Place a 40-byte link map struct at 0x1000 and a name string at
+        // 0x1FF0 (16 bytes before the next page boundary). The name itself
+        // is "/lib/x86_64-linux-gnu/libfoo.so.6\0" (33 bytes including NUL),
+        // so it spans the 0x2000 boundary. The fake reader refuses any
+        // read that crosses a 4096-byte boundary -- exactly mimicking
+        // process_vm_readv's EFAULT behaviour at unmapped page edges.
+        $page_size = 4096;
+        $name = '/lib/x86_64-linux-gnu/libfoo.so.6';
+        $name_addr = 0x1FF0;
+        $struct_addr = 0x1000;
+
+        $memory = [];
+        // l_addr, l_name, l_ld, l_next, l_prev (5 * 8 bytes = 40)
+        $memory[$struct_addr] = pack('PPPPP', 0x10000, $name_addr, 0, 0, 0);
+        // The name plus terminator at $name_addr; pad with NULs before
+        // it so the test reader can serve any aligned read inside the
+        // page that contains the name.
+        $name_with_nul = $name . "\0";
+        // Fill page 0x1000 (covers struct + name) with structured bytes:
+        // 0x1000..0x1027  link-map struct
+        // 0x1FF0..0x2010  name
+        $page_1000 = str_repeat("\0", $page_size);
+        $page_1000 = substr_replace($page_1000, $memory[$struct_addr], 0, 40);
+        $name_in_page_1000 = substr($name_with_nul, 0, $page_size - 0xFF0);
+        $page_1000 = substr_replace(
+            $page_1000,
+            $name_in_page_1000,
+            0xFF0,
+            strlen($name_in_page_1000),
+        );
+        $page_2000 = str_repeat("\0", $page_size);
+        $name_remaining = substr($name_with_nul, $page_size - 0xFF0);
+        $page_2000 = substr_replace($page_2000, $name_remaining, 0, strlen($name_remaining));
+
+        $pages = [
+            0x1000 => $page_1000,
+            0x2000 => $page_2000,
+        ];
+
+        $reader = $this->makePageBoundedReader($pages, $page_size);
+
+        $loader = new LinkMapLoader($reader, new LittleEndianReader());
+        $link_map = $loader->loadFromAddress(123, $struct_addr);
+
+        $this->assertSame($name, $link_map->l_name);
+    }
+
+    public function testReadsCStringThatStartsAtPageBoundary(): void
+    {
+        // Edge case: the name pointer lands exactly on a page boundary.
+        // The very first chunk would otherwise be sized as a full page,
+        // so make sure we still respect the page-boundary clip even when
+        // remaining_in_page == page_size.
+        $page_size = 4096;
+        $name = 'libphp.so';
+        $name_addr = 0x3000;
+        $struct_addr = 0x1000;
+
+        $page_1000 = str_repeat("\0", $page_size);
+        $page_1000 = substr_replace(
+            $page_1000,
+            pack('PPPPP', 0, $name_addr, 0, 0, 0),
+            0,
+            40,
+        );
+        $page_3000 = str_repeat("\0", $page_size);
+        $page_3000 = substr_replace($page_3000, $name . "\0", 0, strlen($name) + 1);
+
+        $pages = [
+            0x1000 => $page_1000,
+            0x3000 => $page_3000,
+            // 0x2000 deliberately unmapped — readCString must not stray
+            // into it via a coincidentally-overrun read.
+        ];
+
+        $reader = $this->makePageBoundedReader($pages, $page_size);
+
+        $loader = new LinkMapLoader($reader, new LittleEndianReader());
+        $link_map = $loader->loadFromAddress(123, $struct_addr);
+
+        $this->assertSame($name, $link_map->l_name);
+    }
+
+    /** @param array<int, string> $pages */
+    private function makePageBoundedReader(array $pages, int $page_size): MemoryReaderInterface
+    {
+        return new class ($pages, $page_size) implements MemoryReaderInterface {
+            private FFI $ffi;
+
+            /** @param array<int, string> $pages */
+            public function __construct(
+                private array $pages,
+                private int $page_size,
+            ) {
+                $this->ffi = FFI::cdef('');
+            }
+
+            #[\Override]
+            public function read(int $pid, int $remote_address, int $size): CData
+            {
+                $page_base = $remote_address & ~($this->page_size - 1);
+                $offset_in_page = $remote_address & ($this->page_size - 1);
+                if ($offset_in_page + $size > $this->page_size) {
+                    throw new MemoryReaderException(
+                        sprintf(
+                            'fake EFAULT: read crosses page boundary (addr=0x%x size=%d)',
+                            $remote_address,
+                            $size,
+                        ),
+                    );
+                }
+                if (!isset($this->pages[$page_base])) {
+                    throw new MemoryReaderException(
+                        sprintf('fake EFAULT: unmapped page 0x%x', $page_base),
+                    );
+                }
+                $bytes = substr($this->pages[$page_base], $offset_in_page, $size);
+                $buffer = $this->ffi->new("unsigned char[{$size}]");
+                if ($buffer === null) {
+                    throw new MemoryReaderException('cannot allocate buffer');
+                }
+                FFI::memcpy($buffer, $bytes, $size);
+                /** @var \FFI\CArray<int> */
+                return $buffer;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Bisect step 3 for ARM64 `zend_mm_heap corrupted` in #664.

Earlier results:
- #666 (cache poison fix only): ARM64 **green**, merged into 0.12.x.
- #667 (cache fix + ELF parser perf group): ARM64 **green**.

This branch adds **resolver sharing + readSlice infrastructure** on top of #667:

- Cherry-picked `7330fe8`: adds `readSlice` to FileReaderInterface / NativeFileReader / CatFileReader, adds resolver-cache to PerBinarySymbolCacheRetriever, threads it through Elf64LazyParseSymbolResolver, switches PhpTsrmLsCacheFinder::resolveTlsBlock to a 64 KB readSlice instead of readAll.

NOT included: NativeFileReader::readAll rewrite (e34cce8 + ba1a298 + 91251b3 + cf2b976). readAll is the upstream 0.12.x 4 KB chunk loop.

**Edit (amended commit):** the original cherry-pick was a broken state — `readSlice` calls `pread`, which the original commit assumed was already declared in cdef (added by `e34cce8`). Without that base, calling `readSlice` threw `FFI\Exception: Attempt to call undefined C function 'pread'` immediately, which would have masked the real test outcome. The amended commit declares `pread` in the cdef using the explicit `long` / `unsigned long` spelling matching `LibcFileReader` and `MemoryDumper`. Verified locally that `readSlice` now succeeds and the unit suite is green; the bisect outcome should now reflect resolver sharing / readSlice behaviour rather than a missing-symbol crash.

If ARM64 is **green** here → culprit is in NativeFileReader::readAll rewrite. Will narrow which sub-commit (fstat+pread vs lseek vs chunked alloc vs type spelling) next.

If ARM64 is **red** here → culprit is in resolver sharing or the readSlice path. Will narrow accordingly.

(Draft, do not merge — bisect probe only.)