### PR TITLE
perf: readSlice + resolveTlsBlock 64 KB read instead of full 19 MB readAll

### DIFF
--- a/src/Lib/File/CatFileReader.php
+++ b/src/Lib/File/CatFileReader.php
@@ -46,4 +46,17 @@ final class CatFileReader implements FileReaderInterface
 
         return $contents;
     }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        // CatFileReader is the proc_open(cat) fallback; we don't shell out
+        // to dd here, so just slice the full read. Callers in the cold-attach
+        // hot path use NativeFileReader anyway.
+        $all = $this->readAll($path);
+        if ($offset < 0 || $offset >= strlen($all)) {
+            return '';
+        }
+        return substr($all, $offset, $size);
+    }
 }

--- a/src/Lib/File/FileReaderInterface.php
+++ b/src/Lib/File/FileReaderInterface.php
@@ -16,4 +16,12 @@ namespace Reli\Lib\File;
 interface FileReaderInterface
 {
     public function readAll(string $path): string;
+
+    /**
+     * Read up to $size bytes starting at $offset. Implementations may return
+     * fewer bytes than requested if the file ends before $offset + $size.
+     * Returns an empty string when the file cannot be opened or the offset
+     * is past EOF.
+     */
+    public function readSlice(string $path, int $offset, int $size): string;
 }

--- a/src/Lib/File/NativeFileReader.php
+++ b/src/Lib/File/NativeFileReader.php
@@ -26,9 +26,33 @@ final class NativeFileReader implements FileReaderInterface
         /** @var FFI\Libc\libc_file_ffi */
         $this->ffi = FFI::cdef('
             int open(const char *pathname, int flags);
-            ssize_t read(int fd, void *buf, size_t count);
+            long read(int fd, void *buf, unsigned long count);
+            long pread(int fd, void *buf, unsigned long count, long offset);
             int close(int fd);
         ');
+    }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        if ($size <= 0) {
+            return '';
+        }
+        $fd = $this->ffi->open($path, 0);
+        if ($fd < 0) {
+            return '';
+        }
+        try {
+            $buffer = $this->ffi->new("unsigned char[{$size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $read_len = $this->ffi->pread($fd, $buffer, $size, $offset);
+            if ($read_len <= 0) {
+                return '';
+            }
+            return FFI::string($buffer, $read_len);
+        } finally {
+            $this->ffi->close($fd);
+        }
     }
 
     #[\Override]

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -80,7 +80,18 @@ final class PhpTsrmLsCacheFinder
             $php_module_name,
         );
 
-        $byte_reader = new StringByteReader($this->file_reader->readAll($php_path));
+        // We only need the ELF header and the program header table here,
+        // both of which sit at the very start of the file -- typically
+        // within the first KB. Pulling the whole 19 MB libphp.so off disk
+        // (and through FFI::string) just to find PT_TLS is what made
+        // resolveTlsBlock the second-largest cold-attach cost after the
+        // symbol resolver. Read 64 KB and call it; that comfortably covers
+        // the program header table for any sane ELF binary.
+        $header_bytes = $this->file_reader->readSlice($php_path, 0, 64 * 1024);
+        if ($header_bytes === '') {
+            return null;
+        }
+        $byte_reader = new StringByteReader($header_bytes);
         $php_elf_header = $this->elf64_parser->parseElfHeader($byte_reader);
         $program_headers = $this->elf64_parser->parseProgramHeader($byte_reader, $php_elf_header);
         $tls_entries = $program_headers->findTls();


### PR DESCRIPTION
Rebased onto current 0.12.x (now includes the cache poison fix from #666 and the ELF parser perf group from #667). The remaining diff is the readSlice infrastructure on its own:

- `FileReaderInterface::readSlice($path, $offset, $size)` declaration
- `NativeFileReader::readSlice` FFI implementation (open + pread + close), with the cdef declaring `pread`/`read` using explicit `long` / `unsigned long` types matching `LibcFileReader` and `MemoryDumper`
- `CatFileReader::readSlice` shell-out fallback (readAll + substr)
- `PhpTsrmLsCacheFinder::resolveTlsBlock` switched from `readAll` to a 64 KB `readSlice` for finding PT_TLS

This was the readSlice-only bisect probe; ARM64 was green here. The resolver-sharing piece (which broke ARM) is intentionally excluded — that's being investigated separately in #674.

This PR is therefore a useful standalone perf improvement: `resolveTlsBlock` no longer pulls the whole 19 MB libphp.so off disk just to inspect the program header. Safe to land independently.