### PR TITLE
[bisect] resolver-sharing + strong-fingerprint cache key

### DIFF
--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -34,10 +34,34 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
         private int $pid,
         private ProcessModuleMemoryMap $module_memory_map,
         private SymbolResolverCreatorInterface $symbol_resolver_creator,
+        private ?PerBinarySymbolCacheRetriever $shared_resolver_cache = null,
+        private ?BinaryFingerprint $fingerprint = null,
     ) {
     }
 
     private function loadResolver(): Elf64SymbolResolver
+    {
+        // Cold attach often constructs several Elf64LazyParseSymbolResolver
+        // instances against the same libphp.so (PhpGlobalsFinder,
+        // resolveTlsBlock, TsrmGlobalsResolver each create their own symbol
+        // reader), and each instance would otherwise re-read and re-parse
+        // the 19 MB binary. The shared resolver cache, keyed on the binary
+        // fingerprint, lets the second-and-later instances skip straight
+        // to the parsed inner resolver.
+        if ($this->shared_resolver_cache !== null && $this->fingerprint !== null) {
+            $shared = $this->shared_resolver_cache->getResolver($this->fingerprint);
+            if ($shared !== null) {
+                return $shared;
+            }
+        }
+        $resolver = $this->loadResolverUncached();
+        if ($this->shared_resolver_cache !== null && $this->fingerprint !== null) {
+            $this->shared_resolver_cache->setResolver($this->fingerprint, $resolver);
+        }
+        return $resolver;
+    }
+
+    private function loadResolverUncached(): Elf64SymbolResolver
     {
         // Both the linear-scan and the dynamic-symbol resolver want the
         // libphp.so contents as a string. Reading the binary once and

--- a/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
+++ b/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolCache;
 
 final class PerBinarySymbolCacheRetriever
@@ -20,11 +21,33 @@ final class PerBinarySymbolCacheRetriever
     /** @var array<string, Elf64SymbolCache> */
     private array $cache = [];
 
+    /**
+     * Holds the parsed inner resolver per binary fingerprint so that a
+     * cold attach which constructs several Elf64LazyParseSymbolResolver
+     * instances against the same libphp.so reuses one parse instead of
+     * re-reading 19 MB off disk per instance.
+     *
+     * @var array<string, Elf64SymbolResolver>
+     */
+    private array $resolver_cache = [];
+
     public function get(BinaryFingerprint $binary_fingerprint): Elf64SymbolCache
     {
         if (!isset($this->cache[(string)$binary_fingerprint])) {
             $this->cache[(string)$binary_fingerprint] = new Elf64SymbolCache();
         }
         return $this->cache[(string)$binary_fingerprint];
+    }
+
+    public function getResolver(BinaryFingerprint $binary_fingerprint): ?Elf64SymbolResolver
+    {
+        return $this->resolver_cache[(string)$binary_fingerprint] ?? null;
+    }
+
+    public function setResolver(
+        BinaryFingerprint $binary_fingerprint,
+        Elf64SymbolResolver $resolver,
+    ): void {
+        $this->resolver_cache[(string)$binary_fingerprint] = $resolver;
     }
 }

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -40,7 +40,19 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
         private ProcessPathResolver $process_path_resolver,
         private BinaryAnalysisCache $binary_analysis_cache,
         private ?ThreadPointerRetrieverInterface $thread_pointer_retriever = null,
+        private ?BinaryFingerprintCreator $binary_fingerprint_creator = null,
     ) {
+    }
+
+    private function fingerprint(int $pid, ProcessModuleMemoryMap $module_memory_map): BinaryFingerprint
+    {
+        if ($this->binary_fingerprint_creator !== null) {
+            return $this->binary_fingerprint_creator->createFromProcessModuleMemoryMap(
+                $pid,
+                $module_memory_map,
+            );
+        }
+        return BinaryFingerprint::fromProcessModuleMemoryMap($module_memory_map);
     }
 
     #[\Override]
@@ -61,7 +73,19 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
         $module_name = $module_memory_map->getModuleName();
         $path = $binary_path ?? $this->process_path_resolver->resolve($pid, $module_name);
 
-        $binary_fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap($module_memory_map);
+        // Use the strong fingerprint (device_id + inode + module_name + ELF
+        // header bytes) rather than the weak fingerprint
+        // (BinaryFingerprint::fromProcessModuleMemoryMap, which is just
+        // device_id + inode + name). The weak fingerprint can collide
+        // across different binaries in container environments where
+        // overlayfs reassigns device_id / inode. Now that resolver_cache
+        // caches the parsed Elf64SymbolResolver per binary fingerprint, a
+        // collision means a different binary's symbol table gets handed
+        // back, yielding garbage st_value addresses, garbage process_vm_readv
+        // reads, and zend_mm_heap corruption when MemoryDumper walks the
+        // wrong region. (Bisect probe: ARM64 CI failure reproduces in
+        // MemoryDumpCommandTest / MemoryCompareCommandIntegrationTest.)
+        $binary_fingerprint = $this->fingerprint($pid, $module_memory_map);
         $symbol_resolver = new Elf64CachedSymbolResolver(
             new Elf64LazyParseSymbolResolver(
                 $path,
@@ -84,9 +108,7 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                 $libpthread_fingerprint = null;
                 if ($libpthread_memory_areas !== []) {
                     $libpthread_module_map = new ProcessModuleMemoryMap($libpthread_memory_areas);
-                    $libpthread_fingerprint = BinaryFingerprint::fromProcessModuleMemoryMap(
-                        $libpthread_module_map
-                    );
+                    $libpthread_fingerprint = $this->fingerprint($pid, $libpthread_module_map);
                 }
                 $thread_pointer_retriever = $this->thread_pointer_retriever
                     ?? match (Architecture::detect()) {

--- a/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
+++ b/src/Lib/Elf/Process/ProcessModuleSymbolReaderCreator.php
@@ -69,6 +69,8 @@ final class ProcessModuleSymbolReaderCreator implements ProcessModuleSymbolReade
                 $pid,
                 $module_memory_map,
                 $this->symbol_resolver_creator,
+                $this->per_binary_symbol_cache_retriever,
+                $binary_fingerprint,
             ),
             $this->per_binary_symbol_cache_retriever->get($binary_fingerprint),
             $this->binary_analysis_cache,

--- a/src/Lib/File/CatFileReader.php
+++ b/src/Lib/File/CatFileReader.php
@@ -46,4 +46,17 @@ final class CatFileReader implements FileReaderInterface
 
         return $contents;
     }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        // CatFileReader is the proc_open(cat) fallback; we don't shell out
+        // to dd here, so just slice the full read. Callers in the cold-attach
+        // hot path use NativeFileReader anyway.
+        $all = $this->readAll($path);
+        if ($offset < 0 || $offset >= strlen($all)) {
+            return '';
+        }
+        return substr($all, $offset, $size);
+    }
 }

--- a/src/Lib/File/FileReaderInterface.php
+++ b/src/Lib/File/FileReaderInterface.php
@@ -16,4 +16,12 @@ namespace Reli\Lib\File;
 interface FileReaderInterface
 {
     public function readAll(string $path): string;
+
+    /**
+     * Read up to $size bytes starting at $offset. Implementations may return
+     * fewer bytes than requested if the file ends before $offset + $size.
+     * Returns an empty string when the file cannot be opened or the offset
+     * is past EOF.
+     */
+    public function readSlice(string $path, int $offset, int $size): string;
 }

--- a/src/Lib/File/NativeFileReader.php
+++ b/src/Lib/File/NativeFileReader.php
@@ -26,9 +26,33 @@ final class NativeFileReader implements FileReaderInterface
         /** @var FFI\Libc\libc_file_ffi */
         $this->ffi = FFI::cdef('
             int open(const char *pathname, int flags);
-            ssize_t read(int fd, void *buf, size_t count);
+            long read(int fd, void *buf, unsigned long count);
+            long pread(int fd, void *buf, unsigned long count, long offset);
             int close(int fd);
         ');
+    }
+
+    #[\Override]
+    public function readSlice(string $path, int $offset, int $size): string
+    {
+        if ($size <= 0) {
+            return '';
+        }
+        $fd = $this->ffi->open($path, 0);
+        if ($fd < 0) {
+            return '';
+        }
+        try {
+            $buffer = $this->ffi->new("unsigned char[{$size}]")
+                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $read_len = $this->ffi->pread($fd, $buffer, $size, $offset);
+            if ($read_len <= 0) {
+                return '';
+            }
+            return FFI::string($buffer, $read_len);
+        } finally {
+            $this->ffi->close($fd);
+        }
     }
 
     #[\Override]

--- a/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
+++ b/src/Lib/PhpProcessReader/PhpTsrmLsCacheFinder.php
@@ -80,7 +80,18 @@ final class PhpTsrmLsCacheFinder
             $php_module_name,
         );
 
-        $byte_reader = new StringByteReader($this->file_reader->readAll($php_path));
+        // We only need the ELF header and the program header table here,
+        // both of which sit at the very start of the file -- typically
+        // within the first KB. Pulling the whole 19 MB libphp.so off disk
+        // (and through FFI::string) just to find PT_TLS is what made
+        // resolveTlsBlock the second-largest cold-attach cost after the
+        // symbol resolver. Read 64 KB and call it; that comfortably covers
+        // the program header table for any sane ELF binary.
+        $header_bytes = $this->file_reader->readSlice($php_path, 0, 64 * 1024);
+        if ($header_bytes === '') {
+            return null;
+        }
+        $byte_reader = new StringByteReader($header_bytes);
         $php_elf_header = $this->elf64_parser->parseElfHeader($byte_reader);
         $program_headers = $this->elf64_parser->parseProgramHeader($byte_reader, $php_elf_header);
         $tls_entries = $program_headers->findTls();


### PR DESCRIPTION
Hypothesis-validation PR for the ARM64 `zend_mm_heap corrupted` triggered by the resolver-sharing change in #669.

Bisect so far:
- #666 (cache poison fix only): green (merged)
- #667 (+ ELF parser perf group): green
- #669 (+ resolver sharing + readSlice infrastructure): **red** on ARM64
- #673 (+ readSlice infrastructure only, no resolver sharing): green
- → culprit is the resolver sharing piece of `7330fe8`

This branch is the resolver-sharing state of #669 plus a single fix on top:

`ProcessModuleSymbolReaderCreator` was using `BinaryFingerprint::fromProcessModuleMemoryMap()` (device_id + inode + module_name) as the `resolver_cache` key. `BinaryFingerprint`'s own docstring already flags that variant as insufficient for container environments — Docker overlayfs can reuse the same device_id + inode across different binaries. Pre-`7330fe8` that collision was harmless because the cache stored per-symbol entries that the caller then translated through the LIVE process's base address. Once `7330fe8` started caching the whole parsed `Elf64SymbolResolver` per fingerprint, a collision now returns the *wrong binary's* symbol table — every translated `st_value` points into unrelated memory, and `process_vm_readv` against those addresses eventually corrupts the runner's zend_mm.

This PR switches the resolver-cache fingerprint to the strong variant (the existing `BinaryFingerprintCreator::createFromProcessModuleMemoryMap()`, which also folds in the ELF header bytes). The constructor gains an optional `BinaryFingerprintCreator` argument with a fall-through to the weak fingerprint so the test sites that build the creator by hand keep compiling without an audit pass.

ARM64 CI on this branch is the experiment:
- **green** → hypothesis confirmed; will land the upgrade as the real fix on the resolver-sharing branch and continue with the rest of the perf work.
- **red** → hypothesis wrong; will look elsewhere inside the `7330fe8` delta (next candidate: state mutation through the shared resolver, e.g. `Elf64CachedSymbolResolver`'s per-instance lazy fields interacting badly with a shared inner).

(Draft, do not merge — bisect probe.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbocTVi82AWJNHJtpsLxpw)_