### PR TITLE
[debug-only] ARM64 zend_mm root cause: parsed-resolver-share + valgrind probe

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,6 +17,13 @@ on:
       - 'docs/**'
       - 'LICENSE'
 
+# Debug branch only: cancel in-progress runs on the same ref so iterating
+# pushes don't accumulate queued ARM jobs. Stable branches keep the
+# default behaviour (every run completes).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ contains(github.ref, 'debug-arm64-memory-corruption-JoXfw') || contains(github.head_ref, 'debug-arm64-memory-corruption-JoXfw') }}
+
 jobs:
 
   phpunit-unit:
@@ -560,6 +567,7 @@ jobs:
             force_parsed: "0"
             use_zend_alloc: ""
             valgrind: "0"
+            disable_bytes_share: "0"
           - name: "PHP 8.4 parsed-share-on"
             targets: "v84"
             php_minor: "8.4"
@@ -567,6 +575,7 @@ jobs:
             force_parsed: "1"
             use_zend_alloc: ""
             valgrind: "0"
+            disable_bytes_share: "0"
           - name: "PHP 8.4 parsed-share-on-noalloc"
             targets: "v84"
             php_minor: "8.4"
@@ -574,6 +583,7 @@ jobs:
             force_parsed: "1"
             use_zend_alloc: "0"
             valgrind: "0"
+            disable_bytes_share: "0"
           - name: "PHP 8.4 parsed-share-on-valgrind"
             targets: "v84"
             php_minor: "8.4"
@@ -581,6 +591,22 @@ jobs:
             force_parsed: "1"
             use_zend_alloc: "0"
             valgrind: "1"
+            disable_bytes_share: "0"
+          # parsed-share-on-no-bytes : matches PR #674's broken state more
+          # exactly. parsed-resolver-share enabled AND the bytes-share that
+          # PR #676 added is bypassed, so every cache miss re-reads the
+          # 19 MB binary from disk, parses it, and drops the string. We
+          # think this combination — repeated 19 MB alloc/free against a
+          # heap that already holds the deep parsed object graph — is
+          # what tripped zend_mm on ARM64 in the first place.
+          - name: "PHP 8.4 parsed-share-on-no-bytes"
+            targets: "v84"
+            php_minor: "8.4"
+            tag: "parsed-share-on-no-bytes"
+            force_parsed: "1"
+            use_zend_alloc: ""
+            valgrind: "0"
+            disable_bytes_share: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -643,6 +669,7 @@ jobs:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
           RELI_DEBUG_RESOLVER_SHARE: "1"
           RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE: ${{ matrix.force_parsed }}
+          RELI_DEBUG_DISABLE_BYTES_SHARE: ${{ matrix.disable_bytes_share }}
           USE_ZEND_ALLOC: ${{ matrix.use_zend_alloc }}
         run: |
           mkdir -p build/logs

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,7 +21,7 @@ jobs:
 
   phpunit-unit:
     name: phpunit (unit)
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +75,7 @@ jobs:
 
   build-dev-image:
     name: Build dev image
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -125,7 +125,7 @@ jobs:
 
   build-test-mysql-images:
     name: Build PHP ${{ matrix.php_version }}+pdo_mysql
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -178,7 +178,7 @@ jobs:
 
   phpunit-target-version:
     name: phpunit (${{ matrix.name }})
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     needs: [build-dev-image, build-test-mysql-images]
     runs-on: ubuntu-latest
     permissions:
@@ -350,7 +350,7 @@ jobs:
 
   phpunit-frankenphp:
     name: phpunit (FrankenPHP)
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     needs: build-dev-image
     runs-on: ubuntu-latest
     permissions:
@@ -432,7 +432,7 @@ jobs:
 
   phpunit-unit-arm64:
     name: phpunit (unit, ARM64)
-    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') && !contains(github.head_ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -672,6 +672,26 @@ jobs:
             docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
           fi
 
+      - name: Dump resolver-share log tail to job output
+        if: always()
+        run: |
+          echo "=== resolver-share log files ==="
+          ls -la /tmp/reli-test/resolver-share-*.log 2>&1 || true
+          echo "=== summary by event tag ==="
+          for f in /tmp/reli-test/resolver-share-*.log; do
+            [ -f "$f" ] || continue
+            echo "--- $f ---"
+            grep -oE '\] [a-z._]+' "$f" | sort | uniq -c | sort -rn || true
+          done
+          echo "=== first 60 + last 60 lines of largest log ==="
+          biggest=$(ls -S /tmp/reli-test/resolver-share-*.log 2>/dev/null | head -1)
+          if [ -n "$biggest" ]; then
+            echo ">>> head $biggest"
+            head -60 "$biggest" || true
+            echo ">>> tail $biggest"
+            tail -60 "$biggest" || true
+          fi
+
       - name: Upload test trace log
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '[0-9]+.[0-9]+.x'
+      - 'claude/debug-arm64-memory-corruption-JoXfw'
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -20,6 +21,7 @@ jobs:
 
   phpunit-unit:
     name: phpunit (unit)
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -73,6 +75,7 @@ jobs:
 
   build-dev-image:
     name: Build dev image
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -122,6 +125,7 @@ jobs:
 
   build-test-mysql-images:
     name: Build PHP ${{ matrix.php_version }}+pdo_mysql
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -174,6 +178,7 @@ jobs:
 
   phpunit-target-version:
     name: phpunit (${{ matrix.name }})
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     needs: [build-dev-image, build-test-mysql-images]
     runs-on: ubuntu-latest
     permissions:
@@ -345,6 +350,7 @@ jobs:
 
   phpunit-frankenphp:
     name: phpunit (FrankenPHP)
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     needs: build-dev-image
     runs-on: ubuntu-latest
     permissions:
@@ -426,6 +432,7 @@ jobs:
 
   phpunit-unit-arm64:
     name: phpunit (unit, ARM64)
+    if: ${{ !contains(github.ref, 'claude/debug-arm64-memory-corruption-JoXfw') }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
@@ -476,7 +483,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.4", "8.2", "8.4"]
+        # Debug branch: only the version we test (v84). The other side
+        # images aren't needed since the target-version matrix is trimmed.
+        php_version: ["8.4"]
     env:
       IMAGE: ghcr.io/${{ github.repository }}/test-php-mysql
     steps:
@@ -530,18 +539,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "PHP 7.4"
-            targets: "v74"
-            php_minor: "7.4"
-          - name: "PHP 8.2"
-            targets: "v82"
-            php_minor: "8.2"
-          - name: "PHP 8.4"
+          # Debug branch: A/B-test the parsed-resolver-share root cause in
+          # one CI run. All entries hit the same v84 target so they share
+          # the docker image cache.
+          #
+          # bytes-share : control. matches the merged #676 behaviour. green.
+          # parsed-share-on : RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=1 reintroduces
+          #     the broken path. Expected to reproduce zend_mm_heap corrupted.
+          # parsed-share-on-noalloc : same + USE_ZEND_ALLOC=0 forces PHP to
+          #     use system malloc, which bypasses zend_mm bookkeeping.
+          #     If GREEN here, the corruption is purely a zend_mm
+          #     bookkeeping issue triggered by the deep object graph.
+          #     If still RED, it's a real heap write somewhere.
+          # parsed-share-on-valgrind : same + valgrind catches the actual
+          #     bad write. Slow (~10x) but gives a usable backtrace.
+          - name: "PHP 8.4 bytes-share"
             targets: "v84"
             php_minor: "8.4"
-          - name: "PHP 8.4 ZTS"
-            targets: "v84_zts"
+            tag: "bytes-share"
+            force_parsed: "0"
+            use_zend_alloc: ""
+            valgrind: "0"
+          - name: "PHP 8.4 parsed-share-on"
+            targets: "v84"
             php_minor: "8.4"
+            tag: "parsed-share-on"
+            force_parsed: "1"
+            use_zend_alloc: ""
+            valgrind: "0"
+          - name: "PHP 8.4 parsed-share-on-noalloc"
+            targets: "v84"
+            php_minor: "8.4"
+            tag: "parsed-share-on-noalloc"
+            force_parsed: "1"
+            use_zend_alloc: "0"
+            valgrind: "0"
+          - name: "PHP 8.4 parsed-share-on-valgrind"
+            targets: "v84"
+            php_minor: "8.4"
+            tag: "parsed-share-on-valgrind"
+            force_parsed: "1"
+            use_zend_alloc: "0"
+            valgrind: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -588,19 +627,73 @@ jobs:
           sudo sysctl -w kernel.core_pattern='/tmp/reli-test/core.%e.%p.%t'
           sudo systemctl stop apport.service 2>/dev/null || true
 
+      - name: Install valgrind in dev image (debug branch only)
+        if: matrix.valgrind == '1'
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/app -w /app reli-dev bash -c "apt-get update && apt-get install -y valgrind && valgrind --version" || true
+          # Bake an updated image so docker compose run picks it up.
+          CID=$(docker run -d -v ${{ github.workspace }}:/app -w /app reli-dev sleep 30)
+          docker exec "$CID" bash -c "apt-get update && apt-get install -y --no-install-recommends valgrind"
+          docker commit "$CID" reli-dev
+          docker rm -f "$CID"
+          docker run --rm reli-dev valgrind --version
+
       - name: Run target version tests
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
+          RELI_DEBUG_RESOLVER_SHARE: "1"
+          RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE: ${{ matrix.force_parsed }}
+          USE_ZEND_ALLOC: ${{ matrix.use_zend_alloc }}
         run: |
           mkdir -p build/logs
-          docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
+          if [ "${{ matrix.valgrind }}" = "1" ]; then
+            # valgrind catches the actual write that corrupts the heap.
+            # USE_ZEND_ALLOC=0 is required so PHP uses system malloc, which
+            # valgrind can track; otherwise zend_mm's bump allocator hides
+            # everything behind one big mmap region.
+            #
+            # --error-exitcode=0 keeps phpunit's own exit code authoritative
+            # so we still see the test report, while the valgrind log goes
+            # to the artifact for analysis.
+            docker compose run reli-test-for-ci bash -c "
+              valgrind \
+                --error-exitcode=0 \
+                --log-file=/tmp/reli-test/valgrind-${{ matrix.tag }}-%p.log \
+                --num-callers=40 \
+                --tool=memcheck \
+                --leak-check=no \
+                --track-origins=yes \
+                vendor/bin/phpunit \
+                  --group target-version \
+                  --filter 'MemoryDumpCommandTest|MemoryCompareCommandIntegrationTest' \
+                  --coverage-clover build/logs/clover.xml
+            " || true
+          else
+            docker compose run reli-test-for-ci vendor/bin/phpunit --group target-version --coverage-clover build/logs/clover.xml
+          fi
 
-      - name: Upload test trace log on failure
-        if: failure()
+      - name: Upload test trace log
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: reli-test-trace-${{ matrix.targets }}-arm64
+          name: reli-test-trace-${{ matrix.targets }}-${{ matrix.tag }}-arm64
           path: /tmp/reli-test/reli-test-trace.log
+          if-no-files-found: ignore
+
+      - name: Upload resolver-share debug log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: reli-resolver-share-${{ matrix.targets }}-${{ matrix.tag }}-arm64
+          path: /tmp/reli-test/resolver-share*.log
+          if-no-files-found: ignore
+
+      - name: Upload valgrind log
+        if: always() && matrix.valgrind == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: reli-valgrind-${{ matrix.targets }}-${{ matrix.tag }}-arm64
+          path: /tmp/reli-test/valgrind-*.log
           if-no-files-found: ignore
 
       - name: Collect crash diagnostics on failure
@@ -616,7 +709,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: reli-crash-${{ matrix.targets }}-arm64
+          name: reli-crash-${{ matrix.targets }}-${{ matrix.tag }}-arm64
           path: /tmp/reli-crash/
           if-no-files-found: ignore
 
@@ -624,15 +717,16 @@ jobs:
         run: sed -i 's|/app/|${{ github.workspace }}/|g' build/logs/clover.xml
 
       - name: Send to coveralls
+        if: matrix.tag == 'bytes-share'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: build/logs/clover.xml
-          flag-name: ${{ matrix.targets }}-arm64
+          flag-name: ${{ matrix.targets }}-${{ matrix.tag }}-arm64
           parallel: true
 
       - name: Save target Docker image for cache
-        if: steps.target-cache.outputs.cache-hit != 'true'
+        if: steps.target-cache.outputs.cache-hit != 'true' && matrix.tag == 'bytes-share'
         run: |
           TARGET_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^php:' | head -1)
           if [ -n "$TARGET_IMAGE" ]; then

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -546,20 +546,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Debug branch: A/B-test the parsed-resolver-share root cause in
-          # one CI run. All entries hit the same v84 target so they share
-          # the docker image cache.
+          # Round 2 of the bisect. Round 1 (5 variants) came back all green,
+          # including parsed-share-on-no-bytes which is the closest possible
+          # match to PR #674's red state. Strongest remaining hypothesis is
+          # that the file-logging in ResolverShareLogger is what masks the
+          # bug — every cache event opens / appends / fsyncs the per-pid log
+          # file, which must dominate the parse-and-attach loop's timing.
+          # Round 2 minimises the matrix to ~9 minutes of ARM time, focused
+          # on validating that hypothesis:
           #
-          # bytes-share : control. matches the merged #676 behaviour. green.
-          # parsed-share-on : RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=1 reintroduces
-          #     the broken path. Expected to reproduce zend_mm_heap corrupted.
-          # parsed-share-on-noalloc : same + USE_ZEND_ALLOC=0 forces PHP to
-          #     use system malloc, which bypasses zend_mm bookkeeping.
-          #     If GREEN here, the corruption is purely a zend_mm
-          #     bookkeeping issue triggered by the deep object graph.
-          #     If still RED, it's a real heap write somewhere.
-          # parsed-share-on-valgrind : same + valgrind catches the actual
-          #     bad write. Slow (~10x) but gives a usable backtrace.
+          # bytes-share         : control. should stay green either way.
+          # parsed-share-no-bytes-quiet : parsed-share + no bytes-share +
+          #     RELI_DEBUG_RESOLVER_SHARE NOT SET (no log writes). If this
+          #     reproduces zend_mm_heap corrupted, logging-induced timing
+          #     was masking the bug. Next probe will read the dump via
+          #     core dump / dmesg only, without per-event file I/O.
           - name: "PHP 8.4 bytes-share"
             targets: "v84"
             php_minor: "8.4"
@@ -568,45 +569,28 @@ jobs:
             use_zend_alloc: ""
             valgrind: "0"
             disable_bytes_share: "0"
-          - name: "PHP 8.4 parsed-share-on"
+            log_share: "1"
+          - name: "PHP 8.4 parsed-share-no-bytes-quiet"
             targets: "v84"
             php_minor: "8.4"
-            tag: "parsed-share-on"
-            force_parsed: "1"
-            use_zend_alloc: ""
-            valgrind: "0"
-            disable_bytes_share: "0"
-          - name: "PHP 8.4 parsed-share-on-noalloc"
-            targets: "v84"
-            php_minor: "8.4"
-            tag: "parsed-share-on-noalloc"
-            force_parsed: "1"
-            use_zend_alloc: "0"
-            valgrind: "0"
-            disable_bytes_share: "0"
-          - name: "PHP 8.4 parsed-share-on-valgrind"
-            targets: "v84"
-            php_minor: "8.4"
-            tag: "parsed-share-on-valgrind"
-            force_parsed: "1"
-            use_zend_alloc: "0"
-            valgrind: "1"
-            disable_bytes_share: "0"
-          # parsed-share-on-no-bytes : matches PR #674's broken state more
-          # exactly. parsed-resolver-share enabled AND the bytes-share that
-          # PR #676 added is bypassed, so every cache miss re-reads the
-          # 19 MB binary from disk, parses it, and drops the string. We
-          # think this combination — repeated 19 MB alloc/free against a
-          # heap that already holds the deep parsed object graph — is
-          # what tripped zend_mm on ARM64 in the first place.
-          - name: "PHP 8.4 parsed-share-on-no-bytes"
-            targets: "v84"
-            php_minor: "8.4"
-            tag: "parsed-share-on-no-bytes"
+            tag: "parsed-share-no-bytes-quiet"
             force_parsed: "1"
             use_zend_alloc: ""
             valgrind: "0"
             disable_bytes_share: "1"
+            log_share: "0"
+          # Sanity check: same flags except logging on, to confirm the only
+          # delta from "quiet" is the log file I/O. If "loud" stays green
+          # but "quiet" goes red, that pins logging as the masker.
+          - name: "PHP 8.4 parsed-share-no-bytes-loud"
+            targets: "v84"
+            php_minor: "8.4"
+            tag: "parsed-share-no-bytes-loud"
+            force_parsed: "1"
+            use_zend_alloc: ""
+            valgrind: "0"
+            disable_bytes_share: "1"
+            log_share: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -667,7 +651,7 @@ jobs:
       - name: Run target version tests
         env:
           RELI_TEST_PHP_TARGETS: ${{ matrix.targets }}
-          RELI_DEBUG_RESOLVER_SHARE: "1"
+          RELI_DEBUG_RESOLVER_SHARE: ${{ matrix.log_share }}
           RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE: ${{ matrix.force_parsed }}
           RELI_DEBUG_DISABLE_BYTES_SHARE: ${{ matrix.disable_bytes_share }}
           USE_ZEND_ALLOC: ${{ matrix.use_zend_alloc }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       core: -1
     environment:
       - RELI_TEST_PHP_TARGETS=${RELI_TEST_PHP_TARGETS:-}
+      - RELI_DEBUG_RESOLVER_SHARE=${RELI_DEBUG_RESOLVER_SHARE:-}
+      - RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=${RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE:-}
+      - USE_ZEND_ALLOC=${USE_ZEND_ALLOC:-}
     volumes:
       - .:/app
       - /var/run/docker.sock:/var/run/docker.sock

--- a/src/Lib/Debug/ResolverShareLogger.php
+++ b/src/Lib/Debug/ResolverShareLogger.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Debug;
+
+/**
+ * Debug-only env-gated logger + experiment switches for the ARM64
+ * zend_mm-corrupted bisect investigation.
+ *
+ *   RELI_DEBUG_RESOLVER_SHARE=1
+ *       Enable file logging of resolver-share / cache events to
+ *       /tmp/reli-test/resolver-share-<pid>.log. The CI workflow
+ *       uploads that path as an artifact on every run.
+ *
+ *   RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=1
+ *       Re-enable the broken parsed-resolver-share path that #676
+ *       removed in favour of bytes-only sharing. With this flag set,
+ *       Elf64LazyParseSymbolResolver caches the parsed
+ *       Elf64SymbolResolver instance (deep object graph) per binary
+ *       fingerprint, reproducing the ARM64 corruption.
+ *
+ * This file is intended to be removed once the root cause is understood
+ * and a real fix lands.
+ */
+final class ResolverShareLogger
+{
+    private static ?bool $enabled = null;
+    private static ?bool $force_parsed_share = null;
+    private static ?string $log_path = null;
+
+    public static function enabled(): bool
+    {
+        if (self::$enabled === null) {
+            self::$enabled = (string)getenv('RELI_DEBUG_RESOLVER_SHARE') === '1';
+        }
+        return self::$enabled;
+    }
+
+    public static function forceParsedResolverShare(): bool
+    {
+        if (self::$force_parsed_share === null) {
+            self::$force_parsed_share =
+                (string)getenv('RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE') === '1';
+        }
+        return self::$force_parsed_share;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public static function log(string $tag, array $fields = []): void
+    {
+        if (!self::enabled()) {
+            return;
+        }
+        $line = sprintf(
+            "[%s pid=%d mem=%d] %s %s\n",
+            self::timestamp(),
+            getmypid(),
+            memory_get_usage(true),
+            $tag,
+            self::formatFields($fields),
+        );
+        @file_put_contents(self::path(), $line, FILE_APPEND | LOCK_EX);
+    }
+
+    /**
+     * Snapshot memory + GC state. Useful for correlating cache populate
+     * events with PHP runtime book-keeping changes.
+     */
+    public static function snapshot(string $tag): void
+    {
+        if (!self::enabled()) {
+            return;
+        }
+        $gc = gc_status();
+        self::log($tag, [
+            'memory' => memory_get_usage(true),
+            'memory_peak' => memory_get_peak_usage(true),
+            'gc_runs' => $gc['runs'] ?? -1,
+            'gc_collected' => $gc['collected'] ?? -1,
+            'gc_threshold' => $gc['threshold'] ?? -1,
+            'gc_roots' => $gc['roots'] ?? -1,
+        ]);
+    }
+
+    private static function path(): string
+    {
+        if (self::$log_path === null) {
+            $dir = is_dir('/tmp/reli-test') ? '/tmp/reli-test' : sys_get_temp_dir();
+            self::$log_path = sprintf('%s/resolver-share-%d.log', $dir, getmypid());
+        }
+        return self::$log_path;
+    }
+
+    private static function timestamp(): string
+    {
+        $t = microtime(true);
+        return date('H:i:s', (int)$t) . sprintf('.%06d', (int)(($t - (int)$t) * 1_000_000));
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private static function formatFields(array $fields): string
+    {
+        $parts = [];
+        foreach ($fields as $k => $v) {
+            if (is_object($v)) {
+                $v = get_class($v);
+            } elseif (is_array($v)) {
+                $v = json_encode($v);
+            } elseif (is_bool($v)) {
+                $v = $v ? 'true' : 'false';
+            } elseif ($v === null) {
+                $v = 'null';
+            }
+            $parts[] = "{$k}={$v}";
+        }
+        return implode(' ', $parts);
+    }
+}

--- a/src/Lib/Debug/ResolverShareLogger.php
+++ b/src/Lib/Debug/ResolverShareLogger.php
@@ -63,10 +63,11 @@ final class ResolverShareLogger
         if (!self::enabled()) {
             return;
         }
+        $pid = getmypid();
         $line = sprintf(
             "[%s pid=%d mem=%d] %s %s\n",
             self::timestamp(),
-            getmypid(),
+            $pid === false ? -1 : $pid,
             memory_get_usage(true),
             $tag,
             self::formatFields($fields),
@@ -98,15 +99,18 @@ final class ResolverShareLogger
     {
         if (self::$log_path === null) {
             $dir = is_dir('/tmp/reli-test') ? '/tmp/reli-test' : sys_get_temp_dir();
-            self::$log_path = sprintf('%s/resolver-share-%d.log', $dir, getmypid());
+            $pid = getmypid();
+            self::$log_path = sprintf('%s/resolver-share-%d.log', $dir, $pid === false ? -1 : $pid);
         }
         return self::$log_path;
     }
 
     private static function timestamp(): string
     {
-        $t = microtime(true);
-        return date('H:i:s', (int)$t) . sprintf('.%06d', (int)(($t - (int)$t) * 1_000_000));
+        $t = (float)microtime(true);
+        $whole = (int)$t;
+        $micros = (int)(($t - (float)$whole) * 1_000_000.0);
+        return date('H:i:s', $whole) . sprintf('.%06d', $micros);
     }
 
     /**
@@ -116,16 +120,17 @@ final class ResolverShareLogger
     {
         $parts = [];
         foreach ($fields as $k => $v) {
-            if (is_object($v)) {
-                $v = get_class($v);
-            } elseif (is_array($v)) {
-                $v = json_encode($v);
-            } elseif (is_bool($v)) {
-                $v = $v ? 'true' : 'false';
-            } elseif ($v === null) {
-                $v = 'null';
-            }
-            $parts[] = "{$k}={$v}";
+            /** @var string $rendered */
+            $rendered = match (true) {
+                is_object($v) => get_class($v),
+                is_array($v) => (string)json_encode($v),
+                is_bool($v) => $v ? 'true' : 'false',
+                $v === null => 'null',
+                is_int($v), is_float($v) => (string)$v,
+                is_string($v) => $v,
+                default => '?',
+            };
+            $parts[] = "{$k}={$rendered}";
         }
         return implode(' ', $parts);
     }

--- a/src/Lib/Debug/ResolverShareLogger.php
+++ b/src/Lib/Debug/ResolverShareLogger.php
@@ -123,7 +123,8 @@ final class ResolverShareLogger
     {
         $t = microtime(true);
         $whole = (int)$t;
-        $micros = (int)(($t - $whole) * 1_000_000.0);
+        $frac = $t - (float)$whole;
+        $micros = (int)($frac * 1_000_000.0);
         return date('H:i:s', $whole) . sprintf('.%06d', $micros);
     }
 
@@ -133,6 +134,7 @@ final class ResolverShareLogger
     private static function formatFields(array $fields): string
     {
         $parts = [];
+        /** @psalm-suppress MixedAssignment */
         foreach ($fields as $k => $v) {
             $parts[] = $k . '=' . self::renderValue($v);
         }

--- a/src/Lib/Debug/ResolverShareLogger.php
+++ b/src/Lib/Debug/ResolverShareLogger.php
@@ -107,9 +107,9 @@ final class ResolverShareLogger
 
     private static function timestamp(): string
     {
-        $t = (float)microtime(true);
+        $t = microtime(true);
         $whole = (int)$t;
-        $micros = (int)(($t - (float)$whole) * 1_000_000.0);
+        $micros = (int)(($t - $whole) * 1_000_000.0);
         return date('H:i:s', $whole) . sprintf('.%06d', $micros);
     }
 
@@ -120,18 +120,35 @@ final class ResolverShareLogger
     {
         $parts = [];
         foreach ($fields as $k => $v) {
-            /** @var string $rendered */
-            $rendered = match (true) {
-                is_object($v) => get_class($v),
-                is_array($v) => (string)json_encode($v),
-                is_bool($v) => $v ? 'true' : 'false',
-                $v === null => 'null',
-                is_int($v), is_float($v) => (string)$v,
-                is_string($v) => $v,
-                default => '?',
-            };
-            $parts[] = "{$k}={$rendered}";
+            $parts[] = $k . '=' . self::renderValue($v);
         }
         return implode(' ', $parts);
+    }
+
+    /**
+     * @param mixed $v
+     */
+    private static function renderValue(mixed $v): string
+    {
+        if ($v === null) {
+            return 'null';
+        }
+        if (is_bool($v)) {
+            return $v ? 'true' : 'false';
+        }
+        if (is_int($v) || is_float($v)) {
+            return (string)$v;
+        }
+        if (is_string($v)) {
+            return $v;
+        }
+        if (is_object($v)) {
+            return get_class($v);
+        }
+        if (is_array($v)) {
+            $encoded = json_encode($v);
+            return $encoded === false ? '?' : $encoded;
+        }
+        return '?';
     }
 }

--- a/src/Lib/Debug/ResolverShareLogger.php
+++ b/src/Lib/Debug/ResolverShareLogger.php
@@ -56,6 +56,20 @@ final class ResolverShareLogger
     }
 
     /**
+     * Bypass the bytes-share cache when set. Combined with
+     * forceParsedResolverShare(), this re-creates #674's broken state
+     * exactly: every miss re-reads the 19 MB binary off disk, parses it,
+     * then keeps only the parsed Elf64SymbolResolver alive in the cache
+     * (the 19 MB string is dropped once parsing completes). Hypothesis:
+     * the repeated 19 MB alloc/free pattern combined with the long-lived
+     * deep object graph is what stresses zend_mm on ARM64.
+     */
+    public static function disableBytesShare(): bool
+    {
+        return (string)getenv('RELI_DEBUG_DISABLE_BYTES_SHARE') === '1';
+    }
+
+    /**
      * @param array<string, mixed> $fields
      */
     public static function log(string $tag, array $fields = []): void

--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -133,7 +133,8 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
         // rather than the parsed Elf64SymbolResolver — see
         // PerBinarySymbolCacheRetriever for why the deep-object-graph
         // variant tripped ARM64 zend_mm.
-        if ($this->shared_binary_cache !== null && $this->fingerprint !== null) {
+        $bytes_share_active = !ResolverShareLogger::disableBytesShare();
+        if ($bytes_share_active && $this->shared_binary_cache !== null && $this->fingerprint !== null) {
             $cached = $this->shared_binary_cache->getBinaryBytes($this->fingerprint);
             if ($cached !== null) {
                 return new StringByteReader($cached);
@@ -148,7 +149,7 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
         if ($raw === '') {
             return null;
         }
-        if ($this->shared_binary_cache !== null && $this->fingerprint !== null) {
+        if ($bytes_share_active && $this->shared_binary_cache !== null && $this->fingerprint !== null) {
             $this->shared_binary_cache->setBinaryBytes($this->fingerprint, $raw);
         }
         return new StringByteReader($raw);

--- a/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
+++ b/src/Lib/Elf/Process/Elf64LazyParseSymbolResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\Elf\Process;
 
 use Reli\Lib\ByteStream\StringByteReader;
+use Reli\Lib\Debug\ResolverShareLogger;
 use Reli\Lib\Elf\Parser\ElfParserException;
 use Reli\Lib\Elf\Structure\Elf64\Elf64SymbolTableEntry;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
@@ -40,6 +41,45 @@ final class Elf64LazyParseSymbolResolver implements Elf64SymbolResolver
     }
 
     private function loadResolver(): Elf64SymbolResolver
+    {
+        ResolverShareLogger::log('lazy.loadResolver.enter', [
+            'target_pid' => $this->pid,
+            'path' => $this->path,
+        ]);
+        // Debug-only: re-enable the broken parsed-resolver-share path that
+        // #676 removed in favour of bytes-only sharing. Behind an env flag
+        // so the matrix can A/B-test bytes-share (green) vs parsed-share
+        // (red on ARM64) within a single CI run.
+        if (
+            ResolverShareLogger::forceParsedResolverShare()
+            && $this->shared_binary_cache !== null
+            && $this->fingerprint !== null
+        ) {
+            $shared = $this->shared_binary_cache->getResolver($this->fingerprint);
+            if ($shared !== null) {
+                ResolverShareLogger::log('lazy.loadResolver.parsed_share_hit', [
+                    'target_pid' => $this->pid,
+                    'class' => $shared,
+                ]);
+                return $shared;
+            }
+        }
+        $resolver = $this->loadResolverUncached();
+        if (
+            ResolverShareLogger::forceParsedResolverShare()
+            && $this->shared_binary_cache !== null
+            && $this->fingerprint !== null
+        ) {
+            $this->shared_binary_cache->setResolver($this->fingerprint, $resolver);
+        }
+        ResolverShareLogger::log('lazy.loadResolver.fresh', [
+            'target_pid' => $this->pid,
+            'class' => $resolver,
+        ]);
+        return $resolver;
+    }
+
+    private function loadResolverUncached(): Elf64SymbolResolver
     {
         // Both the linear-scan and the dynamic-symbol resolver want the
         // libphp.so contents as a string. Reading the binary once and

--- a/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
+++ b/src/Lib/Elf/Process/PerBinarySymbolCacheRetriever.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Reli\Lib\Elf\Process;
 
+use Reli\Lib\Debug\ResolverShareLogger;
 use Reli\Lib\Elf\SymbolResolver\Elf64SymbolCache;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolver;
 
 final class PerBinarySymbolCacheRetriever
 {
@@ -61,5 +63,53 @@ final class PerBinarySymbolCacheRetriever
         string $bytes,
     ): void {
         $this->binary_bytes_cache[(string)$binary_fingerprint] = $bytes;
+    }
+
+    /**
+     * Cache of parsed Elf64SymbolResolver instances per binary fingerprint.
+     *
+     * THIS IS THE BROKEN PATH. Populated only when
+     * RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=1 is set in the environment;
+     * otherwise the array stays empty and the resolver is re-parsed each
+     * time from the cached bytes. Holding parsed Elf64SymbolResolver
+     * instances alive across attaches is what tripped ARM64 zend_mm in
+     * #669 / #674; this debug knob exists so we can re-trigger the
+     * failure under USE_ZEND_ALLOC=0 / valgrind / etc. to localise the
+     * actual write that corrupts the heap.
+     *
+     * @var array<string, Elf64SymbolResolver>
+     */
+    private array $resolver_cache = [];
+
+    public function getResolver(BinaryFingerprint $binary_fingerprint): ?Elf64SymbolResolver
+    {
+        if (!ResolverShareLogger::forceParsedResolverShare()) {
+            return null;
+        }
+        $cached = $this->resolver_cache[(string)$binary_fingerprint] ?? null;
+        ResolverShareLogger::log('parsed_share.get', [
+            'fp' => substr((string)$binary_fingerprint, 0, 80),
+            'hit' => $cached !== null,
+            'class' => $cached,
+            'cache_size' => count($this->resolver_cache),
+        ]);
+        return $cached;
+    }
+
+    public function setResolver(
+        BinaryFingerprint $binary_fingerprint,
+        Elf64SymbolResolver $resolver,
+    ): void {
+        if (!ResolverShareLogger::forceParsedResolverShare()) {
+            return;
+        }
+        ResolverShareLogger::snapshot('parsed_share.set.before');
+        $this->resolver_cache[(string)$binary_fingerprint] = $resolver;
+        ResolverShareLogger::log('parsed_share.set.after', [
+            'fp' => substr((string)$binary_fingerprint, 0, 80),
+            'class' => $resolver,
+            'base_address' => sprintf('0x%x', $resolver->getBaseAddress()->toInt()),
+            'cache_size_after' => count($this->resolver_cache),
+        ]);
     }
 }


### PR DESCRIPTION
**Do not merge.** Investigation harness on top of #676. Goal: explain *why* keeping a parsed `Elf64SymbolResolver` alive across attaches corrupts `zend_mm` on ARM64 only — the question #676's PR description leaves open ("exact PHP / GC interaction is still TBD").

## What this branch does

- Resets to current `0.12.x` (with #676 = bytes-share workaround = green baseline).
- Re-enables the broken parsed-resolver-share path behind a debug env flag (`RELI_DEBUG_FORCE_PARSED_RESOLVER_SHARE=1`). Default off, so a stray run on this branch still behaves like upstream.
- Trims CI to ARM64 v84 only, with four matrix entries that share docker caches and run in parallel:

| matrix tag | force_parsed | USE_ZEND_ALLOC | valgrind | what it tells us |
|---|---|---|---|---|
| `bytes-share`               | 0 | (default) | no  | sanity check vs #676 — green expected |
| `parsed-share-on`           | 1 | (default) | no  | reproduces the original failure |
| `parsed-share-on-noalloc`   | 1 | 0         | no  | green here ⇒ pure zend_mm bookkeeping; red ⇒ real heap write |
| `parsed-share-on-valgrind`  | 1 | 0         | yes | memcheck log for the actual bad write |

- Per-PID resolver-share log to `/tmp/reli-test/resolver-share-<pid>.log` with cache get/set + memory_get_usage / gc_status snapshots; uploaded as artifact every run, not just on failure.

## Outputs to look at

- `reli-resolver-share-v84-<tag>-arm64`: cache populate timing + memory snapshots
- `reli-valgrind-v84-parsed-share-on-valgrind-arm64`: memcheck report
- `reli-crash-v84-<tag>-arm64`: core dumps + dmesg if a job hard-crashes

## Plan after first run lands

If `parsed-share-on-noalloc` is **green** → the corruption is the zend_mm bookkeeping; next probe will narrow within the cached object graph (the user's original suggestions: table-only / strings-only / UInt64-as-int) to identify which sub-object stresses zend_mm.

If still **red** → the valgrind log tells us the exact write; iterate from there.


---
_Generated by [Claude Code](https://claude.ai/code/session_0124UpQ3pmqn1F1dbLVBRd1s)_