### PR TITLE
Handle ELF symbol preemption in statically-linked FrankenPHP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,14 +150,30 @@ non-obvious things bite single-shot `inspector:trace -p` users:
   parallel slow requests rather than a single curl — Caddy reuses
   the first idle worker for serial requests, so the TID you grab from
   `ps` may stay cold no matter how many requests you throw at it.
-- **`inspector:memory:dump` has a second cold-attach failure mode** beyond
-  the TSRM one. The chunk finder reads `eg.current_execute_data` and
-  walks 2 MB-aligned addresses to locate the request heap; between
-  requests `current_execute_data` is 0 and the dump fails with "failed
-  to find ZendMM main chunk". The worker has to be mid-request at the
-  moment of attach. Reproduce with a long `usleep`-tail script and
+- **`inspector:memory:dump` only works while the worker is mid-request.**
+  The chunk finder reads `eg.current_execute_data` and walks 2 MB-aligned
+  addresses to locate the request heap; between requests
+  `current_execute_data` is 0 and the dump fails with "failed to find
+  ZendMM main chunk". Reproduce with a long `usleep`-tail script and
   saturate the workers; CLI mode (`frankenphp php-cli script.php`)
   sidesteps it because the worker stays in PHP for the whole script.
+  In production, prefer `inspector:watch --action=memory-dump` (which
+  fires only when its condition holds, naturally inside a request) or
+  `inspector:sidecar` (which is invoked from PHP itself). This is not a
+  FrankenPHP quirk but a property of ZendMM, which is request-scoped in
+  every SAPI.
+- **`module_registry` is preempted by the embedding executable.**
+  `frankenphp` statically links libphp, so the dynamic linker binds the
+  shared symbols to the executable's copy and leaves libphp.so's BSS at
+  zero. `findModuleRegistry` therefore probes `/proc/{pid}/exe` first
+  and falls back to the libphp.so reader only when the executable does
+  not define it; do not "tidy up" by deleting that fallback ordering.
+  The `*_offset` (TSRM) symbols are also preempted but `TsrmGlobalsResolver`
+  already handles that with the `_offset == 0 → _id` fallback at
+  `TsrmGlobalsResolver.php:111`. `PhpVersionDetector` must NOT cache the
+  host-PHP fallback (`'v' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION`) when
+  detection fails, because doing so silently mis-resolves chunk and
+  struct layouts on every subsequent run against the same binary.
 - **Tests in `tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest`
   share one `BinaryAnalysisCache` across thread iterations.** That's the
   regression test for the cache-poisoning fix; if you put a fresh cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,18 +150,30 @@ non-obvious things bite single-shot `inspector:trace -p` users:
   parallel slow requests rather than a single curl — Caddy reuses
   the first idle worker for serial requests, so the TID you grab from
   `ps` may stay cold no matter how many requests you throw at it.
-- **`inspector:memory:dump` only works while the worker is mid-request.**
-  The chunk finder reads `eg.current_execute_data` and walks 2 MB-aligned
-  addresses to locate the request heap; between requests
-  `current_execute_data` is 0 and the dump fails with "failed to find
-  ZendMM main chunk". Reproduce with a long `usleep`-tail script and
-  saturate the workers; CLI mode (`frankenphp php-cli script.php`)
-  sidesteps it because the worker stays in PHP for the whole script.
-  In production, prefer `inspector:watch --action=memory-dump` (which
-  fires only when its condition holds, naturally inside a request) or
-  `inspector:sidecar` (which is invoked from PHP itself). This is not a
-  FrankenPHP quirk but a property of ZendMM, which is request-scoped in
-  every SAPI.
+- **`inspector:memory:dump` in regular (per-request) mode only works
+  while the worker is mid-request.** The chunk finder reads
+  `eg.current_execute_data` and walks 2 MB-aligned addresses to locate
+  the request heap; between requests `current_execute_data` is 0 and
+  the dump fails with "failed to find ZendMM main chunk". Reproduce
+  with a long `usleep`-tail script and saturate the workers; CLI mode
+  (`frankenphp php-cli script.php`) sidesteps it because the worker
+  stays in PHP for the whole script. In production, prefer
+  `inspector:watch --action=memory-dump` (which fires only when its
+  condition holds, naturally inside a request) or `inspector:sidecar`
+  (which is invoked from PHP itself). This is not a FrankenPHP quirk
+  but a property of ZendMM, which is request-scoped in every SAPI.
+- **FrankenPHP worker mode keeps the request heap alive between
+  requests, so `inspector:memory:dump` works at any time.** A worker
+  loaded with `frankenphp { worker /app/worker.php }` stays parked in
+  the `frankenphp_handle_request()` loop on the PHP call stack while
+  it waits for the next request, so `current_execute_data` is never
+  zero. `inspector:trace` shows a 2-frame
+  `frankenphp_handle_request` / `<main>` stack on idle workers and
+  full handler stacks mid-request, and `memory:dump` succeeds on
+  both — same dump size in both states (heap is the worker's, not
+  the per-request scope). When verifying the docs against worker
+  mode, expect the regular-mode "must be mid-request" caveat to NOT
+  apply.
 - **`module_registry` is preempted by the embedding executable.**
   `frankenphp` statically links libphp, so the dynamic linker binds the
   shared symbols to the executable's copy and leaves libphp.so's BSS at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,19 @@ non-obvious things bite single-shot `inspector:trace -p` users:
   before treating that as a binary-level fact, so the negative result
   is not persisted and the next attach against a warm worker succeeds
   without intervention.
+- **Sequential traffic warms one worker, not all of them.** When
+  reproducing a "cold worker" failure interactively, fire `num_threads`+
+  parallel slow requests rather than a single curl — Caddy reuses
+  the first idle worker for serial requests, so the TID you grab from
+  `ps` may stay cold no matter how many requests you throw at it.
+- **`inspector:memory:dump` has a second cold-attach failure mode** beyond
+  the TSRM one. The chunk finder reads `eg.current_execute_data` and
+  walks 2 MB-aligned addresses to locate the request heap; between
+  requests `current_execute_data` is 0 and the dump fails with "failed
+  to find ZendMM main chunk". The worker has to be mid-request at the
+  moment of attach. Reproduce with a long `usleep`-tail script and
+  saturate the workers; CLI mode (`frankenphp php-cli script.php`)
+  sidesteps it because the worker stays in PHP for the whole script.
 - **Tests in `tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest`
   share one `BinaryAnalysisCache` across thread iterations.** That's the
   regression test for the cache-poisoning fix; if you put a fresh cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,30 +150,34 @@ non-obvious things bite single-shot `inspector:trace -p` users:
   parallel slow requests rather than a single curl — Caddy reuses
   the first idle worker for serial requests, so the TID you grab from
   `ps` may stay cold no matter how many requests you throw at it.
-- **`inspector:memory:dump` in regular (per-request) mode only works
-  while the worker is mid-request.** The chunk finder reads
-  `eg.current_execute_data` and walks 2 MB-aligned addresses to locate
-  the request heap; between requests `current_execute_data` is 0 and
-  the dump fails with "failed to find ZendMM main chunk". Reproduce
-  with a long `usleep`-tail script and saturate the workers; CLI mode
-  (`frankenphp php-cli script.php`) sidesteps it because the worker
-  stays in PHP for the whole script. In production, prefer
-  `inspector:watch --action=memory-dump` (which fires only when its
-  condition holds, naturally inside a request) or `inspector:sidecar`
-  (which is invoked from PHP itself). This is not a FrankenPHP quirk
-  but a property of ZendMM, which is request-scoped in every SAPI.
-- **FrankenPHP worker mode keeps the request heap alive between
-  requests, so `inspector:memory:dump` works at any time.** A worker
-  loaded with `frankenphp { worker /app/worker.php }` stays parked in
-  the `frankenphp_handle_request()` loop on the PHP call stack while
-  it waits for the next request, so `current_execute_data` is never
-  zero. `inspector:trace` shows a 2-frame
+- **Worker mode is the primary FrankenPHP shape, and `memory:dump`
+  works on it any time.** A worker loaded with
+  `frankenphp { worker /app/worker.php }` stays parked in the
+  `frankenphp_handle_request()` loop on the PHP call stack while it
+  waits for the next request, so `executor_globals.current_execute_data`
+  is never zero and the worker's request heap is mapped for the
+  worker's whole lifetime. `inspector:trace` shows a 2-frame
   `frankenphp_handle_request` / `<main>` stack on idle workers and
-  full handler stacks mid-request, and `memory:dump` succeeds on
-  both — same dump size in both states (heap is the worker's, not
-  the per-request scope). When verifying the docs against worker
-  mode, expect the regular-mode "must be mid-request" caveat to NOT
-  apply.
+  full handler stacks mid-request; `memory:dump` succeeds on both,
+  and the dump size is identical (the heap is the worker's, not
+  per-request). Symfony Runtime, Laravel Octane on FrankenPHP, and
+  similar runtimes ship in worker mode by default — assume worker
+  mode unless explicitly told otherwise.
+- **Regular (per-request) mode is the exception, and
+  `memory:dump` is timing-bound there.** Without the `worker`
+  directive FrankenPHP behaves like every other SAPI: between
+  requests the worker tears the request scope down,
+  `current_execute_data` is 0, and `memory:dump` fails with
+  "failed to find ZendMM main chunk". Reproduce with a long
+  `usleep`-tail script and saturate the workers; CLI mode
+  (`frankenphp php-cli script.php`) sidesteps it because the
+  worker stays in PHP for the whole script. In production-like
+  regular-mode setups, prefer `inspector:watch --action=memory-dump`
+  (fires only when its condition holds, naturally inside a request)
+  or `inspector:sidecar` (invoked from PHP itself). This is not a
+  FrankenPHP quirk but a property of ZendMM, which is request-scoped
+  in every SAPI other than the worker-mode-style "long-lived script"
+  shape.
 - **`module_registry` is preempted by the embedding executable.**
   `frankenphp` statically links libphp, so the dynamic linker binds the
   shared symbols to the executable's copy and leaves libphp.so's BSS at

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -151,27 +151,29 @@ TLS-offset cache and lets every subsequent **warm** worker TID
 succeed instantly (a thread that has still never served a
 request stays unresolvable until it does).
 
-There is a second failure mode unique to memory commands in
-HTTP-daemon mode: `inspector:memory:dump`, `inspector:memory`,
-and `inspector:watch -p <pid>` locate the request heap by reading
-`executor_globals.current_execute_data` and walking 2 MB-aligned
-addresses near it. Between requests, FrankenPHP workers park on
-a Go channel with `current_execute_data == 0`, and the chunk
-finder bails out with:
+The other reality memory commands have to live with is that
+ZendMM's main chunk only exists while a request is in flight —
+between requests the worker tears it down. `inspector:memory:dump`,
+`inspector:memory`, and `inspector:watch -p <pid>` therefore need
+the worker to be **mid-request at the moment of attach**, just
+like in any other SAPI. For a one-shot snapshot under HTTP-daemon
+mode that means saturating workers with a long-running PHP page
+(e.g. one that does the work you want to capture and then
+`usleep`s for a few seconds). For automated capture, prefer the
+condition-driven workflows that fire while a request is active by
+construction:
 
-```
-failed to find ZendMM main chunk
-```
+- [`inspector:watch`](capturing-traces.md) with `--memory-usage`,
+  `--watch-function`, `--cpu-usage` etc. plus `--action=memory-dump`
+  polls the target and only triggers when the condition holds, so
+  it naturally lands inside a request.
+- [`inspector:sidecar`](../monitoring/sidecar.md) takes the dump on
+  request from the application (e.g. from a `memory_limit` shutdown
+  handler), guaranteeing the call stack and heap are still set up.
 
-The worker has to be **mid-request at the moment of attach** for
-the dump to succeed. Saturating all workers with a long-running
-PHP page (e.g. a script that does the work you want to capture
-and then `usleep`s for a few seconds) is the most reliable way
-to keep one in PHP code long enough; an idle or short-running
-production server can be very hard to capture without hooking
-the request itself. CLI-style invocations
-(`frankenphp php-cli script.php`) keep the worker in PHP for the
-whole script lifetime and don't have this problem.
+CLI-style invocations (`frankenphp php-cli script.php`) keep the
+worker in PHP for the whole script lifetime and avoid the timing
+issue entirely.
 
 ## Caveats
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -80,9 +80,11 @@ A few realities on FrankenPHP that the snippet above is built around:
   well under a second on a normal dev box; sandboxed or
   IO-constrained environments may take a few seconds. Either way,
   don't time the very first run out aggressively.
-- **Some hex-named workers fail brute-forcing.** A worker that has
-  not yet served a request leaves `_tsrm_ls_cache` zeroed, so the
-  search returns nothing and the call dies with:
+- **Some hex-named workers fail brute-forcing on first attach.**
+  Before the per-binary TLS-offset cache exists, reli locates
+  `_tsrm_ls_cache` by scanning the target's TLS block for a
+  recognisable pattern. On a worker that has not yet served a
+  request that scan can come up empty, and the call dies with:
 
   ```
   executor_globals not found via TSRM on TID <n>. The binary is
@@ -90,18 +92,28 @@ A few realities on FrankenPHP that the snippet above is built around:
   uninitialized -- typical of an idle FrankenPHP worker.
   ```
 
-  Pick a different worker, or push traffic through and retry. A
-  single sequential request usually only warms one worker (Caddy
-  picks the first idle one and sends the rest there too), so the
-  TID you happened to grab from `ps` may stay cold. Concurrent
-  load that saturates all workers — e.g. fire `num_threads`+ slow
-  requests in parallel before attaching — warms every worker at
-  once. Once any one worker succeeds, the per-binary TLS-offset
-  cache lets every other warm worker resolve instantly; only
-  workers that have *still* never served a request stay
-  unresolvable. `inspector:trace` retries roughly ten times at
-  10 ms intervals before giving up, so it sometimes wins races
-  that `inspector:memory:dump` (no retry) loses.
+  Recovery: pick another worker, or push traffic through to warm
+  one. A single sequential request usually only warms one worker
+  (Caddy picks the first idle one and routes follow-on requests
+  there too), so the TID you happened to grab from `ps` may stay
+  cold. Concurrent load that saturates all workers — e.g. fire
+  `num_threads`+ slow requests in parallel before attaching —
+  warms every worker at once. Once **any one worker** succeeds
+  and writes the offset to the per-binary cache, subsequent
+  attaches against the same FrankenPHP process skip the
+  brute-force scan, read the cached offset directly, and resolve
+  TSRM in microseconds — including against workers that have
+  still never served a request, provided their slot was
+  populated at thread startup (which is the case in current
+  FrankenPHP builds).
+
+  TSRM resolving is not the same as having something to look at:
+  `inspector:memory:dump` against a TSRM-resolved cold worker in
+  regular mode still fails downstream with "failed to find ZendMM
+  main chunk" because the request scope hasn't been set up — see
+  the [Memory and watch commands](#memory-and-watch-commands)
+  section. Worker mode keeps the request scope alive throughout
+  the worker's lifetime and so doesn't have this second hurdle.
 
 `--target-thread-regex` is not honoured by `inspector:trace`: the
 single-process mode samples exactly the TID you pass in, so choose
@@ -143,17 +155,20 @@ sudo php ./reli inspector:memory:dump -p "$(
     -o ./frankenphp.relimem
 ```
 
-Unlike `inspector:trace`, `inspector:memory:dump` does **not**
-retry TLS resolution. If the chosen worker happens to be one that
-never handled a request, the dump fails with the
-`executor_globals not found via TSRM on TID <n>` error described
-in the [single-worker section](#attach-to-a-single-worker).
-Recovery: rerun against a different TID, or saturate the workers
-with concurrent traffic and retry. Running a brief
-`inspector:trace` / `inspector:daemon` first populates the
-TLS-offset cache and lets every subsequent **warm** worker TID
-succeed instantly (a thread that has still never served a
-request stays unresolvable until it does).
+If the chosen worker has not yet served a request and the
+per-binary TLS-offset cache is also still empty, the dump fails
+with the `executor_globals not found via TSRM on TID <n>` error
+described in the [single-worker section](#attach-to-a-single-worker).
+Both `inspector:memory:dump` and `inspector:trace` fail at the
+same point in this case — the `--max-retries` knob on
+`inspector:trace` retries failed memory reads inside the sampling
+loop, not the cold-attach TSRM resolution itself. Recovery: rerun
+against a different TID, or saturate the workers with concurrent
+traffic and retry. Running a brief `inspector:trace` /
+`inspector:daemon` first populates the TLS-offset cache and lets
+every subsequent attach against the same FrankenPHP process
+resolve TSRM via the cache regardless of whether the chosen TID
+itself has served a request.
 
 ### Memory commands and FrankenPHP modes
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -151,17 +151,18 @@ TLS-offset cache and lets every subsequent **warm** worker TID
 succeed instantly (a thread that has still never served a
 request stays unresolvable until it does).
 
-The other reality memory commands have to live with is that
-ZendMM's main chunk only exists while a request is in flight —
-between requests the worker tears it down. `inspector:memory:dump`,
-`inspector:memory`, and `inspector:watch -p <pid>` therefore need
-the worker to be **mid-request at the moment of attach**, just
-like in any other SAPI. For a one-shot snapshot under HTTP-daemon
-mode that means saturating workers with a long-running PHP page
-(e.g. one that does the work you want to capture and then
-`usleep`s for a few seconds). For automated capture, prefer the
-condition-driven workflows that fire while a request is active by
-construction:
+The other reality memory commands have to live with applies to
+**regular (per-request) mode only**: ZendMM's main chunk exists
+only while a request is in flight, and between requests the
+worker tears it down. `inspector:memory:dump`, `inspector:memory`,
+and `inspector:watch -p <pid>` therefore need the worker to be
+**mid-request at the moment of attach**, just like in any other
+SAPI. For a one-shot snapshot under regular HTTP-daemon mode
+that means saturating workers with a long-running PHP page (e.g.
+one that does the work you want to capture and then `usleep`s
+for a few seconds). For automated capture, prefer the
+condition-driven workflows that fire while a request is active
+by construction:
 
 - [`inspector:watch`](capturing-traces.md) with `--memory-usage`,
   `--watch-function`, `--cpu-usage` etc. plus `--action=memory-dump`
@@ -171,9 +172,22 @@ construction:
   request from the application (e.g. from a `memory_limit` shutdown
   handler), guaranteeing the call stack and heap are still set up.
 
+[FrankenPHP **worker mode**](https://frankenphp.dev/docs/worker/)
+sidesteps the mid-request requirement entirely. Worker mode keeps
+the worker script (`frankenphp_handle_request()` loop) on the call
+stack between requests, so `executor_globals.current_execute_data`
+is never zero and the request heap stays mapped for the worker's
+whole lifetime. `inspector:memory:dump` therefore succeeds against
+an idle worker-mode worker the same way it succeeds against one
+mid-request — `inspector:trace` shows the 2-frame
+`frankenphp_handle_request` / `<main>` idle stack between
+requests and the full handler stack while one is in flight.
+This is the recommended setup if you want to capture memory
+state on demand without coordinating with traffic.
+
 CLI-style invocations (`frankenphp php-cli script.php`) keep the
 worker in PHP for the whole script lifetime and avoid the timing
-issue entirely.
+issue the same way.
 
 ## Caveats
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -78,13 +78,26 @@ A few realities on FrankenPHP that the snippet above is built around:
   don't time the very first run out aggressively.
 - **Some hex-named workers fail brute-forcing.** A worker that has
   not yet served a request leaves `_tsrm_ls_cache` zeroed, so the
-  search returns nothing and the call dies with `global symbol
-  not found executor_globals`. Pick a different worker (or push
-  some traffic through and retry) — once any one worker succeeds,
-  the cached offset works for every other thread of the same
-  process. `inspector:daemon` and `inspector:trace` retry
-  internally; `inspector:memory:dump` and friends do not, so cold
-  failures are most visible there.
+  search returns nothing and the call dies with:
+
+  ```
+  executor_globals not found via TSRM on TID <n>. The binary is
+  ZTS (PT_TLS present) but this thread's _tsrm_ls_cache slot is
+  uninitialized -- typical of an idle FrankenPHP worker.
+  ```
+
+  Pick a different worker, or push traffic through and retry. A
+  single sequential request usually only warms one worker (Caddy
+  picks the first idle one and sends the rest there too), so the
+  TID you happened to grab from `ps` may stay cold. Concurrent
+  load that saturates all workers — e.g. fire `num_threads`+ slow
+  requests in parallel before attaching — warms every worker at
+  once. Once any one worker succeeds, the per-binary TLS-offset
+  cache lets every other warm worker resolve instantly; only
+  workers that have *still* never served a request stay
+  unresolvable. `inspector:trace` retries roughly ten times at
+  10 ms intervals before giving up, so it sometimes wins races
+  that `inspector:memory:dump` (no retry) loses.
 
 `--target-thread-regex` is not honoured by `inspector:trace`: the
 single-process mode samples exactly the TID you pass in, so choose
@@ -128,12 +141,37 @@ sudo php ./reli inspector:memory:dump -p "$(
 
 Unlike `inspector:trace`, `inspector:memory:dump` does **not**
 retry TLS resolution. If the chosen worker happens to be one that
-never handled a request, the dump fails with `global symbol not
-found executor_globals`. Recovery: rerun against a different TID,
-or push a request through the server and retry. Running a brief
+never handled a request, the dump fails with the
+`executor_globals not found via TSRM on TID <n>` error described
+in the [single-worker section](#attach-to-a-single-worker).
+Recovery: rerun against a different TID, or saturate the workers
+with concurrent traffic and retry. Running a brief
 `inspector:trace` / `inspector:daemon` first populates the
-TLS-offset cache and lets every subsequent worker TID succeed
-immediately.
+TLS-offset cache and lets every subsequent **warm** worker TID
+succeed instantly (a thread that has still never served a
+request stays unresolvable until it does).
+
+There is a second failure mode unique to memory commands in
+HTTP-daemon mode: `inspector:memory:dump`, `inspector:memory`,
+and `inspector:watch -p <pid>` locate the request heap by reading
+`executor_globals.current_execute_data` and walking 2 MB-aligned
+addresses near it. Between requests, FrankenPHP workers park on
+a Go channel with `current_execute_data == 0`, and the chunk
+finder bails out with:
+
+```
+failed to find ZendMM main chunk
+```
+
+The worker has to be **mid-request at the moment of attach** for
+the dump to succeed. Saturating all workers with a long-running
+PHP page (e.g. a script that does the work you want to capture
+and then `usleep`s for a few seconds) is the most reliable way
+to keep one in PHP code long enough; an idle or short-running
+production server can be very hard to capture without hooking
+the request itself. CLI-style invocations
+(`frankenphp php-cli script.php`) keep the worker in PHP for the
+whole script lifetime and don't have this problem.
 
 ## Caveats
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -13,7 +13,11 @@ reli can profile FrankenPHP, but three things differ from a vanilla
 3. Only the PHP worker threads carry valid executor globals; the
    Go-runtime TIDs have no PHP state.
 
-The three CLI flags below match those realities.
+The three CLI flags below match those realities. Trace and
+daemon commands work the same way against both regular
+(per-request) and [worker-mode](https://frankenphp.dev/docs/worker/)
+FrankenPHP setups; the memory commands diverge between the two
+shapes — see [Memory and watch commands](#memory-and-watch-commands).
 
 ## Required flags
 
@@ -151,18 +155,47 @@ TLS-offset cache and lets every subsequent **warm** worker TID
 succeed instantly (a thread that has still never served a
 request stays unresolvable until it does).
 
-The other reality memory commands have to live with applies to
-**regular (per-request) mode only**: ZendMM's main chunk exists
-only while a request is in flight, and between requests the
-worker tears it down. `inspector:memory:dump`, `inspector:memory`,
-and `inspector:watch -p <pid>` therefore need the worker to be
-**mid-request at the moment of attach**, just like in any other
-SAPI. For a one-shot snapshot under regular HTTP-daemon mode
-that means saturating workers with a long-running PHP page (e.g.
-one that does the work you want to capture and then `usleep`s
-for a few seconds). For automated capture, prefer the
-condition-driven workflows that fire while a request is active
-by construction:
+### Memory commands and FrankenPHP modes
+
+FrankenPHP runs in two modes and the memory commands behave very
+differently in each.
+
+[**Worker mode**](https://frankenphp.dev/docs/worker/) — `frankenphp { worker /app/worker.php }` —
+loads the application script once per PHP thread and serves
+requests in a `frankenphp_handle_request()` loop. That loop stays
+on the PHP call stack between requests, so
+`executor_globals.current_execute_data` is never zero and the
+worker's request heap is mapped for the worker's whole lifetime.
+For reli that means:
+
+- `inspector:memory:dump` succeeds against an idle worker-mode
+  worker the same way it succeeds against one mid-request, with
+  the same dump size — there is no per-request scope to wait for.
+- `inspector:trace` against an idle worker-mode worker shows a
+  short 2-frame `frankenphp_handle_request` / `<main>` stack;
+  the same TID mid-request shows the full handler stack on top.
+
+This is reli's happy path on FrankenPHP — being able to introspect
+a worker that has been serving traffic for a long time, without
+having to coordinate with request timing or restart it, is what
+the memory tooling is for. Symfony Runtime, Laravel Octane on
+FrankenPHP, and similar high-perf runtimes all use worker mode by
+default; if you're already running one of them you already have
+the easy case.
+
+**Regular (per-request) mode** — `php_server` without a `worker`
+directive — behaves like every other SAPI: ZendMM's main chunk
+only exists while a request is in flight, and between requests
+the worker tears it down. In this mode `inspector:memory:dump`,
+`inspector:memory`, and `inspector:watch -p <pid>` need the
+worker to be **mid-request at the moment of attach**, with all
+the timing considerations that implies (saturating workers with
+a long-running page, racing the request boundary, etc.). For a
+one-shot snapshot in regular mode, drive workers with a
+long-running PHP page (e.g. one that does the work you want to
+capture and then `usleep`s for a few seconds). For automated
+capture, prefer the condition-driven workflows that fire while a
+request is active by construction:
 
 - [`inspector:watch`](capturing-traces.md) with `--memory-usage`,
   `--watch-function`, `--cpu-usage` etc. plus `--action=memory-dump`
@@ -172,22 +205,9 @@ by construction:
   request from the application (e.g. from a `memory_limit` shutdown
   handler), guaranteeing the call stack and heap are still set up.
 
-[FrankenPHP **worker mode**](https://frankenphp.dev/docs/worker/)
-sidesteps the mid-request requirement entirely. Worker mode keeps
-the worker script (`frankenphp_handle_request()` loop) on the call
-stack between requests, so `executor_globals.current_execute_data`
-is never zero and the request heap stays mapped for the worker's
-whole lifetime. `inspector:memory:dump` therefore succeeds against
-an idle worker-mode worker the same way it succeeds against one
-mid-request — `inspector:trace` shows the 2-frame
-`frankenphp_handle_request` / `<main>` idle stack between
-requests and the full handler stack while one is in flight.
-This is the recommended setup if you want to capture memory
-state on demand without coordinating with traffic.
-
 CLI-style invocations (`frankenphp php-cli script.php`) keep the
-worker in PHP for the whole script lifetime and avoid the timing
-issue the same way.
+worker in PHP for the whole script lifetime and avoid the regular-
+mode timing issue the same way worker mode does.
 
 ## Caveats
 

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -255,6 +255,26 @@ class PhpGlobalsFinder
             return $module_map->getBaseAddress() + $cached['module_registry'];
         }
 
+        // ELF symbol preemption: when libphp is statically linked into
+        // the target's main executable (e.g. FrankenPHP), the dynamic
+        // linker binds shared symbols to the executable's copy and the
+        // separately-mapped libphp.so copy stays at zero in BSS. Probe
+        // the executable first so we resolve to whatever the running
+        // PHP code itself reads through the GOT, falling back to the
+        // libphp.so reader for the common cli / mod_php / fpm cases
+        // where module_registry only exists in one place.
+        $exe_reader = $this->php_symbol_reader_creator->createForExecutable(
+            $process_specifier->pid,
+        );
+        $exe_address = $exe_reader?->resolveAddress('module_registry');
+        if ($exe_address !== null) {
+            // Don't cache against the libphp.so fingerprint -- the address
+            // is relative to a different module's base, and reusing it
+            // through `$module_map->getBaseAddress() + offset` would
+            // resolve to a bogus location.
+            return $exe_address;
+        }
+
         $symbol_reader = $this->tsrm_globals_resolver->getZtsGlobalsSymbolReader(
             $process_specifier,
             $target_php_settings

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -262,11 +262,18 @@ class PhpGlobalsFinder
         // the executable first so we resolve to whatever the running
         // PHP code itself reads through the GOT, falling back to the
         // libphp.so reader for the common cli / mod_php / fpm cases
-        // where module_registry only exists in one place.
-        $exe_reader = $this->php_symbol_reader_creator->createForExecutable(
-            $process_specifier->pid,
-        );
-        $exe_address = $exe_reader?->resolveAddress('module_registry');
+        // where module_registry only exists in one place. Any failure
+        // parsing the executable (e.g. a fully static binary stripped
+        // of its section header table) just falls through to the
+        // libphp.so path.
+        try {
+            $exe_reader = $this->php_symbol_reader_creator->createForExecutable(
+                $process_specifier->pid,
+            );
+            $exe_address = $exe_reader?->resolveAddress('module_registry');
+        } catch (\Throwable) {
+            $exe_address = null;
+        }
         if ($exe_address !== null) {
             // Don't cache against the libphp.so fingerprint -- the address
             // is relative to a different module's base, and reusing it

--- a/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
+++ b/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
@@ -36,6 +36,39 @@ final class PhpSymbolReaderCreator
     }
 
     /**
+     * Build a symbol reader for the target's main executable
+     * (`/proc/{pid}/exe`).
+     *
+     * Used to handle ELF symbol preemption: when libphp is statically
+     * linked into the target's main binary (e.g. FrankenPHP), the global
+     * symbols that exist in both the executable and a separately mapped
+     * `libphp.so` are bound to the executable's copy by the dynamic
+     * linker, leaving the libphp.so copy at zero in BSS. Resolving such
+     * symbols via the executable returns the address actually used at
+     * runtime.
+     *
+     * The reader has no link-map / TLS plumbing (the caller has not
+     * supplied a libpthread reader); it only supports static symbol
+     * lookups. Returns null if `/proc/{pid}/exe` cannot be resolved or
+     * the executable is not present in the process memory map.
+     */
+    public function createForExecutable(int $pid): ?ProcessModuleSymbolReader
+    {
+        $executable_path = readlink("/proc/{$pid}/exe");
+        if ($executable_path === false) {
+            return null;
+        }
+        $full_executable_path = "/proc/{$pid}/root{$executable_path}";
+        $process_memory_map = $this->process_memory_map_creator->getProcessMemoryMap($pid);
+        return $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+            $pid,
+            $process_memory_map,
+            '^' . preg_quote($executable_path) . '$',
+            $full_executable_path,
+        );
+    }
+
+    /**
      * @throws MemoryReaderException
      * @throws ProcessSymbolReaderException
      * @throws TlsFinderException

--- a/src/Lib/PhpProcessReader/PhpVersionDetector.php
+++ b/src/Lib/PhpProcessReader/PhpVersionDetector.php
@@ -115,13 +115,19 @@ class PhpVersionDetector
         }
 
         if (is_null($version)) {
+            // Detection failed. Fall back to the host PHP version so the
+            // caller still gets a TargetPhpSettings it can act on, but do
+            // NOT cache this fallback: the host PHP version has nothing
+            // to do with the target, and persisting it would poison every
+            // subsequent run on the same binary (e.g. resolving a PHP 8.3
+            // FrankenPHP target as v84 because reli itself runs on 8.4,
+            // which then mis-reads ZendMmChunk layouts and breaks
+            // memory:dump). The user can override with --php-version.
             /** @var value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $version */
             $version = 'v' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION;
             /** @psalm-suppress ReservedWord */
             Assert::true(ZendTypeReader::isSupported($version));
-        }
-
-        if ($fingerprint !== null) {
+        } elseif ($fingerprint !== null) {
             $this->binary_analysis_cache->set($fingerprint, 'php_version', ['version' => $version]);
         }
 


### PR DESCRIPTION
## Summary

This PR adds support for resolving global symbols in FrankenPHP, which statically links libphp into its main executable. When libphp is statically linked, the dynamic linker binds shared symbols to the executable's copy, leaving the separately-mapped libphp.so copy at zero in BSS. The changes ensure reli resolves symbols to the addresses actually used at runtime.

## Key Changes

- **New `createForExecutable()` method in `PhpSymbolReaderCreator`**: Creates a symbol reader for the target process's main executable (`/proc/{pid}/exe`), enabling static symbol lookups without link-map or TLS plumbing.

- **Symbol preemption handling in `PhpGlobalsFinder.findModuleRegistry()`**: Probes the executable first when resolving `module_registry`, falling back to the libphp.so reader for standard SAPI cases (cli, mod_php, fpm). This ensures the correct address is resolved when symbols exist in both places.

- **Fixed version detection caching in `PhpVersionDetector`**: Prevents caching the host PHP version fallback when target detection fails. The fallback is now only used as a runtime value, not persisted to the cache, avoiding poisoning subsequent runs against the same binary with incorrect version information.

- **Expanded documentation**: Added comprehensive sections to `docs/tracing/frankenphp.md` and `CLAUDE.md` explaining:
  - Cold worker attachment and TLS resolution caching behavior
  - Differences between worker mode and regular (per-request) mode
  - Memory command behavior and timing considerations in each mode
  - Recovery strategies for cold-attach failures

## Implementation Details

- The executable reader gracefully handles failures (e.g., stripped binaries) by falling through to the libphp.so path
- Symbol addresses resolved from the executable are not cached against the libphp.so fingerprint, preventing bogus address resolution
- The version detection fallback now uses a conditional check (`elseif`) to ensure caching only occurs when detection actually succeeds

https://claude.ai/code/session_01Le7B8Lx2wSJXWWRMaHpGrS