### PR TITLE
Sidecar 0.12.0 release polish: memory safety, error handling, docs

### DIFF
--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -1,85 +1,103 @@
-# sidecar 改善案メモ
+# Sidecar Improvements (Working Notes)
 
-> **Status:** Working scratchpad (Japanese, similar to `future-ideas.md` style).
-> 後で英語化 / セクション分割して個別 PR に切り出す前提の作業メモ。
-
-`reli inspector:sidecar` + `reliforp/reli-prof-sidecar-client` (Packagist 経由)
-の end-to-end 検証中に出てきた改善ネタを忘れる前に列挙したもの。検証日 2026-04-27。
-このメモ単体では実装はしていない。
+> **Status:** Working scratchpad, similar in spirit to `future-ideas.md`.
+> Captures concrete improvement ideas that came out of an end-to-end
+> check of `reli inspector:sidecar` + `reliforp/reli-prof-sidecar-client`
+> (installed via Packagist) on 2026-04-27. Nothing here is implemented
+> yet; intent is to split into per-PR design notes when each item lands.
 
 ---
 
-## A. dump パイプラインのメモリ効率 (本丸)
+## A. Dump pipeline memory efficiency (the main one)
 
-### 現状
+### Current behaviour
 
-`MemoryDumper.php:591-611` で全 region を `process_vm_readv` で読みつつ
-`$regions_data[]` に PHP 文字列として積み、その後 `MemoryDumpWriter::write()`
-で disk に流す。target 停止は `SidecarDumpHandler::doDump()` の `try/finally`
-で `memory_dumper->dump()` 全体を覆っている。
+`MemoryDumper.php:591-611` reads every region with `process_vm_readv`
+into PHP strings appended to `$regions_data[]`, and only after that
+loop completes does `MemoryDumpWriter::write()` flush the regions to
+disk. The target stop window in `SidecarDumpHandler::doDump()` covers
+the whole `memory_dumper->dump()` call, including the disk write.
 
-実測 (1 GB の target):
-- sidecar baseline RSS: ~88 MB
-- dump 中 peak RSS:    ~1109 MB (= target heap + baseline)
-- target 停止時間:      read + write 合計 (~9s)
+Measured against a 1 GB target heap:
 
-つまり「sidecar RSS は target heap 相当」「target 停止は read+write 全部」の
-両方を払っている。どちらの軸でも改善余地あり。
+- Sidecar baseline RSS: ~88 MB
+- Peak sidecar RSS during dump: ~1109 MB (≈ target heap + baseline)
+- Target stop window: read + write combined (~9 s)
 
-### 提案
+So the sidecar is paying both costs at once — RSS scales with target
+heap size, and the target is stopped throughout the disk write phase.
+There is room to improve on either axis.
 
-3 モードに整理可能 (現状は実質「悪いとこ取り」):
+### Proposal
 
-| モード | sidecar peak RSS | target 停止時間 |
+Three modes are distinguishable. The current implementation is
+effectively the worst combination of both axes:
+
+| Mode | Sidecar peak RSS | Target stop window |
 |---|---|---|
-| 現状: full buffer + late resume | target 相当 | read + write |
-| **A: fast-resume** (buffer all → resume → write) | target 相当 | read のみ |
-| **B: streaming** (region 毎 read→write→free) | 数 MB | read + write |
+| Current: full buffer + late resume | ≈ target heap | read + write |
+| **A: fast-resume** (buffer all → resume → write) | ≈ target heap | read only |
+| **B: streaming** (per-region read → write → free) | a few MB | read + write |
 
-`MemoryDumpWriter::writeStreaming()` (line 74-128) は既に実装済み。
-`SidecarDumpHandler` から呼ばれていないだけ。
+`MemoryDumpWriter::writeStreaming()` (lines 74-128) already exists.
+`SidecarDumpHandler` simply does not call it.
 
-### サブタスク
+### Subtasks
 
-- [ ] **A1**: `MemoryDumper::dump` を fast-resume にデフォルト切替
-      (`SidecarDumpHandler` の `try/finally` の `resume()` を read 完了直後に移動)
-      → 無条件改善、API 変更なし
-- [ ] **A2**: `--dump-mode={fast-resume,low-memory}` を `inspector:sidecar` に追加
-- [ ] **A3**: protocol に `mode` field 追加 (additive、protocol_version 据え置き)
-      → `SidecarRequest::$mode`
-      → `SidecarClient::requestDump(..., mode: 'low-memory')`
-      → 古い sidecar に投げても無視される、新しい sidecar が古い client から
-         field 無しで受けたら server default (= --dump-mode) を使う
-- [ ] **A4**: `MemoryLimitHandler::register(... dump_mode: 'low-memory')` を生やす
-      → OOM 経路で sidecar 連鎖死を予防 (target heap == sidecar memory_limit な状況)
+- [ ] **A1** — Switch `MemoryDumper::dump` to fast-resume by default.
+      Move the `resume()` in `SidecarDumpHandler::doDump`'s `try/finally`
+      so it runs immediately after the read phase, before disk write.
+      Strict win, no API change.
+- [ ] **A2** — Add `--dump-mode={fast-resume,low-memory}` to
+      `inspector:sidecar`.
+- [ ] **A3** — Add an additive `mode` field to the IPC protocol
+      (no `protocol_version` bump):
+      - `SidecarRequest::$mode`
+      - `SidecarClient::requestDump(..., mode: 'low-memory')`
+      - Older sidecars ignore the unknown field; newer sidecars receiving
+        a request without `mode` fall back to the server default
+        (`--dump-mode`).
+- [ ] **A4** — Add `MemoryLimitHandler::register(... dump_mode: 'low-memory')`
+      so the OOM-handler path can opt into streaming and avoid taking
+      the sidecar down with itself when `target_heap ≈ sidecar memory_limit`.
 
-優先度: A1 > A2 > A3 > A4。A1 単独で先に PR 切るのが安全。
+Priority: A1 > A2 > A3 > A4. A1 alone makes a clean, standalone PR.
 
 ---
 
-## B. sidecar の自己防衛 (落ちない sidecar)
+## B. Sidecar self-defence (don't die on oversized requests)
 
-### 現状
+### Current behaviour
 
-target heap > sidecar `--memory-limit` の状態で dump 要求すると、
-`MemoryDumper.php:603` の `\FFI::string($data, $entry['size'])` で
-`Allowed memory size exhausted` の PHP Fatal を喰い、**sidecar プロセス全体が死亡**。
+If `target heap > sidecar --memory-limit`, the dump request kills the
+sidecar. The fatal lands at `MemoryDumper.php:603` on
+`\FFI::string($data, $entry['size'])` with
+`Allowed memory size exhausted`. The whole sidecar process exits.
 
-- target は ptrace 経由なので kernel が auto-detach、フリーズはしない
-- socket file は stale で残るが、次の sidecar 起動時に `SidecarServer.php:161` で unlink される
-- partial dump も無し (writer に渡る前に死ぬ)
-- client は `null` 戻り、後続リクエストも ECONNREFUSED (即 null)
-- supervisor (systemd / k8s) 再起動を期待する設計
+- The target is safe — `ProcessStopper` uses `ptrace(PTRACE_ATTACH)`,
+  and the kernel auto-detaches when the tracer dies, so the target
+  resumes.
+- The socket file is left stale, but the next sidecar start unlinks
+  it (`SidecarServer.php:161`).
+- No partial dump is written — the sidecar dies before the writer is
+  invoked.
+- The client gets `null`. Subsequent requests get instant ECONNREFUSED
+  until a supervisor restarts the sidecar.
+- The design implicitly assumes a supervisor (systemd, Kubernetes) is
+  in place to bring the sidecar back up.
 
-死亡した瞬間の dump は永久ロスト = OOM ハンドラ経路で「まさに欲しかった」
-スナップショットを取り損ねる。supervisor 再起動はバックストップとしては有効だが、
-それで救えない種類の損失がある。
+The dump that was in flight when the sidecar died is lost forever.
+For the OOM-handler use case that is exactly the snapshot the user
+wanted. Supervisor restarts handle service recovery, but they cannot
+recover the lost dump request.
 
-### 提案
+### Proposal
 
-`SidecarDumpHandler::doDump()` の `process_stopper->stop()` 直前で
-`heap_stats_reader->read()` 済みなので、dump に必要なメモリを事前計算して
-収まらなければエラー応答で早期 return する。sidecar は生きたまま。
+`SidecarDumpHandler::doDump()` reads `heap_stats_reader->read()`
+**before** calling `process_stopper->stop()`. At that point we know
+the rough size we are about to allocate, so we can pre-flight against
+our own `memory_limit` and bail out with a structured error response,
+keeping the sidecar alive.
 
 ```php
 $memory_limit = self::parseIniBytes(ini_get('memory_limit'));
@@ -97,116 +115,139 @@ if ($memory_limit > 0) {
 }
 ```
 
-効果:
-- sidecar 生存
-- 同居している他 client への dump サービスは継続
-- client は status=error + 具体的な message を受け取る (現状: null だけ)
-- crash loop が起きない
+Effect:
 
-### サブタスク
+- Sidecar stays up.
+- Other clients keep getting served.
+- The requesting client receives `status=error` with a specific
+  `message` instead of just `null`.
+- No crash loop.
 
-- [ ] **B1**: pre-flight memory check を `SidecarDumpHandler::doDump()` 冒頭に追加
-      (~10 行)
-- [ ] **B2**: docs に「supervisor 必須」の運用前提と systemd unit / k8s
-      restartPolicy 例を載せる
+### Subtasks
 
-A の streaming モードが入れば B1 の制約は構造的に消えるが、それまでの間も、
-入った後も「自分の限界を知っているデーモン」としてあった方が動作が分かりやすい。
+- [ ] **B1** — Add the pre-flight check at the top of
+      `SidecarDumpHandler::doDump()` (about 10 lines).
+- [ ] **B2** — Add an "Operations" section to the docs covering the
+      "you must run under a supervisor" assumption, with a sample
+      systemd unit and Kubernetes `restartPolicy: Always`.
 
----
-
-## C. timeout 関連
-
-### 現状
-
-- `SidecarClient::__construct(timeout_seconds: 30)` がデフォルト
-- `stream_set_timeout` は **応答 JSON 受信まで** 効く = sidecar が dump 完了を
-  終えるまで client は block
-- 実測 dump スループット ~110 MB/s (process_vm_readv + disk write)
-  → 30 秒 default は ~3 GB ヒープ相当を捌ける、合理的な値
-- ただし `MemoryLimitHandler::register()` から timeout を渡す手段が無い
-  (内部で `new SidecarClient($socket_path)` するだけ)
-
-### 提案
-
-- [ ] **C1**: `MemoryLimitHandler::register(... timeout_seconds: int = 30)` を追加
-      (内部で `new SidecarClient($socket_path, $timeout_seconds)`)
-- [ ] **C2**: docs に timeout 指針表を追加
-      ```
-      memory_limit  → 推奨 timeout
-      128 M           5  s
-      256 M          10  s
-      512 M          15  s
-      1   G          30  s (default)
-      2   G          60  s
-      ```
-      "デフォルトを下げるな、必要に応じて伸ばせ" と明記。
-- [ ] **C3** (optional): default timeout を 60s に上げる検討。30s は ~3 GB が
-      上限になり、最近の PHP-FPM ワーカーだと割と簡単に超える。
+Once A's streaming mode lands, B1's constraint is structurally gone,
+but B1 is still worth keeping — a daemon that knows its own limits is
+easier to reason about than one that crashes silently.
 
 ---
 
-## D. client API の細かい改善
+## C. Timeout handling
 
-### 現状
+### Current behaviour
+
+- Default constructor: `SidecarClient::__construct(timeout_seconds: 30)`.
+- `stream_set_timeout` covers the **response read**, so the client
+  blocks until the sidecar finishes the dump and writes its JSON
+  reply.
+- Measured dump throughput is roughly 110 MB/s (process_vm_readv +
+  disk write). The 30 s default therefore covers ~3 GB heaps, which
+  is a sensible default.
+- However, `MemoryLimitHandler::register()` does not expose a way to
+  set the timeout — it builds `new SidecarClient($socket_path)`
+  internally with the default.
+
+### Proposal
+
+- [ ] **C1** — Add `timeout_seconds` to
+      `MemoryLimitHandler::register(...)`. Forward it to the inner
+      `new SidecarClient($socket_path, $timeout_seconds)`.
+- [ ] **C2** — Add a timeout-sizing table to the docs:
+      ```
+      memory_limit  →  recommended timeout
+      128 M             5  s
+      256 M            10  s
+      512 M            15  s
+      1   G            30  s (default)
+      2   G            60  s
+      ```
+      Spell out: "do not lower the default; raise it as needed."
+- [ ] **C3** (optional) — Consider raising the default to 60 s. 30 s
+      caps out around ~3 GB, which is a realistic ceiling for modern
+      PHP-FPM workers but not a generous one.
+
+---
+
+## D. Client API ergonomics
+
+### Current behaviour
 
 `SidecarClient::send()`:
+
 ```php
-$sock = @stream_socket_client(... $errno, $errstr, ...);  // @ で warning 抑制
-if ($sock === false) return null;                         // errno/errstr 捨ててる
+$sock = @stream_socket_client(... $errno, $errstr, ...);  // @-suppressed
+if ($sock === false) return null;                         // errno/errstr discarded
 ...
 if ($response === false || $response === '') return null; // timeout / EOF
-return SidecarClientResponse::fromJson(trim($response));   // 不正 JSON も null
+return SidecarClientResponse::fromJson(trim($response));   // bad JSON also null
 ```
 
-「接続失敗」「timeout」「不正 JSON」が全部 `null` で区別できない。
-`MemoryLimitHandler` の `on_error` 文言は固定文字列 `'failed to connect to reli sidecar'`。
+"Connection refused", "read timeout", and "malformed JSON" are all
+indistinguishable to the caller — every failure is `null`.
+`MemoryLimitHandler` reports a fixed string,
+`'failed to connect to reli sidecar'`.
 
-### 提案
+### Proposal
 
-- [ ] **D1**: `on_error` callback の signature を拡張して errno/errstr/原因を渡す
-      (例: `function(string $msg, ?int $errno, ?string $detail)`)
-      → BC のため optional parameters で
-- [ ] **D2** (optional): エラー種別を表す sentinel 値を導入 (例: 専用例外 or
-      `SidecarClientResponse::error(string $reason)` の null 以外の表現)
-      → ただし shutdown handler のメモリ予算とトレードオフあり
+- [ ] **D1** — Extend the `on_error` signature to forward `errno`,
+      `errstr`, and a cause classification. Use optional parameters
+      so existing callers stay compatible:
+      ```
+      on_error(string $message, ?int $errno = null, ?string $detail = null)
+      ```
+- [ ] **D2** (optional) — Introduce a sentinel for error categories,
+      either a dedicated exception type or a non-null
+      `SidecarClientResponse::error(string $reason)` form. Has to be
+      weighed against the shutdown-handler memory budget (the whole
+      reason `MemoryLimitHandler` pre-allocates a reserve).
 
-優先度低め。D1 だけでも運用ログの切り分けには十分役立つ。
+Lower priority. D1 alone is enough to make ops logs separable.
 
 ---
 
-## E. SidecarServer の broken pipe ノイズ
+## E. Broken-pipe noise on client timeout
 
-### 現状
+### Current behaviour
 
-client が timeout で socket 閉じた後、sidecar は dump を完走して JSON を
-書き戻そうとするが、socket は閉じているので `fwrite()` が EPIPE を返す。
-PHP は警告として
+When a client hits its read timeout and closes the socket while the
+sidecar is still working, the sidecar finishes the dump (it writes
+to `--output-dir`, not to the socket), then tries to write the JSON
+reply. The reply `fwrite()` hits EPIPE, and PHP emits:
+
 ```
 PHP Notice: fwrite(): Send of 761 bytes failed with errno=32 Broken pipe
             in src/Inspector/Sidecar/SidecarServer.php on line 134
 ```
-を吐く。dump 自体は disk に完全な状態で保存されている (= orphan dump として
-回収可能)。
 
-### 提案
+The dump file itself is fully written and analyzable — it just
+becomes an "orphan" from the client's point of view.
 
-- [ ] **E1**: `SidecarServer.php:134` 付近の `fwrite` を `@fwrite` + 戻り値チェック
-      に置き換え、`Log::info('client disconnected before reply (dump still saved at <path>)')`
-      のような専用ログを出す。Notice ノイズを消しつつ orphan の発生を可視化。
-- [ ] **E2**: docs に「timeout 切れても dump は `--output-dir` に保存される、
-      `on_error` 後に `ls` で見つけられる」と明記。これは知らないと気付けない
-      安全網。
+### Proposal
+
+- [ ] **E1** — Replace the bare `fwrite` near
+      `SidecarServer.php:134` with `@fwrite` + return-value check, and
+      log a structured message such as
+      `Log::info('client disconnected before reply (dump still saved at <path>)')`.
+      Removes the noisy `Notice` and makes orphans observable.
+- [ ] **E2** — Document the "timed-out client → dump still on disk"
+      safety net. Currently the only way to learn about it is to
+      experience it.
 
 ---
 
-## F. ドキュメント
+## F. Documentation gaps
 
-### F1. Quick Start のソケット親ディレクトリ要件
+### F1. Socket parent directory requirement in Quick Start
 
-`docs/monitoring/sidecar.md` の Quick Start は `--socket=/tmp/reli-sidecar.sock`
-を例示しているが、`SocketPathResolver::assertParentSafe()` は親 dir mode 0700 を
-要求するため、`/tmp` (大抵 0777) では起動失敗する。
+`docs/monitoring/sidecar.md` Quick Start uses
+`--socket=/tmp/reli-sidecar.sock`, but
+`SocketPathResolver::assertParentSafe()` requires the parent directory
+to be mode 0700. `/tmp` is typically 0777, so the example crashes:
 
 ```
 [RuntimeException]
@@ -214,75 +255,94 @@ Sidecar socket parent directory /tmp has mode 0777, expected 0700.
 Run: chmod 0700 '/tmp'
 ```
 
-→ Quick Start を `mkdir -p /tmp/reli-run && chmod 0700 /tmp/reli-run`
-   + `--socket=/tmp/reli-run/sidecar.sock` の形に修正、または default の
-   `$XDG_RUNTIME_DIR/reli/sidecar.sock` を勧める例にする。
+Fix: rewrite the example as
+`mkdir -p /tmp/reli-run && chmod 0700 /tmp/reli-run` followed by
+`--socket=/tmp/reli-run/sidecar.sock`, or steer users toward the
+default `$XDG_RUNTIME_DIR/reli/sidecar.sock`.
 
-### F2. Packagist 経由インストールの明示
+### F2. Packagist install path
 
-現在 docs は「composer require reliforp/reli-prof」 or 「3 ファイル vendoring」
-の 2 択しか書いていないが、実際には `reliforp/reli-prof-sidecar-client` が
-独立パッケージとして Packagist にいる (現状 `dev-main` のみ、tag 無し)。
-これを推奨経路として書くべき:
+The current docs offer two installation routes — `composer require
+reliforp/reli-prof` (the full package) or vendoring the three client
+files manually. There is in fact a third path: the
+`reliforp/reli-prof-sidecar-client` standalone package on Packagist
+(currently `dev-main` only, no tag yet). It should be the recommended
+route:
 
 ```bash
 composer require reliforp/reli-prof-sidecar-client:dev-main
 ```
 
-`minimum-stability: dev` 必須。tag 付け方針も整理したい (semver: 0.1.0 から?)。
+This requires `minimum-stability: dev` until the package is tagged.
+The tagging policy itself needs sorting (semver, starting at 0.1.0?).
 
-### F3. 運用前提の 1 セクション
+### F3. Operations section
 
-- `--memory-limit` のサイジング (= max(全 target memory_limit) + 100 MB 程度)
-- supervisor (systemd unit example, k8s restartPolicy: Always)
-- timeout 指針表 (C2 と統合)
-- orphan dump の存在と回収方法 (E2)
-- streaming モードを使う場合の sizing (将来)
+A single "Operations" section in `sidecar.md` to consolidate:
+
+- Sizing `--memory-limit` (≥ max target `memory_limit` + ~100 MB).
+- Supervisor expectation, with a systemd unit and a Kubernetes
+  `restartPolicy: Always` example.
+- Timeout sizing table (folds C2 in).
+- Orphan dump recovery (folds E2 in).
+- Sizing under streaming mode, once that lands.
 
 ---
 
-## G. テスト / CI
+## G. Tests / CI
 
 ### G1. End-to-end smoke test
 
-`tests/e2e/sidecar-client/` に:
-1. `composer.json` (path repo で `../../reli-prof-sidecar-client` を参照、
-   または Packagist の dev-main を pin)
-2. `bootstrap.php` + `bench.php` 相当の fixture
-3. PHPUnit 1 ケース: `dockerd` 起動 → sidecar background 起動 → fixture 実行
-   → dump 出力を assert
+Add `tests/e2e/sidecar-client/` containing:
 
-これがあると downgrade 後の API ミス (PHP 7.0 で named arg 使ってる等) や
-protocol_version の食い違いを PR 単位で拾える。
+1. `composer.json` — either a path repository pointing to
+   `../../reli-prof-sidecar-client`, or pinning Packagist's `dev-main`.
+2. A bootstrap + benchmark fixture (the moral equivalent of the
+   `bench.php` we used during this check).
+3. A PHPUnit case that boots `dockerd`, starts the sidecar in the
+   background, runs the fixture, and asserts on the produced dump
+   files.
 
-### G2. bench/sidecar-roundtrip.php
+This catches downgrade slip-ups (e.g. named arguments leaking into
+PHP 7.0-targeted client code) and protocol-version drift on a
+per-PR basis.
 
-repo に最小デモを同梱。今回 `/home/user/demo-app/{bench,oom,timing,rss_watch}.php`
-で書き散らしたものを整理して `bench/` 配下に置く。`docker compose up` 一発で
-誰でも再現可能な状態にする。
+### G2. `bench/sidecar-roundtrip.php`
 
----
-
-## まとめ: 推奨 PR 順序
-
-1. **A1** (fast-resume default) — 無条件改善、独立 PR。
-2. **B1** (pre-flight memory check) — 独立、~10 行。`A1` の前後どちらでもよい。
-3. **F1, E2 ドキュメント修正** — F2 と合わせて 1 PR。
-4. **A2 + A3 + A4** (dump-mode 切替) — protocol 変更含むので慎重に。
-5. **C1, C2** — `MemoryLimitHandler` 引数追加と docs。
-6. **E1** (broken pipe ログ整理) — 独立、小。
-7. **D1** (on_error 拡張) — 後回し可。
-8. **G1, G2** (E2E テストとデモ) — 上が落ち着いてから。
+A minimal demo committed to the repo. The scratch scripts created
+during this check
+(`/home/user/demo-app/{bench,oom,timing,rss_watch}.php`) can be
+cleaned up and dropped under `bench/` so anyone can reproduce the
+roundtrip with a single `docker compose up`.
 
 ---
 
-## 検証時のメモ (将来の参考用)
+## Suggested PR ordering
 
-- ホスト PHP 8.4 / reli は ^8.5 require → composer install --ignore-platform-req=php
-  で動かせる (今回もそうした)。
-- Packagist の `dev-main` はちゃんと最新コミット (423ee89) まで追従していた。
-  GitHub→Packagist webhook 設定済み。
-- `/tmp/reli-dumps/` は `--disk-usage-limit=1G` で自動 rotate される。
-  検証で 1.4 GB 残してしまった時は手で `rm -rf` して掃除した。
-- demo-app の検証用スクリプトは `/home/user/demo-app/` に残置。整理して
-  G2 のベースに使える。
+1. **A1** — fast-resume default. Standalone, no protocol change.
+2. **B1** — pre-flight memory check. Standalone, ~10 lines. Order
+   relative to A1 doesn't matter.
+3. **F1 + E2** — doc fixes; bundle F2 with them as one PR.
+4. **A2 + A3 + A4** — dump-mode plumbing. Touches the protocol,
+   so review carefully.
+5. **C1 + C2** — `MemoryLimitHandler` parameter and timeout docs.
+6. **E1** — broken-pipe log cleanup. Small, standalone.
+7. **D1** — `on_error` signature extension. Can wait.
+8. **G1 + G2** — E2E test and demo. After the above stabilise.
+
+---
+
+## Verification notes (kept for future reference)
+
+- Host PHP is 8.4; reli requires `^8.5`. Used
+  `composer install --ignore-platform-req=php` to install the dev
+  dependencies.
+- Packagist's `dev-main` tracks the actual head of main on the
+  generated `reliforp/reli-prof-sidecar-client` repository
+  (commit `423ee89` at time of writing). The GitHub → Packagist
+  webhook is in place.
+- `/tmp/reli-dumps/` is auto-rotated by `--disk-usage-limit=1G`.
+  When the verification left ~1.4 GB of dumps behind, manual
+  `rm -rf` was needed.
+- Verification scripts live at `/home/user/demo-app/`. They can be
+  cleaned up and re-used as the basis for G2.

--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -1,0 +1,288 @@
+# sidecar 改善案メモ
+
+> **Status:** Working scratchpad (Japanese, similar to `future-ideas.md` style).
+> 後で英語化 / セクション分割して個別 PR に切り出す前提の作業メモ。
+
+`reli inspector:sidecar` + `reliforp/reli-prof-sidecar-client` (Packagist 経由)
+の end-to-end 検証中に出てきた改善ネタを忘れる前に列挙したもの。検証日 2026-04-27。
+このメモ単体では実装はしていない。
+
+---
+
+## A. dump パイプラインのメモリ効率 (本丸)
+
+### 現状
+
+`MemoryDumper.php:591-611` で全 region を `process_vm_readv` で読みつつ
+`$regions_data[]` に PHP 文字列として積み、その後 `MemoryDumpWriter::write()`
+で disk に流す。target 停止は `SidecarDumpHandler::doDump()` の `try/finally`
+で `memory_dumper->dump()` 全体を覆っている。
+
+実測 (1 GB の target):
+- sidecar baseline RSS: ~88 MB
+- dump 中 peak RSS:    ~1109 MB (= target heap + baseline)
+- target 停止時間:      read + write 合計 (~9s)
+
+つまり「sidecar RSS は target heap 相当」「target 停止は read+write 全部」の
+両方を払っている。どちらの軸でも改善余地あり。
+
+### 提案
+
+3 モードに整理可能 (現状は実質「悪いとこ取り」):
+
+| モード | sidecar peak RSS | target 停止時間 |
+|---|---|---|
+| 現状: full buffer + late resume | target 相当 | read + write |
+| **A: fast-resume** (buffer all → resume → write) | target 相当 | read のみ |
+| **B: streaming** (region 毎 read→write→free) | 数 MB | read + write |
+
+`MemoryDumpWriter::writeStreaming()` (line 74-128) は既に実装済み。
+`SidecarDumpHandler` から呼ばれていないだけ。
+
+### サブタスク
+
+- [ ] **A1**: `MemoryDumper::dump` を fast-resume にデフォルト切替
+      (`SidecarDumpHandler` の `try/finally` の `resume()` を read 完了直後に移動)
+      → 無条件改善、API 変更なし
+- [ ] **A2**: `--dump-mode={fast-resume,low-memory}` を `inspector:sidecar` に追加
+- [ ] **A3**: protocol に `mode` field 追加 (additive、protocol_version 据え置き)
+      → `SidecarRequest::$mode`
+      → `SidecarClient::requestDump(..., mode: 'low-memory')`
+      → 古い sidecar に投げても無視される、新しい sidecar が古い client から
+         field 無しで受けたら server default (= --dump-mode) を使う
+- [ ] **A4**: `MemoryLimitHandler::register(... dump_mode: 'low-memory')` を生やす
+      → OOM 経路で sidecar 連鎖死を予防 (target heap == sidecar memory_limit な状況)
+
+優先度: A1 > A2 > A3 > A4。A1 単独で先に PR 切るのが安全。
+
+---
+
+## B. sidecar の自己防衛 (落ちない sidecar)
+
+### 現状
+
+target heap > sidecar `--memory-limit` の状態で dump 要求すると、
+`MemoryDumper.php:603` の `\FFI::string($data, $entry['size'])` で
+`Allowed memory size exhausted` の PHP Fatal を喰い、**sidecar プロセス全体が死亡**。
+
+- target は ptrace 経由なので kernel が auto-detach、フリーズはしない
+- socket file は stale で残るが、次の sidecar 起動時に `SidecarServer.php:161` で unlink される
+- partial dump も無し (writer に渡る前に死ぬ)
+- client は `null` 戻り、後続リクエストも ECONNREFUSED (即 null)
+- supervisor (systemd / k8s) 再起動を期待する設計
+
+死亡した瞬間の dump は永久ロスト = OOM ハンドラ経路で「まさに欲しかった」
+スナップショットを取り損ねる。supervisor 再起動はバックストップとしては有効だが、
+それで救えない種類の損失がある。
+
+### 提案
+
+`SidecarDumpHandler::doDump()` の `process_stopper->stop()` 直前で
+`heap_stats_reader->read()` 済みなので、dump に必要なメモリを事前計算して
+収まらなければエラー応答で早期 return する。sidecar は生きたまま。
+
+```php
+$memory_limit = self::parseIniBytes(ini_get('memory_limit'));
+if ($memory_limit > 0) {
+    $needed = (int)($heap_stats->size * 1.15) + 16 * 1024 * 1024;
+    $available = $memory_limit - memory_get_usage(true);
+    if ($needed > $available) {
+        return SidecarResponse::error(sprintf(
+            'dump would need ~%d MB but only %d MB available '
+            . '(sidecar memory_limit=%d MB). Increase --memory-limit '
+            . 'or use --dump-mode=low-memory.',
+            $needed >> 20, $available >> 20, $memory_limit >> 20,
+        ));
+    }
+}
+```
+
+効果:
+- sidecar 生存
+- 同居している他 client への dump サービスは継続
+- client は status=error + 具体的な message を受け取る (現状: null だけ)
+- crash loop が起きない
+
+### サブタスク
+
+- [ ] **B1**: pre-flight memory check を `SidecarDumpHandler::doDump()` 冒頭に追加
+      (~10 行)
+- [ ] **B2**: docs に「supervisor 必須」の運用前提と systemd unit / k8s
+      restartPolicy 例を載せる
+
+A の streaming モードが入れば B1 の制約は構造的に消えるが、それまでの間も、
+入った後も「自分の限界を知っているデーモン」としてあった方が動作が分かりやすい。
+
+---
+
+## C. timeout 関連
+
+### 現状
+
+- `SidecarClient::__construct(timeout_seconds: 30)` がデフォルト
+- `stream_set_timeout` は **応答 JSON 受信まで** 効く = sidecar が dump 完了を
+  終えるまで client は block
+- 実測 dump スループット ~110 MB/s (process_vm_readv + disk write)
+  → 30 秒 default は ~3 GB ヒープ相当を捌ける、合理的な値
+- ただし `MemoryLimitHandler::register()` から timeout を渡す手段が無い
+  (内部で `new SidecarClient($socket_path)` するだけ)
+
+### 提案
+
+- [ ] **C1**: `MemoryLimitHandler::register(... timeout_seconds: int = 30)` を追加
+      (内部で `new SidecarClient($socket_path, $timeout_seconds)`)
+- [ ] **C2**: docs に timeout 指針表を追加
+      ```
+      memory_limit  → 推奨 timeout
+      128 M           5  s
+      256 M          10  s
+      512 M          15  s
+      1   G          30  s (default)
+      2   G          60  s
+      ```
+      "デフォルトを下げるな、必要に応じて伸ばせ" と明記。
+- [ ] **C3** (optional): default timeout を 60s に上げる検討。30s は ~3 GB が
+      上限になり、最近の PHP-FPM ワーカーだと割と簡単に超える。
+
+---
+
+## D. client API の細かい改善
+
+### 現状
+
+`SidecarClient::send()`:
+```php
+$sock = @stream_socket_client(... $errno, $errstr, ...);  // @ で warning 抑制
+if ($sock === false) return null;                         // errno/errstr 捨ててる
+...
+if ($response === false || $response === '') return null; // timeout / EOF
+return SidecarClientResponse::fromJson(trim($response));   // 不正 JSON も null
+```
+
+「接続失敗」「timeout」「不正 JSON」が全部 `null` で区別できない。
+`MemoryLimitHandler` の `on_error` 文言は固定文字列 `'failed to connect to reli sidecar'`。
+
+### 提案
+
+- [ ] **D1**: `on_error` callback の signature を拡張して errno/errstr/原因を渡す
+      (例: `function(string $msg, ?int $errno, ?string $detail)`)
+      → BC のため optional parameters で
+- [ ] **D2** (optional): エラー種別を表す sentinel 値を導入 (例: 専用例外 or
+      `SidecarClientResponse::error(string $reason)` の null 以外の表現)
+      → ただし shutdown handler のメモリ予算とトレードオフあり
+
+優先度低め。D1 だけでも運用ログの切り分けには十分役立つ。
+
+---
+
+## E. SidecarServer の broken pipe ノイズ
+
+### 現状
+
+client が timeout で socket 閉じた後、sidecar は dump を完走して JSON を
+書き戻そうとするが、socket は閉じているので `fwrite()` が EPIPE を返す。
+PHP は警告として
+```
+PHP Notice: fwrite(): Send of 761 bytes failed with errno=32 Broken pipe
+            in src/Inspector/Sidecar/SidecarServer.php on line 134
+```
+を吐く。dump 自体は disk に完全な状態で保存されている (= orphan dump として
+回収可能)。
+
+### 提案
+
+- [ ] **E1**: `SidecarServer.php:134` 付近の `fwrite` を `@fwrite` + 戻り値チェック
+      に置き換え、`Log::info('client disconnected before reply (dump still saved at <path>)')`
+      のような専用ログを出す。Notice ノイズを消しつつ orphan の発生を可視化。
+- [ ] **E2**: docs に「timeout 切れても dump は `--output-dir` に保存される、
+      `on_error` 後に `ls` で見つけられる」と明記。これは知らないと気付けない
+      安全網。
+
+---
+
+## F. ドキュメント
+
+### F1. Quick Start のソケット親ディレクトリ要件
+
+`docs/monitoring/sidecar.md` の Quick Start は `--socket=/tmp/reli-sidecar.sock`
+を例示しているが、`SocketPathResolver::assertParentSafe()` は親 dir mode 0700 を
+要求するため、`/tmp` (大抵 0777) では起動失敗する。
+
+```
+[RuntimeException]
+Sidecar socket parent directory /tmp has mode 0777, expected 0700.
+Run: chmod 0700 '/tmp'
+```
+
+→ Quick Start を `mkdir -p /tmp/reli-run && chmod 0700 /tmp/reli-run`
+   + `--socket=/tmp/reli-run/sidecar.sock` の形に修正、または default の
+   `$XDG_RUNTIME_DIR/reli/sidecar.sock` を勧める例にする。
+
+### F2. Packagist 経由インストールの明示
+
+現在 docs は「composer require reliforp/reli-prof」 or 「3 ファイル vendoring」
+の 2 択しか書いていないが、実際には `reliforp/reli-prof-sidecar-client` が
+独立パッケージとして Packagist にいる (現状 `dev-main` のみ、tag 無し)。
+これを推奨経路として書くべき:
+
+```bash
+composer require reliforp/reli-prof-sidecar-client:dev-main
+```
+
+`minimum-stability: dev` 必須。tag 付け方針も整理したい (semver: 0.1.0 から?)。
+
+### F3. 運用前提の 1 セクション
+
+- `--memory-limit` のサイジング (= max(全 target memory_limit) + 100 MB 程度)
+- supervisor (systemd unit example, k8s restartPolicy: Always)
+- timeout 指針表 (C2 と統合)
+- orphan dump の存在と回収方法 (E2)
+- streaming モードを使う場合の sizing (将来)
+
+---
+
+## G. テスト / CI
+
+### G1. End-to-end smoke test
+
+`tests/e2e/sidecar-client/` に:
+1. `composer.json` (path repo で `../../reli-prof-sidecar-client` を参照、
+   または Packagist の dev-main を pin)
+2. `bootstrap.php` + `bench.php` 相当の fixture
+3. PHPUnit 1 ケース: `dockerd` 起動 → sidecar background 起動 → fixture 実行
+   → dump 出力を assert
+
+これがあると downgrade 後の API ミス (PHP 7.0 で named arg 使ってる等) や
+protocol_version の食い違いを PR 単位で拾える。
+
+### G2. bench/sidecar-roundtrip.php
+
+repo に最小デモを同梱。今回 `/home/user/demo-app/{bench,oom,timing,rss_watch}.php`
+で書き散らしたものを整理して `bench/` 配下に置く。`docker compose up` 一発で
+誰でも再現可能な状態にする。
+
+---
+
+## まとめ: 推奨 PR 順序
+
+1. **A1** (fast-resume default) — 無条件改善、独立 PR。
+2. **B1** (pre-flight memory check) — 独立、~10 行。`A1` の前後どちらでもよい。
+3. **F1, E2 ドキュメント修正** — F2 と合わせて 1 PR。
+4. **A2 + A3 + A4** (dump-mode 切替) — protocol 変更含むので慎重に。
+5. **C1, C2** — `MemoryLimitHandler` 引数追加と docs。
+6. **E1** (broken pipe ログ整理) — 独立、小。
+7. **D1** (on_error 拡張) — 後回し可。
+8. **G1, G2** (E2E テストとデモ) — 上が落ち着いてから。
+
+---
+
+## 検証時のメモ (将来の参考用)
+
+- ホスト PHP 8.4 / reli は ^8.5 require → composer install --ignore-platform-req=php
+  で動かせる (今回もそうした)。
+- Packagist の `dev-main` はちゃんと最新コミット (423ee89) まで追従していた。
+  GitHub→Packagist webhook 設定済み。
+- `/tmp/reli-dumps/` は `--disk-usage-limit=1G` で自動 rotate される。
+  検証で 1.4 GB 残してしまった時は手で `rm -rf` して掃除した。
+- demo-app の検証用スクリプトは `/home/user/demo-app/` に残置。整理して
+  G2 のベースに使える。

--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -240,6 +240,122 @@ becomes an "orphan" from the client's point of view.
 
 ---
 
+## H. Worker hold time / queueing
+
+### Current behaviour
+
+`SidecarServer::run` is a single-threaded loop:
+`stream_select → accept → handleConnection (synchronous dump) → next iteration`.
+Concurrent dump requests are strictly serialized via the kernel's
+listen backlog. Verified by sending a 1024 MB dump alongside two
+16 MB requests with 1 s timeouts: the second and third clients sat
+blocked in `fgets()` until either the in-flight dump finished or
+their own client-side timeout expired. Sidecar logs confirmed FIFO
+order; kernel-buffered request bytes were still processed by the
+server even after the clients had given up, producing orphan dumps
+plus `PHP Notice: fwrite(): ... Broken pipe`.
+
+The actual operational pain isn't dropped dumps (those land on disk
+and are recoverable). The pain is that the **PHP-FPM worker is
+held in `fgets()`** while it waits, holding its `pm.max_children`
+slot, heap, file descriptors, and DB connections for the full
+queue-plus-dump duration. With realistic queue depths against
+hundreds-of-MB targets, that easily exceeds the default 30 s
+client timeout — so tail clients pay the full timeout cost in
+worker hold time before getting `null` back.
+
+### Proposal: ack-and-go reply mode
+
+Add an additive protocol field that lets the client opt into
+"acknowledge-only" replies. Server reads the request, sends a
+short ack JSON immediately, closes the connection, and *then*
+runs the dump. The client returns from `requestDump()` in a few
+ms regardless of in-flight work elsewhere.
+
+Request additive field:
+```json
+{"command": "dump", "pid": 1234, "wait": false, ...}
+```
+
+- `wait` defaults to `true` (existing behaviour, BC preserved).
+- `wait: false` ⇒ ack-only reply.
+- Old sidecars ignore `wait` and reply normally — clients on
+  ack-and-go that hit an old sidecar still work, they just block
+  the way they do today.
+- New sidecars receiving requests without `wait` keep the current
+  full-response behaviour.
+- No `protocol_version` bump (additive change only).
+
+Ack response shape:
+```json
+{"protocol_version": 1, "status": "accepted",
+ "queue_position": 2,
+ "predicted_path": "/tmp/dumps/sidecar-1234-20260427-...-label.dump"}
+```
+
+`predicted_path` is fine because the path is deterministic from
+PID + timestamp + label — `SidecarDumpHandler::doDump()` already
+builds it; it just needs to move *before* the work starts.
+
+Client API:
+```php
+$client->requestDump(pid: getmypid(), wait: false);
+$client->snapshot('after-fixtures', wait: false);
+```
+
+`MemoryLimitHandler::register(... wait_for_completion: false)`,
+defaulting to `false`. Shutdown handlers don't care about the
+response and very much do want to release the worker slot.
+
+### Effects
+
+- Worker hold time becomes O(network roundtrip) instead of
+  O(queue depth × dump time).
+- Queue back-pressure becomes explicit (`queue_position` lets
+  clients log "I'm 12th in line" rather than infer from wall-clock).
+- The `Broken pipe` `Notice` (E1) goes away naturally — the server
+  is no longer trying to write to a socket the client has closed.
+- Composes cleanly with A (dump-mode) and B (pre-flight): each
+  request can be `{"wait": false, "mode": "low-memory"}`.
+- Doesn't add server-side concurrency. One dump at a time, still
+  FIFO. Just stops billing the wait to the client's worker slot.
+
+### Caveats
+
+- For CI-snapshot-style use cases that need to *use* the resulting
+  dump path, `wait: true` is still the right choice — `predicted_path`
+  is a hint, not a guarantee (a subsequent failure isn't reported).
+- A queue-depth limit (`status: "rejected"` when full) is a separate
+  concern but rides on the same protocol change.
+- Server crashes after ack ⇒ dump lost. Same as `wait: true` from
+  the *recoverability* angle (a `wait: true` client also can't tell
+  whether a `null` means "never started" or "started and lost"); the
+  difference is purely in observability.
+
+### Subtasks
+
+- [ ] **H1** — Add `wait` field to `SidecarRequest`, plumb into
+      `SidecarServer::handleConnection`. Move
+      `output_path` construction in `SidecarDumpHandler::doDump`
+      ahead of the stop+dump phase so it can be returned in the ack.
+- [ ] **H2** — Add `SidecarClient::requestDump(..., wait: bool = true)`
+      and `SidecarClient::snapshot(..., wait: bool = true)`.
+      Return a `SidecarClientResponse` with `status='accepted'` and
+      `predicted_path` populated when `wait: false`.
+- [ ] **H3** — Add `wait_for_completion: bool = false` to
+      `MemoryLimitHandler::register()`; forward to the inner client.
+      Default-false because the whole point of the OOM path is "don't
+      hold the worker while shutting down".
+- [ ] **H4** — Optional: include `queue_position` in both ack and
+      full responses so synchronous clients can also log queue
+      depth. Cheap to add since the server can count pending
+      `accept()`s on the listening socket.
+- [ ] **H5** — Optional sibling to H4: `--max-queue-depth=N` server
+      flag; once N is reached, ack with `status: 'rejected', reason:
+      'queue full'` instead of accepting. Reuses the H1 plumbing.
+
+---
+
 ## F. Documentation gaps
 
 ### F1. Socket parent directory requirement in Quick Start
@@ -323,12 +439,18 @@ roundtrip with a single `docker compose up`.
 2. **B1** — pre-flight memory check. Standalone, ~10 lines. Order
    relative to A1 doesn't matter.
 3. **F1 + E2** — doc fixes; bundle F2 with them as one PR.
-4. **A2 + A3 + A4** — dump-mode plumbing. Touches the protocol,
+4. **H1 + H2 + H3** — ack-and-go reply mode. Protocol change
+   (additive). Removes the worker-hold-time problem and obsoletes
+   E1 as a side effect; can be sequenced before or after A2-A4
+   since both are additive protocol fields and don't conflict.
+5. **A2 + A3 + A4** — dump-mode plumbing. Touches the protocol,
    so review carefully.
-5. **C1 + C2** — `MemoryLimitHandler` parameter and timeout docs.
-6. **E1** — broken-pipe log cleanup. Small, standalone.
-7. **D1** — `on_error` signature extension. Can wait.
-8. **G1 + G2** — E2E test and demo. After the above stabilise.
+6. **C1 + C2** — `MemoryLimitHandler` parameter and timeout docs.
+7. **E1** — broken-pipe log cleanup. Small, standalone. Skip if H
+   has already landed (the symptom is gone).
+8. **H4 + H5** — queue depth reporting / rejection. Optional.
+9. **D1** — `on_error` signature extension. Can wait.
+10. **G1 + G2** — E2E test and demo. After the above stabilise.
 
 ---
 

--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -1,11 +1,17 @@
-# Sidecar Improvements (Working Notes)
+# Sidecar — Improvement Notes
 
-> **Status:** Working scratchpad, similar in spirit to `future-ideas.md`.
-> Captures concrete improvement ideas that came out of an end-to-end
-> check of `reli inspector:sidecar` + `reliforp/reli-prof-sidecar-client`
-> (installed via Packagist) on 2026-04-27. Items marked `[x]` have
-> already shipped on the current branch; the rest are split across the
-> 0.12.0 release polish pass and the 0.12.x roadmap.
+Design and follow-up notes for `inspector:sidecar` and the standalone
+`reliforp/reli-prof-sidecar-client` package, accumulated alongside
+the 0.12.0 launch. Items marked `[x]` shipped with the launch batch;
+the rest are tracked candidates for 0.12.x.
+
+This document is in the spirit of `future-ideas.md` — opinionated
+design discussion rather than a contract — and is organised around
+the failure modes and trade-offs surfaced while bringing the
+sidecar to release quality. Each section motivates the change in
+terms of *what currently happens* and *what we want instead*, so
+future revisions can re-evaluate the trade-off when the surrounding
+code shifts.
 
 ## Shipped on this branch (0.12.0 release-blocker batch)
 
@@ -485,11 +491,11 @@ per-PR basis.
 
 ### G2. `bench/sidecar-roundtrip.php`
 
-A minimal demo committed to the repo. The scratch scripts created
-during this check
-(`/home/user/demo-app/{bench,oom,timing,rss_watch}.php`) can be
-cleaned up and dropped under `bench/` so anyone can reproduce the
-roundtrip with a single `docker compose up`.
+A minimal demo committed to the repo so anyone can reproduce the
+roundtrip with a single `docker compose up`. Should cover both the
+manual-snapshot path (`SidecarClient::snapshot`) and the OOM path
+(`MemoryLimitHandler::register`) since the failure modes around
+each are different. Useful as a fixture for G1.
 
 ---
 
@@ -523,17 +529,20 @@ type) remain open discussion items rather than tracked tasks.
 
 ---
 
-## Verification notes (kept for future reference)
+## Operational notes that informed this document
 
-- Host PHP is 8.4; reli requires `^8.5`. Used
-  `composer install --ignore-platform-req=php` to install the dev
-  dependencies.
-- Packagist's `dev-main` tracks the actual head of main on the
-  generated `reliforp/reli-prof-sidecar-client` repository
-  (commit `423ee89` at time of writing). The GitHub → Packagist
-  webhook is in place.
-- `/tmp/reli-dumps/` is auto-rotated by `--disk-usage-limit=1G`.
-  When the verification left ~1.4 GB of dumps behind, manual
-  `rm -rf` was needed.
-- Verification scripts live at `/home/user/demo-app/`. They can be
-  cleaned up and re-used as the basis for G2.
+- The Packagist mirror at `reliforp/reli-prof-sidecar-client`
+  currently exposes `dev-main` only and tracks the upstream
+  `main` branch via the GitHub → Packagist webhook. F2 is what
+  closes the gap to a tagged version.
+- `/tmp/reli-dumps/` (or whatever `--output-dir` points at) is
+  auto-rotated by `--disk-usage-limit` (default `1G`). Stress
+  testing for the H series should keep an eye on this — when the
+  rotator deletes a dump that an orphan reference still mentions
+  in logs, the recovery story in § Operations gets murkier.
+- The current `MemoryDumper` runs the read phase entirely under
+  ptrace stop, which is what makes A1's resume-after-read
+  rearrangement safe. Any future refactor that lets the read phase
+  yield back to the event loop must preserve that invariant
+  (regions read at different ptrace stops are not a consistent
+  snapshot).

--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -3,8 +3,55 @@
 > **Status:** Working scratchpad, similar in spirit to `future-ideas.md`.
 > Captures concrete improvement ideas that came out of an end-to-end
 > check of `reli inspector:sidecar` + `reliforp/reli-prof-sidecar-client`
-> (installed via Packagist) on 2026-04-27. Nothing here is implemented
-> yet; intent is to split into per-PR design notes when each item lands.
+> (installed via Packagist) on 2026-04-27. Items marked `[x]` have
+> already shipped on the current branch; the rest are split across the
+> 0.12.0 release polish pass and the 0.12.x roadmap.
+
+## Shipped on this branch (0.12.0 release-blocker batch)
+
+The following landed together as the "0.12.0 launch polish" change:
+
+- [x] **F1** — Quick Start in `docs/monitoring/sidecar.md` rewritten to
+      use the default `$XDG_RUNTIME_DIR/reli/sidecar.sock`, with an
+      explicit `mkdir + chmod 0700` snippet for hosts where
+      `XDG_RUNTIME_DIR` is unset. Server Options table fixed to show
+      the actual default.
+- [x] **B1** — Pre-flight memory check in
+      `SidecarDumpHandler::doDump()`: rejects with a structured
+      `status=error` response when `target heap × 1.15 + 16 MiB`
+      exceeds the sidecar's available `memory_limit` headroom, instead
+      of taking the daemon down via PHP Fatal in
+      `MemoryDumper.php:603`.
+- [x] **E1** — Replaced the unguarded `fwrite()` reply in
+      `SidecarServer::handleConnection` with a centralised
+      `writeResponse()` helper that swallows `EPIPE`, logs a single
+      structured `sidecar client disconnected before reply` info line
+      with `pid`/`label`/`response_path`, and prints a one-line
+      operator hint when an orphaned dump remains on disk. No more
+      raw `PHP Notice: fwrite(): … Broken pipe`.
+- [x] **A1** — `MemoryDumper::dump()` gained a `?\Closure
+      $on_read_complete` parameter; `SidecarDumpHandler::doDump()`
+      passes a closure that detaches `ptrace` immediately after the
+      read phase. Target stop window is now ≈ read-only (verified
+      ≈ 0.65 s for a 256 MB target where the full roundtrip was
+      1.78 s; previously the whole 1.78 s was inside the stop
+      window). Other callers of `MemoryDumper::dump()` are unchanged
+      because the new parameter defaults to `null`.
+- [x] **C1** — `MemoryLimitHandler::register()` accepts
+      `int $timeout_seconds = 30` and forwards it to the inner
+      `SidecarClient`. Default preserves prior behaviour; OOM-path
+      callers no longer have to drop down to `new SidecarClient(...)`
+      to size the timeout against their `memory_limit`.
+- [x] **B2 + E2 + F3 + concurrency model** — New "Operations"
+      section in `docs/monitoring/sidecar.md` covering
+      `--memory-limit` sizing, supervisor expectation
+      (systemd unit + Kubernetes `restartPolicy: Always`),
+      timeout-sizing table, orphan dump recovery, and the FIFO
+      single-worker concurrency model with kernel-backlog queueing.
+
+The sections below are kept verbatim for context; the items marked
+`[x]` reference the shipped change above. Items still marked `[ ]`
+are 0.12.x candidates.
 
 ---
 
@@ -44,10 +91,15 @@ effectively the worst combination of both axes:
 
 ### Subtasks
 
-- [ ] **A1** — Switch `MemoryDumper::dump` to fast-resume by default.
-      Move the `resume()` in `SidecarDumpHandler::doDump`'s `try/finally`
-      so it runs immediately after the read phase, before disk write.
-      Strict win, no API change.
+- [x] **A1** — Switch `MemoryDumper::dump` to fast-resume by default.
+      Shipped: added `?\Closure $on_read_complete` parameter (default
+      null preserves the old behaviour for `inspector:memory:dump` and
+      other one-shot callers); `SidecarDumpHandler::doDump()` passes a
+      closure that flips a `$stopped` flag and calls
+      `process_stopper->resume()` from `on_read_complete`, with a
+      safety-net call in the surrounding `finally`. Verified target
+      stop window dropped from `read+write` (≈ full roundtrip) to
+      `read` only.
 - [ ] **A2** — Add `--dump-mode={fast-resume,low-memory}` to
       `inspector:sidecar`.
 - [ ] **A3** — Add an additive `mode` field to the IPC protocol
@@ -125,11 +177,19 @@ Effect:
 
 ### Subtasks
 
-- [ ] **B1** — Add the pre-flight check at the top of
-      `SidecarDumpHandler::doDump()` (about 10 lines).
-- [ ] **B2** — Add an "Operations" section to the docs covering the
-      "you must run under a supervisor" assumption, with a sample
-      systemd unit and Kubernetes `restartPolicy: Always`.
+- [x] **B1** — Pre-flight check landed in `SidecarDumpHandler` as
+      `preflightMemoryCheck($heap_stats->size)`, called between
+      `heap_stats_reader->read()` and `process_stopper->stop()`. Uses
+      `ini_parse_quantity(ini_get('memory_limit'))`; returns
+      `SidecarResponse::error(...)` with concrete bytes when the heap
+      cannot fit, and logs an info line so operators have a grep
+      target. Verified end-to-end: 512 MB target against a 128 M
+      sidecar now returns
+      `sidecar memory_limit too small for this target: need ~601 MiB,
+      116 MiB available …` instead of crashing the daemon.
+- [x] **B2** — "Operations" section in `docs/monitoring/sidecar.md`
+      now covers the "must run under a supervisor" assumption with a
+      sample systemd unit and a Kubernetes pointer.
 
 Once A's streaming mode lands, B1's constraint is structurally gone,
 but B1 is still worth keeping — a daemon that knows its own limits is
@@ -154,19 +214,12 @@ easier to reason about than one that crashes silently.
 
 ### Proposal
 
-- [ ] **C1** — Add `timeout_seconds` to
-      `MemoryLimitHandler::register(...)`. Forward it to the inner
-      `new SidecarClient($socket_path, $timeout_seconds)`.
-- [ ] **C2** — Add a timeout-sizing table to the docs:
-      ```
-      memory_limit  →  recommended timeout
-      128 M             5  s
-      256 M            10  s
-      512 M            15  s
-      1   G            30  s (default)
-      2   G            60  s
-      ```
-      Spell out: "do not lower the default; raise it as needed."
+- [x] **C1** — `MemoryLimitHandler::register(...)` now accepts
+      `int $timeout_seconds = 30` and forwards it to the inner
+      `SidecarClient`.
+- [x] **C2** — Timeout-sizing table is in the new "Operations"
+      section of `docs/monitoring/sidecar.md`, with the
+      "do not lower the default; raise it as needed" rule called out.
 - [ ] **C3** (optional) — Consider raising the default to 60 s. 30 s
       caps out around ~3 GB, which is a realistic ceiling for modern
       PHP-FPM workers but not a generous one.
@@ -229,14 +282,16 @@ becomes an "orphan" from the client's point of view.
 
 ### Proposal
 
-- [ ] **E1** — Replace the bare `fwrite` near
-      `SidecarServer.php:134` with `@fwrite` + return-value check, and
-      log a structured message such as
-      `Log::info('client disconnected before reply (dump still saved at <path>)')`.
-      Removes the noisy `Notice` and makes orphans observable.
-- [ ] **E2** — Document the "timed-out client → dump still on disk"
-      safety net. Currently the only way to learn about it is to
-      experience it.
+- [x] **E1** — All three `fwrite` reply sites now go through a single
+      `SidecarServer::writeResponse()` helper. It does
+      `@fwrite` + length check, logs a structured
+      `sidecar client disconnected before reply` info line with
+      `pid`/`label`/`response_status`/`response_path`/`response_bytes`,
+      and emits `[sidecar] client disconnected; orphan dump still
+      saved: <path>` to the operator-facing console output when the
+      orphaned dump succeeded.
+- [x] **E2** — The "Operations" section now has an "Orphan dump
+      recovery" subsection describing the safety net.
 
 ---
 
@@ -358,6 +413,11 @@ response and very much do want to release the worker slot.
 
 ## F. Documentation gaps
 
+> **Status update:** F1 and F3 shipped on this branch. F2 (Packagist
+> path) is deliberately deferred — it depends on tagging the
+> `reliforp/reli-prof-sidecar-client` mirror, which we want to do
+> alongside the actual 0.12.0 tag rather than a step ahead of it.
+
 ### F1. Socket parent directory requirement in Quick Start
 
 `docs/monitoring/sidecar.md` Quick Start uses
@@ -435,22 +495,31 @@ roundtrip with a single `docker compose up`.
 
 ## Suggested PR ordering
 
-1. **A1** — fast-resume default. Standalone, no protocol change.
-2. **B1** — pre-flight memory check. Standalone, ~10 lines. Order
-   relative to A1 doesn't matter.
-3. **F1 + E2** — doc fixes; bundle F2 with them as one PR.
-4. **H1 + H2 + H3** — ack-and-go reply mode. Protocol change
-   (additive). Removes the worker-hold-time problem and obsoletes
-   E1 as a side effect; can be sequenced before or after A2-A4
-   since both are additive protocol fields and don't conflict.
-5. **A2 + A3 + A4** — dump-mode plumbing. Touches the protocol,
-   so review carefully.
-6. **C1 + C2** — `MemoryLimitHandler` parameter and timeout docs.
-7. **E1** — broken-pipe log cleanup. Small, standalone. Skip if H
-   has already landed (the symptom is gone).
-8. **H4 + H5** — queue depth reporting / rejection. Optional.
-9. **D1** — `on_error` signature extension. Can wait.
-10. **G1 + G2** — E2E test and demo. After the above stabilise.
+**Shipped on this branch (release-blocker batch for 0.12.0):**
+A1, B1, B2, C1, C2, E1, E2, F1, F3.
+
+**Remaining for 0.12.x:**
+
+1. **H1 + H2 + H3** — ack-and-go reply mode. Protocol change
+   (additive `wait` field). Removes the worker-hold-time problem;
+   E1 is now a structured log line rather than a Notice, so this PR
+   no longer "obsoletes" E1 — it just reduces how often the
+   disconnect path fires.
+2. **A2 + A3 + A4** — dump-mode plumbing
+   (`--dump-mode={fast-resume,low-memory}` + protocol field +
+   `MemoryLimitHandler` argument). Mostly relevant once someone hits
+   the B1 pre-flight wall on a sidecar they cannot reasonably
+   resize.
+3. **F2** — once the `reliforp/reli-prof-sidecar-client` mirror is
+   tagged, switch the docs from `dev-main` to the first release tag.
+4. **H4 + H5** — queue depth reporting / rejection. Optional.
+5. **D1** — `on_error` signature extension. Optional-parameter
+   addition, fully BC. Useful but not urgent.
+6. **G1 + G2** — E2E test infrastructure and bench demo. Best after
+   A2-A4 land so the test fixture covers all dump modes.
+
+C3 (raising the default timeout to 60 s) and D2 (sentinel error
+type) remain open discussion items rather than tracked tasks.
 
 ---
 

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -273,8 +273,9 @@ upper bound for your workload.
 
 The sidecar can still die from things outside its pre-flight check
 (unexpected crashes, OOM kills from the cgroup, kernel signals, etc.).
-Always run it under a supervisor that restarts it. A minimal systemd
-unit:
+Always run it under a supervisor that restarts it. A systemd unit
+that creates its own runtime / state directories with the right
+permissions:
 
 ```ini
 # /etc/systemd/system/reli-sidecar.service
@@ -284,8 +285,20 @@ After=network.target
 
 [Service]
 Type=simple
+User=reli
+Group=reli
+# %t = $RUNTIME_DIRECTORY (= /run/reli for system services).
+# %S = $STATE_DIRECTORY  (= /var/lib/reli).
+# Both are created by systemd with the User/Group above and the
+# specified mode, so the sidecar's 0700 parent-dir check passes
+# without any pre-create dance.
+RuntimeDirectory=reli
+RuntimeDirectoryMode=0700
+StateDirectory=reli
+StateDirectoryMode=0700
 ExecStart=/usr/local/bin/reli inspector:sidecar \
-  --output-dir=/var/lib/reli/dumps \
+  --socket=%t/reli/sidecar.sock \
+  --output-dir=%S/reli \
   --memory-limit=2G
 Restart=always
 RestartSec=2s
@@ -295,6 +308,22 @@ StartLimitIntervalSec=60
 [Install]
 WantedBy=multi-user.target
 ```
+
+The application processes need to run as the same uid (see
+[§ Security model](#security-model)) and read `RELI_SIDECAR_SOCKET`
+from the environment, e.g.
+
+```ini
+# in the app unit
+[Service]
+User=reli
+Environment=RELI_SIDECAR_SOCKET=/run/reli/sidecar.sock
+```
+
+Create the `reli` system user once at install time
+(`useradd --system --no-create-home --shell /usr/sbin/nologin reli`),
+or replace `User=reli` / `Group=reli` with `DynamicUser=yes` if no
+non-systemd processes on the host need to share the uid.
 
 In Kubernetes, the sidecar container's spec needs `restartPolicy: Always`
 (the pod default) plus enough `resources.limits.memory` to cover the
@@ -471,19 +500,43 @@ This information can be passed to `inspector:memory:analyze` with `--memory-limi
 
 ```yaml
 services:
+  # One-shot helper: prepare /var/run/reli with the right ownership +
+  # mode 0700 *before* either app or sidecar starts. Without it the
+  # sidecar refuses to bind (parent dir must be 0700 + owned by uid 1000)
+  # and the app cannot traverse into the volume.
+  reli-sock-init:
+    image: busybox:1
+    command: >
+      sh -c "mkdir -p /var/run/reli && chmod 0700 /var/run/reli
+             && chown 1000:1000 /var/run/reli"
+    user: "0:0"  # root so the chown works
+    volumes:
+      - reli-sock:/var/run/reli
+
   app:
     image: my-php-app
+    user: "1000:1000"
+    depends_on:
+      reli-sock-init:
+        condition: service_completed_successfully
+    environment:
+      RELI_SIDECAR_SOCKET: /var/run/reli/sidecar.sock
     volumes:
       - reli-sock:/var/run/reli
       - reli-dumps:/tmp/reli-dumps
 
   reli-sidecar:
     image: reliforp/reli-prof
+    user: "1000:1000"  # must match `app` so the 0700 parent dir works
     command: >
       inspector:sidecar
         --socket=/var/run/reli/sidecar.sock
         --output-dir=/tmp/reli-dumps
+        --memory-limit=2G
         --tag product=my-app
+    depends_on:
+      reli-sock-init:
+        condition: service_completed_successfully
     pid: "service:app"
     cap_add:
       - SYS_PTRACE
@@ -498,20 +551,31 @@ volumes:
   reli-dumps:
 ```
 
-Set the socket path in the application container:
-
-```yaml
-services:
-  app:
-    environment:
-      RELI_SIDECAR_SOCKET: /var/run/reli/sidecar.sock
-```
+If your application image already pins `USER 1000` in the Dockerfile,
+drop the `user:` line on `app`; the `reli-sidecar` line still has to
+match. To run everything as root instead, drop both `user:` lines and
+the `reli-sock-init` `chown` step — it just needs to be consistent
+across all three.
 
 ### Kubernetes (sidecar container)
 
 ```yaml
 spec:
   shareProcessNamespace: true
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  initContainers:
+    # Ensure the shared socket dir is 0700 before the sidecar tries to
+    # bind. fsGroup gives 1000 write access to the emptyDir, but the
+    # sidecar's parent-dir checks require mode 0700 specifically.
+    - name: reli-sock-init
+      image: busybox:1
+      command: ["sh", "-c", "chmod 0700 /var/run/reli"]
+      volumeMounts:
+        - name: reli-sock
+          mountPath: /var/run/reli
   containers:
     - name: app
       image: my-php-app
@@ -527,6 +591,7 @@ spec:
         - inspector:sidecar
         - --socket=/var/run/reli/sidecar.sock
         - --output-dir=/tmp/reli-dumps
+        - --memory-limit=2G
       securityContext:
         capabilities:
           add: ["SYS_PTRACE"]
@@ -541,6 +606,11 @@ spec:
     - name: reli-dumps
       emptyDir: {}
 ```
+
+The pod-level `securityContext.runAsUser` ensures both containers
+share uid `1000`; `fsGroup` makes the `emptyDir` volumes writable by
+that uid. The init container narrows the socket directory to mode
+`0700`, which is what the sidecar's parent-dir check requires.
 
 ## CI Workflow: Cross-Release Memory Comparison
 

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -287,10 +287,11 @@ After=network.target
 Type=simple
 User=reli
 Group=reli
-# %t = $RUNTIME_DIRECTORY (= /run/reli for system services).
-# %S = $STATE_DIRECTORY  (= /var/lib/reli).
-# Both are created by systemd with the User/Group above and the
-# specified mode, so the sidecar's 0700 parent-dir check passes
+# %t = runtime directory root (/run for system services).
+# %S = state directory root   (/var/lib by default).
+# RuntimeDirectory=reli creates /run/reli, and StateDirectory=reli
+# creates /var/lib/reli, both with the User/Group above and the
+# specified modes, so the sidecar's 0700 parent-dir check passes
 # without any pre-create dance.
 RuntimeDirectory=reli
 RuntimeDirectoryMode=0700

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -6,12 +6,13 @@ Unlike `inspector:watch` (polling-based monitoring), the sidecar responds to **e
 
 ## Quick Start
 
-**Start the sidecar:**
+**Start the sidecar** (uses the per-user systemd runtime dir, which is
+already mode 0700 on most distros — no setup needed):
 
 ```bash
-reli inspector:sidecar \
-  --socket=/tmp/reli-sidecar.sock \
-  --output-dir=/tmp/reli-dumps
+mkdir -p /tmp/reli-dumps
+reli inspector:sidecar --output-dir=/tmp/reli-dumps
+# → [sidecar] Listening on /run/user/<uid>/reli/sidecar.sock
 ```
 
 **In your PHP application (one line in bootstrap):**
@@ -20,7 +21,27 @@ reli inspector:sidecar \
 \Reli\Sidecar\Client\MemoryLimitHandler::register();
 ```
 
-When your application hits `memory_limit`, the handler automatically requests a dump from the sidecar. The dump file and a `.meta.json` with the call trace and memory stats are written to `--output-dir`.
+When your application hits `memory_limit`, the handler automatically
+requests a dump from the sidecar. The dump file and a `.meta.json` with
+the call trace and memory stats are written to `--output-dir`.
+
+> [!NOTE]
+> The sidecar refuses to bind to a socket whose parent directory is not
+> mode 0700, owned by the current uid, and not a symlink — without that
+> guard a co-tenant could pre-create the socket path on a shared host
+> like `/tmp` and intercept dump requests, since the IPC has no
+> on-the-wire authentication. The default
+> `$XDG_RUNTIME_DIR/reli/sidecar.sock` (typically
+> `/run/user/<uid>/reli/sidecar.sock`) satisfies this. If you must
+> override `--socket` on a host without `XDG_RUNTIME_DIR`, prepare a
+> dedicated parent directory first, e.g.
+>
+> ```bash
+> mkdir -p /var/run/reli && chmod 0700 /var/run/reli
+> reli inspector:sidecar \
+>   --socket=/var/run/reli/sidecar.sock \
+>   --output-dir=/tmp/reli-dumps
+> ```
 
 ## Requirements
 
@@ -169,7 +190,7 @@ Usage:
 
 Options:
   -s, --socket=SOCKET              Unix domain socket path
-                                   [default: /var/run/reli-sidecar.sock]
+                                   [default: $XDG_RUNTIME_DIR/reli/sidecar.sock]
   -o, --output-dir=OUTPUT-DIR      Directory for dump output files [default: .]
       --disk-usage-limit=LIMIT     Max total disk usage for dumps (e.g., 1G, 512M)
                                    [default: 1G]
@@ -179,6 +200,139 @@ Options:
       --memory-limit=LIMIT         Set PHP memory_limit for the sidecar process
       --no-cache                   Disable the binary analysis cache
 ```
+
+## Operations
+
+The sidecar is a single PHP process: one server, one socket, no internal
+parallelism. The notes below cover the things you need to size and
+operate it sensibly under that model.
+
+### Sizing `--memory-limit`
+
+The dumper buffers every region of the target's heap as a PHP string
+before writing the dump file, so the sidecar's peak resident memory
+during a dump is roughly `target heap + ~80 MB baseline`. Size
+`--memory-limit` (and the matching cgroup / pod limit) at least to:
+
+```
+--memory-limit  ≥  max(target memory_limit across all clients) + 100 MB
+```
+
+The sidecar refuses any request it knows it cannot fit and replies with
+a structured error like
+`sidecar memory_limit too small for this target: need ~512 MiB, …` —
+the daemon stays up, only that one request fails. Without enough
+headroom, every oversized dump request returns this error instead of
+producing a snapshot, so set the limit conservatively.
+
+### Run under a supervisor
+
+The sidecar can still die from things outside its pre-flight check
+(unexpected crashes, OOM kills from the cgroup, kernel signals, etc.).
+Always run it under a supervisor that restarts it. A minimal systemd
+unit:
+
+```ini
+# /etc/systemd/system/reli-sidecar.service
+[Unit]
+Description=reli-prof sidecar
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/reli inspector:sidecar \
+  --output-dir=/var/lib/reli/dumps \
+  --memory-limit=2G
+Restart=always
+RestartSec=2s
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Install]
+WantedBy=multi-user.target
+```
+
+In Kubernetes, the sidecar container's spec needs `restartPolicy: Always`
+(the pod default) plus enough `resources.limits.memory` to cover the
+`--memory-limit` value above; see [§ Docker / Kubernetes Setup](#docker--kubernetes-setup)
+for the rest of the deployment shape.
+
+### Client timeout sizing
+
+`SidecarClient` blocks on the response read for the full dump duration
+because the protocol delivers a single JSON reply at the end. Measured
+dump throughput is roughly 100 MB/s (`process_vm_readv` + disk write),
+so size `timeout_seconds` against the target's `memory_limit`:
+
+| Target `memory_limit` | Dump time at ~100 MB/s | Recommended `timeout_seconds` |
+|---|---|---|
+| 128 M | ~1.3 s | 5  |
+| 256 M | ~2.5 s | 10 |
+| 512 M | ~5  s  | 15 |
+| 1 G   | ~10 s  | 30 (default) |
+| 2 G   | ~20 s  | 60 |
+
+Do **not** lower the default to make the shutdown handler "feel
+faster". Raise it if your `memory_limit` exceeds the value the default
+covers. `MemoryLimitHandler::register(...)` accepts `timeout_seconds`
+directly:
+
+```php
+\Reli\Sidecar\Client\MemoryLimitHandler::register(
+    timeout_seconds: 60, // memory_limit ~ 2G
+);
+```
+
+### Concurrency model and queue behaviour
+
+Requests are served strictly first-in / first-out by a single worker.
+While one dump is in flight, additional client connections sit in the
+kernel's listen backlog (`SOMAXCONN`, typically 4096 on Linux) and
+**block in `fgets()` on the client side until the daemon gets to
+them**. The protocol does not expose queue depth, so a client cannot
+distinguish "queued for 8 seconds" from "actively being dumped for 8
+seconds".
+
+Practical implications:
+
+- If a burst of N clients arrives at once, the last client waits
+  roughly N × *previous-dump duration* for its response. Size
+  `timeout_seconds` accordingly when you expect bursts (e.g. many
+  PHP-FPM workers OOM-ing at once).
+- If a queued client times out and closes its socket, the request
+  it already wrote to the kernel buffer is **still served** when
+  its turn arrives; the sidecar produces the dump and writes the
+  file to `--output-dir`. The client never sees the response, but
+  the dump itself is recoverable — see § Orphan dump recovery.
+- If the queued client's *target process* dies before the sidecar
+  reaches its request (common when the trigger was an OOM
+  shutdown and the supervisor took longer than expected), the
+  sidecar replies with `process <pid> not found`. No work
+  performed.
+
+### Orphan dump recovery
+
+A client can give up — typically because its `timeout_seconds`
+expired, or the OOM-handler PHP process exited — while the sidecar is
+still running its dump. When that happens the dump file is **already
+fully written** to `--output-dir`; the only thing missing is the JSON
+reply that would have told the client where it landed.
+
+So:
+
+- Successful dumps land at `--output-dir/sidecar-<pid>-<datetime>[-<label>].dump`
+  with their `.meta.json` sibling regardless of whether the client
+  was still listening.
+- After a client `on_error` ("`failed to connect to reli sidecar`",
+  null result, etc.), an operator can usually find the dump by
+  matching `<pid>` in the output directory.
+- The sidecar logs a single `sidecar client disconnected before reply`
+  line per orphan, with the response path, so grep-based audits work
+  without ploughing through PHP `Notice` output.
+
+This is a useful safety net for OOM diagnosis: even if the client's
+shutdown handler ran out of time, the snapshot you actually wanted is
+still on disk.
 
 ## Session Tags
 

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -118,7 +118,7 @@ With custom callbacks:
 use Reli\Sidecar\Client\SidecarClientResponse;
 
 \Reli\Sidecar\Client\MemoryLimitHandler::register(
-    socket_path: '/tmp/reli-sidecar.sock',
+    socket_path: '/var/run/reli/sidecar.sock',
     on_response: function (SidecarClientResponse $r) {
         error_log("reli dump: {$r->path} ({$r->bytes} bytes)");
         foreach ($r->trace as $frame) {
@@ -133,7 +133,7 @@ use Reli\Sidecar\Client\SidecarClientResponse;
 ```php
 use Reli\Sidecar\Client\SidecarClient;
 
-$client = new SidecarClient('/tmp/reli-sidecar.sock');
+$client = new SidecarClient('/var/run/reli/sidecar.sock');
 $response = $client->requestDump(
     pid: getmypid(),
     error_file: __FILE__,
@@ -165,11 +165,46 @@ The socket path is resolved in this order:
 
 1. Constructor argument (`$socket_path`)
 2. `RELI_SIDECAR_SOCKET` environment variable
-3. Default: `/var/run/reli-sidecar.sock`
+3. Default: `$XDG_RUNTIME_DIR/reli/sidecar.sock` (typically
+   `/run/user/<uid>/reli/sidecar.sock` on systemd hosts). The
+   resolver throws if `XDG_RUNTIME_DIR` is unset — there is no
+   `/tmp` fallback because the path's parent directory must be
+   `0700` and owned by the current uid for the sidecar to bind
+   safely (see [§ Security model](#security-model)).
 
 ```bash
-export RELI_SIDECAR_SOCKET=/tmp/reli-sidecar.sock
+export RELI_SIDECAR_SOCKET=/var/run/reli/sidecar.sock
 ```
+
+### Security model
+
+The sidecar IPC has no on-the-wire authentication: anyone who can
+`connect()` to the socket can request a dump of any PID in the same
+PID namespace. Access control is therefore done entirely through
+filesystem permissions on the socket and its parent directory.
+
+`SocketPathResolver::assertParentSafe()` enforces that the parent
+directory:
+
+- is **owned by the current uid**,
+- has mode **`0700`**, and
+- is **not a symlink**.
+
+If any of these fail the sidecar refuses to bind. This is the only
+thing that prevents a local attacker on a shared host from racing the
+sidecar to pre-create a socket at the same path and impersonate it.
+
+A consequence is that **the sidecar and every client must run under
+the same uid**, because a 0700 parent directory cannot be traversed
+by other uids regardless of the socket file's own mode. The socket
+itself is `chmod 0660` for forward-compatibility with a future
+"shared group" mode, but with the current resolver that bit is
+effectively unused.
+
+For Docker / Kubernetes, the practical implication is to run the
+sidecar container with the same `runAsUser` / `USER` as the
+application container, or to mount the socket directory with
+matching ownership; see [§ Docker / Kubernetes Setup](#docker--kubernetes-setup).
 
 ### Default Metadata
 
@@ -209,21 +244,30 @@ operate it sensibly under that model.
 
 ### Sizing `--memory-limit`
 
-The dumper buffers every region of the target's heap as a PHP string
-before writing the dump file, so the sidecar's peak resident memory
-during a dump is roughly `target heap + ~80 MB baseline`. Size
-`--memory-limit` (and the matching cgroup / pod limit) at least to:
+The dumper buffers every region the target exposes — the ZendMM heap,
+opcache SHM, the VM stack and compiler arena, and (with
+`--include-binary`) read-only binary segments — as PHP strings before
+flushing the dump file, so the sidecar's peak resident memory during
+a dump is roughly `everything the dump file ends up containing` plus
+an `~80 MB` baseline. As a starting point, size `--memory-limit` (and
+the matching cgroup / pod limit) at least to:
 
 ```
---memory-limit  ≥  max(target memory_limit across all clients) + 100 MB
+--memory-limit  ≥  max(target memory_limit across all clients)
+                + opcache SHM (if opcache is enabled in targets)
+                + 100 MB headroom
 ```
 
-The sidecar refuses any request it knows it cannot fit and replies with
-a structured error like
-`sidecar memory_limit too small for this target: need ~512 MiB, …` —
-the daemon stays up, only that one request fails. Without enough
-headroom, every oversized dump request returns this error instead of
-producing a snapshot, so set the limit conservatively.
+The sidecar pre-flights every request against this limit using the
+target's heap size and refuses with a structured error like
+`sidecar memory_limit too small for the target heap alone: need ~512
+MiB, …` — the daemon stays up, only that one request fails. The
+pre-flight only inspects the **heap**, so the dump can still OOM the
+sidecar later if the non-heap regions push the working set over
+`--memory-limit`; treat the check as a fast-fail for the obvious
+case, not a guarantee. Size the limit conservatively (see the formula
+above), and watch sidecar RSS in production until you have a real
+upper bound for your workload.
 
 ### Run under a supervisor
 
@@ -343,8 +387,7 @@ reli inspector:sidecar \
   --tag product=my-app \
   --tag version=2.4.0 \
   --tag commit=$(git rev-parse --short HEAD) \
-  --socket=/tmp/reli.sock \
-  --output-dir=/tmp/dumps
+  --output-dir=/tmp/reli-dumps
 ```
 
 Tags from three sources are merged (later wins on key conflict):
@@ -413,6 +456,16 @@ This information can be passed to `inspector:memory:analyze` with `--memory-limi
 
 > [!CAUTION]
 > The sidecar must share the PID namespace with the target processes. Without this, `process_vm_readv` cannot read the target's memory.
+
+> [!IMPORTANT]
+> The sidecar and the application **must run as the same uid**. The
+> sidecar refuses to bind unless the socket's parent directory is mode
+> `0700` and owned by the current uid (see [§ Security model](#security-model)),
+> and a `0700` directory cannot be traversed from a different uid even
+> if the volume is shared. Either set both containers to the same
+> `runAsUser` / `USER`, or run a single uid for the whole pod. Running
+> the sidecar as root and the app as a non-root user (or vice versa)
+> will not work.
 
 ### docker compose
 
@@ -526,11 +579,17 @@ jobs:
           path: baseline/
         continue-on-error: true
 
+      # Prepare a 0700 parent dir for the sidecar socket. GitHub Actions
+      # runners do not set XDG_RUNTIME_DIR, so we have to pick the path
+      # explicitly and lock down its parent.
+      - name: Prepare runtime dir
+        run: mkdir -p /tmp/reli-run && chmod 0700 /tmp/reli-run
+
       # Start sidecar
       - name: Start sidecar
         run: |
           reli inspector:sidecar \
-            --socket=/tmp/reli.sock \
+            --socket=/tmp/reli-run/sidecar.sock \
             --output-dir=/tmp/dumps \
             --tag version=${{ github.head_ref }} \
             --tag commit=${{ github.sha }} &
@@ -538,7 +597,7 @@ jobs:
       # Run benchmark
       - name: Run benchmark
         env:
-          RELI_SIDECAR_SOCKET: /tmp/reli.sock
+          RELI_SIDECAR_SOCKET: /tmp/reli-run/sidecar.sock
         run: php bench/memory_trend.php
 
       # Analyze dumps. Either .rmem or SQLite is fine — both are

--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -51,6 +51,14 @@ final class MemoryDumper
      *
      * @param TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $target_php_settings
      * @param list<array{address: int, count: int}> $interned_string_arrays
+     * @param \Closure|null $on_read_complete invoked once after every remote
+     *     memory region has been read into local PHP strings, before the dump
+     *     file is opened for writing. The sidecar uses this hook to
+     *     `PTRACE_DETACH` the target right after the read phase, so the target
+     *     can resume while the (potentially slow) disk write happens. Other
+     *     callers can leave it null and pay the read+write window as one stop
+     *     window. Typed as a `Closure` so the resume logic can capture the
+     *     `$stopped` flag by reference.
      */
     public function dump(
         ProcessSpecifier $process_specifier,
@@ -61,6 +69,7 @@ final class MemoryDumper
         bool $include_binary = false,
         bool $include_heap = false,
         array $interned_string_arrays = [],
+        ?\Closure $on_read_complete = null,
     ): MemoryDumpResult {
         $php_version = $target_php_settings->php_version;
         $zend_type_reader = $this->zend_type_reader_creator->create(
@@ -608,6 +617,16 @@ final class MemoryDumper
                     . ': ' . $e->getMessage(),
                 );
             }
+        }
+
+        // All remote reads are now buffered locally as PHP strings, so the
+        // target no longer has to stay stopped while we open the dump file
+        // and stream the regions out to disk. Callers that pass a
+        // `$on_read_complete` hook (currently the sidecar) take advantage of
+        // this to release the ptrace stop early; the rest still pay the
+        // combined read+write stop window.
+        if ($on_read_complete !== null) {
+            $on_read_complete();
         }
 
         $all_areas = $memory_map->findByNameRegex('.*');

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -105,7 +105,31 @@ final class SidecarDumpHandler
         );
         $rss_bytes = $this->rss_reader->read($pid);
 
+        // Pre-flight: refuse the dump if we already know we cannot fit the
+        // target's heap into our own memory_limit. The current dumper buffers
+        // every region as a PHP string before flushing, so peak sidecar RSS
+        // tracks the target's heap size + ~80 MB baseline. Without this
+        // check, an oversized request would kill the sidecar with a PHP
+        // Fatal partway through the read loop, taking down the daemon for
+        // every other client until a supervisor restarts it. Returning a
+        // structured error keeps the daemon alive and gives the operator a
+        // line to grep for.
+        $preflight = self::preflightMemoryCheck($heap_stats->size);
+        if ($preflight !== null) {
+            return $preflight;
+        }
+
         $stopped = $this->process_stopper->stop($pid);
+        // Closure that detaches ptrace and flips $stopped so the finally
+        // block doesn't try to detach again. Captured by reference so the
+        // dumper's `on_read_complete` hook and the safety-net finally below
+        // see the same flag.
+        $resume = function () use ($pid, &$stopped): void {
+            if ($stopped) {
+                $this->process_stopper->resume($pid);
+                $stopped = false;
+            }
+        };
         try {
             $trace_strings = $this->readTrace(
                 $pid,
@@ -125,6 +149,12 @@ final class SidecarDumpHandler
                 $label_slug,
             );
 
+            // Fast-resume: ask the dumper to call us back the moment the
+            // remote read phase finishes. We detach ptrace there, so the
+            // target can run again while we're still streaming the buffered
+            // regions to disk. The finally below remains as a safety net
+            // for the case where the read phase throws before the hook
+            // fires.
             $result = $this->memory_dumper->dump(
                 $process_specifier,
                 $target_php_settings,
@@ -132,14 +162,10 @@ final class SidecarDumpHandler
                 $cg_address,
                 $output_path,
                 $this->include_binary,
+                on_read_complete: $resume,
             );
         } finally {
-            // Resume the target as soon as dump is captured.
-            // Everything below (metadata write, response build) doesn't
-            // need the process stopped — minimize the stop window.
-            if ($stopped) {
-                $this->process_stopper->resume($pid);
-            }
+            $resume();
         }
 
         $this->disk_tracker->recordFile($output_path);
@@ -258,5 +284,52 @@ final class SidecarDumpHandler
             $meta_path,
             (string)json_encode($meta, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n",
         );
+    }
+
+    /**
+     * Returns an error response if the target's heap clearly cannot fit in
+     * what's left of the sidecar's own `memory_limit`, or null when the
+     * dump should proceed. The 1.15 multiplier and 16 MiB headroom cover
+     * per-region overhead from the PHP-string copies that
+     * {@see \Reli\Inspector\MemoryDump\MemoryDumper} accumulates before
+     * writing; if the dumper is later switched to a streaming mode that
+     * does not buffer everything in PHP strings, this check should be
+     * relaxed accordingly (or skipped for that mode).
+     */
+    private static function preflightMemoryCheck(int $target_heap_bytes): ?SidecarResponse
+    {
+        $limit_raw = ini_get('memory_limit');
+        if (!is_string($limit_raw) || $limit_raw === '') {
+            return null;
+        }
+        $limit = ini_parse_quantity($limit_raw);
+        if ($limit <= 0) {
+            // -1 / 0 → unlimited; nothing to check.
+            return null;
+        }
+
+        $needed = (int)((float)$target_heap_bytes * 1.15) + (16 * 1024 * 1024);
+        $available = $limit - memory_get_usage(true);
+        if ($needed <= $available) {
+            return null;
+        }
+
+        $msg = sprintf(
+            'sidecar memory_limit too small for this target: '
+            . 'need ~%d MiB, %d MiB available (limit=%d MiB, used=%d MiB). '
+            . 'Raise --memory-limit on the sidecar process to roughly '
+            . '(max target heap + 100 MiB).',
+            (int)ceil($needed / (1024 * 1024)),
+            (int)floor($available / (1024 * 1024)),
+            (int)floor($limit / (1024 * 1024)),
+            (int)ceil(memory_get_usage(true) / (1024 * 1024)),
+        );
+        Log::info('sidecar pre-flight rejected dump', [
+            'target_heap_bytes' => $target_heap_bytes,
+            'needed_bytes' => $needed,
+            'available_bytes' => $available,
+            'memory_limit' => $limit,
+        ]);
+        return SidecarResponse::error($msg);
     }
 }

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -287,14 +287,22 @@ final class SidecarDumpHandler
     }
 
     /**
-     * Returns an error response if the target's heap clearly cannot fit in
-     * what's left of the sidecar's own `memory_limit`, or null when the
-     * dump should proceed. The 1.15 multiplier and 16 MiB headroom cover
-     * per-region overhead from the PHP-string copies that
-     * {@see \Reli\Inspector\MemoryDump\MemoryDumper} accumulates before
-     * writing; if the dumper is later switched to a streaming mode that
-     * does not buffer everything in PHP strings, this check should be
-     * relaxed accordingly (or skipped for that mode).
+     * Returns an error response when the target's *heap* alone clearly
+     * cannot fit in what's left of the sidecar's own `memory_limit`, or
+     * null when the dump should proceed.
+     *
+     * This is a best-effort early reject, not a hard guarantee that the
+     * dump will succeed. {@see \Reli\Inspector\MemoryDump\MemoryDumper}
+     * also collects opcache SHM, the VM stack, the compiler arena, and
+     * (when `--include-binary` is set) read-only binary segments, none
+     * of which {@see \Reli\Inspector\Watch\HeapStatsReader} reports.
+     * The check therefore catches the common case — the target's
+     * ZendMM heap is bigger than the sidecar can possibly hold — but a
+     * dump can still OOM the sidecar later if the non-heap regions
+     * push it over the limit. The 1.15 multiplier and 16 MiB headroom
+     * are a small buffer for the per-region PHP-string overhead the
+     * dumper currently accumulates; once a streaming dump mode lands
+     * this whole check can be skipped in that mode.
      */
     private static function preflightMemoryCheck(int $target_heap_bytes): ?SidecarResponse
     {
@@ -315,16 +323,18 @@ final class SidecarDumpHandler
         }
 
         $msg = sprintf(
-            'sidecar memory_limit too small for this target: '
+            'sidecar memory_limit too small for the target heap alone: '
             . 'need ~%d MiB, %d MiB available (limit=%d MiB, used=%d MiB). '
-            . 'Raise --memory-limit on the sidecar process to roughly '
-            . '(max target heap + 100 MiB).',
+            . 'Raise --memory-limit on the sidecar process; size it to at '
+            . 'least (max target heap + opcache SHM + 100 MiB), since the '
+            . 'dump may also include opcache, VM stack, and compiler arena '
+            . 'that are not counted here.',
             (int)ceil($needed / (1024 * 1024)),
             (int)floor($available / (1024 * 1024)),
             (int)floor($limit / (1024 * 1024)),
             (int)ceil(memory_get_usage(true) / (1024 * 1024)),
         );
-        Log::info('sidecar pre-flight rejected dump', [
+        Log::info('sidecar pre-flight rejected dump (target heap alone exceeds memory_limit)', [
             'target_heap_bytes' => $target_heap_bytes,
             'needed_bytes' => $needed,
             'available_bytes' => $available,

--- a/src/Inspector/Sidecar/SidecarServer.php
+++ b/src/Inspector/Sidecar/SidecarServer.php
@@ -96,6 +96,7 @@ final class SidecarServer
      */
     private function handleConnection($client, OutputInterface $output): void
     {
+        $request = null;
         try {
             stream_set_timeout($client, 5);
             $line = fgets($client, 8192);
@@ -106,13 +107,13 @@ final class SidecarServer
             $request = SidecarRequest::fromJson(trim($line));
             if ($request === null) {
                 $response = SidecarResponse::error('invalid request');
-                fwrite($client, $response->toJson() . "\n");
+                self::writeResponse($client, $response, $output);
                 return;
             }
 
             if ($request->command !== 'dump') {
                 $response = SidecarResponse::error("unknown command: {$request->command}");
-                fwrite($client, $response->toJson() . "\n");
+                self::writeResponse($client, $response, $output, $request);
                 return;
             }
 
@@ -131,7 +132,7 @@ final class SidecarServer
 
             $response = $this->dump_handler->handle($request);
 
-            fwrite($client, $response->toJson() . "\n");
+            self::writeResponse($client, $response, $output, $request);
 
             if ($response->status === 'ok') {
                 $output->writeln(sprintf(
@@ -150,9 +151,50 @@ final class SidecarServer
                 'error' => $e->getMessage(),
             ]);
             $response = SidecarResponse::error($e->getMessage());
-            @fwrite($client, $response->toJson() . "\n");
+            self::writeResponse($client, $response, $output, $request);
         } finally {
             fclose($client);
+        }
+    }
+
+    /**
+     * Write the response back to the client, swallowing the broken-pipe
+     * case that happens whenever the client gave up before the dump
+     * completed (most commonly due to its own `stream_set_timeout`
+     * firing while we were still doing `process_vm_readv` + disk write).
+     *
+     * The dump file itself is already on disk at this point — see
+     * {@see SidecarDumpHandler}. We log a single structured info line so
+     * orphaned dumps stay observable, instead of letting PHP emit a raw
+     * `Notice: fwrite(): … Broken pipe` for every disconnected client.
+     *
+     * @param resource $client
+     */
+    private static function writeResponse(
+        $client,
+        SidecarResponse $response,
+        OutputInterface $output,
+        ?SidecarRequest $request = null,
+    ): void {
+        $payload = $response->toJson() . "\n";
+        $written = @fwrite($client, $payload);
+        if ($written !== false && $written === strlen($payload)) {
+            return;
+        }
+
+        Log::info('sidecar client disconnected before reply', [
+            'pid' => $request?->pid,
+            'label' => $request?->label,
+            'response_status' => $response->status,
+            'response_path' => $response->path,
+            'response_bytes' => $response->bytes,
+        ]);
+
+        if ($response->status === 'ok' && $response->path !== null) {
+            $output->writeln(sprintf(
+                '<comment>[sidecar] client disconnected; orphan dump still saved: %s</comment>',
+                $response->path,
+            ));
         }
     }
 

--- a/src/Inspector/Sidecar/SidecarServer.php
+++ b/src/Inspector/Sidecar/SidecarServer.php
@@ -158,10 +158,11 @@ final class SidecarServer
     }
 
     /**
-     * Write the response back to the client, swallowing the broken-pipe
-     * case that happens whenever the client gave up before the dump
-     * completed (most commonly due to its own `stream_set_timeout`
-     * firing while we were still doing `process_vm_readv` + disk write).
+     * Write the response back to the client, looping over short
+     * `fwrite()` returns and swallowing the broken-pipe case that
+     * happens whenever the client gave up before the dump completed
+     * (most commonly due to its own `stream_set_timeout` firing while
+     * we were still doing `process_vm_readv` + disk write).
      *
      * The dump file itself is already on disk at this point — see
      * {@see SidecarDumpHandler}. We log a single structured info line so
@@ -177,8 +178,21 @@ final class SidecarServer
         ?SidecarRequest $request = null,
     ): void {
         $payload = $response->toJson() . "\n";
-        $written = @fwrite($client, $payload);
-        if ($written !== false && $written === strlen($payload)) {
+        $total = strlen($payload);
+        $offset = 0;
+        // Loop over short writes. PHP's stream layer may return fewer
+        // bytes than requested even on blocking sockets (e.g. when the
+        // kernel send buffer fills); a single `fwrite` is not enough to
+        // claim "delivered". Stop when the kernel rejects the write
+        // (false / 0) — that is the broken-pipe case we want to log.
+        while ($offset < $total) {
+            $chunk = @fwrite($client, substr($payload, $offset));
+            if ($chunk === false || $chunk === 0) {
+                break;
+            }
+            $offset += $chunk;
+        }
+        if ($offset === $total) {
             return;
         }
 
@@ -188,6 +202,8 @@ final class SidecarServer
             'response_status' => $response->status,
             'response_path' => $response->path,
             'response_bytes' => $response->bytes,
+            'bytes_written' => $offset,
+            'bytes_total' => $total,
         ]);
 
         if ($response->status === 'ok' && $response->path !== null) {

--- a/src/Sidecar/Client/MemoryLimitHandler.php
+++ b/src/Sidecar/Client/MemoryLimitHandler.php
@@ -56,12 +56,17 @@ final class MemoryLimitHandler
      * @param (callable(SidecarClientResponse): void)|null $on_response
      * @param (callable(string): void)|null $on_error called with error message on failure
      * @param int $reserve_bytes emergency memory reserve size (default: 256 KB)
+     * @param int $timeout_seconds socket I/O timeout passed to {@see SidecarClient}.
+     *     Sidecar dump throughput is roughly 100 MB/s, and the client blocks on
+     *     the response read for the full dump duration, so size this against the
+     *     target's `memory_limit` (default 30 s comfortably covers ~3 GB heaps).
      */
     public static function register(
         ?string $socket_path = null,
         ?callable $on_response = null,
         ?callable $on_error = null,
         int $reserve_bytes = self::DEFAULT_RESERVE_BYTES,
+        int $timeout_seconds = 30,
     ): void {
         // Pre-load classes so autoload doesn't run inside the shutdown handler.
         // Autoloading involves file I/O + parsing which can easily exceed
@@ -71,7 +76,7 @@ final class MemoryLimitHandler
 
         self::$reserve = str_repeat("\0", $reserve_bytes);
         register_shutdown_function(
-            self::createHandler($socket_path, $on_response, $on_error),
+            self::createHandler($socket_path, $on_response, $on_error, $timeout_seconds),
         );
     }
 
@@ -85,8 +90,9 @@ final class MemoryLimitHandler
         ?string $socket_path,
         ?callable $on_response,
         ?callable $on_error,
+        int $timeout_seconds,
     ): \Closure {
-        return static function () use ($socket_path, $on_response, $on_error): void {
+        return static function () use ($socket_path, $on_response, $on_error, $timeout_seconds): void {
             // Release emergency reserve to free memory for socket operations
             self::$reserve = null;
 
@@ -104,7 +110,7 @@ final class MemoryLimitHandler
                 return;
             }
 
-            $client = new SidecarClient($socket_path);
+            $client = new SidecarClient($socket_path, $timeout_seconds);
             $response = $client->requestDump(
                 pid: $pid,
                 error_file: $error['file'] ?? null,


### PR DESCRIPTION
## Summary

This PR implements the "0.12.0 launch polish" batch of sidecar improvements, focusing on memory safety, graceful error handling, and operational documentation. The changes ensure the sidecar daemon stays alive under adverse conditions, provides better visibility into failures, and includes comprehensive guidance for production deployment.

## Key Changes

### Memory Safety & Self-Defence (B1)
- **Pre-flight memory check** in `SidecarDumpHandler::doDump()`: rejects dump requests with a structured error response when the target heap size would exceed available sidecar memory, instead of crashing the daemon with a PHP Fatal error
- Uses a 1.15× multiplier + 16 MiB headroom to account for per-region PHP string overhead
- Keeps the sidecar alive so other clients continue to be served
- Logs a structured info line for operator observability

### Dump Pipeline Efficiency (A1)
- **Fast-resume mode** for the dump pipeline: `MemoryDumper::dump()` now accepts an optional `$on_read_complete` closure parameter
- `SidecarDumpHandler` passes a closure that detaches `ptrace` immediately after the remote read phase completes, allowing the target process to resume while disk writes are still in progress
- Reduces target stop window from ~read+write time to ~read-only time (verified: 0.65 s vs 1.78 s for a 256 MB target)
- Backward compatible: other callers of `MemoryDumper::dump()` are unaffected (parameter defaults to null)

### Broken-Pipe Error Handling (E1)
- **Centralized response writing** via new `SidecarServer::writeResponse()` helper
- Swallows `EPIPE` errors that occur when clients disconnect before the sidecar finishes writing the response
- Logs a single structured `sidecar client disconnected before reply` info line with request metadata instead of raw PHP Notices
- Prints an operator hint when an orphaned dump file remains on disk

### Client Timeout Configuration (C1)
- `MemoryLimitHandler::register()` now accepts `int $timeout_seconds = 30` parameter
- Forwards timeout to the inner `SidecarClient` so OOM-path callers can size timeouts against their `memory_limit` without dropping to manual `SidecarClient` instantiation
- Default preserves prior behavior

### Documentation (F1, F3)
- **Quick Start rewritten** to use the default `$XDG_RUNTIME_DIR/reli/sidecar.sock` with explicit setup instructions for hosts without `XDG_RUNTIME_DIR`
- **Server Options table** corrected to show actual default socket path
- **New "Operations" section** covering:
  - `--memory-limit` sizing guidance (max target heap + 100 MiB)
  - Supervisor requirements with systemd unit and Kubernetes examples
  - Client timeout sizing table (100 MB/s throughput baseline)
  - Concurrency model and queue behavior (single-worker FIFO with kernel backlog)
  - Orphan dump recovery procedures

## Implementation Details

- Pre-flight check uses `ini_parse_quantity()` to handle various `memory_limit` formats
- Resume closure captures `$stopped` flag by reference to coordinate between the `on_read_complete` hook and the surrounding `finally` block
- Response writing helper uses `@fwrite()` to suppress warnings, then validates bytes written
- All changes are backward compatible; new parameters default to preserving existing behavior

https://claude.ai/code/session_01W57n1KZ81zMS36JkMMESvM