### PR TITLE
Validate TSRM cache candidates to prevent empty stack traces

### DIFF
--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -185,11 +185,13 @@ class PhpGlobalsFinder
             // here so callers get a clean null and the friendly TSRM error
             // path fires, rather than silently returning a pointer that
             // makes the trace loop sample empty stacks forever.
-            if (!$this->tsrm_ls_cache_finder->validateCandidate(
+            assert($target_php_settings->isDecided());
+            $is_valid = $this->tsrm_ls_cache_finder->validateCandidate(
                 $process_specifier,
                 $target_php_settings,
                 $tsrm_ls_cache_address,
-            )) {
+            );
+            if (!$is_valid) {
                 return null;
             }
             return $tsrm_ls_cache_address;

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -178,6 +178,20 @@ class PhpGlobalsFinder
             if ($tsrm_ls_cache_address === 0) {
                 return null;
             }
+            // The slot may be populated for a thread that never ran PHP
+            // (e.g. an idle FrankenPHP regular-mode worker): TSRM allocates
+            // the per-thread cache structure at thread startup, but the
+            // executor_globals it points to remains zero/empty. Validate
+            // here so callers get a clean null and the friendly TSRM error
+            // path fires, rather than silently returning a pointer that
+            // makes the trace loop sample empty stacks forever.
+            if (!$this->tsrm_ls_cache_finder->validateCandidate(
+                $process_specifier,
+                $target_php_settings,
+                $tsrm_ls_cache_address,
+            )) {
+                return null;
+            }
             return $tsrm_ls_cache_address;
         } catch (\Throwable) {
             return null;

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -115,6 +115,22 @@ class PhpGlobalsFinder
                 $this->tsrm_ls_cache_cache[$process_specifier->pid] = null;
                 return null;
             }
+            // Same per-thread garbage hazard as the cached-offset path:
+            // an idle ZTS thread may have a non-null but unusable slot
+            // value (TSRM allocated the cache structure at thread startup
+            // but the executor_globals it points to is still zero). Without
+            // this validate, the trace loop samples empty stacks forever
+            // instead of failing fast with the friendly TSRM error.
+            assert($target_php_settings->isDecided());
+            $is_valid = $this->tsrm_ls_cache_finder->validateCandidate(
+                $process_specifier,
+                $target_php_settings,
+                $tsrm_ls_cache_address,
+            );
+            if (!$is_valid) {
+                $this->tsrm_ls_cache_cache[$process_specifier->pid] = null;
+                return null;
+            }
             $this->tsrm_ls_cache_cache[$process_specifier->pid] = $tsrm_ls_cache_address;
             return $tsrm_ls_cache_address;
         }


### PR DESCRIPTION
## Summary
Added validation of TSRM cache candidates to prevent returning invalid pointers that would result in empty stack traces. This addresses an issue where idle worker threads (such as FrankenPHP regular-mode workers) may have allocated per-thread cache structures with uninitialized executor_globals.

## Key Changes
- Added a validation check after retrieving the TSRM LS cache address to ensure the candidate is actually valid before returning it
- If validation fails, the method now returns `null` to trigger the friendly TSRM error path instead of silently returning an invalid pointer
- This prevents the trace loop from sampling empty stacks indefinitely when working with threads that never executed PHP code

## Implementation Details
The validation leverages the existing `validateCandidate()` method from `tsrm_ls_cache_finder` to verify that the retrieved cache address points to a properly initialized executor_globals structure. This ensures that only valid TSRM cache pointers are returned to callers, maintaining data integrity and providing better error handling for edge cases in multi-threaded PHP environments.

https://claude.ai/code/session_01Cj9TDtZES2cvgiwpKEmzPD