### PR TITLE
docs(sidecar): standalone-client install route + 0.12.0 release runbook

### DIFF
--- a/docs/internals/sidecar-improvements.md
+++ b/docs/internals/sidecar-improvements.md
@@ -444,19 +444,20 @@ default `$XDG_RUNTIME_DIR/reli/sidecar.sock`.
 
 ### F2. Packagist install path
 
-The current docs offer two installation routes — `composer require
-reliforp/reli-prof` (the full package) or vendoring the three client
-files manually. There is in fact a third path: the
-`reliforp/reli-prof-sidecar-client` standalone package on Packagist
-(currently `dev-main` only, no tag yet). It should be the recommended
-route:
+[x] **Docs side shipped on this branch.** "Installing the client code
+in your application" in `docs/monitoring/sidecar.md` now lists three
+options and recommends the standalone
+`reliforp/reli-prof-sidecar-client` package over the full
+`reliforp/reli-prof` dependency or hand-vendoring. The example shows
+the `dev-main` pin + `minimum-stability: dev` until a tag exists.
 
-```bash
-composer require reliforp/reli-prof-sidecar-client:dev-main
-```
-
-This requires `minimum-stability: dev` until the package is tagged.
-The tagging policy itself needs sorting (semver, starting at 0.1.0?).
+[ ] **Residual:** tag the
+`reliforp/reli-prof-sidecar-client` mirror and update the docs
+snippet from `:dev-main` to a `^0.x` constraint. This is what gets
+recommended-by-default rather than an explicit `dev-main` pin
++ stability flag. Tagging policy itself still needs sorting
+(semver, presumably starting at `0.12.0` to track the upstream tag,
+or `0.1.0` if we want the mirror's version line to be independent).
 
 ### F3. Operations section
 
@@ -502,7 +503,9 @@ each are different. Useful as a fixture for G1.
 ## Suggested PR ordering
 
 **Shipped on this branch (release-blocker batch for 0.12.0):**
-A1, B1, B2, C1, C2, E1, E2, F1, F3.
+A1, B1, B2, C1, C2, E1, E2, F1, F3, plus the docs portion of F2
+(standalone-client install route documented; mirror tagging is the
+remaining residual).
 
 **Remaining for 0.12.x:**
 
@@ -516,8 +519,11 @@ A1, B1, B2, C1, C2, E1, E2, F1, F3.
    `MemoryLimitHandler` argument). Mostly relevant once someone hits
    the B1 pre-flight wall on a sidecar they cannot reasonably
    resize.
-3. **F2** — once the `reliforp/reli-prof-sidecar-client` mirror is
-   tagged, switch the docs from `dev-main` to the first release tag.
+3. **F2 (residual)** — the docs now recommend
+   `reliforp/reli-prof-sidecar-client` as the primary install route,
+   pinned to `dev-main`. Remaining work is to tag the mirror and
+   replace the `dev-main` pin in the docs snippet with the first
+   release tag.
 4. **H4 + H5** — queue depth reporting / rejection. Optional.
 5. **D1** — `on_error` signature extension. Optional-parameter
    addition, fully BC. Useful but not urgent.

--- a/docs/internals/sidecar-release-process.md
+++ b/docs/internals/sidecar-release-process.md
@@ -161,16 +161,19 @@ convention.
 
 ## Patch releases (`0.12.1`, `0.12.2`, …)
 
-Same playbook, with one decision up front:
+Same playbook, no exceptions: the mirror gets a tag with the same
+version as the upstream patch, regardless of whether
+`src/Sidecar/Client/` changed.
 
 | `src/Sidecar/Client/` changed in the patch? | Action |
 |---|---|
-| **Yes** (any client-facing change, however small) | Mandatory: regenerate, push to mirror, tag `0.12.x` on the mirror first, then upstream. |
-| **No** | Optional but recommended. Re-running the build script is cheap and gives the mirror a clean snapshot of the current Rector tooling. Skipping is acceptable — `^0.12` users keep getting `0.12.0` until the next mirror tag. |
+| **Yes** (any client-facing change, however small) | Regenerate, push to mirror, tag `0.12.x` on the mirror first, then upstream. |
+| **No** | Still tag the mirror with the same version. Re-run the build script so the mirror tree reflects the current Rector tooling, push as a fresh sync commit, and tag — even when the resulting tree is byte-identical to the previous tag. The tag itself preserves the "reli `0.12.x` pairs with client `0.12.x`" mental model and removes a class of "is there a matching mirror tag for this upstream patch?" support questions. Tags are cheap; ambiguity is not. |
 
-When skipping the mirror tag, note it in the upstream release notes
-("client package unchanged, still pins `^0.12`") so users do not
-look for a `0.12.1` mirror tag that does not exist.
+The single-rule version, kept short for the runbook reader: **every
+upstream tag in the `Reli\Sidecar\Client\` namespace's lifetime gets
+a matching mirror tag. No exceptions, no conditional language in
+release notes.**
 
 ## Recovery
 

--- a/docs/internals/sidecar-release-process.md
+++ b/docs/internals/sidecar-release-process.md
@@ -1,0 +1,226 @@
+# Sidecar Release Process
+
+How to ship a `reliforp/reli-prof` release that involves the
+`Reli\Sidecar\Client\` namespace, given the two-repository topology
+(upstream + auto-generated read-only mirror on Packagist).
+
+The process is small but order-sensitive: doing the upstream tag
+before the mirror tag leaves the upstream release notes pointing at
+a Packagist version that does not exist yet, and `composer require
+reliforp/reli-prof-sidecar-client:^0.x` fails for everyone who
+copies the install snippet during that window.
+
+## Repositories
+
+| Repo | Role | Branch you tag |
+|---|---|---|
+| `reliforp/reli-prof` | Upstream — owns the full source under `src/Sidecar/Client/`, the build script (`tools/build-sidecar-client.sh`), the Rector config (`rector-sidecar-client.php`), the docs in `docs/monitoring/sidecar.md`, and this file. | the maintenance branch (`0.12.x`, `0.13.x`, …) |
+| `reliforp/reli-prof-sidecar-client` | Read-only mirror published on Packagist as the standalone client package. Files are produced by the Rector downgrade pipeline; nobody opens PRs here. | `main` |
+
+The mirror's `main` branch tracks upstream's current maintenance
+branch. Each commit on the mirror has the form
+`Sync from upstream 0.12.x@<sha>`, where `<sha>` is the upstream
+commit whose tree was downgraded.
+
+## Versioning policy
+
+**Mirror tag = upstream tag, exactly.** When upstream tags `0.12.0`,
+the mirror tags `0.12.0`. Patch releases follow the same rule:
+upstream `0.12.1` ⇒ mirror `0.12.1`, even when `src/Sidecar/Client/`
+did not change in that patch (the Rector tooling, `composer.json`
+metadata, or PHP-version handling may have shifted, and a fresh tag
+captures that state).
+
+This is deliberately stricter than "tag the mirror only when the
+client API changes", because:
+
+- it gives users a single mental model (`reli 0.12 → client ^0.12`)
+  rather than a lookup table,
+- empty bumps cost nothing (a tag is one git push), and
+- it removes a class of "did the mirror also need a tag this time?"
+  ambiguity from every patch.
+
+## Tag-day playbook
+
+> **Order matters: mirror first, upstream second.** The upstream
+> release notes / docs reference the mirror tag, so the mirror tag
+> has to exist by the time the upstream tag is pushed.
+
+### 1. Pre-flight (do this once per release)
+
+```bash
+# In the upstream checkout, on the maintenance branch:
+git checkout 0.12.x
+git pull --ff-only
+composer install               # picks up the matching rector pin
+tools/build-sidecar-client.sh  # regenerates build/sidecar-client/
+
+# Smoke-check the artifact against a fresh consumer project:
+mkdir /tmp/sidecar-smoke && cd /tmp/sidecar-smoke
+cat > composer.json <<EOF
+{
+  "require": { "reliforp/reli-prof-sidecar-client": "*" },
+  "repositories": [
+    {"type": "path",
+     "url": "$OLDPWD/build/sidecar-client",
+     "options": {"symlink": false}}
+  ],
+  "minimum-stability": "dev"
+}
+EOF
+composer install --no-progress
+php -r 'require "vendor/autoload.php";
+        new Reli\Sidecar\Client\SidecarClient("/dev/null");'
+```
+
+If the smoke test fails, fix it on the upstream branch first — never
+hand-edit the build artifact, and never commit divergent code on the
+mirror. The mirror is a function of upstream + the Rector pipeline.
+
+### 2. Stage the upstream docs change (do **not** commit yet)
+
+In `docs/monitoring/sidecar.md`, swap the install snippet from the
+`dev-main` form to a tagged constraint:
+
+```diff
+-  composer require reliforp/reli-prof-sidecar-client:dev-main
++  composer require 'reliforp/reli-prof-sidecar-client:^0.12'
+```
+
+Drop the `Until the first tagged release …` paragraph and the
+`minimum-stability: dev` requirement. Keep the patch in your working
+tree — it is committed in step 5 once the mirror tag is live.
+
+### 3. Push the regenerated mirror, then tag it
+
+In a checkout of `reliforp/reli-prof-sidecar-client`:
+
+```bash
+# Replace the working tree with the freshly built artifact.
+rsync -a --delete --exclude=.git \
+  /path/to/reli-prof/build/sidecar-client/ ./
+
+git add -A
+git commit -m "Sync from upstream 0.12.x@$(cd /path/to/reli-prof && git rev-parse --short HEAD)"
+git push origin main
+
+# Tag it. The tag name must match the upstream tag we are about to push.
+git tag -a 0.12.0 -m "Mirror sync for reliforp/reli-prof 0.12.0"
+git push origin 0.12.0
+```
+
+### 4. Wait for Packagist to ingest the tag
+
+The Packagist webhook usually picks up new tags within ~30 seconds.
+Verify before moving on:
+
+```bash
+curl -sS https://packagist.org/p2/reliforp/reli-prof-sidecar-client.json \
+  | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+versions = [v["version"] for v in data["packages"]["reliforp/reli-prof-sidecar-client"]]
+print(versions[:5])
+'
+# Expect: ['0.12.0', 'dev-main', ...]
+```
+
+If the new tag is missing for more than a couple of minutes, log in
+to Packagist and click **Update** on the package page (requires
+maintainer permission). The webhook may have been throttled or the
+mirror push may not have triggered it.
+
+### 5. Land the upstream docs change
+
+Commit the docs patch you staged in step 2 onto the upstream
+maintenance branch, push, and verify CI is green. This is what
+`composer require reliforp/reli-prof-sidecar-client:^0.12` users
+will read on the tagged release page.
+
+### 6. Tag the upstream release
+
+```bash
+# In the upstream checkout, on 0.12.x with the docs commit landed:
+git tag -a 0.12.0 -m "..."
+git push origin 0.12.0
+```
+
+### 7. Release notes
+
+In the GitHub release notes, name the matching client version
+explicitly:
+
+> Pairs with `reliforp/reli-prof-sidecar-client` **v0.12.0** on
+> Packagist. Install with `composer require
+> reliforp/reli-prof-sidecar-client:^0.12`.
+
+This serves two purposes: it lets readers paste the exact constraint
+without copying from the upstream docs, and it gives future
+maintainers a clear precedent for the "mirror tag = upstream tag"
+convention.
+
+## Patch releases (`0.12.1`, `0.12.2`, …)
+
+Same playbook, with one decision up front:
+
+| `src/Sidecar/Client/` changed in the patch? | Action |
+|---|---|
+| **Yes** (any client-facing change, however small) | Mandatory: regenerate, push to mirror, tag `0.12.x` on the mirror first, then upstream. |
+| **No** | Optional but recommended. Re-running the build script is cheap and gives the mirror a clean snapshot of the current Rector tooling. Skipping is acceptable — `^0.12` users keep getting `0.12.0` until the next mirror tag. |
+
+When skipping the mirror tag, note it in the upstream release notes
+("client package unchanged, still pins `^0.12`") so users do not
+look for a `0.12.1` mirror tag that does not exist.
+
+## Recovery
+
+### "I tagged upstream first by mistake."
+
+The release page now points at a non-existent client version. Fix
+forward:
+
+1. Push the mirror tag (`0.12.0`).
+2. Cut a docs-only `0.12.1` upstream patch that re-asserts the
+   correct install snippet (or, if step 5 did land correctly, do
+   nothing — the only damage is the brief window).
+
+Do **not** delete-and-retag the upstream tag. Packagist caches
+deleted tags aggressively and the resulting "version exists but is
+empty" state is worse than the original mistake.
+
+### "The Rector output is wrong."
+
+Fix on upstream, regenerate, push to mirror as a fresh sync commit,
+re-tag with the next patch number. Treat the bad mirror tag as
+released — that is what users on `^0.12` may have already pulled.
+
+### "The webhook is silent."
+
+Manual `Update` on the Packagist package page is the supported
+escape hatch. If that also fails, the package's API key needs
+rotating; a maintainer with Packagist account access has to do
+that.
+
+## One-time setup verification
+
+Before the very first tagged release on a new mirror repository:
+
+- [ ] The `reliforp/reli-prof-sidecar-client` Packagist package
+      has a maintainer account that matches the release engineer
+      (or a service account they can use).
+- [ ] The mirror repository on GitHub has a webhook to
+      `https://packagist.org/api/github` configured (Packagist's
+      "How to update packages" page has the canonical instructions).
+- [ ] `tools/build-sidecar-client.sh` runs cleanly on a fresh
+      `composer install` of the upstream maintenance branch.
+- [ ] The mirror's `composer.json` (regenerated by the script) has
+      no leftover `version` field — Packagist must derive versions
+      from git tags.
+
+## Future automation
+
+The whole sequence above is mechanical and a good fit for a CI
+workflow. The shape of that automation is sketched in
+`docs/internals/sidecar-improvements.md` § F2, and is on the 0.12.x
+roadmap rather than the launch scope. Until it lands, this page is
+the source of truth for the manual procedure.

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -75,23 +75,55 @@ The client library requires **no FFI** and has **no heavy dependencies**. It's d
 
 ### Installing the client code in your application
 
-The classes under `Reli\Sidecar\Client\` (`MemoryLimitHandler`, `SidecarClient`, `SidecarClientResponse`) must be available in the target application's autoloader. There are two practical options today:
+The classes under `Reli\Sidecar\Client\` (`MemoryLimitHandler`,
+`SidecarClient`, `SidecarClientResponse`) must be available in the
+target application's autoloader. There are three practical options
+today; the recommended one is the standalone client package because
+it keeps the application's dependency graph free of FFI / PCNTL.
 
-- **Composer dependency** — add `reliforp/reli-prof` as a dependency
-  in the application (`composer require reliforp/reli-prof`). The
-  client classes are pulled in along with the rest of the package.
-  The client side has no FFI / PCNTL requirement, so this works on
-  any modern PHP runtime that hosts your application.
-- **Vendoring the three files** — for applications that don't want
-  the full dependency, copy `src/Sidecar/Client/MemoryLimitHandler.php`,
+- **Composer, standalone client (recommended)** —
+  [`reliforp/reli-prof-sidecar-client`](https://packagist.org/packages/reliforp/reli-prof-sidecar-client)
+  on Packagist is a generated, FFI-free mirror of the
+  `Reli\Sidecar\Client\` namespace, downgraded to target PHP 7.0+
+  so it runs anywhere your application does:
+
+  ```bash
+  composer require reliforp/reli-prof-sidecar-client
+  ```
+
+  Until the first tagged release, the package is published as
+  `dev-main` only. Pin it explicitly and allow dev stability:
+
+  ```bash
+  composer require reliforp/reli-prof-sidecar-client:dev-main
+  ```
+
+  with `"minimum-stability": "dev"` and `"prefer-stable": true` in
+  `composer.json`. **Do not open PRs against the mirror repo** — its
+  contents are regenerated from `src/Sidecar/Client/` in
+  `reliforp/reli-prof` by the Rector-based downgrade pipeline.
+
+- **Composer, full reli-prof** —
+  `composer require reliforp/reli-prof` pulls the client classes in
+  alongside the rest of the package. The client side has no FFI /
+  PCNTL requirement, but the full package's autoload tree is much
+  larger; prefer the standalone client unless you also intend to
+  invoke `reli` CLI commands from the same project (e.g. analysis
+  tooling living in the same composer install).
+
+- **Vendoring the three files** — for applications that cannot or
+  will not take a Composer dependency, copy
+  `src/Sidecar/Client/MemoryLimitHandler.php`,
   `src/Sidecar/Client/SidecarClient.php`, and
-  `src/Sidecar/Client/SidecarClientResponse.php` into your project
-  and wire them into your autoloader (PSR-4 under the
+  `src/Sidecar/Client/SidecarClientResponse.php` (plus
+  `SocketPathResolver.php` for the default-path resolution) into
+  your project and wire them into your autoloader (PSR-4 under the
   `Reli\Sidecar\Client\` namespace, or any namespace as long as you
   update the `use` statements).
 
-Either way, only the `Reli\Sidecar\Client\` namespace is needed
-application-side; the rest of reli runs in the sidecar process.
+Whichever option you pick, only the `Reli\Sidecar\Client\` namespace
+is needed application-side; the rest of reli runs in the sidecar
+process.
 
 ### Emergency Memory Reserve
 

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -103,13 +103,27 @@ it keeps the application's dependency graph free of FFI / PCNTL.
   contents are regenerated from `src/Sidecar/Client/` in
   `reliforp/reli-prof` by the Rector-based downgrade pipeline.
 
-- **Composer, full reli-prof** —
-  `composer require reliforp/reli-prof` pulls the client classes in
-  alongside the rest of the package. The client side has no FFI /
-  PCNTL requirement, but the full package's autoload tree is much
-  larger; prefer the standalone client unless you also intend to
-  invoke `reli` CLI commands from the same project (e.g. analysis
-  tooling living in the same composer install).
+- **Composer, full reli-prof** — strongly discouraged for
+  application-only deploys. `reliforp/reli-prof`'s `composer.json`
+  declares `php: ^8.5`, `ext-ffi`, `ext-pcntl` as hard requirements
+  (they are needed by the `reli` CLI itself, not by the client
+  classes), and a typical PHP-FPM application image has none of
+  them. `composer require reliforp/reli-prof` therefore fails the
+  platform check, and bypassing it means asserting at install
+  time that the runtime constraints are someone else's problem:
+
+  ```bash
+  composer require reliforp/reli-prof \
+      --ignore-platform-req=php \
+      --ignore-platform-req=ext-ffi \
+      --ignore-platform-req=ext-pcntl
+  ```
+
+  Even when this works, you still ship the entire reli analysis
+  toolchain into the application image. Use this option only when
+  the project ALSO runs `reli` CLI commands (analysis tooling, CI
+  step, dev-only container). For application code, prefer the
+  standalone client package above.
 
 - **Vendoring the three files** — for applications that cannot or
   will not take a Composer dependency, copy


### PR DESCRIPTION
Two follow-ups on top of #681 (already merged), both docs-only.

## 1. Standalone client as the primary install route

The "Installing the client code in your application" section in
`docs/monitoring/sidecar.md` previously listed only `reliforp/reli-prof`
and hand-vendoring as options. The standalone Packagist mirror
`reliforp/reli-prof-sidecar-client` — which is the whole reason
the Rector downgrade pipeline exists — was missing entirely.

This PR makes the standalone client the recommended option, with
the `dev-main` pin + `minimum-stability: dev` workaround spelled
out for the period before the mirror is tagged. It also walks the
"Composer, full reli-prof" alternative back to honesty:
`reliforp/reli-prof`'s `composer.json` declares
`php: ^8.5`, `ext-ffi`, `ext-pcntl` as hard requirements, none of
which a typical PHP-FPM application image loads, so a plain
`composer require reliforp/reli-prof` fails the platform check.
The doc now shows the `--ignore-platform-req=…` invocation that
gets past it and explicitly steers application-only deploys back
to the standalone client.

The matching F2 entry in `docs/internals/sidecar-improvements.md`
is split into "docs side shipped" (this PR) and "tagging residual"
(handled at tag time).

## 2. Release runbook for the two-repo topology

New `docs/internals/sidecar-release-process.md` captures the
mirror-first / upstream-second order that an upstream release
involving `Reli\Sidecar\Client\` requires. The motivation is the
window between an upstream tag and a missing mirror tag, where the
release notes' install snippet
(`composer require reliforp/reli-prof-sidecar-client:^0.12`) would
fail for everyone copying it.

Covers:

- Versioning policy: **mirror tag = upstream tag**, including empty
  bumps for patch releases that did not touch
  `src/Sidecar/Client/`. Single mental model
  (`reli 0.12 → client ^0.12`); empty tags cost one push.
- Tag-day playbook: pre-flight smoke against `build/sidecar-client/`,
  staging the upstream docs `:dev-main` → `:^0.12` swap, mirror
  push + tag, Packagist verification, upstream docs commit,
  upstream tag, release notes wording.
- Patch-release decision table for "did `src/Sidecar/Client/`
  change?".
- Recovery for "tagged upstream first by mistake", "Rector output
  wrong", "Packagist webhook silent".
- One-time setup checklist (Packagist maintainer, GitHub webhook,
  no `version` field in mirror `composer.json`).
- Forward pointer to the F2 automation sketch in
  `sidecar-improvements.md`.

## Test plan

- [ ] Read `docs/monitoring/sidecar.md` end-to-end and verify the
      three install options and the new caveats render correctly
      in GitHub markdown.
- [ ] Read `docs/internals/sidecar-release-process.md` and check
      the tag-day playbook against the actual `0.12.0` release
      this is meant to support.
- [ ] Confirm `tools/build-sidecar-client.sh` still runs cleanly
      from the upstream maintenance branch (this PR does not touch
      the script itself, but the runbook references it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W57n1KZ81zMS36JkMMESvM)_