### PR TITLE
Fix incomplete chunk walk detection to include cached chunks and huge allocations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1409,6 +1409,9 @@
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php">
     <InvalidOperand>
+      <code><![CDATA[$cached_chunks_size / 1024 / 1024]]></code>
+      <code><![CDATA[$captured_bytes / 1024 / 1024]]></code>
+      <code><![CDATA[$huge_total_bytes / 1024 / 1024]]></code>
       <code><![CDATA[$memory_get_usage_real_size * 0.5]]></code>
       <code><![CDATA[$memory_get_usage_real_size / 1024 / 1024]]></code>
       <code><![CDATA[$walked_chunk_bytes / 1024 / 1024]]></code>

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -158,6 +158,7 @@ final class MemoryLocationsCollector
             $walked_chunk_count++;
         }
         $huge_memory_locations = new MemoryLocations();
+        $huge_total_bytes = 0;
         foreach ($zend_mm_main_chunk->heap_slot->iterateHugeList($dereferencer) as $huge_list) {
             $huge_memory_locations->add(
                 ZendMmChunkMemoryLocation::fromZendMmHugeList($huge_list)
@@ -165,6 +166,7 @@ final class MemoryLocationsCollector
             $memory_locations->add(
                 ZendMmHugeListMemoryLocation::fromZendMmHugeList($huge_list)
             );
+            $huge_total_bytes += $huge_list->size;
         }
 
         $memory_get_usage_size = $zend_mm_main_chunk->heap_slot->size;
@@ -179,9 +181,14 @@ final class MemoryLocationsCollector
         $last_chunks_delete_count = $zend_mm_main_chunk->heap_slot->last_chunks_delete_count;
 
         // Warn if chunk walk was incomplete (corrupt next pointer or
-        // chunks outside dump region).
+        // chunks outside dump region). real_size is ZendMM's bookkeeping
+        // for everything currently mmap'd from the OS — active chunks +
+        // cached (held-for-reuse) chunks + huge allocations — so the
+        // captured-bytes side has to include all three or single huge
+        // allocations falsely trip the guard.
         $walked_chunk_bytes = $walked_chunk_count * ZendMmChunk::SIZE;
-        if ($memory_get_usage_real_size > 0 && $walked_chunk_bytes < $memory_get_usage_real_size * 0.5) {
+        $captured_bytes = $walked_chunk_bytes + $cached_chunks_size + $huge_total_bytes;
+        if ($memory_get_usage_real_size > 0 && $captured_bytes < $memory_get_usage_real_size * 0.5) {
             $walked_mb = number_format($walked_chunk_bytes / 1024 / 1024, 1);
             $real_mb = number_format($memory_get_usage_real_size / 1024 / 1024, 1);
             fwrite(STDERR, "WARNING: ZendMM chunk walk incomplete — found {$walked_mb} MB"

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -190,9 +190,14 @@ final class MemoryLocationsCollector
         $captured_bytes = $walked_chunk_bytes + $cached_chunks_size + $huge_total_bytes;
         if ($memory_get_usage_real_size > 0 && $captured_bytes < $memory_get_usage_real_size * 0.5) {
             $walked_mb = number_format($walked_chunk_bytes / 1024 / 1024, 1);
+            $cached_mb = number_format($cached_chunks_size / 1024 / 1024, 1);
+            $huge_mb = number_format($huge_total_bytes / 1024 / 1024, 1);
+            $captured_mb = number_format($captured_bytes / 1024 / 1024, 1);
             $real_mb = number_format($memory_get_usage_real_size / 1024 / 1024, 1);
-            fwrite(STDERR, "WARNING: ZendMM chunk walk incomplete — found {$walked_mb} MB"
-                . " in {$walked_chunk_count} chunks, but real_size is {$real_mb} MB."
+            fwrite(STDERR, "WARNING: ZendMM chunk walk incomplete — captured {$captured_mb} MB"
+                . " ({$walked_mb} MB in {$walked_chunk_count} chunks"
+                . " + {$cached_mb} MB cached + {$huge_mb} MB huge),"
+                . " but real_size is {$real_mb} MB."
                 . " Some chunks may be outside the dump region.\n");
         }
 


### PR DESCRIPTION
## Summary
Fixed the incomplete ZendMM chunk walk detection logic to properly account for all memory tracked by `memory_get_usage(true)`, including cached chunks and huge allocations. This prevents false warnings when the dump contains significant cached or huge memory.

## Key Changes
- Added tracking of total huge allocation bytes (`$huge_total_bytes`) during iteration of the huge list
- Updated the incomplete walk detection to compare against `$captured_bytes` (walked chunks + cached chunks + huge allocations) instead of just walked chunks
- Expanded the warning comment to explain that `real_size` includes active chunks, cached chunks, and huge allocations, so the captured bytes calculation must include all three

## Implementation Details
The fix addresses a logic gap where the guard condition only compared walked regular chunks against the total real memory size. Since `memory_get_usage(true)` includes:
- Active chunks (walked via iteration)
- Cached/held-for-reuse chunks (already tracked as `$cached_chunks_size`)
- Huge allocations (now tracked as `$huge_total_bytes`)

The captured bytes calculation now properly sums all three components to accurately detect when the chunk walk is genuinely incomplete (less than 50% of expected memory), rather than falsely triggering on legitimate cached or huge allocations.

https://claude.ai/code/session_014Kyvga9qtMskzfbfF3AqCd