### PR TITLE
docs(frankenphp): drop "slot populated at thread startup" claim

### DIFF
--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -101,11 +101,18 @@ A few realities on FrankenPHP that the snippet above is built around:
   warms every worker at once. Once **any one worker** succeeds
   and writes the offset to the per-binary cache, subsequent
   attaches against the same FrankenPHP process skip the
-  brute-force scan, read the cached offset directly, and resolve
-  TSRM in microseconds — including against workers that have
-  still never served a request, provided their slot was
-  populated at thread startup (which is the case in current
-  FrankenPHP builds).
+  brute-force scan and read the cached offset directly, but the
+  attach still only succeeds against workers whose
+  `_tsrm_ls_cache` slot has actually been populated. Whether
+  idle (never-served-a-request) workers have a populated slot
+  varies by FrankenPHP build: on some builds the slot is set at
+  thread startup and the cached offset is enough, on others
+  (observed on `dunglas/frankenphp:latest` with PHP 8.5.5) the
+  slot stays zero until the worker handles its first request and
+  cold attaches keep failing per-thread. If you hit the
+  uninitialised-slot error against a thread that has never
+  served a request, push traffic through that worker first
+  regardless of cache state.
 
   TSRM resolving is not the same as having something to look at:
   `inspector:memory:dump` against a TSRM-resolved cold worker in

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -103,16 +103,10 @@ A few realities on FrankenPHP that the snippet above is built around:
   attaches against the same FrankenPHP process skip the
   brute-force scan and read the cached offset directly, but the
   attach still only succeeds against workers whose
-  `_tsrm_ls_cache` slot has actually been populated. Whether
-  idle (never-served-a-request) workers have a populated slot
-  varies by FrankenPHP build: on some builds the slot is set at
-  thread startup and the cached offset is enough, on others
-  (observed on `dunglas/frankenphp:latest` with PHP 8.5.5) the
-  slot stays zero until the worker handles its first request and
-  cold attaches keep failing per-thread. If you hit the
-  uninitialised-slot error against a thread that has never
-  served a request, push traffic through that worker first
-  regardless of cache state.
+  `_tsrm_ls_cache` slot has actually been populated. A
+  never-served-a-request worker may still fail with the
+  uninitialised-slot error even with a warm cache; recovery is
+  the same — push traffic through that worker first.
 
   TSRM resolving is not the same as having something to look at:
   `inspector:memory:dump` against a TSRM-resolved cold worker in


### PR DESCRIPTION
## Summary

- Walked through `docs/tracing/frankenphp.md` end-to-end against
  `dunglas/frankenphp:latest` (PHP 8.5.5 ZTS) — every command, regex, and
  expected error message reproduced as written, except for one nuance.
- The doc currently asserts that once the per-binary TLS-offset cache is
  warm, attaches succeed against any worker including ones that have
  never served a request, "provided their slot was populated at thread
  startup (which is the case in current FrankenPHP builds)." On
  `dunglas/frankenphp:latest`, idle workers still fail with
  `_tsrm_ls_cache slot is uninitialized` even with a warm cache, until
  they actually handle their first request. Whether this is a build
  difference, a regression, or always-was-the-case is not something I
  verified, so this PR just drops the unverified parenthetical rather
  than replacing it with another assertion.
- Net change: state only that the cached offset alone is not enough if
  the slot is unpopulated, and reaffirm the existing recovery (push
  traffic through the worker first).

No code changes — docs only.

## Test plan

- [x] `dunglas/frankenphp:latest` worker mode: `inspector:trace`,
      `inspector:memory:dump`, `inspector:daemon` all behave as the
      (rest of the) doc describes.
- [x] Regular mode: idle worker → `_tsrm_ls_cache slot is uninitialized`;
      warm-but-between-requests worker → `failed to find ZendMM main chunk`;
      mid-request worker → dump succeeds; `inspector:watch --memory-usage
      --action=memory-dump --oneshot=1` fires inside a request and writes
      a dump.
- [ ] Spot-check the rendered Markdown on GitHub.

https://claude.ai/code/session_01KDWF5CAYQGotYLYiaitA3i