### PR TITLE
Update command syntax from shorthand to full names in documentation

### DIFF
--- a/docs/internals/memory-dump-vs-gcore.md
+++ b/docs/internals/memory-dump-vs-gcore.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-`i:m:dump` produces a minimal, analyzer-ready dump that beats `gcore`
+`inspector:memory:dump` produces a minimal, analyzer-ready dump that beats `gcore`
 on both size and speed for typical PHP workloads. The key techniques:
 
 - **Pagemap residency filter**: reads `/proc/pid/pagemap` to skip
@@ -20,7 +20,7 @@ on both size and speed for typical PHP workloads. The key techniques:
 
 ### Results: 30 OSS library test cases
 
-| Metric | `i:m:dump` (default) | `gcore` |
+| Metric | `inspector:memory:dump` (default) | `gcore` |
 |---|---|---|
 | Size (typical) | **2-50x smaller** | baseline |
 | Size (extension-heavy) | **50x smaller** | baseline |
@@ -53,7 +53,7 @@ Phase 5: Bulk read + write
 
 ## `--exclude-heap` usage guide
 
-By default `i:m:dump` captures the full process memory including the
+By default `inspector:memory:dump` captures the full process memory including the
 glibc `[heap]` and anonymous writable mmap regions. This gives complete
 coverage: every byte the analyzer might need is present in the dump.
 

--- a/docs/memory/memory-dump.md
+++ b/docs/memory/memory-dump.md
@@ -99,7 +99,7 @@ php ./reli inspector:memory:analyze snapshot.relimem \
 
 ## Comparison with `gcore`
 
-| | `i:m:dump` | `gcore` |
+| | `inspector:memory:dump` | `gcore` |
 |---|---|---|
 | Output format | `.relimem` (analyzer-ready) | ELF core (needs post-processing) |
 | Size | Pagemap-filtered (resident pages only) | All writable VMAs |

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -79,7 +79,7 @@ Options:
 This tool can be used like this.
 
 ```
-sudo ./reli i:m --pretty-print -p <pid_of_target_process> >memory_analyzed.json
+sudo ./reli inspector:memory --pretty-print -p <pid_of_target_process> >memory_analyzed.json
 ```
 
 The analysis takes seconds in many case. During the analysis, the target process is stopped by default.
@@ -452,7 +452,7 @@ register_shutdown_function(
         $pid = getmypid();
         $file_opt = '--memory-limit-error-file=' . escapeshellarg($error['file']);
         $line_opt = '--memory-limit-error-line=' . escapeshellarg((string)$error['line']);
-        system("sudo reli i:m -p {$pid} --no-stop-process {$file_opt} {$line_opt} >{$pid}_memory_analyzed.json");
+        system("sudo reli inspector:memory -p {$pid} --no-stop-process {$file_opt} {$line_opt} >{$pid}_memory_analyzed.json");
     }
 );
 
@@ -473,7 +473,7 @@ If you need to analyze the target at the exact timing you want, you have to touc
 
 ```php
 $pid = getmypid();
-system("sudo reli i:m -p {$pid} --no-stop-process >{$pid}_memory_analyzed.json");
+system("sudo reli inspector:memory -p {$pid} --no-stop-process >{$pid}_memory_analyzed.json");
 ```
 
 And you can also use [Xdebug](https://xdebug.org/). If the target is stopped at one of the breakpoints you set, then it's a good timing to analyze the target by Reli. This way you don't have to change the target code, though the behavior of the PHP VM isn't exactly same as the production enviornment in this case. Xdebug itself can be used to get the content of variables, but if you use Reli in addition to it, you can also get the statical data of the memory usage or reference graphs. 
@@ -782,13 +782,13 @@ It's not a bug of Reli, but a limitation of `jq`. Currently, `jq` doesn't have a
 Try this.
 
 ```bash
-$ docker run -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof i:m -p <pid_of_target_process> >memory_analyzed.json
+$ docker run -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof inspector:memory -p <pid_of_target_process> >memory_analyzed.json
 ```
 
 If you hit the memory_limit during the analysis, then you can increase the memory_limit like this.
 
 ```bash
-$ docker run --entrypoint=php -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof -dmemory_limit=2G reli i:m -p <pid_of_target_process> >memory_analyzed.json
+$ docker run --entrypoint=php -it --security-opt="apparmor=unconfined" --cap-add=SYS_PTRACE --pid=host reliforp/reli-prof -dmemory_limit=2G reli inspector:memory -p <pid_of_target_process> >memory_analyzed.json
 ```
 
 # Database output


### PR DESCRIPTION
## Summary
Updated all documentation references to use the full command syntax `inspector:memory` instead of the shorthand `i:m`, and `inspector:memory:dump` instead of `i:m:dump`. This improves clarity and consistency across the documentation.

## Changes Made
- Replaced all instances of `reli i:m` with `reli inspector:memory` in command examples
- Replaced all instances of `i:m:dump` with `inspector:memory:dump` in documentation text and tables
- Updated examples in:
  - Memory profiler documentation (command usage examples)
  - Memory dump documentation (comparison tables and descriptions)
  - Memory dump vs gcore documentation (summary and results tables)
  - Docker command examples

## Details
This is a documentation-only change that standardizes the command references to use the full, more descriptive command names rather than their shorthand aliases. This makes the documentation more accessible to new users and clearer about what each command does.

https://claude.ai/code/session_015jFXYSwBWmQdtNLGyYBa5Y