### PR TITLE
Fix HeapStatsReader DI binding for VariableReader concrete class

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -80,6 +80,8 @@ return [
     ProcessSearcherInterface::class => autowire(ProcessSearcher::class),
     Config::class => fn () => AppDirectory::loadConfig(__DIR__ . '/config.php'),
     TemplatePathResolverInterface::class => autowire(TemplatePathResolver::class),
+    VariableReader::class => autowire()
+        ->constructorParameter('heap_stats_reader', autowire(HeapStatsReader::class)),
     VariableReaderInterface::class => autowire(VariableReader::class)
         ->constructorParameter('heap_stats_reader', autowire(HeapStatsReader::class)),
     StateCollector::class => function (Container $container) {

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -208,6 +208,65 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
         $this->assertSame(123, $json['global::$val']['value']);
     }
 
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekMemoryVariable(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            $padding = str_repeat('x', 1024 * 1024);
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $command = $this->createCommand();
+        $app = new Application();
+        $app->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => [
+                'memory::memory_get_usage',
+                'memory::memory_get_peak_usage',
+            ],
+            '--format' => 'json',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $json = json_decode(trim($tester->getDisplay()), true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('memory::memory_get_usage', $json);
+        $this->assertNotNull(
+            $json['memory::memory_get_usage'],
+            'memory::memory_get_usage must not be null'
+                . ' (regression: HeapStatsReader was missing from'
+                . ' the concrete VariableReader DI binding)',
+        );
+        $this->assertSame('long', $json['memory::memory_get_usage']['type']);
+        $this->assertGreaterThan(
+            1024 * 1024,
+            $json['memory::memory_get_usage']['value'],
+        );
+        $this->assertNotNull($json['memory::memory_get_peak_usage']);
+        $this->assertGreaterThanOrEqual(
+            $json['memory::memory_get_usage']['value'],
+            $json['memory::memory_get_peak_usage']['value'],
+        );
+    }
+
     public function testNoVarReturnsError(): void
     {
         $command = $this->createCommand();


### PR DESCRIPTION
## Summary
This PR fixes a dependency injection configuration issue where the `HeapStatsReader` was only bound for the `VariableReaderInterface` but not for the concrete `VariableReader` class, causing memory inspection features to fail.

## Changes
- **DI Configuration**: Added explicit DI binding for the `VariableReader` concrete class with the `HeapStatsReader` constructor parameter, mirroring the existing `VariableReaderInterface` binding
- **Test Coverage**: Added `testPeekMemoryVariable()` integration test that verifies memory variable inspection (`memory::memory_get_usage` and `memory::memory_get_peak_usage`) works correctly across all supported PHP versions

## Implementation Details
The test creates a target PHP process with a 1MB memory allocation, then uses the peek command to inspect memory statistics via JSON output. It validates that:
- Memory usage values are properly retrieved and typed as `long`
- Memory usage exceeds the 1MB padding allocation
- Peak memory usage is greater than or equal to current usage

This regression test ensures the HeapStatsReader is properly injected into the VariableReader when used directly, not just through the interface.

https://claude.ai/code/session_01XiQbaoaKHUtdg2RmM84Aje