### PR TITLE
Add signal handling to gracefully cancel trace loops

### DIFF
--- a/src/Command/Rbt/RecoverCommand.php
+++ b/src/Command/Rbt/RecoverCommand.php
@@ -67,6 +67,10 @@ final class RecoverCommand extends ReliCommand
                 $count++;
             }
         } else {
+            // Always emit a valid (possibly empty) rbt file. Lazily creating
+            // the writer only when the first sample arrives leaves stdout as
+            // zero bytes when nothing is recoverable, and the next
+            // rbt:analyze in the pipeline then bails with "Invalid magic".
             $writer = null;
             foreach ($reader->readWithRecovery($input_stream) as $sample) {
                 if ($writer === null) {
@@ -83,15 +87,25 @@ final class RecoverCommand extends ReliCommand
                 );
                 $count++;
             }
-            if ($writer !== null) {
-                $writer->writeCheckpoint();
-                $writer->writeSegmentEnd();
+            if ($writer === null) {
+                $writer = new BinaryTraceWriter(
+                    STDOUT,
+                    $reader->getSamplingPeriodUs() ?: 10000,
+                    has_timestamps: true,
+                );
+                $writer->writeHeader();
             }
+            $writer->writeCheckpoint();
+            $writer->writeSegmentEnd();
         }
 
-        if ($output instanceof \Symfony\Component\Console\Output\ConsoleOutputInterface) {
-            $output->getErrorOutput()->writeln("Recovered {$count} samples");
-        }
+        // Always go through STDERR explicitly. Routing via Symfony's
+        // ConsoleOutputInterface::getErrorOutput() works in CLI today, but
+        // any caller that wraps the command with a non-ConsoleOutputInterface
+        // would silently drop the message — and a future change could just
+        // as easily mix it into stdout, which would corrupt the binary
+        // trace stream when --format=rbt.
+        fwrite(STDERR, "Recovered {$count} samples\n");
 
         return 0;
     }

--- a/src/Inspector/TraceLoopProvider.php
+++ b/src/Inspector/TraceLoopProvider.php
@@ -22,6 +22,7 @@ use Reli\Lib\Loop\LoopMiddleware\CallableMiddleware;
 use Reli\Lib\Loop\LoopMiddleware\KeyboardCancelMiddleware;
 use Reli\Lib\Loop\LoopMiddleware\NanoSleepMiddleware;
 use Reli\Lib\Loop\LoopMiddleware\RetryOnExceptionMiddleware;
+use Reli\Lib\Loop\LoopMiddleware\SignalCancelMiddleware;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\ProcessNotFoundException;
 
@@ -37,6 +38,7 @@ final class TraceLoopProvider
         return $this->loop_builder
             ->addProcess(ExitLoopOnSpecificExceptionMiddleware::class, [[ProcessNotFoundException::class]])
             ->addProcess(RetryOnExceptionMiddleware::class, [$settings->max_retries, [MemoryReaderException::class]])
+            ->addProcess(SignalCancelMiddleware::class, [])
             ->addProcess(KeyboardCancelMiddleware::class, [$settings->cancel_key, new EchoBackCanceller()])
             ->addProcess(NanoSleepMiddleware::class, [$settings->sleep_nano_seconds])
             ->addProcess(CallableMiddleware::class, [$main])

--- a/src/Lib/Loop/LoopMiddleware/SignalCancelMiddleware.php
+++ b/src/Lib/Loop/LoopMiddleware/SignalCancelMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Loop\LoopMiddleware;
+
+use Reli\Lib\Loop\LoopMiddlewareInterface;
+
+/**
+ * Returns false from the loop on SIGINT / SIGTERM so callers can run their
+ * usual end-of-loop finalization (e.g. BinaryTraceOutput::finish() to flush
+ * the run-length-encoded sample buffer and write CHECKPOINT + SEGMENT_END).
+ *
+ * Without this, Ctrl-C / `kill <pid>` exits PHP before destructors run and
+ * the .rbt file is left as just header + definitions with zero samples on
+ * disk.
+ */
+final class SignalCancelMiddleware implements LoopMiddlewareInterface
+{
+    private bool $cancelled = false;
+
+    public function __construct(
+        private LoopMiddlewareInterface $chain,
+    ) {
+        if (!function_exists('pcntl_async_signals') || !function_exists('pcntl_signal')) {
+            return;
+        }
+        pcntl_async_signals(true);
+        $handler = function (): void {
+            $this->cancelled = true;
+        };
+        pcntl_signal(SIGINT, $handler);
+        pcntl_signal(SIGTERM, $handler);
+    }
+
+    #[\Override]
+    public function invoke(): bool
+    {
+        if ($this->cancelled) {
+            return false;
+        }
+        return $this->chain->invoke();
+    }
+}

--- a/tests/Lib/Loop/LoopMiddleware/SignalCancelMiddlewareTest.php
+++ b/tests/Lib/Loop/LoopMiddleware/SignalCancelMiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\Loop\LoopMiddleware;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use ReflectionClass;
+use Reli\BaseTestCase;
+
+class SignalCancelMiddlewareTest extends BaseTestCase
+{
+    public function testPassesThroughUntilCancelled(): void
+    {
+        $reflection = new ReflectionClass(SignalCancelMiddleware::class);
+        $middleware = $reflection->newInstanceWithoutConstructor();
+        (function () {
+            /** @var SignalCancelMiddleware $this */
+            $this->chain = new CallableMiddleware(fn () => true);
+            $this->cancelled = false;
+        })->bindTo($middleware, $middleware)();
+
+        $this->assertTrue($middleware->invoke());
+
+        (function () {
+            /** @var SignalCancelMiddleware $this */
+            $this->cancelled = true;
+        })->bindTo($middleware, $middleware)();
+
+        $this->assertFalse($middleware->invoke());
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testReturnsFalseAfterSigint(): void
+    {
+        if (!function_exists('pcntl_signal') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('pcntl/posix not available');
+        }
+        $middleware = new SignalCancelMiddleware(
+            new CallableMiddleware(fn () => true),
+        );
+        $this->assertTrue($middleware->invoke());
+
+        posix_kill(posix_getpid(), SIGINT);
+        // pcntl_async_signals(true) was enabled in the constructor, so the
+        // handler runs at the next safe point - which by the time we get
+        // here has already happened.
+        $this->assertFalse($middleware->invoke());
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testReturnsFalseAfterSigterm(): void
+    {
+        if (!function_exists('pcntl_signal') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('pcntl/posix not available');
+        }
+        $middleware = new SignalCancelMiddleware(
+            new CallableMiddleware(fn () => true),
+        );
+        $this->assertTrue($middleware->invoke());
+
+        posix_kill(posix_getpid(), SIGTERM);
+        $this->assertFalse($middleware->invoke());
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds graceful signal handling to the trace loop infrastructure, ensuring that SIGINT and SIGTERM signals allow the application to complete finalization tasks (like flushing output buffers) before exiting, rather than terminating abruptly.

## Key Changes

- **New `SignalCancelMiddleware` class**: Implements signal handling for SIGINT and SIGTERM that sets a cancellation flag, allowing the loop to exit cleanly on the next iteration rather than being forcefully terminated. This ensures destructors run and output buffers are flushed properly.

- **Comprehensive test coverage**: Added `SignalCancelMiddlewareTest` with three test cases:
  - Unit test verifying the middleware passes through until cancelled
  - Integration test for SIGINT handling
  - Integration test for SIGTERM handling

- **Integrated into `TraceLoopProvider`**: The new middleware is added to the main trace loop builder, ensuring all trace operations benefit from graceful signal handling.

- **Improved `RecoverCommand` robustness**: 
  - Always emits a valid (possibly empty) RBT file, even when no samples are recovered, preventing downstream pipeline failures
  - Changed error output routing to explicitly use STDERR instead of relying on Symfony's `ConsoleOutputInterface`, ensuring the message doesn't corrupt binary trace streams when `--format=rbt` is used

## Implementation Details

The `SignalCancelMiddleware` uses PHP's `pcntl_async_signals()` to enable asynchronous signal handling, allowing signal handlers to run at safe points in the PHP execution. When SIGINT or SIGTERM is received, the handler sets a flag that causes `invoke()` to return `false`, signaling the loop to exit. This approach is safer than immediate termination and allows proper cleanup.

The middleware gracefully handles environments where PCNTL functions are unavailable by skipping signal registration.

https://claude.ai/code/session_01Vmu3gJtEhrGwaNK4qfnpmP