### PR TITLE
Documentation: Update command names and improve clarity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ Tip: **`-f binary` (`.rmem`) is the fastest format** and what the analysers belo
 
 | I want to... | Use | More |
 |---|---|---|
-| Just get the EG address (e.g. to feed phpspy manually) | `inspector:eg -p <pid>` | [tracing/capturing-traces.md](tracing/capturing-traces.md) |
+| Just get the EG address (e.g. to feed phpspy manually) | `inspector:eg_address -p <pid>` | [tracing/capturing-traces.md](tracing/capturing-traces.md) |
 | Install phpspy | `phpspy:install` | [tracing/phpspy-hybrid.md](tracing/phpspy-hybrid.md) |
 | Clear or bypass the binary analysis cache | `cache:clear`, `--no-cache` | [internals/binary-analysis-cache.md](internals/binary-analysis-cache.md) |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -557,7 +557,7 @@ cost modest.)
 reli can find VM state from ZTS interpreters: daemon-mode traces
 of threads started via [ext-parallel](https://github.com/krakjoe/parallel)
 are captured automatically, which phpspy alone cannot do.
-`inspector:eg` exposes just the EG address so you can feed it to
+`inspector:eg_address` exposes just the EG address so you can feed it to
 phpspy manually for ZTS targets, and the
 [hybrid phpspy mode](tracing/phpspy-hybrid.md) (`phpspy:trace` /
 `phpspy:daemon`) combines reli's ZTS-aware EG resolution with

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,6 +114,13 @@ composer install
 > The rest of this page uses **`reli`** as the command name, matching
 > the Docker-wrapper install above. On a native checkout (Composer or
 > Git) the equivalent command is `./reli` — substitute as you read.
+>
+> The `./reli` shebang is `#!/usr/bin/env php`, so the `php` on your
+> `PATH` must be **8.5+**. On distros that ship an older default
+> (e.g. Ubuntu with `php8.4-cli` from deadsnakes/sury), either install
+> `php8.5-cli` and switch the default — `sudo update-alternatives
+> --set php /usr/bin/php8.5` — or invoke explicitly with
+> `php8.5 ./reli ...`. The Docker wrapper sidesteps this entirely.
 
 ## 2. Smoke test
 

--- a/docs/inspection/trace-var-command.md
+++ b/docs/inspection/trace-var-command.md
@@ -50,7 +50,7 @@ common runtime and target requirements. No command-specific overrides apply.
 
 `--trace-var` takes **exactly the same expression grammar** as
 `inspector:peek-var --var` — see the full reference in
-[docs/peek-var-command.md](peek-var-command.md#variable-specification). In
+[peek-var-command.md § Variable Specification](peek-var-command.md#variable-specification). In
 short:
 
 | Scope | Syntax | What it reads |
@@ -72,7 +72,7 @@ Nested array keys and object properties use the same path syntax:
 The `memory::` scope exposes `memory_get_usage()` / `memory_get_peak_usage()`
 equivalents. Available names: `memory_get_usage`, `memory_get_peak_usage`,
 `memory_get_usage_real`, `memory_get_peak_usage_real`. See
-[docs/peek-var-command.md](peek-var-command.md#memory-scope) for details.
+[peek-var-command.md § Memory Scope](peek-var-command.md#memory-scope) for details.
 
 For `local::` and `func_static::`, the function name is **required**; use
 `<main>` for the top-level script scope.

--- a/docs/internals/design-trace-var-peek.md
+++ b/docs/internals/design-trace-var-peek.md
@@ -200,7 +200,7 @@ Payload:
 event after the `SAMPLE` / `COMPACT_SAMPLE`. The annotation values are
 interned through the segment's `STRING_DEF` table, so repeated values
 (e.g. the same SQL query across many samples) cost only one pair of varints
-per sample after the first. See `docs/binary-trace-format.md` §SAMPLE_ANNOTATION
+per sample after the first. See `docs/tracing/binary-trace-format.md` §SAMPLE_ANNOTATION
 for the full spec.
 
 ### Impact on REPEAT_SAMPLE (RLE)
@@ -390,7 +390,7 @@ Two changes:
    (`src/Converter/BinaryTrace/BinaryTraceWriter.php:193`) — accept
    `?array $annotations = null` and emit `SAMPLE_ANNOTATION` right after
    `writePidSample()`. The rbt spec explicitly allows `SAMPLE_ANNOTATION`
-   to follow `PID_SAMPLE` (see `docs/binary-trace-format.md`
+   to follow `PID_SAMPLE` (see `docs/tracing/binary-trace-format.md`
    §SAMPLE_ANNOTATION). `writePidSample()` does not participate in the
    RLE / run-length path, so the annotation logic is a straight append —
    no pending-run state to reason about.
@@ -536,10 +536,10 @@ sample. The worker then proceeds to the next attach cycle.
 - phpspy varpeek format — upstream `phpspy` emits `# key = value` comment
   lines inside each sample block; reli-prof's parser already treats any
   `#`-prefixed token as a comment (`src/Converter/PhpSpyCompatibleParser.php:47`).
-- `docs/binary-trace-format.md` §SAMPLE_ANNOTATION — authoritative definition
+- `docs/tracing/binary-trace-format.md` §SAMPLE_ANNOTATION — authoritative definition
   of event `0x0B`.
-- `docs/peek-var-command.md` — variable expression grammar.
-- `docs/watch-command.md#variable-value-watch-var` — the same grammar in the
+- `docs/inspection/peek-var-command.md` — variable expression grammar.
+- `docs/monitoring/watch-command.md#variable-value-watch-var` — the same grammar in the
   watch context.
 - `docs/internals/php-variable-reading.md` — how `VariableReader` walks Zend
   structures.

--- a/docs/internals/rmem-serve-design.md
+++ b/docs/internals/rmem-serve-design.md
@@ -357,7 +357,7 @@ For CLI:
 echo '{"action":"query.children","node_id":123}' | \
   nc -U $XDG_RUNTIME_DIR/reli/rmem-serve/abc123.sock
 
-php reli rmem:query --server=$XDG_RUNTIME_DIR/reli/rmem-serve/abc123.sock \
+reli rmem:query --server=$XDG_RUNTIME_DIR/reli/rmem-serve/abc123.sock \
   --node=123 --children
 ```
 

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -38,39 +38,22 @@ See [Getting started § Install](../getting-started.md#1-install) for the
 recommended install paths (Docker wrapper, Composer, Git).
 
 # Options
-```bash
-./reli inspector:memory --help
-Description:
-  get memory usage from an outer process
 
-Usage:
-  inspector:memory [options] [--] [<cmd> [<args>...]]
+`./reli inspector:memory --help` is the source of truth for the full
+flag list and defaults. The flags you most often reach for:
 
-Arguments:
-  cmd                                                                command to execute as a target: either pid (via -p/--pid) or cmd must be specified
-  args                                                               command line arguments for cmd
-
-Options:
-      --stop-process|--no-stop-process                               stop the process while inspecting (default: on)
-      --pretty-print|--no-pretty-print                               pretty print the result (default: off)
-      --memory-limit-error-file=MEMORY-LIMIT-ERROR-FILE              file path where memory_limit is exceeded
-      --memory-limit-error-line=MEMORY-LIMIT-ERROR-LINE              line number where memory_limit is exceeded
-      --memory-limit-error-max-depth[=MEMORY-LIMIT-ERROR-MAX-DEPTH]  max attempts to trace back the VM stack on memory_limit error [default: 512]
-  -p, --pid=PID                                                      process id
-      --php-regex[=PHP-REGEX]                                        regex to find the php binary loaded in the target process
-      --libpthread-regex[=LIBPTHREAD-REGEX]                          regex to find the libpthread.so loaded in the target process
-      --php-version[=PHP-VERSION]                                    php version (auto|v7[0-4]|v8[012345]) of the target (default: auto)
-      --php-path[=PHP-PATH]                                          path to the php binary (only needed in tracing chrooted ZTS target)
-      --libpthread-path[=LIBPTHREAD-PATH]                            path to the libpthread.so (only needed in tracing chrooted ZTS target)
-  -h, --help                                                         Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                                                        Do not output any message
-  -V, --version                                                      Display this application version
-      --ansi|--no-ansi                                               Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction                                               Do not ask any interactive question
-      --memory-limit=MEMORY-LIMIT                                     set PHP memory_limit for analysis (e.g. 2G, 512M)
-  -v|vv|vvv, --verbose                                               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
-```
+- `-p, --pid <PID>` — target process id (or pass a `cmd` after `--` to spawn one)
+- `-f, --output-format <fmt>` — `json` (default), `sqlite3`, `binary` (`.rmem`),
+  `report`, `report-json`, `mysql`, `postgresql`. `binary` / `sqlite3` /
+  `mysql` / `postgresql` require `-o` (or `--db-*`).
+- `-o, --output <path>` — write to a file instead of stdout
+- `--pretty-print` — pretty-print the JSON output (default: off)
+- `--stop-process` / `--no-stop-process` — `SIGSTOP` the target during the read (default: on)
+- `--db-host` / `--db-port` / `--db-name` / `--db-user` / `--db-password` — destination for `mysql` / `postgresql` formats
+- `--memory-limit-error-file` / `--memory-limit-error-line` / `--memory-limit-error-max-depth` — focus analysis on a specific `memory_limit` site (used by `inspector:sidecar`)
+- `--php-regex` / `--libpthread-regex` / `--zts-globals-regex` / `--php-version` / `--php-path` / `--libpthread-path` — target binary discovery and version overrides (rarely needed; ZTS / chroot / unusual binary names)
+- `--no-cache` — bypass the binary analysis cache for this run
+- `--memory-limit <size>` — `ini_set('memory_limit', ...)` for the analyser itself, not the target
 
 # Usage
 > [!CAUTION]

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -26,7 +26,7 @@ everywhere — see [§ Three-way focus bus](#three-way-focus-bus).
 Interactive terminal UI for browsing a memory snapshot.
 
 ```bash
-php reli rmem:explore output.rmem
+reli rmem:explore output.rmem
 ```
 
 ### Views
@@ -92,23 +92,23 @@ to manual-drill-only.
 
 ```bash
 # Start focused on a specific node (from report findings)
-php reli rmem:explore output.rmem --node=12345
+reli rmem:explore output.rmem --node=12345
 
 # Start focused on a memory address
-php reli rmem:explore output.rmem --address=0x7f1234567890
+reli rmem:explore output.rmem --address=0x7f1234567890
 
 # Set memory limit
-php reli rmem:explore output.rmem --memory-limit=4G
+reli rmem:explore output.rmem --memory-limit=4G
 
 # Fork a query server for AI assistant access
-php reli rmem:explore output.rmem --serve
+reli rmem:explore output.rmem --serve
 
 # Enable TUI control via the query server
-php reli rmem:explore output.rmem --serve --serve-control
+reli rmem:explore output.rmem --serve --serve-control
 
 # Fork an HTTP/SSE bridge so browsers follow this TUI live.
 # Combine with --serve to expose both the Unix socket and HTTP.
-php reli rmem:explore output.rmem --http-bridge 8080
+reli rmem:explore output.rmem --http-bridge 8080
 # Then press `f` inside the TUI and open http://127.0.0.1:8080/
 
 # Rewrite file paths recorded in the snapshot for local navigation.
@@ -116,7 +116,7 @@ php reli rmem:explore output.rmem --http-bridge 8080
 # remote host and you want the "source:" lines in the detail pane
 # to point at your local checkout. May be repeated; longest prefix
 # wins.
-php reli rmem:explore output.rmem \
+reli rmem:explore output.rmem \
     --path-map /var/www/html=/home/me/project
 ```
 
@@ -184,7 +184,7 @@ finding in explore:
 ```
 
 ```bash
-php reli rmem:explore output.rmem --node=113629
+reli rmem:explore output.rmem --node=113629
 ```
 
 ## rmem:viz
@@ -200,14 +200,14 @@ views backed by d3 and 3d-force-graph, loaded from a CDN at runtime:
 | **3D Force** | Reference graph / cluster layout in WebGL |
 
 ```bash
-php reli rmem:viz output.rmem
+reli rmem:viz output.rmem
 # wrote output.rmem.viz.html
 
 # Inspect a larger subgraph / include reference edges
-php reli rmem:viz output.rmem --top 1000 --depth 2 --all-edges
+reli rmem:viz output.rmem --top 1000 --depth 2 --all-edges
 
 # Send somewhere specific
-php reli rmem:viz output.rmem -o /tmp/viz.html
+reli rmem:viz output.rmem -o /tmp/viz.html
 ```
 
 ### Options
@@ -255,11 +255,11 @@ channel** so browsers stay in sync with each other and with any TUI
 / MCP client that joins the bus.
 
 ```bash
-php reli rmem:live output.rmem
+reli rmem:live output.rmem
 # listening on tcp://127.0.0.1:8080 — open http://127.0.0.1:8080/ in a browser
 
 # Larger subgraph, wider-open network
-php reli rmem:live output.rmem --port 18080 --host 0.0.0.0 --top 2000
+reli rmem:live output.rmem --port 18080 --host 0.0.0.0 --top 2000
 ```
 
 ### Options
@@ -302,21 +302,21 @@ Persistent headless query server. Loads the `.rmem` file once and
 serves queries over a Unix domain socket.
 
 ```bash
-php reli rmem:serve output.rmem
+reli rmem:serve output.rmem
 # serving on /run/user/1000/reli/rmem-serve/a1b2c3d4.sock
 
 # With custom socket path
-php reli rmem:serve output.rmem --socket=/tmp/my-rmem.sock
+reli rmem:serve output.rmem --socket=/tmp/my-rmem.sock
 
 # Auto-shutdown after 30 minutes of inactivity
-php reli rmem:serve output.rmem --timeout=1800
+reli rmem:serve output.rmem --timeout=1800
 ```
 
 ### Querying
 
 ```bash
 # Using rmem:query CLI
-php reli rmem:query --server=sock:/run/user/.../a1b2c3d4.sock
+reli rmem:query --server=sock:/run/user/.../a1b2c3d4.sock
 
 # Using socat
 echo '{"action":"query.roots"}' | socat - UNIX-CONNECT:/run/user/.../a1b2c3d4.sock
@@ -360,16 +360,16 @@ use the tools automatically.
 
 ```bash
 # Headless mode: loads .rmem in-process
-php reli rmem:mcp --rmem=output.rmem
+reli rmem:mcp --rmem=output.rmem
 
 # Connect to existing server
-php reli rmem:mcp --socket=/path/to/sock
+reli rmem:mcp --socket=/path/to/sock
 
 # With TUI control (requires explore --serve --serve-control)
-php reli rmem:mcp --socket=/path/to/sock --control
+reli rmem:mcp --socket=/path/to/sock --control
 
 # With HTTP bridge (so AI navigation lights up every connected browser)
-php reli rmem:mcp --rmem=output.rmem --bridge=http://127.0.0.1:8080
+reli rmem:mcp --rmem=output.rmem --bridge=http://127.0.0.1:8080
 ```
 
 ### Claude Code integration

--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -6,14 +6,24 @@ Unlike `inspector:watch` (polling-based monitoring), the sidecar responds to **e
 
 ## Quick Start
 
-**Start the sidecar** (uses the per-user systemd runtime dir, which is
-already mode 0700 on most distros — no setup needed):
+**Start the sidecar.** When `$XDG_RUNTIME_DIR` is set (interactive
+desktop / SSH login session under systemd), the default socket path
+sits inside the per-user runtime dir, which is already mode 0700 — no
+setup needed:
 
 ```bash
 mkdir -p /tmp/reli-dumps
 reli inspector:sidecar --output-dir=/tmp/reli-dumps
 # → [sidecar] Listening on /run/user/<uid>/reli/sidecar.sock
 ```
+
+If `$XDG_RUNTIME_DIR` isn't set (root shells outside a user session,
+basic Docker / systemd-nspawn containers, sandboxed CI environments),
+this command exits with `Cannot resolve default sidecar socket path`.
+Pre-create a 0700 parent directory you own and pass `--socket`
+explicitly — see the override block below — or set
+`$RELI_SIDECAR_SOCKET` to the same path so the application-side
+`MemoryLimitHandler` finds the daemon without further configuration.
 
 **In your PHP application (one line in bootstrap):**
 

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -15,7 +15,7 @@ tracing backend, [phpspy-hybrid.md](phpspy-hybrid.md).
 | `inspector:trace` | Sample one process (by `-p <pid>`) or spawn one and sample it |
 | `inspector:daemon` | Concurrently sample every process whose command-line matches a regex |
 | `inspector:top` | UNIX-`top`-style live aggregated view across matching processes |
-| `inspector:eg` | Just the EG address (e.g. to feed phpspy manually) |
+| `inspector:eg_address` | Just the EG address (e.g. to feed phpspy manually) |
 
 All four require `CAP_SYS_PTRACE` on the reli process (running as
 root is usually enough).
@@ -148,7 +148,7 @@ Flags are the regex/pool subset of `inspector:daemon`:
 `-P/--target-regex`, `-T/--threads`, `-d/--depth`, `-s/--sleep-ns`,
 `--with-native-trace`.
 
-## `inspector:eg`
+## `inspector:eg_address`
 
 Just the EG address, no sampling. Useful if you want to feed phpspy
 manually, or script an integration that needs to bootstrap phpspy
@@ -156,7 +156,7 @@ itself with an EG address (which phpspy alone cannot resolve for
 ZTS):
 
 ```bash
-$ sudo php ./reli inspector:eg -p <pid>
+$ sudo php ./reli inspector:eg_address -p <pid>
 0x555ae7825d80
 ```
 

--- a/docs/tracing/phpspy-hybrid.md
+++ b/docs/tracing/phpspy-hybrid.md
@@ -57,10 +57,10 @@ sudo php ./reli phpspy:trace -p <zts-pid>
 ```
 
 If you only need the EG address (e.g. you want to invoke phpspy
-yourself with a custom workflow), use `inspector:eg`:
+yourself with a custom workflow), use `inspector:eg_address`:
 
 ```bash
-sudo php ./reli inspector:eg -p <zts-pid>
+sudo php ./reli inspector:eg_address -p <zts-pid>
 # 0x555ae7825d80
 ```
 


### PR DESCRIPTION
## Summary
This PR updates documentation to reflect command naming conventions and improves clarity around installation, usage patterns, and cross-references.

## Key Changes

- **Command name standardization**: Updated `inspector:eg` to `inspector:eg_address` throughout documentation to match the actual command name
- **Removed `php` prefix from command examples**: Changed `php reli <cmd>` to `reli <cmd>` in most examples to match the recommended Docker-wrapper install pattern, while clarifying in getting-started that native installs use `./reli`
- **Simplified memory profiler options documentation**: Replaced exhaustive flag listing with a curated set of commonly-used flags and a note that `--help` is the source of truth, making the docs more maintainable
- **Added PHP version requirement note**: Documented that the `./reli` shebang requires PHP 8.5+, with guidance for distros shipping older defaults
- **Improved sidecar setup documentation**: Expanded explanation of `$XDG_RUNTIME_DIR` behavior and added guidance for environments where it's not set (root shells, containers, CI)
- **Fixed cross-reference paths**: Updated internal doc links to reflect the reorganized docs structure (e.g., `docs/binary-trace-format.md` → `docs/tracing/binary-trace-format.md`)
- **Enhanced link formatting**: Improved markdown link syntax in several places for better readability

## Notable Details

- The changes maintain backward compatibility in functionality while improving documentation accuracy
- Command examples now consistently reflect the recommended installation method (Docker wrapper)
- Documentation is now more maintainable by deferring exhaustive flag documentation to `--help` output

https://claude.ai/code/session_01KkyQy19s6sDYUZgSWD2JfR