### PR TITLE
Throw catchable exception when ProcessModuleMemoryMap accessors hit an empty map

### DIFF
--- a/src/Lib/Process/MemoryMap/ProcessModuleMemoryMap.php
+++ b/src/Lib/Process/MemoryMap/ProcessModuleMemoryMap.php
@@ -28,6 +28,7 @@ final class ProcessModuleMemoryMap implements ProcessModuleMemoryMapInterface
     #[\Override]
     public function getBaseAddress(): int
     {
+        $this->assertNotEmpty(__FUNCTION__);
         if (!isset($this->base_address)) {
             $base_address = PHP_INT_MAX;
             foreach ($this->memory_areas as $memory_area) {
@@ -41,6 +42,7 @@ final class ProcessModuleMemoryMap implements ProcessModuleMemoryMapInterface
     #[\Override]
     public function getMemoryAddressFromOffset(int $offset): int
     {
+        $this->assertNotEmpty(__FUNCTION__);
         $ranges = $this->getSortedOffsetToMemoryAreaMap();
         $file_offset_decided = 0;
         foreach ($ranges as $file_offset => $_memory_begin) {
@@ -79,18 +81,46 @@ final class ProcessModuleMemoryMap implements ProcessModuleMemoryMapInterface
     #[\Override]
     public function getDeviceId(): string
     {
+        $this->assertNotEmpty(__FUNCTION__);
         return $this->memory_areas[0]->device_id;
     }
 
     #[\Override]
     public function getInodeNumber(): int
     {
+        $this->assertNotEmpty(__FUNCTION__);
         return $this->memory_areas[0]->inode_num;
     }
 
     #[\Override]
     public function getModuleName(): string
     {
+        $this->assertNotEmpty(__FUNCTION__);
         return $this->memory_areas[0]->name;
+    }
+
+    /**
+     * Refuse access on a regex-mismatched (empty) map. The original symptom
+     * was "Undefined array key 0" / "Attempt to read property on null"
+     * warnings followed by a TypeError from getDeviceId() when a too-broad
+     * regex picked up a non-PHP candidate. Surfacing as a single catchable
+     * \RuntimeException lets the existing catch (\Throwable) sites in
+     * BinaryFingerprintCreator / ProcessDescriptorRetriever continue
+     * filtering those candidates out without reading their entire
+     * executable file -- accessors are gated rather than the constructor
+     * because the construct-then-fingerprint flow relies on the
+     * catch (\Throwable) downstream to reject the candidate.
+     */
+    private function assertNotEmpty(string $caller): void
+    {
+        if ($this->memory_areas === []) {
+            throw new \RuntimeException(
+                sprintf(
+                    'ProcessModuleMemoryMap::%s called on a map with no memory areas;'
+                    . ' the regex used to filter /proc/{pid}/maps matched nothing',
+                    $caller,
+                ),
+            );
+        }
     }
 }

--- a/tests/Lib/Process/MemoryMap/ProcessModuleMemoryMapTest.php
+++ b/tests/Lib/Process/MemoryMap/ProcessModuleMemoryMapTest.php
@@ -77,6 +77,45 @@ class ProcessModuleMemoryMapTest extends BaseTestCase
         );
     }
 
+    public function testEmptyMemoryAreasThrowsCatchableException(): void
+    {
+        // When the regex used to filter /proc/{pid}/maps matches no module
+        // (e.g. user passing --php-regex='libphp\.so$' against a CLI binary,
+        // or daemon searcher feeding a non-PHP candidate that a too-broad
+        // --target-regex picked up), every accessor that has to look at a
+        // memory area must throw a single catchable exception rather than
+        // emit "Undefined array key 0" / "Attempt to read property on null"
+        // warnings followed by a TypeError, OR silently fall back to a
+        // PHP_INT_MAX base address. ProcessDescriptorRetriever::
+        // getProcessDescriptor already catch (\Throwable) and skips the
+        // candidate, so this shape preserves the implicit "non-PHP
+        // candidate" filter while dropping the noisy warning chain.
+        $map = new ProcessModuleMemoryMap([]);
+        $accessors = [
+            'getDeviceId' => [],
+            'getInodeNumber' => [],
+            'getModuleName' => [],
+            'getBaseAddress' => [],
+            'getMemoryAddressFromOffset' => [0],
+        ];
+        foreach ($accessors as $method => $args) {
+            try {
+                $map->$method(...$args);
+                $this->fail("$method must throw on an empty map");
+            } catch (\RuntimeException $e) {
+                $this->assertStringContainsString('no memory areas', $e->getMessage());
+            }
+        }
+    }
+
+    public function testIsInRangeIsSafeOnEmptyMap(): void
+    {
+        // isInRange is a pure scan, so it can answer without looking at any
+        // particular area. Empty map means "no address is in range".
+        $map = new ProcessModuleMemoryMap([]);
+        $this->assertFalse($map->isInRange(0x10000000));
+    }
+
     public function testIsInRange()
     {
         $process_module_memory_map = new ProcessModuleMemoryMap(


### PR DESCRIPTION
## Summary

`inspector:daemon` / `inspector:memory` against `php -r '...'` (or any
target whose `--php-regex` matches no module in `/proc/{pid}/maps`) used
to dereference `$memory_areas[0]` inside `ProcessModuleMemoryMap`'s
metadata accessors. With the array empty, PHP emitted

```
PHP Warning:  Undefined array key 0 in src/Lib/Process/MemoryMap/ProcessModuleMemoryMap.php on line 82
PHP Warning:  Attempt to read property "device_id" on null in ...:82
```

and then aborted with a `TypeError` ("Return value must be of type
string, null returned"). `getBaseAddress` silently returned `PHP_INT_MAX`
in the same scenario, and `getMemoryAddressFromOffset` emitted its own
`Undefined array key 0` warning, so the broken state kept flowing further
down before something else finally noticed.

## What this PR changes

This PR is intentionally narrow:

- `src/Lib/Process/MemoryMap/ProcessModuleMemoryMap.php`
  - new private `assertNotEmpty(string $caller): void` that throws a
    single `\RuntimeException` mentioning the offending accessor and the
    fact that the regex matched nothing
  - `getDeviceId`, `getInodeNumber`, `getModuleName`, `getBaseAddress`,
    `getMemoryAddressFromOffset` all call it before reading any area
  - `isInRange` is left as-is (it can answer "no" with no areas)
- `tests/Lib/Process/MemoryMap/ProcessModuleMemoryMapTest.php`
  - asserts the throw shape across all five guarded accessors
  - asserts `isInRange` stays empty-safe

No changes to `PhpGlobalsFinder`, `PhpTsrmLsCacheFinder`,
`TsrmGlobalsResolver`, `BinaryFingerprintCreator`, or any cold-attach
call site -- their existing `catch (\Throwable)` blocks already do the
right thing once the warning chain becomes a clean exception.

## Why accessor-level, not constructor-level

The construct-then-fingerprint flow relies on the existing
`catch (\Throwable)` in
`BinaryFingerprintCreator::createFromProcessModuleMemoryMap` and
`ProcessDescriptorRetriever::getProcessDescriptor` to filter out
non-PHP candidates: when a too-broad `--target-regex` picks up a
non-PHP process (e.g. the `docker run` wrapper itself matching
`source` because the inner cmd it forwards contains `/source`), the
old `TypeError` used to bubble into that catch and the candidate was
skipped before any binary was loaded.

An earlier draft of this PR returned `('', 0, '')` sentinels here.
That silenced the warnings, but it also broke the implicit filter
above, sending `PhpSymbolReaderCreator::create -> readlink /proc/{pid}/exe -> NativeFileReader::readAll`
into the docker binary (~45 MB) and OOMing PHP's 128 MB `memory_limit`
in `WatchCommandIntegrationTest::testWatchDaemonMode`. Throwing
explicitly keeps both shapes happy: the user-facing single-pid case
gets a clear "regex matched nothing" message, and the daemon-searcher
case stays filtered without reading any candidate's executable.

Constructing `new ProcessModuleMemoryMap([])` itself stays legal for
the same reason -- the construct-and-fingerprint helpers further up
expect to be able to build the object and let the downstream catch
deal with it.

## Test plan

- [x] `php vendor/bin/phpunit --exclude-group target-version --exclude-group frankenphp --exclude-group mod_php`
- [x] `php vendor/bin/psalm.phar`
- [x] `php vendor/bin/phpcs --standard=PSR12 src/ tests/`
- [x] manual repro: `php ./reli inspector:memory -p $(pid_of_php_r) --php-regex='.*/libphp\.so$'`
      now reports `RuntimeException: ProcessModuleMemoryMap::getDeviceId called on a map with no memory areas; the regex used to filter /proc/{pid}/maps matched nothing` instead of the warning chain + TypeError
- [x] full CI on the previous (sentinel-only) shape failed every
      target-version PHP version with the OOM described above; the
      current shape brings the matrix back to green

https://claude.ai/code/session_01PC8NTA79j8HUt98A61XkFD