### PR TITLE
Support negative values in varint encoding and improve flamegraph converter

### DIFF
--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -98,13 +98,18 @@ IDs, lengths, depths, and timestamp deltas use **protobuf-compatible base-128 va
 - The lower 7 bits of each byte carry data
 - MSB (bit 7) is the continuation flag: 1 = more bytes follow, 0 = final byte
 - Little-endian byte order (least significant byte first)
-- Unsigned integers only
+- Values are 64-bit signed integers; non-negatives take 1–9 bytes. Negative
+  values follow protobuf's `int64` rules — encoded as their 64-bit
+  two's-complement bit pattern and always take 10 bytes. The only field
+  that legitimately goes negative is `lineno` (`-1` for internal /
+  unknown-line frames); other fields (IDs, lengths, deltas) are unsigned.
 
 | Value Range | Bytes |
 |-------------|-------|
 | 0 - 127 | 1 |
 | 128 - 16,383 | 2 |
 | 16,384 - 2,097,151 | 3 |
+| any negative `int64` | 10 |
 
 ---
 

--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -100,9 +100,9 @@ IDs, lengths, depths, and timestamp deltas use **protobuf-compatible base-128 va
 - Little-endian byte order (least significant byte first)
 - Values are 64-bit signed integers; non-negatives take 1–9 bytes. Negative
   values follow protobuf's `int64` rules — encoded as their 64-bit
-  two's-complement bit pattern and always take 10 bytes. The only field
-  that legitimately goes negative is `lineno` (`-1` for internal /
-  unknown-line frames); other fields (IDs, lengths, deltas) are unsigned.
+  two's-complement bit pattern and always take 10 bytes. The writer emits
+  `lineno = -1` for internal-call / unknown-line PHP frames; other fields
+  (IDs, lengths, deltas) are unsigned in practice and stay within 1–9 bytes.
 
 | Value Range | Bytes |
 |-------------|-------|

--- a/src/Command/Converter/FlameGraphCommand.php
+++ b/src/Command/Converter/FlameGraphCommand.php
@@ -17,6 +17,7 @@ use Noodlehaus\Config;
 use PhpCast\Cast;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
+use Reli\Converter\PhpSpyCompatibleFormatter;
 use Reli\Converter\TraceInputReader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -88,23 +89,19 @@ final class FlameGraphCommand extends ReliCommand
         fclose($stackcollapse_pipes[1]);
 
         $reader = new TraceInputReader();
-        foreach ($reader->read(STDIN) as $trace) {
-            foreach ($trace->call_frames as $depth => $frame) {
-                fwrite(
-                    $stackcollapse_pipes[0],
-                    $depth . ' '
-                    . $frame->function_name . ' '
-                    . $frame->file_name . ':' . $frame->lineno
-                    . "\n"
-                );
-            }
-            fwrite($stackcollapse_pipes[0], "\n");
-        }
+        $formatter = new PhpSpyCompatibleFormatter();
+        $formatter->writeTracesTo($stackcollapse_pipes[0], $reader->read(STDIN));
         fclose($stackcollapse_pipes[0]);
 
-        proc_close($stackcollapse_process);
-        proc_close($flamegraph_process);
+        $stackcollapse_status = proc_close($stackcollapse_process);
+        $flamegraph_status = proc_close($flamegraph_process);
 
+        if ($stackcollapse_status !== 0) {
+            return $stackcollapse_status;
+        }
+        if ($flamegraph_status !== 0) {
+            return $flamegraph_status;
+        }
         return 0;
     }
 }

--- a/src/Command/Converter/FlameGraphCommand.php
+++ b/src/Command/Converter/FlameGraphCommand.php
@@ -17,6 +17,7 @@ use Noodlehaus\Config;
 use PhpCast\Cast;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
+use Reli\Converter\TraceInputReader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -38,7 +39,7 @@ final class FlameGraphCommand extends ReliCommand
     public function configure(): void
     {
         $this->setName('converter:flamegraph')
-            ->setDescription('convert phpspy-compatible trace file to flamegraph')
+            ->setDescription('convert traces to flamegraph SVG (auto-detects rbt or phpspy input)')
         ;
     }
 
@@ -55,7 +56,7 @@ final class FlameGraphCommand extends ReliCommand
                 $stackcollapse,
             ],
             [
-                0 => STDIN,
+                0 => ['pipe', 'r'],
                 1 => ['pipe', 'w'],
                 2 => STDERR,
             ],
@@ -73,12 +74,33 @@ final class FlameGraphCommand extends ReliCommand
                 1 => STDOUT,
                 2 => STDERR,
             ],
-            $stackcollapse_pipes
+            $flamegraph_pipes
         );
         if ($flamegraph_process === false) {
+            fclose($stackcollapse_pipes[0]);
+            fclose($stackcollapse_pipes[1]);
             proc_close($stackcollapse_process);
             throw new \RuntimeException('Failed to open flamegraph process');
         }
+
+        // Close our copy of stackcollapse's stdout so flamegraph sees EOF
+        // once stackcollapse exits (otherwise flamegraph hangs).
+        fclose($stackcollapse_pipes[1]);
+
+        $reader = new TraceInputReader();
+        foreach ($reader->read(STDIN) as $trace) {
+            foreach ($trace->call_frames as $depth => $frame) {
+                fwrite(
+                    $stackcollapse_pipes[0],
+                    $depth . ' '
+                    . $frame->function_name . ' '
+                    . $frame->file_name . ':' . $frame->lineno
+                    . "\n"
+                );
+            }
+            fwrite($stackcollapse_pipes[0], "\n");
+        }
+        fclose($stackcollapse_pipes[0]);
 
         proc_close($stackcollapse_process);
         proc_close($flamegraph_process);

--- a/src/Command/Converter/PhpspyCommand.php
+++ b/src/Command/Converter/PhpspyCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Command\Converter;
 
+use Reli\Converter\PhpSpyCompatibleFormatter;
 use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
@@ -39,16 +40,10 @@ final class PhpspyCommand extends ReliCommand
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $reader = new TraceInputReader();
+        $formatter = new PhpSpyCompatibleFormatter();
 
         foreach ($reader->read(STDIN) as $trace) {
-            foreach ($trace->call_frames as $depth => $frame) {
-                $output->writeln(
-                    $depth . ' '
-                    . $frame->function_name . ' '
-                    . $frame->file_name . ':' . $frame->lineno
-                );
-            }
-            $output->writeln('');
+            $output->write($formatter->formatTrace($trace));
         }
 
         return 0;

--- a/src/Converter/BinaryTrace/CallTraceConverter.php
+++ b/src/Converter/BinaryTrace/CallTraceConverter.php
@@ -28,9 +28,7 @@ final class CallTraceConverter
             $frames[] = new ParsedCallFrame(
                 $call_frame->getFullyQualifiedFunctionName(),
                 $call_frame->file_name,
-                // getLineno() returns -1 when opline is null (line unknown).
-                // Varint encoding requires unsigned values, so clamp to 0.
-                max(0, $call_frame->getLineno()),
+                $call_frame->getLineno(),
                 opcode_name: $opcode !== '' ? $opcode : null,
             );
         }
@@ -57,7 +55,7 @@ final class CallTraceConverter
                 $frames[] = new ParsedCallFrame(
                     $php->getFullyQualifiedFunctionName(),
                     $php->file_name,
-                    max(0, $php->getLineno()),
+                    $php->getLineno(),
                     opcode_name: $opcode !== '' ? $opcode : null,
                 );
             }

--- a/src/Converter/BinaryTrace/Varint.php
+++ b/src/Converter/BinaryTrace/Varint.php
@@ -16,15 +16,22 @@ namespace Reli\Converter\BinaryTrace;
 final class Varint
 {
     /**
-     * Encode an unsigned integer as a base-128 varint (protobuf style).
+     * Encode a 64-bit integer as a base-128 varint (protobuf int64 wire format).
+     *
+     * Non-negative values use 1–9 bytes. Negative values are encoded as their
+     * 64-bit two's-complement representation and always take 10 bytes —
+     * matching protobuf's int64 encoding. Round-trips through {@see decode}
+     * back to the original signed PHP int.
      */
     public static function encode(int $value): string
     {
-        assert($value >= 0);
         $bytes = '';
         do {
             $byte = $value & 0x7F;
-            $value >>= 7;
+            // PHP's >> is arithmetic (sign-extending). Mask the top 7 bits to
+            // make this a logical right shift so negative values terminate at
+            // 10 bytes instead of looping forever.
+            $value = ($value >> 7) & 0x01FFFFFFFFFFFFFF;
             if ($value !== 0) {
                 $byte |= 0x80;
             }

--- a/src/Converter/PhpSpyCompatibleFormatter.php
+++ b/src/Converter/PhpSpyCompatibleFormatter.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+/**
+ * Formats {@see ParsedCallTrace} as phpspy-compatible text.
+ *
+ * Each frame is written as `"<depth> <function_name> <file_name>:<lineno>"`
+ * on its own line; traces are separated by a single blank line, matching
+ * the format produced by phpspy and consumed by both
+ * {@see PhpSpyCompatibleParser} and the upstream `stackcollapse-phpspy.pl`.
+ */
+final class PhpSpyCompatibleFormatter
+{
+    public function formatTrace(ParsedCallTrace $trace): string
+    {
+        $out = '';
+        foreach ($trace->call_frames as $depth => $frame) {
+            $out .= $depth . ' '
+                . $frame->function_name . ' '
+                . $frame->file_name . ':' . $frame->lineno
+                . "\n";
+        }
+        $out .= "\n";
+        return $out;
+    }
+
+    /**
+     * @param resource $stream
+     * @param iterable<ParsedCallTrace> $traces
+     */
+    public function writeTracesTo($stream, iterable $traces): void
+    {
+        foreach ($traces as $trace) {
+            fwrite($stream, $this->formatTrace($trace));
+        }
+    }
+}

--- a/tests/Converter/BinaryTrace/CallTraceConverterTest.php
+++ b/tests/Converter/BinaryTrace/CallTraceConverterTest.php
@@ -19,7 +19,7 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
 final class CallTraceConverterTest extends BaseTestCase
 {
-    public function testNullOplineProducesLinenoZero(): void
+    public function testNullOplineProducesNegativeOneLineno(): void
     {
         $call_trace = new CallTrace(
             new CallFrame('MyClass', 'myMethod', '/file.php', null),
@@ -30,18 +30,18 @@ final class CallTraceConverterTest extends BaseTestCase
         $this->assertCount(1, $parsed->call_frames);
         $this->assertSame('MyClass::myMethod', $parsed->call_frames[0]->function_name);
         $this->assertSame('/file.php', $parsed->call_frames[0]->file_name);
-        $this->assertSame(0, $parsed->call_frames[0]->lineno);
+        $this->assertSame(-1, $parsed->call_frames[0]->lineno);
     }
 
-    public function testNullOplineDoesNotTriggerVarintAssert(): void
+    public function testNullOplineRoundTripsNegativeOneThroughBinaryTrace(): void
     {
         $call_trace = new CallTrace(
             new CallFrame('', 'main', '/index.php', null),
         );
 
         $parsed = CallTraceConverter::toParsed($call_trace);
+        $this->assertSame(-1, $parsed->call_frames[0]->lineno);
 
-        // This should not throw: Varint::encode(0) is valid
         $stream = fopen('php://memory', 'r+');
         assert($stream !== false);
 
@@ -57,6 +57,6 @@ final class CallTraceConverterTest extends BaseTestCase
         fclose($stream);
 
         $this->assertCount(1, $results);
-        $this->assertSame(0, $results[0]->trace->call_frames[0]->lineno);
+        $this->assertSame(-1, $results[0]->trace->call_frames[0]->lineno);
     }
 }

--- a/tests/Converter/BinaryTrace/VarintTest.php
+++ b/tests/Converter/BinaryTrace/VarintTest.php
@@ -39,6 +39,14 @@ final class VarintTest extends BaseTestCase
         yield '300' => [300, 'ac02'];
         yield '16384' => [16384, '808001'];
         yield '10000' => [10000, '904e'];
+        yield 'PHP_INT_MAX' => [PHP_INT_MAX, 'ffffffffffffffff7f'];
+        // Negative values use protobuf int64 wire format: 64-bit two's
+        // complement, always 10 bytes. -1 is the sentinel reli writes for
+        // internal-call linenos, so this is a regression case for the
+        // encoder hanging in an infinite loop.
+        yield '-1' => [-1, 'ffffffffffffffffff01'];
+        yield '-2' => [-2, 'feffffffffffffffff01'];
+        yield 'PHP_INT_MIN' => [PHP_INT_MIN, '80808080808080808001'];
     }
 
     public function testDecodeWithOffset(): void

--- a/tests/Converter/PhpSpyCompatibleFormatterTest.php
+++ b/tests/Converter/PhpSpyCompatibleFormatterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Converter;
+
+use Reli\BaseTestCase;
+
+final class PhpSpyCompatibleFormatterTest extends BaseTestCase
+{
+    public function testFormatTraceMatchesPhpSpyTextLayout(): void
+    {
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('sleep', '<internal>', -1),
+            new ParsedCallFrame('aaa', '/tmp/sample.php', 5),
+            new ParsedCallFrame('Ns\\Cls::run', '/tmp/sample.php', 22),
+        );
+
+        $expected = "0 sleep <internal>:-1\n"
+            . "1 aaa /tmp/sample.php:5\n"
+            . "2 Ns\\Cls::run /tmp/sample.php:22\n"
+            . "\n";
+
+        $this->assertSame($expected, (new PhpSpyCompatibleFormatter())->formatTrace($trace));
+    }
+
+    public function testFormatRoundTripsThroughPhpSpyParser(): void
+    {
+        $trace = new ParsedCallTrace(
+            new ParsedCallFrame('sleep', '<internal>', -1),
+            new ParsedCallFrame('aaa', '/tmp/sample.php', 5),
+            new ParsedCallFrame('main', '/tmp/sample.php', 25),
+        );
+
+        $text = (new PhpSpyCompatibleFormatter())->formatTrace($trace);
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        fwrite($stream, $text);
+        rewind($stream);
+
+        $parsed = iterator_to_array((new PhpSpyCompatibleParser())->parseFile($stream));
+        fclose($stream);
+
+        $this->assertCount(1, $parsed);
+        $this->assertCount(3, $parsed[0]->call_frames);
+        $this->assertSame('sleep', $parsed[0]->call_frames[0]->function_name);
+        $this->assertSame('<internal>', $parsed[0]->call_frames[0]->file_name);
+        $this->assertSame(-1, $parsed[0]->call_frames[0]->lineno);
+        $this->assertSame(5, $parsed[0]->call_frames[1]->lineno);
+        $this->assertSame(25, $parsed[0]->call_frames[2]->lineno);
+    }
+
+    public function testWriteTracesToWritesEachTraceWithBlankSeparator(): void
+    {
+        $traces = [
+            new ParsedCallTrace(
+                new ParsedCallFrame('a', '/f.php', 1),
+                new ParsedCallFrame('main', '/f.php', 10),
+            ),
+            new ParsedCallTrace(
+                new ParsedCallFrame('b', '/f.php', 2),
+                new ParsedCallFrame('main', '/f.php', 11),
+            ),
+        ];
+
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+        (new PhpSpyCompatibleFormatter())->writeTracesTo($stream, $traces);
+        rewind($stream);
+        $text = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertSame(
+            "0 a /f.php:1\n1 main /f.php:10\n\n0 b /f.php:2\n1 main /f.php:11\n\n",
+            $text,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR enhances the binary trace format handling to support negative integers in varint encoding (following protobuf int64 wire format) and improves the flamegraph converter to properly handle trace input using the new `TraceInputReader`.

## Key Changes

- **Varint encoding for signed integers**: Updated `Varint::encode()` to handle negative values by encoding them as 64-bit two's-complement representations (always 10 bytes), matching protobuf's int64 wire format. This is necessary for fields like `lineno` which use `-1` as a sentinel value for internal/unknown-line frames.

- **Flamegraph converter improvements**:
  - Changed stdin handling from `STDIN` constant to `['pipe', 'r']` descriptor for proper process pipe management
  - Integrated `TraceInputReader` to parse input traces and write formatted stack frames to stackcollapse
  - Added proper pipe closure handling to prevent hanging processes
  - Updated command description to reflect support for both rbt and phpspy input formats

- **Documentation updates**: Updated binary trace format documentation to clarify that varint values are 64-bit signed integers, with negative values always taking 10 bytes.

- **Test coverage**: Added regression tests for negative varint encoding (`-1`, `-2`, `PHP_INT_MIN`) and `PHP_INT_MAX` to ensure proper round-tripping through encode/decode.

## Implementation Details

The varint encoder now uses a logical right shift (via masking) instead of PHP's arithmetic right shift to properly handle negative values. This ensures negative values terminate at 10 bytes rather than looping infinitely.

The flamegraph converter now reads traces from stdin using `TraceInputReader`, iterates through call frames, and writes them in the format expected by stackcollapse, with proper pipe lifecycle management to avoid deadlocks.

https://claude.ai/code/session_01RqrjngGuzXC9X2NzBQCU2q