### PR TITLE
docs: fix rmem:query server arg, refresh memory JSON example, add native-trace and worker caveats

### DIFF
--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -103,34 +103,34 @@ And the output is like below. The target process is [psalm](https://github.com/v
     ],
     "location_types_summary": {
         "ZendObjectMemoryLocation": {
-            "location_count": 124341,
+            "count": 124341,
             "memory_usage": 45245784
         },
         "ZendArrayTableOverheadMemoryLocation": {
-            "location_count": 108548,
+            "count": 108548,
             "memory_usage": 21204736
         },
         "ZendArrayTableMemoryLocation": {
-            "location_count": 109462,
+            "count": 109462,
             "memory_usage": 17964240
         },
         "ZendStringMemoryLocation": {
-            "location_count": 242532,
+            "count": 242532,
             "memory_usage": 16149456
         },
 <--- snip --->
     "class_objects_summary": {
         "Psalm\\CodeLocation": {
             "count": 32875,
-            "total_size": 13413000
+            "memory_usage": 13413000
         },
         "Psalm\\Type\\Union": {
             "count": 24924,
-            "total_size": 12960480
+            "memory_usage": 12960480
         },
         "Psalm\\Internal\\MethodIdentifier": {
             "count": 8838,
-            "total_size": 636336
+            "memory_usage": 636336
         },
 <--- snip --->
     "context": {

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -248,6 +248,15 @@ the HTML itself:
 | three.js | 0.150.1 | MIT |
 | 3d-force-graph | 1.73.0 | MIT |
 
+> **Network access required when opening the HTML.** The generated
+> `<file>.viz.html` references the libraries above by `https://unpkg.com/...`
+> URLs. On an air-gapped host or a browser without internet access
+> the page renders an empty canvas (no errors, just blank panels).
+> If you need offline viewing, mirror the three scripts to a local
+> path and rewrite the `<script src="...">` tags in the emitted
+> HTML, or run `rmem:live` instead and serve over a private network
+> from a host that can reach unpkg.
+
 ## rmem:live
 
 Same viz as `rmem:viz`, but served over HTTP with a **live SSE event
@@ -315,8 +324,8 @@ reli rmem:serve output.rmem --timeout=1800
 ### Querying
 
 ```bash
-# Using rmem:query CLI
-reli rmem:query --server=sock:/run/user/.../a1b2c3d4.sock
+# Using rmem:query CLI (--server takes the bare socket path)
+reli rmem:query --server=/run/user/.../a1b2c3d4.sock --node=12345
 
 # Using socat
 echo '{"action":"query.roots"}' | socat - UNIX-CONNECT:/run/user/.../a1b2c3d4.sock

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -72,6 +72,15 @@ Native frames are labeled with `[native]:0` and show
 `execute_ex`, reflecting that all PHP execution happens inside the
 VM's opcode dispatcher.
 
+> **Stop-process is required.** Native unwinding needs the target's
+> register state (`ptrace(PTRACE_GETREGS)`), which is only available
+> while the target is `SIGSTOP`-ped. `--with-native-trace` /
+> `--native-trace-anytime` therefore implicitly enable
+> `--stop-process` (`-S`) and reli prints
+> `Implicitly enabling --stop-process (-S).` on startup. There is no
+> non-stop variant; if you cannot afford the per-sample stop, leave
+> the flag off and capture PHP-only frames.
+
 Capture to `.rbt` and analyse interactively:
 
 ```bash
@@ -90,6 +99,15 @@ $ ./reli converter:flamegraph <trace.rbt >flame_native.svg
 - **JIT-compiled function names** resolve via `/tmp/perf-<pid>.map`
   when the target has `opcache.jit_debug=0x10` (see the JIT section
   below).
+
+> Distro-built PHP binaries (e.g. Debian / Ubuntu `php8.X-cli`) only
+> export a small set of symbols in `.dynsym`. The internal call
+> implementations of standard library functions (`zif_usleep`,
+> `zif_strlen`, …) and most engine internals are **not** exported,
+> so they show up as `php8.X::0x<address> [native]:0` rather than
+> the symbolic names in the example above. Install the matching
+> `php8.X-dbgsym` / `-debuginfo` package to get full coverage; the
+> example above was captured against a debug-symbol-equipped PHP.
 
 ### Native traces during interpreter init / shutdown
 

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -129,11 +129,31 @@ sudo php ./reli inspector:daemon -P "^php-fpm" -F rbt -o ./traces/
 Useful flags (in addition to the `inspector:trace` set):
 
 - `-P/--target-regex <regex>` (required)
-- `-T/--threads <N>` — worker pool size
+- `-T/--threads <N>` — worker pool size (default 8)
 
 Output modes for `.rbt` come in two flavours: per-worker files
 (`-F rbt -o <dir>/`) which each worker writes independently, or a
 single bundled stream. See [binary-trace-format.md](binary-trace-format.md).
+
+### Sizing `-T`
+
+Workers are reli's tracer threads, not target threads. Match `-T`
+roughly to the number of target processes you expect the regex to
+match concurrently:
+
+- **Workers > matched targets**: idle workers stay parked. With
+  `-F rbt -o <dir>/` they still create their `worker_<pid>.rbt`
+  output files, so directories will contain 0-byte files for the
+  idle workers (harmless, but `find <dir> -size 0 -delete` cleans
+  up after a run if it bothers downstream tooling).
+- **Workers < matched targets**: surplus matches share workers
+  round-robin. Each worker can sample multiple targets, but the
+  effective per-target rate drops with the share count. For dense
+  pools (php-fpm with many children, FrankenPHP worker arrays),
+  raise `-T` until each worker handles a small handful of targets.
+- **Default 8** is sized for "medium pool" cases. A 64-worker
+  php-fpm pool will under-cover at the default; a single-target
+  smoke test will leave 7 workers idle.
 
 ## `inspector:top`
 


### PR DESCRIPTION
## Summary

Second-pass cleanup from the README/docs walkthrough. Each item is something a copy-paste user can hit but the docs currently mislead them on.

- **`rmem:query --server`**: doc showed `--server=sock:<path>`, but the option takes the bare socket path; the `sock:` prefix makes it bail with `Cannot connect to sock:/...: No such file or directory`. Drop the prefix from the example and add `--node=12345` so the snippet is runnable as-is. (`docs/memory/rmem-explore-and-serve.md`)
- **`inspector:memory` JSON example**: the JSON sample claimed `location_types_summary[*].location_count` and `class_objects_summary[*].total_size`, but the actual output (and the jq snippets a few sections below) use `count` / `memory_usage`. Fix the example to match. (`docs/memory/memory-profiler.md`)
- **`--with-native-trace` requires `-S`**: native unwinding needs `ptrace(PTRACE_GETREGS)`, so the flag implicitly enables `--stop-process`. reli prints a notice on startup but the doc was silent — add a note so users know the per-sample stop is unavoidable. (`docs/tracing/advanced-capture.md`)
- **Distro PHP and `zif_*` symbols**: the example block resolves `zif_usleep+0x42`, but Debian/Ubuntu's `php8.X-cli` doesn't export those internals in `.dynsym`, so they show as `php8.X::0x<address>`. Note that `-dbgsym` / `-debuginfo` is needed to get the symbolic example output. (`docs/tracing/advanced-capture.md`)
- **`inspector:daemon -T` sizing**: explain that workers are reli's tracer threads, not target threads; that idle workers leave 0-byte `worker_<pid>.rbt` files when `-T` exceeds matched targets; and that surplus targets share a worker round-robin (per-target rate drops). (`docs/tracing/capturing-traces.md`)
- **`rmem:viz` HTML needs internet**: the generated `<file>.viz.html` references d3 / three.js / 3d-force-graph by `unpkg.com` URLs, so an air-gapped browser shows a blank canvas with no error. Call this out and point at `rmem:live` / a local mirror as the offline path. (`docs/memory/rmem-explore-and-serve.md`)

All findings were reproduced locally against `0.12.x` before drafting the patch; relative markdown links still resolve (verified with a small script).

## Test plan

- [x] `git diff --stat` matches the items above (4 files, +57/-10)
- [x] All in-repo `[...](relative.md)` links still resolve
- [x] `rmem:query --server=<path>` (no prefix) connects to a running `rmem:serve` and returns the queried node
- [x] `inspector:memory --pretty-print` output uses `count` / `memory_usage` (no `location_count` / `total_size` anywhere)
- [x] `inspector:trace --with-native-trace -p <pid>` prints the `Implicitly enabling --stop-process (-S).` notice referenced in the new note
- [x] `inspector:daemon -P <regex> -T 8 -F rbt -o <dir>/` against a 1-target setup leaves 5+ zero-byte `worker_*.rbt` files (the behaviour the new section warns about)

https://claude.ai/code/session_01KkyQy19s6sDYUZgSWD2JfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkyQy19s6sDYUZgSWD2JfR)_