### PR TITLE
Clean up empty trace artifacts from idle workers and sessions

### DIFF
--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
@@ -49,6 +49,10 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
 
         $output_settings = $set_settings_message->output_settings;
         $use_binary_direct = $output_settings !== null && $output_settings->isBinaryTrace();
+        $binary_output_dir = $use_binary_direct ? $output_settings->output_path : null;
+        if ($use_binary_direct && $output_settings->rbt_compress) {
+            $this->compress = true;
+        }
 
         // Derive sampling period from loop settings (ns → µs)
         $sampling_period_us = (int)(
@@ -58,18 +62,24 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
             $sampling_period_us = 10000;
         }
 
-        // Open the output file once; segments share the stream
-        if ($use_binary_direct && $output_settings->output_path !== null) {
-            $this->compress = $output_settings->rbt_compress;
-            $this->openBinaryStream($output_settings->output_path);
-        }
-
         $this->installSignalHandler();
 
         while ($this->loop_condition->shouldContinue()) {
             $attach_message = $this->protocol->receiveAttach();
             Log::debug('attach_message', [$attach_message]);
             $pid = $attach_message->process_descriptor->pid;
+
+            // Open the output file lazily on the first attach. Workers
+            // spawned in excess of the active target count never reach
+            // this point, so they don't leave behind a zero-byte
+            // worker_<pid>.rbt artifact in the output directory.
+            if (
+                $use_binary_direct
+                && $this->binary_stream === null
+                && $binary_output_dir !== null
+            ) {
+                $this->openBinaryStream($binary_output_dir);
+            }
 
             // Start a new self-contained segment for this attach.
             // A fresh BinaryTraceWriter resets frame/stack intern state.

--- a/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
@@ -51,6 +51,19 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     }
 
     /**
+     * Whether any sample has been written through this output.
+     *
+     * Header is emitted lazily on the first sample, so this also indicates
+     * whether the underlying stream has any bytes written via this output.
+     * Used by callers (e.g. TraceSession) to drop empty trace artifacts
+     * when a session is opened but no sample is ever recorded.
+     */
+    public function hasSamples(): bool
+    {
+        return $this->header_written;
+    }
+
+    /**
      * Finalize: write checkpoint + segment end, then gzip if configured.
      */
     public function finish(): void

--- a/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
+++ b/src/Inspector/Output/TraceOutput/BinaryTraceOutput.php
@@ -22,6 +22,7 @@ use Reli\Lib\PhpProcessReader\CallTraceReader\MergedCallTrace;
 final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
 {
     private bool $header_written = false;
+    private bool $sample_written = false;
     private ?int $last_hrtime_ns = null;
 
     /**
@@ -53,14 +54,15 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
     /**
      * Whether any sample has been written through this output.
      *
-     * Header is emitted lazily on the first sample, so this also indicates
-     * whether the underlying stream has any bytes written via this output.
-     * Used by callers (e.g. TraceSession) to drop empty trace artifacts
-     * when a session is opened but no sample is ever recorded.
+     * Tracked independently of header_written so the answer stays correct
+     * even if a future change makes the header eager (e.g. emitted at
+     * construction or on an explicit start() call). Used by callers
+     * (e.g. TraceSession) to drop empty trace artifacts when a session
+     * is opened but no sample is ever recorded.
      */
     public function hasSamples(): bool
     {
-        return $this->header_written;
+        return $this->sample_written;
     }
 
     /**
@@ -111,6 +113,7 @@ final class BinaryTraceOutput implements TraceOutput, MergedTraceOutput
         $this->last_hrtime_ns = $now_ns;
 
         $this->writer->writeTrace($parsed, $delta_us, $annotations);
+        $this->sample_written = true;
 
         if ($this->writer->getSamplesSinceCheckpoint() >= $this->checkpoint_interval) {
             $this->writer->writeCheckpoint();

--- a/src/Inspector/Watch/TraceSession.php
+++ b/src/Inspector/Watch/TraceSession.php
@@ -86,15 +86,25 @@ final class TraceSession
     /**
      * Stop the current trace recording session.
      *
-     * Finalizes the .rbt file (checkpoint + segment end).
+     * Finalizes the .rbt file (checkpoint + segment end). When the session
+     * was opened but no sample was ever recorded — e.g. ENTER fired and
+     * `--oneshot` terminated the watch loop on the next poll, before the
+     * first sample could be taken — the trace file would otherwise be left
+     * at zero bytes. In that case we drop the empty file so the output
+     * directory does not accumulate inert artifacts.
      */
     public function stop(): void
     {
         if ($this->output === null) {
             return;
         }
+        $had_samples = $this->output->hasSamples();
         $this->output->finish();
         $this->output = null;
+        if (!$had_samples && $this->current_path !== null) {
+            @\unlink($this->current_path);
+            $this->current_path = null;
+        }
     }
 
     public function isActive(): bool

--- a/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
+++ b/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
@@ -23,7 +23,9 @@ use Reli\Inspector\Daemon\Reader\Protocol\Message\SetSettingsMessage;
 use Reli\Inspector\Daemon\Reader\Protocol\Message\TraceMessage;
 use Reli\Inspector\Daemon\Reader\Protocol\PhpReaderWorkerProtocolInterface;
 use Reli\Inspector\Settings\GetTraceSettings\GetTraceSettings;
+use Reli\Inspector\Settings\OutputSettings\OutputSettings;
 use Reli\Inspector\Settings\TraceLoopSettings\TraceLoopSettings;
+use Reli\Lib\Loop\LoopCondition\LoopConditionInterface;
 use Reli\Lib\Loop\LoopCondition\OnlyOnceCondition;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
@@ -154,6 +156,61 @@ class PhpReaderEntryPointTest extends BaseTestCase
         );
 
         $entry_point->run();
+    }
+
+    public function testIdleWorkerLeavesNoBinaryArtifact(): void
+    {
+        // A daemon worker that never receives an attach message — i.e.
+        // -T is larger than the live target count — must not leave a
+        // zero-byte worker_<pid>.rbt behind in the output directory.
+        // The output stream is opened lazily on first attach, so an
+        // idle worker drops out via shouldContinue() without creating
+        // any file.
+        $tmpdir = \sys_get_temp_dir() . '/reli-test-idle-worker-' . \getmypid();
+        @\mkdir($tmpdir, 0755, true);
+        try {
+            $output_settings = new OutputSettings(
+                output_format: 'rbt',
+                output_path: $tmpdir,
+                rbt_timestamps: 'delta',
+                rbt_compress: false,
+            );
+            $settings = new SetSettingsMessage(
+                new TraceLoopSettings(1, 'q', 10, false),
+                new GetTraceSettings(PHP_INT_MAX),
+                $output_settings,
+            );
+            $php_reader_task = Mockery::mock(PhpReaderTraceLoopInterface::class);
+            $protocol = Mockery::mock(PhpReaderWorkerProtocolInterface::class);
+            $protocol->expects()->receiveSettings()->andReturns($settings)->once();
+            // Loop never enters: receiveAttach is not called.
+            $protocol->shouldNotReceive('receiveAttach');
+
+            $never = Mockery::mock(LoopConditionInterface::class);
+            $never->shouldReceive('shouldContinue')->andReturn(false);
+
+            $entry_point = new PhpReaderEntryPoint(
+                $php_reader_task,
+                $protocol,
+                $never,
+            );
+            $entry_point->run();
+
+            $files = \glob($tmpdir . '/*');
+            $this->assertSame(
+                [],
+                $files === false ? [] : $files,
+                'idle worker must not create any rbt file',
+            );
+        } finally {
+            $files = \glob($tmpdir . '/*');
+            if ($files !== false) {
+                foreach ($files as $f) {
+                    @\unlink($f);
+                }
+            }
+            @\rmdir($tmpdir);
+        }
     }
 
     private function getTestTrace(string $function, ?int $pid = null): TraceMessage

--- a/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
+++ b/tests/Inspector/Output/TraceOutput/BinaryTraceOutputTest.php
@@ -65,6 +65,31 @@ final class BinaryTraceOutputTest extends BaseTestCase
         fclose($stream);
     }
 
+    public function testHasSamplesReflectsSamplePresence(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        assert($stream !== false);
+
+        $writer = new BinaryTraceWriter($stream, 10000);
+        $output = new BinaryTraceOutput($writer);
+
+        $this->assertFalse($output->hasSamples());
+
+        $output->output(
+            new CallTrace(
+                new CallFrame('App', 'run', '/app.php', null),
+            ),
+        );
+
+        $this->assertTrue($output->hasSamples());
+
+        // finish() must not change the answer either way.
+        $output->finish();
+        $this->assertTrue($output->hasSamples());
+
+        fclose($stream);
+    }
+
     public function testFinishWithCompressProducesGzip(): void
     {
         $buffer = fopen('php://temp', 'r+');

--- a/tests/Inspector/Watch/TraceSessionTest.php
+++ b/tests/Inspector/Watch/TraceSessionTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Reli\Inspector\Watch;
 
 use PHPUnit\Framework\TestCase;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallFrame;
+use Reli\Lib\PhpProcessReader\CallTraceReader\CallTrace;
 
 class TraceSessionTest extends TestCase
 {
@@ -107,5 +109,44 @@ class TraceSessionTest extends TestCase
         $this->assertNotNull($path);
         $this->assertFileExists($path);
         $session->stop();
+    }
+
+    public function testEmptySessionLeavesNoArtifact(): void
+    {
+        // Reproducer for the watch + --on-enter=trace + --oneshot=N
+        // race: ENTER opens the trace file but the watch loop terminates
+        // before any sample reaches recordSample(). The .rbt header is
+        // never written, so without cleanup the file would be left at
+        // zero bytes in the action-output-dir.
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $path = $session->getCurrentPath();
+        $this->assertNotNull($path);
+        $this->assertFileExists($path);
+
+        $session->stop();
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertNull($session->getCurrentPath());
+    }
+
+    public function testRecordedSessionKeepsFile(): void
+    {
+        $session = new TraceSession($this->tmpdir);
+        $session->start(1234, 1700000000.0);
+        $path = $session->getCurrentPath();
+        $this->assertNotNull($path);
+
+        $session->recordSample(
+            new CallTrace(
+                new CallFrame('App', 'run', '/app.php', null),
+            ),
+        );
+
+        $session->stop();
+
+        $this->assertFileExists($path);
+        $this->assertGreaterThan(0, \filesize($path));
+        $this->assertSame($path, $session->getCurrentPath());
     }
 }


### PR DESCRIPTION
## Summary
This PR prevents empty trace files from being created when workers or sessions are opened but never actually record any samples. This addresses race conditions in daemon workers and watch sessions where files could be left at zero bytes in the output directory.

## Key Changes

- **Lazy binary stream initialization in daemon workers**: Moved the opening of binary output streams from initialization to the first attach message. This ensures that idle workers (spawned in excess of active targets) never create output files since they exit via `shouldContinue()` before receiving any attach message.

- **Empty trace file cleanup in watch sessions**: Added logic to detect when a trace session was opened but never recorded any samples, and automatically delete the empty file on `stop()`. This handles the race condition where `--on-enter=trace` opens a file but `--oneshot` terminates before the first sample is recorded.

- **Sample tracking in BinaryTraceOutput**: Added `hasSamples()` method to track whether any data has been written through the output stream, backed by a dedicated `sample_written` flag (decoupled from the lazy `header_written` state so it stays correct if the header is ever written eagerly in the future).

## Implementation Details

- The `PhpReaderEntryPoint` now stores the output directory path and defers stream opening until the first `receiveAttach()` call within the loop.
- `TraceSession.stop()` checks `hasSamples()` before finalizing and removes the file if it's empty.
- Both changes maintain backward compatibility—files with recorded samples are preserved as before.
- Tests added to verify idle workers leave no artifacts and empty sessions are cleaned up properly.

## Scope

This removes zero-byte artifacts from workers that never receive an attach
and from watch sessions that stop before the first sample. A daemon worker
that *does* receive an attach but records no real samples (e.g. a target
that yields only empty `CallTrace` markers for the worker's whole lifetime)
may still produce a header+metadata-only `.rbt` segment with zero samples;
handling that is left as a separate follow-up.

https://claude.ai/code/session_01XNfRguRxrTvHJuahW8oT8i