### PR TITLE
Preserve output settings when passing to worker processes

### DIFF
--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -132,7 +132,12 @@ final class DaemonCommand extends ReliCommand
 
         // Pass resolved output dir to workers (not the raw user path)
         $worker_output_settings = $rbt_output_dir !== null
-            ? new OutputSettings($output_settings->output_format, $rbt_output_dir)
+            ? new OutputSettings(
+                $output_settings->output_format,
+                $rbt_output_dir,
+                $output_settings->rbt_timestamps,
+                $output_settings->rbt_compress,
+            )
             : $output_settings;
 
         $worker_pool = WorkerPool::create(


### PR DESCRIPTION
## Summary
Fixed a bug where output settings were not fully preserved when passing configuration to worker processes in the daemon command.

## Key Changes
- Updated `OutputSettings` instantiation for worker processes to include all configuration options
- Added `rbt_timestamps` and `rbt_compress` parameters that were previously omitted
- These settings are now properly propagated from the parent process to worker processes, ensuring consistent behavior across the worker pool

## Implementation Details
The worker output settings were being created with only the output format and directory, losing the timestamp and compression settings from the original configuration. This change ensures all output-related settings are consistently applied to worker processes.

https://claude.ai/code/session_014NTvTnsJWvUnhRkwXBoB8D