### PR TITLE
Document filename handling for rbt compression modes

### DIFF
--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -676,6 +676,8 @@ reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
 - No raw `.rbt` data touches disk — only compressed data is written
 - Without `--rbt-compress`, output is raw `.rbt` per worker (default, best for recovery/tail)
 
+**Single-shot and bundled modes don't auto-suffix the filename.** Only daemon per-worker mode rewrites the extension, because there reli generates the per-worker filename itself (`worker_{pid}.rbt` → `worker_{pid}.rbt.gz`). In `inspector:trace` and `-F rbt-bundled`, `-o` is treated as the exact output path: `-o foo.rbt --rbt-compress` writes gzip content to a file named `foo.rbt`. `rbt:analyze` auto-detects gzip so the file still works, but external tools (`file`, `tar`) will see a `.rbt`-named gzip blob. Pass `-o foo.rbt.gz` explicitly if you want the extension to match the contents.
+
 ### When to use which
 
 | Format | Best for |


### PR DESCRIPTION
## Summary
Added clarification to the binary trace format documentation explaining how filename suffixing works differently across rbt compression modes.

## Changes
- Added a note documenting that single-shot and bundled modes don't auto-suffix filenames when using `--rbt-compress`
- Clarified that only daemon per-worker mode automatically rewrites file extensions (`.rbt` → `.rbt.gz`)
- Explained that in `inspector:trace` and `-F rbt-bundled` modes, the `-o` flag is treated as the exact output path, so users must explicitly specify `.rbt.gz` if they want the extension to match gzip content
- Noted that `rbt:analyze` auto-detects gzip format, so mismatched extensions don't break functionality, but external tools may show incorrect file types

## Details
This documentation update helps users understand the subtle but important differences in how the three rbt output modes handle filename extensions when compression is enabled, preventing confusion when the file extension doesn't match the actual file format.

https://claude.ai/code/session_01LdFGdfYEsv2sDR5X7tFzeB