### PR TITLE
fix(daemon): drop attach-but-no-sample rbt segments

### DIFF
--- a/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
+++ b/src/Inspector/Daemon/Reader/Worker/PhpReaderEntryPoint.php
@@ -53,6 +53,7 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
         if ($use_binary_direct && $output_settings->rbt_compress) {
             $this->compress = true;
         }
+        $has_timestamps = $output_settings !== null && $output_settings->hasRbtTimestamps();
 
         // Derive sampling period from loop settings (ns → µs)
         $sampling_period_us = (int)(
@@ -69,39 +70,16 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
             Log::debug('attach_message', [$attach_message]);
             $pid = $attach_message->process_descriptor->pid;
 
-            // Open the output file lazily on the first attach. Workers
-            // spawned in excess of the active target count never reach
-            // this point, so they don't leave behind a zero-byte
-            // worker_<pid>.rbt artifact in the output directory.
-            if (
-                $use_binary_direct
-                && $this->binary_stream === null
-                && $binary_output_dir !== null
-            ) {
-                $this->openBinaryStream($binary_output_dir);
-            }
-
-            // Start a new self-contained segment for this attach.
-            // A fresh BinaryTraceWriter resets frame/stack intern state.
-            $has_timestamps = $output_settings !== null && $output_settings->hasRbtTimestamps();
-            if ($use_binary_direct && $this->binary_stream !== null) {
-                if ($this->compress) {
-                    $buf = fopen('php://temp', 'r+');
-                    assert($buf !== false);
-                    $this->segment_buffer = $buf;
-                    $write_target = $this->segment_buffer;
-                } else {
-                    $write_target = $this->binary_stream;
-                }
-                $this->binary_writer = new BinaryTraceWriter(
-                    $write_target,
-                    $sampling_period_us,
-                    has_timestamps: $has_timestamps,
-                );
-                $this->binary_writer->writeHeader();
-                $this->binary_writer->writeMetadata('pid', (string)$pid);
-                $this->last_hrtime_ns = null;
-            }
+            // Writer construction, header/metadata emission, and (for
+            // the worker's first segment) the underlying file open are
+            // all deferred to the first non-empty trace. An attach that
+            // observes only the trace loop's idle ride-through markers
+            // (empty CallTrace) for its whole lifetime therefore writes
+            // no segment, leaving no header+metadata-only artifact in
+            // the output directory. The previous attach's intern state
+            // does not carry over either: a fresh BinaryTraceWriter is
+            // built on the first sample of this attach.
+            $this->last_hrtime_ns = null;
 
             try {
                 $loop_runner = $this->trace_loop->run(
@@ -122,10 +100,21 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
                         // timestamped (--rbt-timestamps=delta) rbt output.
                         continue;
                     }
-                    if ($use_binary_direct && $this->binary_writer !== null) {
-                        // Per-worker rbt mode: annotations never leave the
-                        // worker — they go straight into our own .rbt file.
-                        $this->writeBinaryTrace($message->trace, $message->annotations);
+                    if ($use_binary_direct) {
+                        if ($this->binary_writer === null) {
+                            $this->openBinarySegment(
+                                $pid,
+                                $sampling_period_us,
+                                $has_timestamps,
+                                $binary_output_dir,
+                            );
+                        }
+                        if ($this->binary_writer !== null) {
+                            // Per-worker rbt mode: annotations never leave
+                            // the worker — they go straight into our own
+                            // .rbt file.
+                            $this->writeBinaryTrace($message->trace, $message->annotations);
+                        }
                     } else {
                         // Bundled / template modes: forward annotations to
                         // the controller via IPC for it to write out.
@@ -142,7 +131,11 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
                 ]);
             }
 
-            // Close the segment cleanly on detach
+            // Close the segment cleanly on detach. binary_writer is
+            // non-null only when at least one real sample reached us
+            // for this attach; an attach that produced no samples
+            // leaves no segment behind (and, if this was the worker's
+            // first attach, also no file).
             if ($this->binary_writer !== null) {
                 $this->binary_writer->writeCheckpoint();
                 $this->binary_writer->writeSegmentEnd();
@@ -158,6 +151,43 @@ final class PhpReaderEntryPoint implements WorkerEntryPointInterface
         }
 
         $this->closeBinaryStream();
+    }
+
+    /**
+     * Lazily open the per-worker output file (if not already open) and
+     * construct a fresh BinaryTraceWriter for the current attach,
+     * emitting the rbt header and the per-segment `pid` metadata. Called
+     * from inside the trace loop on the first non-empty TraceMessage of
+     * each attach, so a worker that only ever observes empty markers
+     * never reaches this path.
+     */
+    private function openBinarySegment(
+        int $pid,
+        int $sampling_period_us,
+        bool $has_timestamps,
+        ?string $binary_output_dir,
+    ): void {
+        if ($this->binary_stream === null && $binary_output_dir !== null) {
+            $this->openBinaryStream($binary_output_dir);
+        }
+        if ($this->binary_stream === null) {
+            return;
+        }
+        if ($this->compress) {
+            $buf = fopen('php://temp', 'r+');
+            assert($buf !== false);
+            $this->segment_buffer = $buf;
+            $write_target = $this->segment_buffer;
+        } else {
+            $write_target = $this->binary_stream;
+        }
+        $this->binary_writer = new BinaryTraceWriter(
+            $write_target,
+            $sampling_period_us,
+            has_timestamps: $has_timestamps,
+        );
+        $this->binary_writer->writeHeader();
+        $this->binary_writer->writeMetadata('pid', (string)$pid);
     }
 
     private function openBinaryStream(string $output_dir): void

--- a/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
+++ b/tests/Inspector/Daemon/Reader/Worker/PhpReaderEntryPointTest.php
@@ -213,6 +213,80 @@ class PhpReaderEntryPointTest extends BaseTestCase
         }
     }
 
+    public function testAttachWithOnlyEmptyTracesLeavesNoArtifact(): void
+    {
+        // A daemon worker that *does* receive an attach but observes
+        // only the trace loop's idle ride-through markers (empty
+        // CallTrace) for the entire attach must not leave behind a
+        // header+metadata-only worker_<pid>.rbt segment. Header,
+        // metadata, writer construction, and stream open are all
+        // deferred to the first non-empty trace, so an attach that
+        // never produces a real sample also produces no artifact.
+        $tmpdir = \sys_get_temp_dir() . '/reli-test-empty-attach-' . \getmypid();
+        @\mkdir($tmpdir, 0755, true);
+        try {
+            $output_settings = new OutputSettings(
+                output_format: 'rbt',
+                output_path: $tmpdir,
+                rbt_timestamps: 'delta',
+                rbt_compress: false,
+            );
+            $settings = new SetSettingsMessage(
+                new TraceLoopSettings(1, 'q', 10, false),
+                new GetTraceSettings(PHP_INT_MAX),
+                $output_settings,
+            );
+            $attach = new AttachMessage(
+                new TargetProcessDescriptor(
+                    424242,
+                    0,
+                    0,
+                    ZendTypeReader::V80,
+                ),
+            );
+            $php_reader_task = Mockery::mock(PhpReaderTraceLoopInterface::class);
+            $protocol = Mockery::mock(PhpReaderWorkerProtocolInterface::class);
+            $protocol->expects()->receiveSettings()->andReturns($settings)->once();
+            $protocol->expects()->receiveAttach()->andReturns($attach)->once();
+            // Trace loop yields only the idle ride-through marker —
+            // no real PHP frames ever observed for this attach.
+            $php_reader_task->shouldReceive('run')->andReturns(
+                (function () {
+                    yield new TraceMessage(new CallTrace(), null, null);
+                    yield new TraceMessage(new CallTrace(), null, null);
+                    yield new TraceMessage(new CallTrace(), null, null);
+                })()
+            );
+            $protocol->shouldNotReceive('sendTrace');
+            $protocol->expects()
+                ->sendDetachWorker()
+                ->with(Matchers::equalTo(new DetachWorkerMessage(424242)))
+                ->once();
+
+            $entry_point = new PhpReaderEntryPoint(
+                $php_reader_task,
+                $protocol,
+                new OnlyOnceCondition(),
+            );
+            $entry_point->run();
+
+            $files = \glob($tmpdir . '/*');
+            $this->assertSame(
+                [],
+                $files === false ? [] : $files,
+                'attach with only empty traces must not create any rbt artifact',
+            );
+        } finally {
+            $files = \glob($tmpdir . '/*');
+            if ($files !== false) {
+                foreach ($files as $f) {
+                    @\unlink($f);
+                }
+            }
+            @\rmdir($tmpdir);
+        }
+    }
+
     private function getTestTrace(string $function, ?int $pid = null): TraceMessage
     {
         return new TraceMessage(


### PR DESCRIPTION
## Summary

Closes #698. Follow-up to #696.

A daemon worker that received an attach but observed only the trace loop's idle ride-through markers (empty `CallTrace`) for the entire attach still wrote a header + `METADATA(pid)` + checkpoint + segment_end segment. The result was a small (~30 byte) but non-empty `.rbt` with zero samples — noise in the output directory and the remaining gap behind the broad "empty trace artifacts" framing of #696.

## Change

`PhpReaderEntryPoint::run()` is refactored to be sample-driven, mirroring the lazy-header pattern already used by `BinaryTraceOutput`.

- The eager attach-time block (open writer, write header, write `METADATA pid`) is removed.
- A new helper `openBinarySegment()` runs lazily inside the trace loop on the first non-empty `TraceMessage` of each attach: it opens the underlying file (if not already open), constructs a fresh `BinaryTraceWriter`, writes the header, and emits the per-segment `pid` metadata.
- The detach-time `writeCheckpoint() + writeSegmentEnd() + flushCompressedSegment()` block is unchanged in shape (still gated on `binary_writer !== null`), but its precondition is now stronger: non-null writer at detach time strictly implies "at least one real sample reached us this attach". An attach that produces no samples therefore writes no segment, and a worker whose every attach is sampleless writes no file at all.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Worker never receives an attach (`-T` > targets) | No file (fixed in #696) | No file |
| Worker receives attach, normal samples | Segment with samples | Segment with samples |
| Worker receives attach, only empty markers | header + metadata + empty segment (~30 B) | No segment / no file |
| Worker receives attach 1 with samples, attach 2 sampleless | 2 segments (one real, one metadata-only) | 1 segment (real only) |

## Test plan

- [x] Added `testAttachWithOnlyEmptyTracesLeavesNoArtifact` — fails on `0.12.x`, passes on this branch.
- [x] `testRun`, `testEmptyCallTracesAreDroppedBeforeIpc`, `testIdleWorkerLeavesNoBinaryArtifact` still pass.
- [x] `phpunit --exclude-group target-version`: 3242 / 3245 pass; the 3 failures are pre-existing Docker-dependent FrankenPHP / mod_php integration tests, unrelated.
- [x] `psalm` (baseline applied): no errors. `phpcs --standard=PSR12`: clean.
- [x] Integration smoke test: `inspector:daemon -T 4` against one idle target — only the active worker's file exists, 374 samples written normally over 3.74 s.

https://claude.ai/code/session_01XNfRguRxrTvHJuahW8oT8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNfRguRxrTvHJuahW8oT8i)_