### PR TITLE
fix(watch): stop injecting implicit memory-dump when lifecycle actions are configured

### DIFF
--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -99,8 +99,11 @@ final class WatchSettingsFromConsoleInput
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'actions to execute while active with cooldown'
-                    . ' (memory-dump, trace-once, log, exec)',
-                ['memory-dump'],
+                    . ' (memory-dump, trace-once, log, exec).'
+                    . ' Defaults to memory-dump only when neither --action'
+                    . ' nor any lifecycle action (--on-enter / --on-exit)'
+                    . ' is specified.',
+                [],
             )
             ->addOption(
                 'on-enter',
@@ -263,6 +266,20 @@ final class WatchSettingsFromConsoleInput
         $on_enter_actions = $input->getOption('on-enter');
         /** @var list<string> $on_exit_actions */
         $on_exit_actions = $input->getOption('on-exit');
+
+        // Implicit memory-dump fallback: only when the user opts into
+        // none of the action mechanisms. Specifying --on-enter or
+        // --on-exit signals "I want lifecycle-driven actions" and the
+        // legacy "default to memory-dump" behaviour would otherwise
+        // silently produce a multi-MB heap dump alongside, e.g.,
+        // a continuous trace session.
+        if (
+            count($actions) === 0
+            && count($on_enter_actions) === 0
+            && count($on_exit_actions) === 0
+        ) {
+            $actions = ['memory-dump'];
+        }
 
         // --oneshot=N is an alias for --max-triggers=N
         $max_triggers_raw = (string)(

--- a/src/Inspector/Watch/ActionFactory.php
+++ b/src/Inspector/Watch/ActionFactory.php
@@ -78,20 +78,12 @@ final class ActionFactory
             }
         }
 
-        if (count($actions) === 0) {
-            /** @psalm-suppress InvalidArgument */
-            $actions[] = new MemoryDumpAction(
-                $this->memory_dumper,
-                $this->process_stopper,
-                $target_php_settings,
-                $eg_address,
-                $cg_address,
-                $settings->action_output_dir,
-                $disk_tracker,
-                $settings->include_binary,
-            );
-        }
-
+        // Settings is the single source of truth for which actions
+        // run; an empty list means "no regular actions, use lifecycle
+        // / triggers for side-effects". The implicit "default to
+        // memory-dump" lives in WatchSettingsFromConsoleInput so it
+        // can be gated on the user not having configured --on-enter
+        // or --on-exit.
         return $actions;
     }
 
@@ -136,12 +128,8 @@ final class ActionFactory
             }
         }
 
-        if (count($actions) === 0) {
-            $actions[] = $settings->log_file !== null
-                ? LogAction::toFile($settings->log_file)
-                : new LogAction();
-        }
-
+        // See buildActions() — Settings owns the implicit memory-dump
+        // fallback, gated on no lifecycle action being configured.
         return $actions;
     }
 

--- a/tests/Command/Inspector/WatchCommandTest.php
+++ b/tests/Command/Inspector/WatchCommandTest.php
@@ -97,8 +97,12 @@ class WatchCommandTest extends TestCase
     {
         $cmd = self::makeCommand();
         $def = $cmd->getDefinition();
+        // --action's CLI-level default is empty: the implicit
+        // "memory-dump if nothing else specified" lives in
+        // WatchSettingsFromConsoleInput::createSettings, gated on
+        // no --on-enter / --on-exit being set.
         $action_opt = $def->getOption('action');
-        $this->assertSame(['memory-dump'], $action_opt->getDefault());
+        $this->assertSame([], $action_opt->getDefault());
 
         $output_dir = $def->getOption('action-output-dir');
         $this->assertNull($output_dir->getDefault());

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -33,7 +33,7 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'cpu-usage' => null,
             'cpu-usage-exit' => null,
             'cpu-sustain' => null,
-            'action' => ['memory-dump'],
+            'action' => [],
             'on-enter' => [],
             'on-exit' => [],
             'action-exec-command' => null,
@@ -184,6 +184,57 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             ]));
 
         $this->assertSame(['trace-once', 'log'], $settings->actions);
+    }
+
+    public function testImplicitMemoryDumpWhenNothingSpecified(): void
+    {
+        // Backward-compat: `reli inspector:watch -p X --memory-usage=256M`
+        // (no --action, no lifecycle) still falls back to memory-dump.
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput());
+
+        $this->assertSame(['memory-dump'], $settings->actions);
+    }
+
+    public function testNoImplicitMemoryDumpWhenOnEnterIsSet(): void
+    {
+        // The user opted into lifecycle-driven actions; we must not
+        // silently inject a memory-dump alongside (which previously
+        // produced a multi-MB heap dump next to a continuous trace).
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'on-enter' => ['trace'],
+            ]));
+
+        $this->assertSame([], $settings->actions);
+        $this->assertSame(['trace'], $settings->on_enter_actions);
+    }
+
+    public function testNoImplicitMemoryDumpWhenOnExitIsSet(): void
+    {
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'on-exit' => ['stop-trace'],
+            ]));
+
+        $this->assertSame([], $settings->actions);
+        $this->assertSame(['stop-trace'], $settings->on_exit_actions);
+    }
+
+    public function testExplicitActionWithLifecycleHonoredAsIs(): void
+    {
+        // Both --action and lifecycle are explicit — no fallback runs,
+        // both lists pass through verbatim.
+        $settings = (new WatchSettingsFromConsoleInput())
+            ->createSettings($this->makeInput([
+                'action' => ['log'],
+                'on-enter' => ['trace'],
+                'on-exit' => ['stop-trace'],
+            ]));
+
+        $this->assertSame(['log'], $settings->actions);
+        $this->assertSame(['trace'], $settings->on_enter_actions);
+        $this->assertSame(['stop-trace'], $settings->on_exit_actions);
     }
 
     public function testMaxDumpSize(): void

--- a/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
+++ b/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
@@ -160,8 +160,14 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
         $this->assertInstanceOf(ExecAction::class, $actions[0]);
     }
 
-    public function testBuildActionsDefaultsToMemoryDump(): void
+    public function testBuildActionsEmptyReturnsEmpty(): void
     {
+        // ActionFactory is no longer responsible for the implicit
+        // "default to memory-dump" fallback — that decision lives in
+        // WatchSettingsFromConsoleInput, gated on the absence of any
+        // lifecycle action. With actions=[] in settings, buildActions
+        // returns an empty list verbatim so the watch loop's
+        // `count($actions) > 0` guard skips the regular-action path.
         $factory = $this->makeFactory();
         $output = Mockery::mock(TraceOutput::class);
         $tps = new TargetPhpSettings(php_version: 'v84');
@@ -177,8 +183,7 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
             $tps,
             new DiskUsageTracker(1024 * 1024),
         );
-        $this->assertCount(1, $actions);
-        $this->assertInstanceOf(MemoryDumpAction::class, $actions[0]);
+        $this->assertSame([], $actions);
     }
 
     public function testBuildActionsMultiple(): void

--- a/tests/Inspector/Watch/ActionFactoryTest.php
+++ b/tests/Inspector/Watch/ActionFactoryTest.php
@@ -115,8 +115,12 @@ class ActionFactoryTest extends BaseTestCase
         $this->assertInstanceOf(ExecAction::class, $actions[0]);
     }
 
-    public function testBuildDaemonActionsDefaultsToLog(): void
+    public function testBuildDaemonActionsEmptyReturnsEmpty(): void
     {
+        // The factory has no implicit fallback any more — Settings
+        // owns the "default to memory-dump" decision and gates it on
+        // the absence of any lifecycle action. An empty actions list
+        // therefore passes through verbatim.
         $factory = new ActionFactory(
             Mockery::mock('overload:' . \Reli\Lib\PhpProcessReader\CallTraceReader\CallTraceReader::class),
             Mockery::mock('overload:' . \Reli\Inspector\MemoryDump\MemoryDumper::class),
@@ -129,8 +133,7 @@ class ActionFactoryTest extends BaseTestCase
             $output,
             new DiskUsageTracker(1024 * 1024 * 1024),
         );
-        $this->assertCount(1, $actions);
-        $this->assertInstanceOf(LogAction::class, $actions[0]);
+        $this->assertSame([], $actions);
     }
 
     public function testBuildDaemonActionsMultiple(): void


### PR DESCRIPTION
## Summary

`--action` defaulted to `['memory-dump']` in `WatchSettingsFromConsoleInput`, and `ActionFactory` had a backstop that re-injected `MemoryDumpAction` (or `LogAction` in daemon mode) whenever the resolved action list was empty. The combined effect was:

```bash
reli inspector:watch -p $PID --watch-function='X' \
    --on-enter=trace --on-exit=stop-trace --oneshot=1
```

silently produced a multi-MB ZendMM heap dump alongside the trace, because `memory-dump` fired as a regular action on the same poll where the lifecycle ENTER fired. With `--oneshot=1` it shipped one giant `.dump` every run; without `--oneshot` it shipped one per cooldown window for as long as the trigger stayed active.

## Change

Make `WatchSettingsFromConsoleInput` the single owner of the implicit-fallback decision, and gate it on no lifecycle action being configured.

- `--action` CLI default → `[]`.
- `WatchSettingsFromConsoleInput::createSettings` sets `actions = ['memory-dump']` only when `--action`, `--on-enter`, and `--on-exit` are all empty. Preserves the `reli inspector:watch -p X --memory-usage=256M` UX (no flags → still a heap dump on trigger).
- `ActionFactory::buildActions` / `buildDaemonActions` drop their empty fallbacks — they iterate `$settings->actions` and return the result verbatim. The watch loop's `count($actions) > 0` guard already short-circuits cleanly when the list is empty, so lifecycle-only configurations no longer trigger the regular-action path.

## Behavior

| User specifies | Before (effective `actions`) | After (effective `actions`) |
|---|---|---|
| `--memory-usage=256M` | `['memory-dump']` | `['memory-dump']` (unchanged) |
| `--memory-usage=256M --action=log` | `['log']` | `['log']` (unchanged) |
| `--watch-function=X --on-enter=trace --on-exit=stop-trace` | `['memory-dump']` ⚠️ | `[]` ✅ |
| `--watch-function=X --action=log --on-enter=trace` | `['log']` | `['log']` (unchanged) |

## Side effects worth flagging

- **`--oneshot=N` becomes a true no-op when only `--on-enter` / `--on-exit` are set**, because `action_count` was always counting regular-action firings only. Previously the implicit memory-dump made it *look* like oneshot was working with lifecycle. The lifecycle-aware `--oneshot` semantics (count ENTER, wait for EXIT before exit) are tracked separately as a follow-up — this PR doesn't change anything in that direction.
- **Daemon mode** previously fell back to `LogAction` on empty actions; that path was dead in normal CLI flow (Settings always supplied `['memory-dump']`). The fallback removal aligns daemon and single-process modes on "no actions = run no regular actions".

## Test plan

- [x] New tests in `WatchSettingsFromConsoleInputTest`:
  - `testImplicitMemoryDumpWhenNothingSpecified` (back-compat)
  - `testNoImplicitMemoryDumpWhenOnEnterIsSet`
  - `testNoImplicitMemoryDumpWhenOnExitIsSet`
  - `testExplicitActionWithLifecycleHonoredAsIs`
- [x] `ActionFactoryBuildActionsTest::testBuildActionsDefaultsToMemoryDump` → renamed to `testBuildActionsEmptyReturnsEmpty` (pins new factory contract: empty in, empty out).
- [x] `ActionFactoryTest::testBuildDaemonActionsDefaultsToLog` → renamed to `testBuildDaemonActionsEmptyReturnsEmpty` (same).
- [x] `WatchCommandTest::testOptionDefaults` updated to assert `--action` CLI default is `[]`.
- [x] `phpunit --exclude-group target-version`: 3245 / 3248 pass; the 3 failures are pre-existing FrankenPHP / mod_php Docker integration tests, unrelated.
- [x] `psalm` (baseline applied): no errors. `phpcs --standard=PSR12`: clean.
- [x] Integration smoke against a target with a periodic `busy_X()` call: `--on-enter=trace --on-exit=stop-trace` no longer produces any `.dump` artifact, only `.rbt` traces (as intended).

https://claude.ai/code/session_01XNfRguRxrTvHJuahW8oT8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNfRguRxrTvHJuahW8oT8i)_