### PR TITLE
Change MemoryAnalyzeCommand Docker profile from Full to Minimal

### DIFF
--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -30,7 +30,7 @@ final class MemoryAnalyzeCommand extends ReliCommand
     #[\Override]
     public static function getDockerProfile(): DockerProfile
     {
-        return DockerProfile::Full;
+        return DockerProfile::Minimal;
     }
 
     public function __construct(


### PR DESCRIPTION
## Summary
Updated the Docker profile requirement for the MemoryAnalyzeCommand to use the Minimal profile instead of Full.

## Changes
- Modified `MemoryAnalyzeCommand::getDockerProfile()` to return `DockerProfile::Minimal` instead of `DockerProfile::Full`

## Details
This change reduces the Docker resource requirements for running the memory analysis command, allowing it to execute in environments with more constrained resources while maintaining the necessary functionality for memory analysis operations.

https://claude.ai/code/session_01F5rAgbcW3EfAWfRLa9Dp43