### PR TITLE
Improve error message for SQLite files passed to rmem tools

### DIFF
--- a/docs/memory/coredump.md
+++ b/docs/memory/coredump.md
@@ -48,8 +48,8 @@ $ php ./reli rmem:explore snapshot.rmem
 
 `-f sqlite3` is also supported if you want to query the same snapshot
 with SQL tools — `inspector:memory:report` / `inspector:memory:compare`
-accept either format. `rmem:explore`, `rmem:serve`, and `rmem:mcp`
-read `.rmem` only.
+accept either format. `rmem:explore`, `rmem:query`, `rmem:serve`,
+and `rmem:mcp` read `.rmem` only.
 
 The output of `inspector:coredump` uses the same
 [`MemoryProfilerSettings`](../../src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php)
@@ -59,7 +59,7 @@ Which downstream tool you can feed depends on the format:
 
 - `inspector:memory:report` and `inspector:memory:compare` accept
   `.rmem` (binary) or SQLite (`.db` / `.sqlite`).
-- `rmem:explore`, `rmem:serve`, and `rmem:mcp` require `.rmem`.
+- `rmem:explore`, `rmem:query`, `rmem:serve`, and `rmem:mcp` require `.rmem`.
 
 ## Arguments and options
 

--- a/docs/memory/memory-dump.md
+++ b/docs/memory/memory-dump.md
@@ -20,7 +20,7 @@ php ./reli inspector:memory:report snapshot.rmem
 
 `-f sqlite3` is also supported by `inspector:memory:analyze` / `inspector:memory:report` /
 `inspector:memory:compare` if you want to query with SQL tools, but `rmem:explore`,
-`rmem:serve`, and `rmem:mcp` read `.rmem` only.
+`rmem:query`, `rmem:serve`, and `rmem:mcp` read `.rmem` only.
 
 ## How it works
 

--- a/docs/memory/memory-profiler-database.md
+++ b/docs/memory/memory-profiler-database.md
@@ -1,7 +1,7 @@
 # Database Output for Memory Profiler
 
 > [!NOTE]
-> **`.rmem` (`-f binary`) is the primary storage format** — it's the fastest and is what `rmem:explore` / `rmem:serve` / `rmem:mcp` read natively. `inspector:memory:report` / `inspector:memory:compare` also prefer it. Reach for the SQL-database outputs documented on this page when you specifically need ad-hoc SQL querying, JOIN-based analysis against your own tables, or ingestion into an existing data-warehouse pipeline. (`inspector:memory:report` and `inspector:memory:compare` accept SQLite too, so you can use the database outputs alongside the normal analysers.)
+> **`.rmem` (`-f binary`) is the primary storage format** — it's the fastest and is what `rmem:explore` / `rmem:query` / `rmem:serve` / `rmem:mcp` read natively. `inspector:memory:report` / `inspector:memory:compare` also prefer it. Reach for the SQL-database outputs documented on this page when you specifically need ad-hoc SQL querying, JOIN-based analysis against your own tables, or ingestion into an existing data-warehouse pipeline. (`inspector:memory:report` and `inspector:memory:compare` accept SQLite too, so you can use the database outputs alongside the normal analysers.)
 
 The memory profiler supports outputting analysis results to a relational database. This is useful for analyzing large memory snapshots without `jq`, and enables ad-hoc querying with SQL.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,7 @@ The sidecar **client** (the application-side library) does not require FFI — o
 
 ## `rmem:explore` won't open my file
 
-`rmem:explore`, `rmem:serve`, and `rmem:mcp` read **`.rmem` only** (binary memory snapshots produced by `inspector:memory -f binary`, `inspector:memory:dump` + `inspector:memory:analyze -f binary`, or `inspector:coredump -f binary`).
+`rmem:explore`, `rmem:query`, `rmem:serve`, and `rmem:mcp` read **`.rmem` only** (binary memory snapshots produced by `inspector:memory -f binary`, `inspector:memory:dump` + `inspector:memory:analyze -f binary`, or `inspector:coredump -f binary`). Pointing any of them at a SQLite snapshot fails with `Invalid rmem magic: 53514c69` (the hex is `"SQLi"`, the start of the SQLite file header).
 
 If your snapshot is a SQLite `.db` / `.sqlite` file, either re-capture with `-f binary -o snapshot.rmem`, or use the SQL-aware analysers instead (`inspector:memory:report`, `inspector:memory:compare`, raw `sqlite3` / `duckdb`). To convert an existing dump, run `inspector:memory:analyze <dump> -f binary -o snapshot.rmem`.
 

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/Reader.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/Reader.php
@@ -110,7 +110,14 @@ final class Reader
 
         $magic = substr($headerBytes, 0, 4);
         if ($magic !== Format::MAGIC) {
-            throw new \RuntimeException('Invalid rmem magic: ' . bin2hex($magic));
+            $message = 'Invalid rmem magic: ' . bin2hex($magic);
+            if (str_starts_with($headerBytes, "SQLite format 3\x00")) {
+                $message .= ' (this looks like a SQLite file — re-capture with'
+                    . ' `-f binary -o snapshot.rmem`, or convert an existing dump'
+                    . ' with `inspector:memory:analyze <dump> -f binary -o snapshot.rmem`;'
+                    . ' see docs/troubleshooting.md)';
+            }
+            throw new \RuntimeException($message);
         }
 
         $version = unpack('V', $headerBytes, 4)[1];


### PR DESCRIPTION
## Summary
Enhanced the error handling in the binary format reader to provide helpful guidance when users accidentally pass SQLite database files to tools that only accept `.rmem` (binary) format.

## Key Changes
- **Reader.php**: Updated the "Invalid rmem magic" exception to detect SQLite files and provide actionable error guidance
  - Checks if the file header matches the SQLite format signature (`"SQLite format 3\x00"`)
  - Appends helpful instructions directing users to either re-capture with `-f binary` or convert existing dumps using `inspector:memory:analyze`
  - References the troubleshooting documentation for additional help

- **Documentation updates**: Consistently added `rmem:query` to lists of tools that require `.rmem` format across multiple documentation files:
  - `docs/memory/coredump.md`
  - `docs/memory/memory-dump.md`
  - `docs/memory/memory-profiler-database.md`
  - `docs/troubleshooting.md` (also added example of the SQLite magic bytes error)

## Implementation Details
The error detection uses `str_starts_with()` to check the raw header bytes for the SQLite magic number before throwing the exception. This provides users with immediate, contextual help when they encounter this common mistake, reducing friction and support burden.

https://claude.ai/code/session_01S8FAypwh2VdJGJD8YPzWwd