### PR TITLE
docs: make getting-started PID lookup robust with pgrep -nf

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,7 +159,8 @@ php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
 # (-F rbt is implied by the .rbt extension on -o)
-reli inspector:trace -p "$(pgrep -f your-script.php)" -o trace.rbt
+# Use -n (newest) to avoid passing multiple PIDs when several commands match.
+reli inspector:trace -p "$(pgrep -nf your-script.php)" -o trace.rbt
 ```
 
 The target process must be reachable with `ptrace(2)`. Under the


### PR DESCRIPTION
### Motivation
- Make the quickstart trace example more robust because `pgrep -f` can match multiple commands and expand to space-separated PIDs that break the `-p` argument.

### Description
- Replace the example in `docs/getting-started.md` to use `pgrep -nf your-script.php` and add an inline note that `-n` selects the newest match, preventing accidental multi-PID expansion.

### Testing
- Ran `git -C /workspace/reli-prof status --short && git -C /workspace/reli-prof diff -- docs/getting-started.md`, committed the change with `git -C /workspace/reli-prof commit`, and verified the updated lines with `nl -ba /workspace/reli-prof/docs/getting-started.md | sed -n '150,172p'`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f073dd6c832982fa7e1bc663c633)