### PR TITLE
Lower minimum PHP version requirement from 8.5 to 8.4

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.5
+          php-version: 8.4
           extensions: dom, mbstring
           coverage: none
           tools: cs2pr

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,15 +19,19 @@ on:
 jobs:
 
   phpunit-unit:
-    name: phpunit (unit)
+    name: phpunit (unit, PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.5
+          php-version: ${{ matrix.php-version }}
           extensions: ffi, dom, mbstring
           coverage: pcov
 
@@ -39,8 +43,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}-
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -68,7 +72,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: build/logs/clover.xml
-          flag-name: unit
+          flag-name: unit-php${{ matrix.php-version }}
           parallel: true
 
   build-dev-image:
@@ -425,15 +429,19 @@ jobs:
       image: ${{ env.IMAGE }}:${{ steps.hash.outputs.tag }}
 
   phpunit-unit-arm64:
-    name: phpunit (unit, ARM64)
+    name: phpunit (unit, PHP ${{ matrix.php-version }}, ARM64)
     runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.5
+          php-version: ${{ matrix.php-version }}
           extensions: ffi, dom, mbstring
           coverage: pcov
 
@@ -445,8 +453,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-composer-
+          key: ${{ runner.os }}-${{ runner.arch }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-composer-${{ matrix.php-version }}-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
@@ -465,7 +473,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: build/logs/clover.xml
-          flag-name: unit-arm64
+          flag-name: unit-arm64-php${{ matrix.php-version }}
           parallel: true
 
   build-test-mysql-images-arm64:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.5
+          php-version: 8.4
           extensions: dom, mbstring
           coverage: none
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM php:8.5-cli-bookworm
+FROM php:8.4-cli-bookworm
 
 RUN apt-get update && apt-get install -y \
       libffi-dev \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/images/logos/banner_bg_white.png" alt="Reli" width="100%">
 </h1>
 
-![PHP (runner): 8.5.0+](https://img.shields.io/badge/php%20%28runner%29-8.5.0%2B-blue.svg)
+![PHP (runner): 8.4.0+](https://img.shields.io/badge/php%20%28runner%29-8.4.0%2B-blue.svg)
 ![PHP (target): 7.0+](https://img.shields.io/badge/php%20%28target%29-7.0%2B-8892BF.svg)
 [![Packagist](https://img.shields.io/packagist/v/reliforp/reli-prof.svg)](https://packagist.org/packages/reliforp/reli-prof)
 [![Github Actions](https://github.com/reliforp/reli-prof/workflows/build/badge.svg)](https://github.com/reliforp/reli-prof/actions)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": "^8.5",
+    "php": "^8.4",
     "ext-ffi": "*",
     "ext-filter": "*",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d10a91ed1c349f2416b4b282a9c956ed",
+    "content-hash": "793b464924f1bd586c8bd780d1d7ec31",
     "packages": [
         {
             "name": "amphp/amp",
@@ -5859,7 +5859,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.5",
+        "php": "^8.4",
         "ext-ffi": "*",
         "ext-filter": "*",
         "ext-json": "*",

--- a/docs/bench/README.md
+++ b/docs/bench/README.md
@@ -172,7 +172,8 @@ literature cited in the comparison doc.
   measuring baseline; the current scripts load it correctly.
 - **phpspy** is built from upstream HEAD, attached at 1 ms
   sampling.
-- **reli** runs from this repo on PHP 8.5 (per `composer.json`),
+- **reli** runs from this repo on PHP 8.5 (the runner floor in
+  `composer.json` is `^8.4`; these benchmarks were captured on 8.5),
   attached to the PHP 8.4 target via the `-- cmd args` form so
   reli's startup happens before the timed code begins. The 1 ms
   sampling period is set with `--sleep-ns 1000000`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,10 +117,8 @@ composer install
 > Git) the equivalent command is `./reli` — substitute as you read.
 >
 > The `./reli` shebang is `#!/usr/bin/env php`, so the `php` on your
-> `PATH` must be **8.4+**. Debian 13 (trixie), Ubuntu 25.10, Fedora 43,
-> and Alpine 3.22 ship 8.4 as the default and work out of the box.
-> On older distro defaults (e.g. Ubuntu 24.04 LTS with PHP 8.3),
-> install `php8.4-cli` and switch the default — `sudo update-alternatives
+> `PATH` must be **8.4+**. If your default is older, install
+> `php8.4-cli` and switch the default — `sudo update-alternatives
 > --set php /usr/bin/php8.4` — or invoke explicitly with
 > `php8.4 ./reli ...`. The Docker wrapper sidesteps this entirely.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ For the full catalogue of tasks-and-commands, see the
 
 ### Runtime
 
-- PHP 8.5+ (NTS / ZTS)
+- PHP 8.4+ (NTS / ZTS)
 - 64bit Linux x86_64 (or AArch64, experimental)
 - `FFI` extension enabled
 - `PCNTL` extension enabled
@@ -61,7 +61,8 @@ For the full catalogue of tasks-and-commands, see the
 ## 1. Install
 
 The Docker image is the easiest starting point — PHP 8.5, FFI, and
-PCNTL pre-built, no host toolchain needed. A one-line command
+PCNTL pre-built, no host toolchain needed (the published image runs
+on PHP 8.5 even though the supported runner floor is 8.4). A one-line command
 installs a shell function `reli` so the rest of this doc works
 exactly as written, with no docker flag incantations to remember:
 
@@ -116,11 +117,12 @@ composer install
 > Git) the equivalent command is `./reli` — substitute as you read.
 >
 > The `./reli` shebang is `#!/usr/bin/env php`, so the `php` on your
-> `PATH` must be **8.5+**. On distros that ship an older default
-> (e.g. Ubuntu with `php8.4-cli` from deadsnakes/sury), either install
-> `php8.5-cli` and switch the default — `sudo update-alternatives
-> --set php /usr/bin/php8.5` — or invoke explicitly with
-> `php8.5 ./reli ...`. The Docker wrapper sidesteps this entirely.
+> `PATH` must be **8.4+**. Debian 13 (trixie), Ubuntu 25.10, Fedora 43,
+> and Alpine 3.22 ship 8.4 as the default and work out of the box.
+> On older distro defaults (e.g. Ubuntu 24.04 LTS with PHP 8.3),
+> install `php8.4-cli` and switch the default — `sudo update-alternatives
+> --set php /usr/bin/php8.4` — or invoke explicitly with
+> `php8.4 ./reli ...`. The Docker wrapper sidesteps this entirely.
 
 ## 2. Smoke test
 


### PR DESCRIPTION
## Summary
This PR lowers the minimum PHP version requirement for running Reli from 8.5 to 8.4, expanding compatibility with a broader range of environments while maintaining support for newer PHP versions.

## Key Changes

- **composer.json**: Updated PHP requirement from `^8.5` to `^8.4`
- **CI/CD Workflows**: 
  - Modified `phpunit.yml` to test against both PHP 8.4 and 8.5 using matrix strategy for both x86_64 and ARM64 runners
  - Updated cache keys to include PHP version to prevent cache conflicts across versions
  - Updated Coveralls flag names to distinguish coverage reports by PHP version
  - Changed `phpcs.yml` and `static-analysis.yml` to use PHP 8.4 as the baseline
- **Docker**: Updated `Dockerfile-dev` to use `php:8.4-cli-bookworm` instead of 8.5
- **Documentation**: 
  - Updated runtime requirements in `docs/getting-started.md` to reflect PHP 8.4+ minimum
  - Clarified that published Docker images run PHP 8.5 while the supported floor is 8.4
  - Updated benchmark documentation to clarify the PHP version floor
- **README**: Updated badge to reflect PHP 8.4.0+ as the minimum runner version

## Implementation Details

The matrix testing strategy ensures compatibility is verified across both supported PHP versions (8.4 and 8.5) on multiple architectures, with separate cache entries per version to avoid dependency resolution conflicts.

https://claude.ai/code/session_014AcWSrd6iZoBW86Gp5YpHD