### PR TITLE
Update docker-wrapper docs to include inspector:memory:analyze command

### DIFF
--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -45,9 +45,9 @@ the top of the emitted wrapper. At the time of writing:
 
 - `cache:clear`
 - `converter:*` (callgrind, flamegraph, folded, phpspy, pprof, rbt, speedscope)
-- `inspector:memory:compare`, `inspector:memory:dump:inspect`,
-  `inspector:memory:normalize-dump`, `inspector:memory:report`,
-  `inspector:optimize-memory-db`
+- `inspector:memory:analyze`, `inspector:memory:compare`,
+  `inspector:memory:dump:inspect`, `inspector:memory:normalize-dump`,
+  `inspector:memory:report`, `inspector:optimize-memory-db`
 - `rbt:analyze`, `rbt:explore`, `rbt:recover`
 - `rmem:*` (explore, live, mcp, query, serve, viz)
 


### PR DESCRIPTION
## Summary
Updated the documentation for docker-wrapper to reflect the addition of the `inspector:memory:analyze` command to the list of supported commands.

## Changes
- Added `inspector:memory:analyze` to the list of inspector memory commands in the docker-wrapper documentation
- Reformatted the inspector command list for improved readability by adjusting line breaks and alignment

## Details
The `inspector:memory:analyze` command is now documented as part of the inspector memory command suite, alongside existing commands like `inspector:memory:compare`, `inspector:memory:dump:inspect`, `inspector:memory:normalize-dump`, and `inspector:memory:report`.

https://claude.ai/code/session_01RAk9hCrUGCHM2aNrzEhPMZ