### PR TITLE
psalm: shrink baseline by 143 entries via FFI/cast cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get update && apt-get install -y \
 # uses assert() for two distinct purposes: type narrowing for Psalm (the
 # downstream code is strictly typed and would crash with TypeError on
 # violation, so the assert is purely informational), and runtime contracts
-# whose failure would silently corrupt output (those are explicitly written
-# as Webmozart\Assert::* and are unaffected by this setting). With
+# whose failure would silently corrupt output (those are written as
+# regular runtime checks — either Webmozart\Assert::* or an explicit
+# `if (...) throw` — and are unaffected by this setting). With
 # zend.assertions=-1 the bare assert() calls are stripped at compile time;
 # the dev image (Dockerfile-dev) leaves the PHP default of 1 in place so
 # the type-narrowing asserts still fire during phpunit.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
-  <file src="src/Command/Inspector/MemoryCompareCommand.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int)$size_u[1]]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Command/Inspector/MemoryDumpNormalizeCommand.php">
     <InvalidOperand>
       <code><![CDATA[$result['total_bytes'] / 1024.0]]></code>
@@ -26,14 +21,10 @@
   </file>
   <file src="src/Command/Rmem/RmemMcpCommand.php">
     <MixedAssignment>
-      <code><![CDATA[$backendRequest[(string)$key]]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$resp]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string)$key]]></code>
-    </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!($result['ok'] ?? false)]]></code>
     </RiskyTruthyFalsyComparison>
@@ -46,9 +37,6 @@
       <code><![CDATA[unpack('V', $data, $offset)[1]]]></code>
       <code><![CDATA[unpack('V', $data, 0)[1]]]></code>
     </PossiblyInvalidArrayAccess>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int) $size[1]]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Command/Rmem/RmemServeCommand.php">
     <MixedAssignment>
@@ -95,9 +83,6 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$buf]]></code>
-    </InaccessibleMethod>
     <PossiblyInvalidArgument>
       <code><![CDATA[$buf[$elemOffset]]]></code>
     </PossiblyInvalidArgument>
@@ -118,9 +103,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheWriter.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$data]]></code>
-    </InaccessibleMethod>
     <InvalidOperand>
       <code><![CDATA[getmypid()]]></code>
     </InvalidOperand>
@@ -143,90 +125,6 @@
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$allColIdx]]></code>
-      <code><![CDATA[$allColIdx]]></code>
-      <code><![CDATA[$allDeg]]></code>
-      <code><![CDATA[$allDeg]]></code>
-      <code><![CDATA[$allDeg]]></code>
-      <code><![CDATA[$allDeg]]></code>
-      <code><![CDATA[$allPos]]></code>
-      <code><![CDATA[$allPos]]></code>
-      <code><![CDATA[$allPos]]></code>
-      <code><![CDATA[$allPos]]></code>
-      <code><![CDATA[$allPos]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$allRowPtr]]></code>
-      <code><![CDATA[$nontreeColIdx]]></code>
-      <code><![CDATA[$nontreeColIdx]]></code>
-      <code><![CDATA[$nontreeDeg]]></code>
-      <code><![CDATA[$nontreeDeg]]></code>
-      <code><![CDATA[$nontreeDeg]]></code>
-      <code><![CDATA[$nontreeDeg]]></code>
-      <code><![CDATA[$nontreePos]]></code>
-      <code><![CDATA[$nontreePos]]></code>
-      <code><![CDATA[$nontreePos]]></code>
-      <code><![CDATA[$nontreePos]]></code>
-      <code><![CDATA[$nontreePos]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$nontreeRowPtr]]></code>
-      <code><![CDATA[$treeColIdx]]></code>
-      <code><![CDATA[$treeColIdx]]></code>
-      <code><![CDATA[$treeDeg]]></code>
-      <code><![CDATA[$treeDeg]]></code>
-      <code><![CDATA[$treeDeg]]></code>
-      <code><![CDATA[$treeDeg]]></code>
-      <code><![CDATA[$treeLinkNames]]></code>
-      <code><![CDATA[$treeLinkNames]]></code>
-      <code><![CDATA[$treeParents]]></code>
-      <code><![CDATA[$treeParents]]></code>
-      <code><![CDATA[$treeParents]]></code>
-      <code><![CDATA[$treeParents]]></code>
-      <code><![CDATA[$treePos]]></code>
-      <code><![CDATA[$treePos]]></code>
-      <code><![CDATA[$treePos]]></code>
-      <code><![CDATA[$treePos]]></code>
-      <code><![CDATA[$treePos]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeRowPtr]]></code>
-      <code><![CDATA[$treeStrength]]></code>
-      <code><![CDATA[$treeStrength]]></code>
-    </InaccessibleMethod>
-    <InvalidCast>
-      <code><![CDATA[$allDeg[$i]]]></code>
-      <code><![CDATA[$allDeg[$parent_idx]]]></code>
-      <code><![CDATA[$allPos[$parent_idx]]]></code>
-      <code><![CDATA[$allRowPtr[$i]]]></code>
-      <code><![CDATA[$allRowPtr[$i]]]></code>
-      <code><![CDATA[$allRowPtr[$nc]]]></code>
-      <code><![CDATA[$nontreeDeg[$i]]]></code>
-      <code><![CDATA[$nontreeDeg[$parent_idx]]]></code>
-      <code><![CDATA[$nontreePos[$parent_idx]]]></code>
-      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
-      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
-      <code><![CDATA[$nontreeRowPtr[$nc]]]></code>
-      <code><![CDATA[$treeDeg[$i]]]></code>
-      <code><![CDATA[$treeDeg[$parent_idx]]]></code>
-      <code><![CDATA[$treePos[$parent_idx]]]></code>
-      <code><![CDATA[$treeRowPtr[$i]]]></code>
-      <code><![CDATA[$treeRowPtr[$i]]]></code>
-      <code><![CDATA[$treeRowPtr[$nc]]]></code>
-    </InvalidCast>
     <MixedArgument>
       <code><![CDATA[$nodeSlots]]></code>
       <code><![CDATA[$nodeSlots * 4]]></code>
@@ -245,30 +143,6 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$edgeRows]]></code>
-      <code><![CDATA[$locIndex]]></code>
-      <code><![CDATA[$locRows]]></code>
-      <code><![CDATA[$locRows]]></code>
-      <code><![CDATA[$locRows]]></code>
-    </InaccessibleMethod>
-    <InvalidCast>
-      <code><![CDATA[$locIndex[$info['sample_child_node_id']]]]></code>
-      <code><![CDATA[$locIndex[$nid]]]></code>
-      <code><![CDATA[$locIndex[$nodeId]]]></code>
-      <code><![CDATA[$nodeSizes[$child]]]></code>
-      <code><![CDATA[$nodeSizes[$child]]]></code>
-      <code><![CDATA[$nodeSizes[$child]]]></code>
-      <code><![CDATA[$nodeSizes[$child]]]></code>
-    </InvalidCast>
     <InvalidPropertyFetch>
       <code><![CDATA[$edgeRows[$i]->child_node_id]]></code>
       <code><![CDATA[$edgeRows[$i]->child_node_id]]></code>
@@ -314,10 +188,6 @@
       <code><![CDATA[$locRows[$li]->location_type_id]]></code>
       <code><![CDATA[$locRows[$li]->string_value_id]]></code>
     </PossiblyNullPropertyFetch>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string)$value]]></code>
-      <code><![CDATA[(string)($values[0] ?? '')]]></code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition>
       <code><![CDATA[$cnt <= 50]]></code>
       <code><![CDATA[$info['ref_count'] <= 50]]></code>
@@ -393,38 +263,6 @@
     <PropertyTypeCoercion>
       <code><![CDATA[$profiles]]></code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int)$cls_u[1]]]></code>
-      <code><![CDATA[(int)$size_u[1]]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php">
-    <RedundantCondition>
-      <code><![CDATA[FFIHelper::cast('void *', $addr_holder)]]></code>
-      <code><![CDATA[FFIHelper::cast('void *', $data_holder)]]></code>
-      <code><![CDATA[FFIHelper::new('long')]]></code>
-      <code><![CDATA[FFIHelper::new('long')]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull>
-      <code><![CDATA[throw new CannotAllocateBufferException('cannot allocate buffer')]]></code>
-      <code><![CDATA[throw new CannotAllocateBufferException('cannot allocate buffer')]]></code>
-      <code><![CDATA[throw new CannotCastCDataException('cannot cast buffer')]]></code>
-      <code><![CDATA[throw new CannotCastCDataException('cannot cast buffer')]]></code>
-    </TypeDoesNotContainNull>
-  </file>
-  <file src="src/Lib/Libc/Sys/Ptrace/PtraceX64.php">
-    <RedundantCondition>
-      <code><![CDATA[FFIHelper::cast('void *', $addr_holder)]]></code>
-      <code><![CDATA[FFIHelper::cast('void *', $data_holder)]]></code>
-      <code><![CDATA[FFIHelper::new('long')]]></code>
-      <code><![CDATA[FFIHelper::new('long')]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull>
-      <code><![CDATA[throw new CannotAllocateBufferException('cannot allocate buffer')]]></code>
-      <code><![CDATA[throw new CannotAllocateBufferException('cannot allocate buffer')]]></code>
-      <code><![CDATA[throw new CannotCastCDataException('cannot cast buffer')]]></code>
-      <code><![CDATA[throw new CannotCastCDataException('cannot cast buffer')]]></code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="src/Lib/PhpInternals/Types/Zend/ZendOp.php">
     <TypeDoesNotContainNull>
@@ -455,20 +293,6 @@
     </RedundantCast>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$map]]></code>
-      <code><![CDATA[$map]]></code>
-      <code><![CDATA[$map]]></code>
-      <code><![CDATA[$map]]></code>
-      <code><![CDATA[$new_classes]]></code>
-      <code><![CDATA[$new_classes]]></code>
-      <code><![CDATA[$this->perNodeClasses]]></code>
-      <code><![CDATA[$this->perNodeClasses]]></code>
-      <code><![CDATA[$this->perNodeClasses]]></code>
-      <code><![CDATA[$this->perNodeSizes]]></code>
-      <code><![CDATA[$this->perNodeSizes]]></code>
-      <code><![CDATA[$this->perNodeSizes]]></code>
-    </InaccessibleMethod>
     <InvalidCast>
       <code><![CDATA[$this->perNodeClasses[$node_id]]]></code>
       <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
@@ -489,13 +313,6 @@
     </RedundantCast>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php">
-    <InaccessibleMethod>
-      <code><![CDATA[$old_slots]]></code>
-      <code><![CDATA[$this->slots]]></code>
-      <code><![CDATA[$this->slots]]></code>
-      <code><![CDATA[$this->slots]]></code>
-      <code><![CDATA[$this->slots]]></code>
-    </InaccessibleMethod>
     <InvalidCast>
       <code><![CDATA[$old_slots[$i]]]></code>
       <code><![CDATA[$this->slots[$slot]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,19 @@
       <code><![CDATA[$result['total_bytes'] / 1024.0]]></code>
     </InvalidOperand>
   </file>
+  <file src="src/Command/Rbt/AnalyzeCommand.php">
+    <MixedArgument>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedAssignment>
+    <PossiblyNullIterator>
+      <code><![CDATA[$entry['annotations']]]></code>
+    </PossiblyNullIterator>
+  </file>
   <file src="src/Command/Rmem/RmemExploreCommand.php">
     <MixedArrayAssignment>
       <code><![CDATA[$response['data']['serve_control']]]></code>
@@ -21,6 +34,7 @@
   </file>
   <file src="src/Command/Rmem/RmemMcpCommand.php">
     <MixedAssignment>
+      <code><![CDATA[$backendRequest[$key]]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$resp]]></code>
       <code><![CDATA[$value]]></code>
@@ -45,19 +59,6 @@
     <RedundantCondition>
       <code><![CDATA[$running]]></code>
     </RedundantCondition>
-  </file>
-  <file src="src/Command/Rbt/AnalyzeCommand.php">
-    <MixedArgument>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <PossiblyNullIterator>
-      <code><![CDATA[$entry['annotations']]]></code>
-    </PossiblyNullIterator>
   </file>
   <file src="src/Inspector/CoreDumpReader/CoreDumpReaderFactory.php">
     <TypeDoesNotContainNull>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -126,6 +126,23 @@
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php">
+    <InvalidCast>
+      <code><![CDATA[$allDeg[$i]]]></code>
+      <code><![CDATA[$allDeg[$parent_idx]]]></code>
+      <code><![CDATA[$allPos[$parent_idx]]]></code>
+      <code><![CDATA[$allRowPtr[$i]]]></code>
+      <code><![CDATA[$allRowPtr[$i]]]></code>
+      <code><![CDATA[$nontreeDeg[$i]]]></code>
+      <code><![CDATA[$nontreeDeg[$parent_idx]]]></code>
+      <code><![CDATA[$nontreePos[$parent_idx]]]></code>
+      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
+      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
+      <code><![CDATA[$treeDeg[$i]]]></code>
+      <code><![CDATA[$treeDeg[$parent_idx]]]></code>
+      <code><![CDATA[$treePos[$parent_idx]]]></code>
+      <code><![CDATA[$treeRowPtr[$i]]]></code>
+      <code><![CDATA[$treeRowPtr[$i]]]></code>
+    </InvalidCast>
     <MixedArgument>
       <code><![CDATA[$nodeSlots]]></code>
       <code><![CDATA[$nodeSlots * 4]]></code>

--- a/src/Command/Inspector/MemoryCompareCommand.php
+++ b/src/Command/Inspector/MemoryCompareCommand.php
@@ -344,7 +344,7 @@ final class MemoryCompareCommand extends ReliCommand
                 'node_id' => $node_id_u[1],
                 'location_type_id' => $type_id_u[1],
                 'class_id' => $class_id_u[1],
-                'size' => (int)$size_u[1],
+                'size' => $size_u[1],
             ];
         }
         return $result;

--- a/src/Command/Rmem/RmemMcpCommand.php
+++ b/src/Command/Rmem/RmemMcpCommand.php
@@ -288,7 +288,7 @@ final class RmemMcpCommand extends ReliCommand
         /** @var array<string, mixed> $backendRequest */
         $backendRequest = ['action' => $action];
         foreach ($args as $key => $value) {
-            $backendRequest[(string)$key] = $value;
+            $backendRequest[$key] = $value;
         }
 
         $result = $this->queryBackend($backendRequest);

--- a/src/Command/Rmem/RmemQueryCommand.php
+++ b/src/Command/Rmem/RmemQueryCommand.php
@@ -363,7 +363,7 @@ final class RmemQueryCommand extends ReliCommand
                 '  type=%s addr=0x%x size=%s refcount=%d',
                 $type_name,
                 $addr[1],
-                SizeFormatter::format((int) $size[1]),
+                SizeFormatter::format($size[1]),
                 $refcount[1],
             );
             if ($class_name !== '') {

--- a/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
+use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DiskBackedStringDict;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Writer;
@@ -247,9 +248,9 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                 $is_tree = ord($data[$off + 12]);
 
                 if ($parent_idx < $nc) {
-                    $allDeg[$parent_idx] = (int)$allDeg[$parent_idx] + 1;
+                    $allDeg[$parent_idx] = Cast::toInt($allDeg[$parent_idx]) + 1;
                     if ($is_tree === 1) {
-                        $treeDeg[$parent_idx] = (int)$treeDeg[$parent_idx] + 1;
+                        $treeDeg[$parent_idx] = Cast::toInt($treeDeg[$parent_idx]) + 1;
                         $treeEdgeCount++;
 
                         // Track tree parent for child
@@ -260,7 +261,7 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                             $treeParents[$child_idx] = $parent_idx;
                         }
                     } else {
-                        $nontreeDeg[$parent_idx] = (int)$nontreeDeg[$parent_idx] + 1;
+                        $nontreeDeg[$parent_idx] = Cast::toInt($nontreeDeg[$parent_idx]) + 1;
                         $nontreeEdgeCount++;
                     }
                 }
@@ -278,14 +279,14 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         $allRowPtr[0] = 0;
         $nontreeRowPtr[0] = 0;
         for ($i = 0; $i < $nc; $i++) {
-            $treeRowPtr[$i + 1] = (int)$treeRowPtr[$i] + (int)$treeDeg[$i];
-            $allRowPtr[$i + 1] = (int)$allRowPtr[$i] + (int)$allDeg[$i];
-            $nontreeRowPtr[$i + 1] = (int)$nontreeRowPtr[$i] + (int)$nontreeDeg[$i];
+            $treeRowPtr[$i + 1] = Cast::toInt($treeRowPtr[$i]) + Cast::toInt($treeDeg[$i]);
+            $allRowPtr[$i + 1] = Cast::toInt($allRowPtr[$i]) + Cast::toInt($allDeg[$i]);
+            $nontreeRowPtr[$i + 1] = Cast::toInt($nontreeRowPtr[$i]) + Cast::toInt($nontreeDeg[$i]);
         }
 
-        $totalAllEdges = (int)$allRowPtr[$nc];
-        $totalTreeEdges = (int)$treeRowPtr[$nc];
-        $totalNontreeEdges = (int)$nontreeRowPtr[$nc];
+        $totalAllEdges = Cast::toInt($allRowPtr[$nc]);
+        $totalTreeEdges = Cast::toInt($treeRowPtr[$nc]);
+        $totalNontreeEdges = Cast::toInt($nontreeRowPtr[$nc]);
 
         // Allocate col_idx + link_name + strength arrays
         $allColIdx = FFIHelper::new("int32_t[" . max(1, $totalAllEdges) . "]");
@@ -299,9 +300,9 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         $allPos = FFIHelper::new("int32_t[{$nc}]");
         $nontreePos = FFIHelper::new("int32_t[{$nc}]");
         for ($i = 0; $i < $nc; $i++) {
-            $treePos[$i] = (int)$treeRowPtr[$i];
-            $allPos[$i] = (int)$allRowPtr[$i];
-            $nontreePos[$i] = (int)$nontreeRowPtr[$i];
+            $treePos[$i] = Cast::toInt($treeRowPtr[$i]);
+            $allPos[$i] = Cast::toInt($allRowPtr[$i]);
+            $nontreePos[$i] = Cast::toInt($nontreeRowPtr[$i]);
         }
 
         // ---- Pass 2: fill col_idx ----
@@ -337,18 +338,18 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
 
                 if ($parent_idx < $nc) {
                     // All edges
-                    $pos = (int)$allPos[$parent_idx];
+                    $pos = Cast::toInt($allPos[$parent_idx]);
                     $allColIdx[$pos] = $child_idx;
                     $allPos[$parent_idx] = $pos + 1;
 
                     if ($is_tree === 1) {
-                        $pos = (int)$treePos[$parent_idx];
+                        $pos = Cast::toInt($treePos[$parent_idx]);
                         $treeColIdx[$pos] = $child_idx;
                         $treeLinkNames[$pos] = $link_name_id;
                         $treeStrength[$pos] = $strength;
                         $treePos[$parent_idx] = $pos + 1;
                     } else {
-                        $pos = (int)$nontreePos[$parent_idx];
+                        $pos = Cast::toInt($nontreePos[$parent_idx]);
                         $nontreeColIdx[$pos] = $child_idx;
                         $nontreePos[$parent_idx] = $pos + 1;
                     }

--- a/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
@@ -248,9 +248,13 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                 $is_tree = ord($data[$off + 12]);
 
                 if ($parent_idx < $nc) {
-                    $allDeg[$parent_idx] = Cast::toInt($allDeg[$parent_idx]) + 1;
+                    // (int) on FFI int32_t[] reads: avoid Cast::toInt() in
+                    // this O(edgeCount) loop. Element type is provably int
+                    // at runtime, but Psalm's FFI stub leaves offsetGet as
+                    // CData|null|scalar, so InvalidCast stays in baseline.
+                    $allDeg[$parent_idx] = (int)$allDeg[$parent_idx] + 1;
                     if ($is_tree === 1) {
-                        $treeDeg[$parent_idx] = Cast::toInt($treeDeg[$parent_idx]) + 1;
+                        $treeDeg[$parent_idx] = (int)$treeDeg[$parent_idx] + 1;
                         $treeEdgeCount++;
 
                         // Track tree parent for child
@@ -261,7 +265,7 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                             $treeParents[$child_idx] = $parent_idx;
                         }
                     } else {
-                        $nontreeDeg[$parent_idx] = Cast::toInt($nontreeDeg[$parent_idx]) + 1;
+                        $nontreeDeg[$parent_idx] = (int)$nontreeDeg[$parent_idx] + 1;
                         $nontreeEdgeCount++;
                     }
                 }
@@ -278,12 +282,14 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         $treeRowPtr[0] = 0;
         $allRowPtr[0] = 0;
         $nontreeRowPtr[0] = 0;
+        // O(nc) prefix-sum: keep `(int)` to match the per-edge loops above.
         for ($i = 0; $i < $nc; $i++) {
-            $treeRowPtr[$i + 1] = Cast::toInt($treeRowPtr[$i]) + Cast::toInt($treeDeg[$i]);
-            $allRowPtr[$i + 1] = Cast::toInt($allRowPtr[$i]) + Cast::toInt($allDeg[$i]);
-            $nontreeRowPtr[$i + 1] = Cast::toInt($nontreeRowPtr[$i]) + Cast::toInt($nontreeDeg[$i]);
+            $treeRowPtr[$i + 1] = (int)$treeRowPtr[$i] + (int)$treeDeg[$i];
+            $allRowPtr[$i + 1] = (int)$allRowPtr[$i] + (int)$allDeg[$i];
+            $nontreeRowPtr[$i + 1] = (int)$nontreeRowPtr[$i] + (int)$nontreeDeg[$i];
         }
 
+        // One-shot scalar reads — Cast::toInt() is fine here, only 3 calls.
         $totalAllEdges = Cast::toInt($allRowPtr[$nc]);
         $totalTreeEdges = Cast::toInt($treeRowPtr[$nc]);
         $totalNontreeEdges = Cast::toInt($nontreeRowPtr[$nc]);
@@ -300,9 +306,9 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         $allPos = FFIHelper::new("int32_t[{$nc}]");
         $nontreePos = FFIHelper::new("int32_t[{$nc}]");
         for ($i = 0; $i < $nc; $i++) {
-            $treePos[$i] = Cast::toInt($treeRowPtr[$i]);
-            $allPos[$i] = Cast::toInt($allRowPtr[$i]);
-            $nontreePos[$i] = Cast::toInt($nontreeRowPtr[$i]);
+            $treePos[$i] = (int)$treeRowPtr[$i];
+            $allPos[$i] = (int)$allRowPtr[$i];
+            $nontreePos[$i] = (int)$nontreeRowPtr[$i];
         }
 
         // ---- Pass 2: fill col_idx ----
@@ -337,19 +343,19 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                 $strength = ord($data[$off + 13]);
 
                 if ($parent_idx < $nc) {
-                    // All edges
-                    $pos = Cast::toInt($allPos[$parent_idx]);
+                    // All edges — `(int)` for the same hot-loop reasoning.
+                    $pos = (int)$allPos[$parent_idx];
                     $allColIdx[$pos] = $child_idx;
                     $allPos[$parent_idx] = $pos + 1;
 
                     if ($is_tree === 1) {
-                        $pos = Cast::toInt($treePos[$parent_idx]);
+                        $pos = (int)$treePos[$parent_idx];
                         $treeColIdx[$pos] = $child_idx;
                         $treeLinkNames[$pos] = $link_name_id;
                         $treeStrength[$pos] = $strength;
                         $treePos[$parent_idx] = $pos + 1;
                     } else {
-                        $pos = Cast::toInt($nontreePos[$parent_idx]);
+                        $pos = (int)$nontreePos[$parent_idx];
                         $nontreeColIdx[$pos] = $child_idx;
                         $nontreePos[$parent_idx] = $pos + 1;
                     }

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\Report;
 
 use FFI;
+use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\StringDict;
@@ -317,7 +318,7 @@ final class BinaryReportDataProvider
                 if ($child < 0 || $child >= $nodeSizesSlots) {
                     continue;
                 }
-                $size = (int)$nodeSizes[$child];
+                $size = Cast::toInt($nodeSizes[$child]);
                 if ($size <= 0) {
                     continue;
                 }
@@ -346,7 +347,7 @@ final class BinaryReportDataProvider
                 if ($child < 0 || $child >= $nodeSizesSlots) {
                     continue;
                 }
-                $size = (int)$nodeSizes[$child];
+                $size = Cast::toInt($nodeSizes[$child]);
                 if ($size <= 0) {
                     continue;
                 }
@@ -382,7 +383,7 @@ final class BinaryReportDataProvider
                 if ($nid < 0 || $nid >= $nodeSizesSlots) {
                     continue;
                 }
-                $cur = (int)$locIndex[$nid];
+                $cur = Cast::toInt($locIndex[$nid]);
                 if ($cur === -1) {
                     // First row for this node
                     $locIndex[$nid] = $i;
@@ -424,7 +425,7 @@ final class BinaryReportDataProvider
             }
             $sampleLocType = null;
             if ($locIndex !== null && $locRows !== null) {
-                $li = (int)$locIndex[$info['sample_child_node_id']];
+                $li = Cast::toInt($locIndex[$info['sample_child_node_id']]);
                 if ($li >= 0) {
                     $sampleLocType = $dict->lookup((int)$locRows[$li]->location_type_id);
                 }
@@ -484,7 +485,7 @@ final class BinaryReportDataProvider
                 if ($child < 0 || $child >= $nodeSizesSlots) {
                     continue;
                 }
-                $size = (int)$nodeSizes[$child];
+                $size = Cast::toInt($nodeSizes[$child]);
                 if ($size <= 0) {
                     continue;
                 }
@@ -507,7 +508,7 @@ final class BinaryReportDataProvider
                 if ($child < 0 || $child >= $nodeSizesSlots) {
                     continue;
                 }
-                $size = (int)$nodeSizes[$child];
+                $size = Cast::toInt($nodeSizes[$child]);
                 if ($size <= 0) {
                     continue;
                 }
@@ -857,7 +858,7 @@ final class BinaryReportDataProvider
         if ($locIndex === null || $locRows === null) {
             return $meta;
         }
-        $li = (int)$locIndex[$nodeId];
+        $li = Cast::toInt($locIndex[$nodeId]);
         if ($li < 0) {
             return $meta;
         }
@@ -1220,18 +1221,15 @@ final class BinaryReportDataProvider
         if ($string_counts !== []) {
             arsort($string_counts);
             $values = array_keys($string_counts);
-            $top_value = (string)($values[0] ?? '');
+            $top_value = $values[0] ?? '';
             if (strlen($top_value) > 60) {
                 $top_value = substr($top_value, 0, 57) . '...';
             }
 
             $samples = array_map(
-                static function (string|int $value): string {
-                    $value = (string)$value;
-                    return strlen($value) > 40
-                        ? substr($value, 0, 37) . '...'
-                        : $value;
-                },
+                static fn (string $value): string => strlen($value) > 40
+                    ? substr($value, 0, 37) . '...'
+                    : $value,
                 array_slice($values, 0, 5),
             );
 

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -348,15 +348,13 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     continue;
                 }
 
-                /** @var array{1: int} */
                 $size_u = unpack('P', $sizesData, $i * 8);
-                $size = (int)$size_u[1];
+                $size = $size_u[1];
                 $ffiNodeSizes[$csrIdx] = $size;
                 $substrate->nodeSizesSum += $size;
 
-                /** @var array{1: int} */
                 $cls_u = unpack('V', $classesData, $i * 4);
-                $cls_id = (int)$cls_u[1];
+                $cls_id = $cls_u[1];
                 if ($cls_id !== Format::NULL_STRING_ID) {
                     $className = $dict->lookup($cls_id);
                     if ($className !== null) {

--- a/src/Lib/FFI/FFIHelper.php
+++ b/src/Lib/FFI/FFIHelper.php
@@ -35,24 +35,32 @@ final class FFIHelper
      * would otherwise blow up PHPUnit's RunTestsInSeparateProcesses
      * serialization.
      *
+     * Throws on the rare null return path (e.g. invalid type spec) so the
+     * non-nullable return type is honest and callers do not need to write
+     * `?? throw new …` at every site — Psalm would otherwise flag those
+     * as RedundantCondition / TypeDoesNotContainNull.
+     *
      * @template T of CData
      * @param \FFI\CType|non-empty-string $type
-     * @psalm-suppress InvalidNullableReturnType, NullableReturnStatement
      */
     public static function cast(\FFI\CType|string $type, CData &$ptr): CData
     {
-        /** @var CData */
-        return self::ffi()->cast($type, $ptr);
+        return self::ffi()->cast($type, $ptr)
+            ?? throw new CannotCastCDataException(
+                'FFI::cast(' . (is_string($type) ? $type : '<CType>') . ') returned null'
+            );
     }
 
     /**
      * @param \FFI\CType|non-empty-string $type
-     * @psalm-suppress InvalidNullableReturnType, NullableReturnStatement
+     * @throws CannotAllocateBufferException when FFI::new() returns null
      */
     public static function new(\FFI\CType|string $type, bool $owned = true, bool $persistent = false): CData
     {
-        /** @var CData */
-        return self::ffi()->new($type, $owned, $persistent);
+        return self::ffi()->new($type, $owned, $persistent)
+            ?? throw new CannotAllocateBufferException(
+                'FFI::new(' . (is_string($type) ? $type : '<CType>') . ') returned null'
+            );
     }
 
     /**

--- a/src/Lib/FFI/FFIHelper.php
+++ b/src/Lib/FFI/FFIHelper.php
@@ -40,7 +40,6 @@ final class FFIHelper
      * `?? throw new …` at every site — Psalm would otherwise flag those
      * as RedundantCondition / TypeDoesNotContainNull.
      *
-     * @template T of CData
      * @param \FFI\CType|non-empty-string $type
      */
     public static function cast(\FFI\CType|string $type, CData &$ptr): CData

--- a/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
+++ b/src/Lib/Libc/Sys/Ptrace/PtraceAarch64.php
@@ -16,7 +16,6 @@ namespace Reli\Lib\Libc\Sys\Ptrace;
 use FFI\CData;
 use FFI\CInteger;
 use Reli\Lib\FFI\CannotAllocateBufferException;
-use Reli\Lib\FFI\CannotCastCDataException;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\Libc\Addressable;
 
@@ -73,19 +72,15 @@ final class PtraceAarch64 implements Ptrace
     ): int {
         if (is_null($addr) or is_int($addr)) {
             /** @var CInteger */
-            $addr_holder = FFIHelper::new('long')
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $addr_holder = FFIHelper::new('long');
             $addr_holder->cdata = (int)$addr;
-            $addr = FFIHelper::cast('void *', $addr_holder)
-                ?? throw new CannotCastCDataException('cannot cast buffer');
+            $addr = FFIHelper::cast('void *', $addr_holder);
         }
         if (is_null($data) or is_int($data)) {
             /** @var CInteger */
-            $data_holder = FFIHelper::new('long')
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $data_holder = FFIHelper::new('long');
             $data_holder->cdata = (int)$data;
-            $data = FFIHelper::cast('void *', $data_holder)
-                ?? throw new CannotCastCDataException('cannot cast buffer');
+            $data = FFIHelper::cast('void *', $data_holder);
         }
 
         $addr_pointer = $addr instanceof Addressable ? $addr->toVoidPointer() : $addr;

--- a/src/Lib/Libc/Sys/Ptrace/PtraceX64.php
+++ b/src/Lib/Libc/Sys/Ptrace/PtraceX64.php
@@ -15,8 +15,6 @@ namespace Reli\Lib\Libc\Sys\Ptrace;
 
 use FFI\CData;
 use FFI\CInteger;
-use Reli\Lib\FFI\CannotAllocateBufferException;
-use Reli\Lib\FFI\CannotCastCDataException;
 use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\Libc\Addressable;
 
@@ -99,19 +97,15 @@ final class PtraceX64 implements Ptrace
     ): int {
         if (is_null($addr) or is_int($addr)) {
             /** @var CInteger */
-            $addr_holder = FFIHelper::new('long')
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $addr_holder = FFIHelper::new('long');
             $addr_holder->cdata = (int)$addr;
-            $addr = FFIHelper::cast('void *', $addr_holder)
-                ?? throw new CannotCastCDataException('cannot cast buffer');
+            $addr = FFIHelper::cast('void *', $addr_holder);
         }
         if (is_null($data) or is_int($data)) {
             /** @var CInteger */
-            $data_holder = FFIHelper::new('long')
-                ?? throw new CannotAllocateBufferException('cannot allocate buffer');
+            $data_holder = FFIHelper::new('long');
             $data_holder->cdata = (int)$data;
-            $data = FFIHelper::cast('void *', $data_holder)
-                ?? throw new CannotCastCDataException('cannot cast buffer');
+            $data = FFIHelper::cast('void *', $data_holder);
         }
 
         $addr_pointer = $addr instanceof Addressable ? $addr->toVoidPointer() : $addr;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -282,7 +282,12 @@ final class BinaryContextTreeSink implements ContextTreeSink
                 $this->flushLocations();
             }
 
-            // Accumulate per-node sizes and classes for on-disk sections
+            // Accumulate per-node sizes and classes for on-disk sections.
+            // `(int)` on the FFI int64_t/int32_t reads here is deliberate —
+            // emitNode() is called per location during analysis, so a
+            // PhpCast\Cast::toInt() method dispatch on every iteration
+            // would show up. Element type is provably int at runtime;
+            // the InvalidCast entries are kept in psalm-baseline.xml.
             $this->ensurePerNodeCapacity($node_id);
             $this->perNodeSizes[$node_id] = (int)$this->perNodeSizes[$node_id] + $location->size;
             if (

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
@@ -24,6 +24,13 @@ use Reli\Lib\FFI\FFIHelper;
  *
  * Uses 0 as empty sentinel (no valid memory address is 0).
  * Linear probing with 75% max load factor, grows 2x.
+ *
+ * The `(int)` casts on `$this->slots[...]` are deliberate: add()/has()
+ * are called per memory location during analysis (millions of ops),
+ * and the FFI int64_t[] element type is provably int at runtime.
+ * PhpCast\Cast::toInt() would be safer in principle but its per-call
+ * method dispatch is measurable here. The resulting InvalidCast entries
+ * stay in psalm-baseline.xml on purpose.
  */
 final class FfiIntSet
 {

--- a/tools/stubs/ffi/ffi.php
+++ b/tools/stubs/ffi/ffi.php
@@ -289,39 +289,36 @@ namespace FFI {
     class CData
     {
         /**
-         * Note that this method does not physically exist and is only required
-         * for correct type inference.
+         * Array-access methods are declared public so that `$cdata[$i]`
+         * type-checks: ext/ffi implements the indexing operator on
+         * CArray-shaped CData at the engine level (no actual PHP method
+         * is called at runtime), but Psalm still checks visibility on
+         * the synthetic ArrayAccess methods. The upstream stub marked
+         * these private with a comment that they "don't physically
+         * exist", which is true at the C level but causes Psalm to
+         * report InaccessibleMethod on every legitimate `$cdata[$i]`.
          *
          * @param int $offset
          * @return bool
          */
-        private function offsetExists(int $offset) {}
+        public function offsetExists(int $offset) {}
 
         /**
-         * Note that this method does not physically exist and is only required
-         * for correct type inference.
-         *
          * @param int $offset
          * @return CData|int|float|bool|null|string
          */
-        private function offsetGet(int $offset) {}
+        public function offsetGet(int $offset) {}
 
         /**
-         * Note that this method does not physically exist and is only required
-         * for correct type inference.
-         *
          * @param int $offset
          * @param CData|int|float|bool|null|string $value
          */
-        private function offsetSet(int $offset, $value) {}
+        public function offsetSet(int $offset, $value) {}
 
         /**
-         * Note that this method does not physically exist and is only required
-         * for correct type inference.
-         *
          * @param int $offset
          */
-        private function offsetUnset(int $offset) {}
+        public function offsetUnset(int $offset) {}
 
         /**
          * Note that this method does not physically exist and is only required


### PR DESCRIPTION
Follow-up to #712 / #713. Three independent fixes that together remove ~127 entries from `psalm-baseline.xml` (377 → 250).

## 1. FFI stub: `CData::offsetGet/Set/Exists/Unset` → public (-94 InaccessibleMethod)

The upstream FFI stub had these `private` with a comment that they "don't physically exist" — true at the C level (ext/ffi handles indexing in the engine, no PHP method is invoked) but it caused Psalm to flag every legitimate `$cdata[$i]` as `InaccessibleMethod`. The stub now matches the engine behaviour: `$cdata[$i]` is array-access at runtime, so the synthetic methods are public.

## 2. `FFIHelper::new()` / `cast()` throw on null instead of suppressing (-16 across two files)

The wrappers had:
```php
/** @psalm-suppress InvalidNullableReturnType, NullableReturnStatement */
public static function new(...): CData {
    /** @var CData */
    return self::ffi()->new(...);  // actually returns ?CData on OOM etc.
}
```
… plus a `@psalm-suppress` to lie about the return type. Callers (Ptrace{X64,Aarch64}) compensated with `?? throw new …`, which Psalm correctly diagnosed as `RedundantCondition` (left side never null per signature) + `TypeDoesNotContainNull` (throw unreachable). Move the throw into the wrapper, drop the suppress, drop the now-dead `?? throw` at call sites; signature and runtime behaviour line up.

Also drops the unused `@template T of CData` from `FFIHelper::cast()` — the return type is plain CData, the template was never applied to a parameter or the return.

## 3. Prefer `PhpCast\Cast::toInt` over `(int)` on FFI int-array reads, in non-hot paths

`(int)` silently coerces `"abc"` to 0, `[1,2,3]` to 1 (and `[]` to 0), `true` to 1, etc. — **no warning, even with `strict_types=1`**. `PhpCast\Cast::toInt` (already a project dep) keeps PHP's loose-mode coercion *with* a `TypeError` on uncoercible values like arrays/objects — fail-loud behaviour the codebase prefers.

Applied to:
- `BinaryMemoryOutput::write()` — only the three one-shot `totalAllEdges` / `totalTreeEdges` / `totalNontreeEdges` scalar reads. The per-edge / per-row-ptr O(edgeCount)/O(nodeCount) loops were converted at first but **rolled back to bare `(int)`** after a perf review (see below).
- `BinaryReportDataProvider::*` report-pass loops (post-analysis report generation, no target-process overhead).

**Hot paths intentionally left as `(int)`** with the baseline entries kept and a code comment at every site so a later reader doesn't "clean up" by routing through `Cast::toInt`:
- `FfiIntSet::add` / `::has` — called per memory location during analysis (millions of ops)
- `BinaryContextTreeSink::emitNode` — same path
- `BinaryMemoryOutput` edge / row-ptr loops — O(edgeCount) build of CSR sections

### Perf check: BinaryReportDataProvider Cast::toInt is in noise

Per ChatGPT review on this PR. Profiled `inspector:memory:report` on a real 134 MB `.rmem` snapshot (`tmp/watch-dump.rmem`, ~6 M edges) using the dogfooding recipe in CLAUDE.md (outer reli traces inner reli):

```
$ php ./reli inspector:trace -F rbt -o /tmp/p.rbt -s 1000000 \
    -- php ./reli inspector:memory:report tmp/watch-dump.rmem --memory-limit=4G \
       --no-prefetch -f report -o /tmp/r.txt
$ php ./reli rbt:analyze --match='Cast::|toInt' --top=20 < /tmp/p.rbt
| 3 | 100.0% | PhpCast\Cast::toInt |
```

`Cast::toInt` accounts for **3 of 3291 samples = 0.09 %** of total report time, all of it inside `BinaryReportDataProvider::getDedupCandidateStats`. Substrate load is 51 %, pass execution 30 %, `getChildren` 11 %; the cast-call overhead is fully dominated by those.

5-run wall-clock comparison on the same snapshot (warm derived cache, `--no-prefetch` to defeat OS cache effects):

| build | run-1 | run-2 | run-3 | run-4 | run-5 | median |
|---|---:|---:|---:|---:|---:|---:|
| origin/0.12.x (`(int)` everywhere) | 5.12 | 4.07 | 4.16 | 4.20 | 3.98 | 4.16 s |
| this branch (`Cast::toInt` in report passes) | 4.00 | 4.04 | 4.10 | 4.43 | 3.97 | 4.04 s |

Differences are within noise. `Cast::toInt` in the report path stays.

Also: dropped `(int)unpack(...)[1]` and `(string)$x` casts that #712's unpack stub made provably redundant. (-6 `RedundantCastGivenDocblockType`)

## Numbers

|  | before | after |
|---|---:|---:|
| baseline `<code>` entries | 377 | 250 |
| `<file src=` blocks | 30 | ~26 |
| Psalm errors | 0 | 0 |

`findUnusedBaselineEntry=true` (set by #712) keeps the surviving entries honest — any future fix that obviates a baseline line will surface as an `UnusedBaselineEntry` error.

## Test plan

- [x] `php vendor/bin/psalm.phar` — 0 errors
- [x] `phpcs --standard=PSR12 -n` — clean
- [x] `phpunit tests/Inspector/Output tests/Lib/Process tests/Lib/PhpProcessReader/PhpMemoryReader` — all touched paths pass; 12 errors / 1 failure are pre-existing sandbox/integration env failures (per CLAUDE.md "Sandbox-only ptrace failures" + "Known flaky integration tests")
- [x] `inspector:memory:report` dogfooding profile on 134 MB `.rmem` — Cast::toInt is 0.09 % of CPU time, walltime equal to baseline within noise
- [ ] CI green on the full matrix

## Also includes

A tiny Dockerfile comment fix: #713's worker-entry guard ended up as an explicit `if (...) throw` (Webmozart's `Assert::count` lacks an `@psalm-assert` to narrow `$argv` away from null), so the comment about "runtime contracts written as `Webmozart\Assert::*`" was incomplete — updated to cover the if/throw path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)