### PR TITLE
Improve opcode tracing documentation and fix PHP version requirement

### DIFF
--- a/docs/monitoring/sidecar.md
+++ b/docs/monitoring/sidecar.md
@@ -115,7 +115,7 @@ it keeps the application's dependency graph free of FFI / PCNTL.
 
 - **Composer, full reli-prof** — strongly discouraged for
   application-only deploys. `reliforp/reli-prof`'s `composer.json`
-  declares `php: ^8.5`, `ext-ffi`, `ext-pcntl` as hard requirements
+  declares `php: ^8.4`, `ext-ffi`, `ext-pcntl` as hard requirements
   (they are needed by the `reli` CLI itself, not by the client
   classes), and a typical PHP-FPM application image has none of
   them. `composer require reliforp/reli-prof` therefore fails the

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -32,13 +32,26 @@ it differently:
   3 <main> /home/sji/work/test/mandelbrot.php:45:ZEND_DO_FCALL
   ```
 
-  The currently executing opcode becomes the first frame of the
-  callstack, so visualisations like flamegraph show opcode usage
-  directly.
+  When the sample lands while a PHP-level opcode is being
+  dispatched, the currently executing opcode is prepended as an
+  extra leaf frame (`<VM>::<OPCODE> <VM>:-1`), so visualisations
+  like flamegraph show opcode usage directly. If the leaf frame is
+  an internal function call (e.g. `usleep`, `preg_match`), the
+  sample is taken inside the C implementation and the extra
+  `<VM>::` frame is omitted — you'll see the internal function
+  itself at index 0:
+
+  ```bash
+  $ sudo php ./reli i:trace --output-format=template:phpspy_with_opcode \
+        -- php -r "for(;;){usleep(10000);}"
+  0 usleep <internal>:-1
+  1 <main> Command line code:1:ZEND_DO_ICALL
+  ```
 
   For informational purposes, the executing opcode is also appended
   to the end of each call frame line (second position onward).
-  Expect function-call opcodes like `ZEND_DO_FCALL` there.
+  Expect function-call opcodes like `ZEND_DO_FCALL` / `ZEND_DO_ICALL`
+  there.
 
 If JIT is enabled on the target, line / opcode information may be
 slightly inaccurate. For JIT-compiled function names specifically,


### PR DESCRIPTION
## Summary
This PR improves the documentation for opcode tracing behavior and corrects a PHP version requirement in the sidecar deployment guide.

## Key Changes

- **Enhanced opcode tracing documentation** (`docs/tracing/advanced-capture.md`):
  - Clarified the behavior when samples land on PHP-level opcodes vs. internal function calls
  - Added a concrete example showing how internal functions (like `usleep`) appear in traces without the `<VM>::` prefix
  - Updated opcode examples to include both `ZEND_DO_FCALL` and `ZEND_DO_ICALL` as expected opcodes
  - Improved explanation of how the extra leaf frame is prepended to the callstack

- **Fixed PHP version requirement** (`docs/monitoring/sidecar.md`):
  - Corrected the minimum PHP version for `reliforp/reli-prof` from `^8.5` to `^8.4`

## Implementation Details

The opcode documentation changes provide clearer guidance on interpreting flame graphs and traces, particularly distinguishing between:
- PHP-level opcode execution (where `<VM>::<OPCODE>` frame is added)
- Internal C function calls (where the internal function appears directly without the `<VM>::` wrapper)

This helps users better understand the trace output and avoid confusion when analyzing performance profiles.

https://claude.ai/code/session_01Nqgy8mdTJ6jWgm683m1yoQ