### PR TITLE
Extract rmem integration protocols to dedicated documentation

### DIFF
--- a/docs/internals/rmem-protocol.md
+++ b/docs/internals/rmem-protocol.md
@@ -1,14 +1,23 @@
-# rmem Integration Protocols
+# rmem Integration Surface
 
-Wire-level reference for code that integrates with the `rmem:*`
-commands: HTTP/SSE for browsers, Unix-socket JSON for headless query
-servers, MCP tool surface for AI agents, and the focus bus that ties
-all three together.
+Index of the wire surfaces that the `rmem:*` commands expose for
+external clients: HTTP/SSE for browsers, Unix-socket JSON for headless
+query servers, MCP tool surface for AI agents, and the focus bus that
+ties all three together.
+
+> **Audience and stability.** This document is integration-facing — a
+> reference for code that talks to a running `rmem:live` / `rmem:serve` /
+> `rmem:mcp` process from the outside. It lives under `internals/` for
+> filing convenience, but is not a private implementation note: this
+> page is the source of truth for external clients. Wire details may
+> still change before 1.0; breaking changes will be called out in
+> release notes.
 
 For end-user usage of the commands themselves see
 [../memory/rmem-explore-and-serve.md](../memory/rmem-explore-and-serve.md).
-For the design rationale of the headless query server see
-[rmem-serve-design.md](rmem-serve-design.md).
+The full JSON-over-Unix-socket request/response specification lives in
+[rmem-serve-design.md](rmem-serve-design.md); this page indexes the
+action surface and points there for shapes.
 
 ## HTTP / SSE bridge
 
@@ -92,11 +101,10 @@ was launched.
   *set* of nodes together (useful for "these N are part of the
   leak"); empty array clears.
 
-The server includes built-in instructions that teach the AI agent
-about PHP memory concepts (shallow vs retained size, tree edges,
-SCCs, etc.) and recommended investigation workflows, so no
-additional documentation is needed for the agent to use the tools
-effectively.
+The server ships with built-in instructions covering PHP memory
+concepts (shallow vs retained size, tree edges, SCCs, etc.) and
+recommended investigation workflows, so MCP-capable clients can
+usually start with useful built-in guidance.
 
 ## Three-way focus bus
 

--- a/docs/internals/rmem-protocol.md
+++ b/docs/internals/rmem-protocol.md
@@ -1,0 +1,133 @@
+# rmem Integration Protocols
+
+Wire-level reference for code that integrates with the `rmem:*`
+commands: HTTP/SSE for browsers, Unix-socket JSON for headless query
+servers, MCP tool surface for AI agents, and the focus bus that ties
+all three together.
+
+For end-user usage of the commands themselves see
+[../memory/rmem-explore-and-serve.md](../memory/rmem-explore-and-serve.md).
+For the design rationale of the headless query server see
+[rmem-serve-design.md](rmem-serve-design.md).
+
+## HTTP / SSE bridge
+
+Started by `rmem:live` (standalone) or by `rmem:explore --http-bridge PORT`
+(forked child of the TUI). Both expose the same surface.
+
+### Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/` | viz HTML (gzip when the client supports it) |
+| `GET`  | `/api/events` | Server-Sent Events stream |
+| `POST` | `/api/navigate` | Body `{"node_id": int}` → broadcasts a `focus_node` SSE event to every subscriber |
+| `POST` | `/api/highlight_set` | Body `{"node_ids": [int, …]}` → broadcasts a `highlight_set` SSE event |
+
+### SSE payloads
+
+```
+event: focus_node
+data: {"node_id": 1234, "path_node_ids": [0, 4, 5, 6, 7], "label": "StringContext = \"book\""}
+
+event: highlight_set
+data: {"node_ids": [100, 200, 300]}
+```
+
+Browsers handle `focus_node` by highlighting the target (or the
+nearest visible ancestor if the node isn't in the induced subgraph
+— `path_node_ids` drives the fallback); `highlight_set` dims
+non-members in 3D Force and rings each member in the SVG views.
+
+## Unix-socket query protocol
+
+Started by `rmem:serve`. Newline-delimited JSON over a Unix domain
+socket. Full protocol specification is in
+[rmem-serve-design.md](rmem-serve-design.md).
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `server.hello` | Server info, node/edge counts |
+| `query.roots` | Root branches |
+| `query.children` | Children of a node (sorted by retained) |
+| `query.parents` | Parents that retain a node |
+| `query.sandwich` | Parents + detail + children in one call |
+| `query.node_detail` | Full node detail |
+| `query.path_to_root` | Ownership chain to root |
+| `query.class_ranking` | Classes by memory |
+| `query.type_ranking` | Node types by memory |
+| `query.top_retained` | Largest retained nodes |
+| `query.search` | Global search across labels, classes, strings |
+| `query.scc_ranking` | Reference cycles by size |
+| `query.scc_for_node` | Cycle detail for a node |
+| `query.subtree_stats` | Type/class breakdown of a subtree |
+
+## MCP tools
+
+Exposed by `rmem:mcp`. Tool availability depends on how the server
+was launched.
+
+**Query tools** (always available):
+`rmem_roots`, `rmem_children`, `rmem_parents`, `rmem_sandwich`,
+`rmem_node_detail`, `rmem_path_to_root`, `rmem_class_ranking`,
+`rmem_type_ranking`, `rmem_top_retained`, `rmem_search`,
+`rmem_scc_ranking`, `rmem_scc_for_node`, `rmem_subtree_stats`,
+`rmem_nodes_by_class`, `rmem_nodes_by_type`,
+`rmem_find_by_address`, `rmem_find_function_def`,
+`rmem_find_class_def`, `rmem_hello`
+
+**UI control tools** (with `--control`, requires
+`rmem:explore --serve --serve-control`):
+`rmem_navigate`, `rmem_navigate_roots`, `rmem_navigate_back`,
+`rmem_navigate_class_ranking`, `rmem_navigate_type_ranking`,
+`rmem_navigate_top_retained`, `rmem_get_focus`, `rmem_get_selection`
+
+**Browser bridge tools** (with `--bridge URL`):
+- `rmem_broadcast_focus` — POST `/api/navigate` to highlight a node
+  across every connected browser (and the TUI, when it is the
+  origin of the bridge).
+- `rmem_highlight_set` — POST `/api/highlight_set` to light up a
+  *set* of nodes together (useful for "these N are part of the
+  leak"); empty array clears.
+
+The server includes built-in instructions that teach the AI agent
+about PHP memory concepts (shallow vs retained size, tree edges,
+SCCs, etc.) and recommended investigation workflows, so no
+additional documentation is needed for the agent to use the tools
+effectively.
+
+## Three-way focus bus
+
+`rmem:explore --http-bridge` plus `rmem:mcp --bridge URL` pointed at
+the same port create a single live bus that every surface reads
+from and writes to:
+
+```
+             focus pipe          SSE                 POST /api/navigate
+    ┌──────────────────────▶ bridge child ────▶ Browsers (any tab) ─────────┐
+    │                        (HTTP/SSE)                                     │
+    │                              ▲                                        │
+    │                              │ POST /api/navigate  ┌──────────────────┘
+    │                              │                     │
+    │                              │                 MCP ──▶ AI agents
+    │                              │                 (--bridge URL)
+    │                              │
+    │              navigate pipe (child → TUI)
+    TUI ◀─────────────────────────┘
+    (rmem:explore --http-bridge)
+```
+
+- TUI cursor with **follow mode on** (`f`) → every browser re-rings
+  the focused node and the AI can query it by id.
+- **Browser click or Pack-zoom** → `POST /api/navigate` →
+  re-broadcast as SSE to every other browser **and** handed to the
+  TUI over the reverse pipe so the sandwich view jumps there.
+- **AI** calls `rmem_broadcast_focus(node_id)` / `rmem_highlight_set(ids)`
+  via MCP → browsers plus the TUI react instantly.
+
+Out-of-subgraph focus events carry the full ancestor chain
+(`path_node_ids`); the browser falls back to the nearest visible
+ancestor and surfaces a breadcrumb in the detail panel so the user
+never gets a blank highlight.

--- a/docs/internals/rmem-protocol.md
+++ b/docs/internals/rmem-protocol.md
@@ -113,27 +113,45 @@ the same port create a single live bus that every surface reads
 from and writes to:
 
 ```
-             focus pipe          SSE                 POST /api/navigate
-    ┌──────────────────────▶ bridge child ────▶ Browsers (any tab) ─────────┐
-    │                        (HTTP/SSE)                                     │
-    │                              ▲                                        │
-    │                              │ POST /api/navigate  ┌──────────────────┘
-    │                              │                     │
-    │                              │                 MCP ──▶ AI agents
-    │                              │                 (--bridge URL)
-    │                              │
-    │              navigate pipe (child → TUI)
-    TUI ◀─────────────────────────┘
-    (rmem:explore --http-bridge)
+    ┌──── focus pipe (TUI → child) ──────────┐
+    │                                        ▼
+    TUI  ◀── navigate pipe (child → TUI) ── bridge child  ──SSE──▶ Browsers (any tab)
+    (rmem:explore                           (HTTP/SSE)                    │
+     --http-bridge)                               ▲                       │
+                                                  │ POST /api/navigate    │
+                                                  ├───────────────────────┘
+                                                  │
+                                                  │ POST /api/navigate
+                                                  │
+                                            MCP server ◀── tool calls ── AI agents
+                                            (--bridge URL)
 ```
 
-- TUI cursor with **follow mode on** (`f`) → every browser re-rings
-  the focused node and the AI can query it by id.
-- **Browser click or Pack-zoom** → `POST /api/navigate` →
-  re-broadcast as SSE to every other browser **and** handed to the
-  TUI over the reverse pipe so the sandwich view jumps there.
+The bridge child is the hub. Three peer surfaces connect to it:
+
+- **TUI**, via two anonymous pipes — focus pipe (TUI → child) when
+  follow mode is on, and navigate pipe (child → TUI) for events
+  flowing back from the network.
+- **Browsers**, via HTTP — `GET /api/events` for the SSE stream, and
+  `POST /api/navigate` / `POST /api/highlight_set` to push focus
+  back into the bus.
+- **MCP server**, via the same HTTP `POST /api/navigate` endpoint
+  that browsers use. AI agents do not talk to the bridge directly —
+  they call `rmem_broadcast_focus` / `rmem_highlight_set` tools on
+  the MCP server, and the MCP server (started with `--bridge URL`)
+  translates each tool call into a POST.
+
+Concrete flows:
+
+- TUI cursor with **follow mode on** (`f`) → focus pipe → bridge
+  child → SSE → every browser; the AI can also pull the current
+  focus via `rmem_get_focus`.
+- **Browser click or Pack-zoom** → `POST /api/navigate` → bridge
+  child → SSE to every other browser **and** navigate pipe → TUI,
+  so the sandwich view jumps there.
 - **AI** calls `rmem_broadcast_focus(node_id)` / `rmem_highlight_set(ids)`
-  via MCP → browsers plus the TUI react instantly.
+  via MCP → MCP server → `POST /api/navigate` → bridge child → all
+  browsers and the TUI react instantly.
 
 Out-of-subgraph focus events carry the full ancestor chain
 (`path_node_ids`); the browser falls back to the nearest visible

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -19,7 +19,7 @@ interactively:
 
 The TUI, browser, and AI surfaces can be wired together over a single
 focus bus so that moving the cursor anywhere is reflected everywhere
-— see [§ Three-way focus bus](#three-way-focus-bus).
+— see [internals/rmem-protocol.md](../internals/rmem-protocol.md#three-way-focus-bus).
 
 ## rmem:explore
 
@@ -81,12 +81,12 @@ between top-level branches without returning to the roots list.
 
 When follow mode is on, every cursor move in the TUI — arrow keys,
 mouse click, `Tab` between panes, scroll wheel — emits a focus_node
-event to the HTTP bridge (see [§ rmem:live](#rmemlive) and
-[§ Three-way focus bus](#three-way-focus-bus)). Browsers highlight
-the node the cursor is on; AI agents connected via `rmem:mcp
---bridge` see the same focus. A green `follow` badge appears in the
-footer while the mode is active. Toggle again with `f` to return
-to manual-drill-only.
+event to the HTTP bridge (see [§ rmem:live](#rmemlive) and the
+[focus bus diagram](../internals/rmem-protocol.md#three-way-focus-bus)).
+Browsers highlight the node the cursor is on; AI agents connected
+via `rmem:mcp --bridge` see the same focus. A green `follow` badge
+appears in the footer while the mode is active. Toggle again with
+`f` to return to manual-drill-only.
 
 ### Options
 
@@ -156,9 +156,9 @@ render time.
 ### HTTP bridge options (`--http-bridge`)
 
 When `--http-bridge PORT` is set, a child process is forked that
-serves the browser viz at `/` and an SSE focus stream at
-`/api/events`. The bridge mirrors TUI focus changes out, and
-browser / MCP `POST /api/navigate` back into the TUI.
+serves the browser viz at `/` and mirrors TUI focus to it. Wire-level
+endpoints are documented in
+[internals/rmem-protocol.md](../internals/rmem-protocol.md#http--sse-bridge).
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -281,29 +281,11 @@ Same subgraph knobs as `rmem:viz` (`--top`, `--depth`, `--all-edges`,
 | `--host` | `127.0.0.1` | Bind host (use `0.0.0.0` or `::` for LAN access) |
 | `--port N` / `-p` | `8080` | TCP port |
 
-### HTTP endpoints
+### Wire protocol
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| `GET`  | `/` | viz HTML (gzip when the client supports it) |
-| `GET`  | `/api/events` | Server-Sent Events stream |
-| `POST` | `/api/navigate` | Body `{"node_id": int}` → broadcasts a `focus_node` SSE event to every subscriber |
-| `POST` | `/api/highlight_set` | Body `{"node_ids": [int, …]}` → broadcasts a `highlight_set` SSE event |
-
-SSE payloads:
-
-```
-event: focus_node
-data: {"node_id": 1234, "path_node_ids": [0, 4, 5, 6, 7], "label": "StringContext = \"book\""}
-
-event: highlight_set
-data: {"node_ids": [100, 200, 300]}
-```
-
-Browsers handle `focus_node` by highlighting the target (or the
-nearest visible ancestor if the node isn't in the induced subgraph
-— `path_node_ids` drives the fallback); `highlight_set` dims
-non-members in 3D Force and rings each member in the SVG views.
+HTTP endpoints (`/api/events`, `/api/navigate`, `/api/highlight_set`)
+and SSE payload shapes are documented in
+[internals/rmem-protocol.md](../internals/rmem-protocol.md#http--sse-bridge).
 
 ## rmem:serve
 
@@ -336,28 +318,10 @@ echo '{"action":"query.sandwich","node_id":12345}' | socat - UNIX-CONNECT:/path/
 
 ### Protocol
 
-Newline-delimited JSON over Unix socket. See
-[rmem-serve-design.md](../internals/rmem-serve-design.md) for the full
-protocol specification.
-
-Key actions:
-
-| Action | Description |
-|--------|-------------|
-| `server.hello` | Server info, node/edge counts |
-| `query.roots` | Root branches |
-| `query.children` | Children of a node (sorted by retained) |
-| `query.parents` | Parents that retain a node |
-| `query.sandwich` | Parents + detail + children in one call |
-| `query.node_detail` | Full node detail |
-| `query.path_to_root` | Ownership chain to root |
-| `query.class_ranking` | Classes by memory |
-| `query.type_ranking` | Node types by memory |
-| `query.top_retained` | Largest retained nodes |
-| `query.search` | Global search across labels, classes, strings |
-| `query.scc_ranking` | Reference cycles by size |
-| `query.scc_for_node` | Cycle detail for a node |
-| `query.subtree_stats` | Type/class breakdown of a subtree |
+Newline-delimited JSON over Unix socket. The action list and full
+specification are in
+[internals/rmem-protocol.md](../internals/rmem-protocol.md#unix-socket-query-protocol)
+and [internals/rmem-serve-design.md](../internals/rmem-serve-design.md).
 
 ## rmem:mcp
 
@@ -415,27 +379,10 @@ For co-pilot mode (AI + human sharing TUI):
 
 ### Tools provided
 
-**Query tools** (always available):
-`rmem_roots`, `rmem_children`, `rmem_parents`, `rmem_sandwich`,
-`rmem_node_detail`, `rmem_path_to_root`, `rmem_class_ranking`,
-`rmem_type_ranking`, `rmem_top_retained`, `rmem_search`,
-`rmem_scc_ranking`, `rmem_scc_for_node`, `rmem_subtree_stats`,
-`rmem_nodes_by_class`, `rmem_nodes_by_type`,
-`rmem_find_by_address`, `rmem_find_function_def`,
-`rmem_find_class_def`, `rmem_hello`
-
-**UI control tools** (with `--control`):
-`rmem_navigate`, `rmem_navigate_roots`, `rmem_navigate_back`,
-`rmem_navigate_class_ranking`, `rmem_navigate_type_ranking`,
-`rmem_navigate_top_retained`, `rmem_get_focus`, `rmem_get_selection`
-
-**Browser bridge tools** (with `--bridge URL`):
-- `rmem_broadcast_focus` — POST `/api/navigate` to highlight a node
-  across every connected browser (and the TUI, when it is the
-  origin of the bridge).
-- `rmem_highlight_set` — POST `/api/highlight_set` to light up a
-  *set* of nodes together (useful for "these N are part of the
-  leak"); empty array clears.
+Three categories — query (always available), UI control (with
+`--control`), and browser bridge (with `--bridge URL`). The full
+tool list is in
+[internals/rmem-protocol.md](../internals/rmem-protocol.md#mcp-tools).
 
 The server includes built-in instructions that teach the AI agent
 about PHP memory concepts (shallow vs retained size, tree edges,
@@ -446,33 +393,7 @@ effectively.
 ## Three-way focus bus
 
 `rmem:explore --http-bridge` plus `rmem:mcp --bridge URL` pointed at
-the same port create a single live bus that every surface reads
-from and writes to:
-
-```
-             focus pipe          SSE                 POST /api/navigate
-    ┌──────────────────────▶ bridge child ────▶ Browsers (any tab) ─────────┐
-    │                        (HTTP/SSE)                                     │
-    │                              ▲                                        │
-    │                              │ POST /api/navigate  ┌──────────────────┘
-    │                              │                     │
-    │                              │                 MCP ──▶ AI agents
-    │                              │                 (--bridge URL)
-    │                              │
-    │              navigate pipe (child → TUI)
-    TUI ◀─────────────────────────┘
-    (rmem:explore --http-bridge)
-```
-
-- TUI cursor with **follow mode on** (`f`) → every browser re-rings
-  the focused node and the AI can query it by id.
-- **Browser click or Pack-zoom** → `POST /api/navigate` →
-  re-broadcast as SSE to every other browser **and** handed to the
-  TUI over the reverse pipe so the sandwich view jumps there.
-- **AI** calls `rmem_broadcast_focus(node_id)` / `rmem_highlight_set(ids)`
-  via MCP → browsers plus the TUI react instantly.
-
-Out-of-subgraph focus events carry the full ancestor chain
-(`path_node_ids`); the browser falls back to the nearest visible
-ancestor and surfaces a breadcrumb in the detail panel so the user
-never gets a blank highlight.
+the same port create a single live bus where TUI cursor moves,
+browser clicks, and AI tool calls all reflect everywhere. Architecture
+diagram and event flow:
+[internals/rmem-protocol.md § Three-way focus bus](../internals/rmem-protocol.md#three-way-focus-bus).

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -259,7 +259,7 @@ the HTML itself:
 
 ## rmem:live
 
-Same viz as `rmem:viz`, but served over HTTP with a **live SSE event
+Same viz as `rmem:viz`, but served over HTTP with a **live sync
 channel** so browsers stay in sync with each other and with any TUI
 / MCP client that joins the bus.
 
@@ -379,16 +379,22 @@ For co-pilot mode (AI + human sharing TUI):
 
 ### Tools provided
 
-Three categories — query (always available), UI control (with
-`--control`), and browser bridge (with `--bridge URL`). The full
-tool list is in
+Three categories:
+
+- **Query tools** (always available) — inspect roots, nodes,
+  parents/children, rankings, cycles, and full-text search.
+- **UI control tools** (with `--control`) — move the TUI focus when
+  connected to `rmem:explore --serve --serve-control`.
+- **Browser bridge tools** (with `--bridge URL`) — broadcast focus
+  and highlight events to every connected visualization.
+
+The full tool list is in
 [internals/rmem-protocol.md](../internals/rmem-protocol.md#mcp-tools).
 
-The server includes built-in instructions that teach the AI agent
-about PHP memory concepts (shallow vs retained size, tree edges,
-SCCs, etc.) and recommended investigation workflows, so no
-additional documentation is needed for the agent to use the tools
-effectively.
+The server ships with built-in instructions covering PHP memory
+concepts (shallow vs retained size, tree edges, SCCs, etc.) and
+recommended investigation workflows, so MCP-capable clients can
+usually start with useful built-in guidance.
 
 ## Three-way focus bus
 


### PR DESCRIPTION
## Summary

Splits the rmem documentation so the user-facing guide reads as a usage
guide and integration-facing wire details live in a dedicated index.

The previous `docs/memory/rmem-explore-and-serve.md` mixed end-user
material (TUI keys, command flags, MCP setup) with integration-facing
material (HTTP endpoints, SSE payload shapes, Unix-socket actions, full
MCP tool list, focus bus wiring diagram). For someone who just wants to
browse a snapshot, the latter is heavy.

## Changes

**New file: `docs/internals/rmem-protocol.md`** — integration surface
index for external clients (browser integrations, MCP clients, headless
query clients):
- HTTP/SSE bridge endpoints and SSE payload shapes
- Unix-socket query action list (full request/response spec stays in
  `rmem-serve-design.md`; this page indexes the action surface and
  links there)
- MCP tool list (query / UI control / browser bridge categories)
- Three-way focus bus architecture diagram and event flow

The doc opens with an explicit audience/stability note clarifying that
it lives under `internals/` for filing convenience but is the source of
truth for external clients, not a private implementation note.

**Updated `docs/memory/rmem-explore-and-serve.md`** (478 → 405 lines):
- Replaced inline HTTP endpoint tables, SSE payload examples,
  Unix-socket action table, MCP tool list, and focus bus diagram with
  cross-references to the new doc
- Kept command usage, flags, TUI keymap, mouse, follow mode, source
  locations, report integration, and viz/live/serve/mcp setup intact
- Restored a one-line description per MCP tool category so readers see
  at a glance what's available without jumping out

## Rationale

- User guide is now usage-focused; readers don't have to skim past
  endpoint tables and payload schemas to find the next command flag.
- A single source of truth for wire surfaces makes it easier for
  integrators (browser devs, MCP clients, headless query clients) to
  find what they need.
- File path stays the same (`rmem-explore-and-serve.md`), so existing
  links from `README.md`, `docs/README.md`, `getting-started.md`,
  `troubleshooting.md`, `recipes.md`, etc. remain valid.

## Test plan

- [x] Render both docs and confirm anchors resolve
  (`#http--sse-bridge`, `#unix-socket-query-protocol`, `#mcp-tools`,
  `#three-way-focus-bus`)
- [x] Click through cross-links from `rmem-explore-and-serve.md` to
  `rmem-protocol.md` and back
- [x] Confirm pre-existing links to `rmem-explore-and-serve.md` from
  `README.md`, `docs/README.md`, `docs/getting-started.md`,
  `docs/troubleshooting.md`, `docs/recipes.md`,
  `docs/memory/memory-profiler.md`, `docs/memory/coredump.md`, and
  `docs/internals/rmem-derived-cache.md` still resolve

https://claude.ai/code/session_01Nh5RYhvgdbUeL4QJeoVoyw