### PR TITLE
Improve watch command performance documentation clarity

### DIFF
--- a/docs/monitoring/watch-command.md
+++ b/docs/monitoring/watch-command.md
@@ -472,14 +472,23 @@ spec:
 
 ## Performance
 
-Measured polling overhead (PHP 8.4, median):
+At the default `--poll-interval=1000` (1 second), polling overhead is negligible
+for any trigger combination. Roughly in increasing order of cost:
+**memory / RSS triggers ≪ function / depth triggers < variable watch**.
+
+<details>
+<summary>Measured polling overhead (PHP 8.4, median)</summary>
 
 | Configuration | Latency | Max polls/sec |
 |---------------|---------|---------------|
-| Tier 1 only (memory triggers) | ~680μs | ~1,470 |
-| Tier 1 + Tier 2 (+ function/depth) | ~750μs | ~1,330 |
-| Tier 1 + 2 + 3 (+ variable watch) | ~2,170μs | ~460 |
+| Memory triggers only | ~680μs | ~1,470 |
+| + function / depth | ~750μs | ~1,330 |
+| + variable watch | ~2,170μs | ~460 |
 
-Trigger evaluation itself is < 1μs. The cost is dominated by `process_vm_readv` calls for reading target process memory.
+Trigger evaluation itself is < 1μs; cost is dominated by `process_vm_readv`
+calls. Even the heaviest configuration uses ~0.2% of a 1s polling interval.
 
-At the default `--poll-interval=1000` (1 second), even the heaviest configuration uses only ~0.2% of the polling interval.
+See [docs/internals/watch-command-architecture.md](../internals/watch-command-architecture.md#tiers-adaptive-polling-cost)
+for the per-tier breakdown.
+
+</details>

--- a/docs/monitoring/watch-command.md
+++ b/docs/monitoring/watch-command.md
@@ -472,9 +472,11 @@ spec:
 
 ## Performance
 
-At the default `--poll-interval=1000` (1 second), polling overhead is negligible
-for any trigger combination. Roughly in increasing order of cost:
-**memory / RSS triggers ≪ function / depth triggers < variable watch**.
+At the default `--poll-interval=1000` (1 second), per-target polling overhead is
+negligible for typical trigger combinations. Roughly: memory / RSS and
+function / depth triggers stay sub-millisecond; variable watch is the expensive
+tier, but still small at the default interval. In daemon mode the total cost
+scales with the number of monitored processes.
 
 <details>
 <summary>Measured polling overhead (PHP 8.4, median)</summary>


### PR DESCRIPTION
## Summary
Reorganized and enhanced the Performance section of the watch command documentation to better communicate performance characteristics and provide clearer context for users.

## Key Changes
- **Restructured performance overview**: Added introductory statement clarifying that polling overhead is negligible at default settings, with a relative cost ordering of different trigger types
- **Improved table formatting**: Simplified configuration labels in the performance metrics table for better readability (e.g., "Memory triggers only" instead of "Tier 1 only (memory triggers)")
- **Collapsed detailed metrics**: Wrapped the measured polling overhead table in a `<details>` element to reduce visual clutter while keeping detailed data accessible
- **Enhanced explanatory text**: Clarified that trigger evaluation cost is minimal and dominated by `process_vm_readv` calls, with concrete percentage usage (0.2% of polling interval)
- **Added cross-reference**: Included link to architecture documentation for users interested in per-tier performance breakdown details

## Implementation Details
The changes maintain all original performance data while improving information hierarchy and readability. The collapsible details section allows users to quickly understand performance implications without being overwhelmed by technical details, while still providing access to comprehensive metrics for those who need them.

https://claude.ai/code/session_01NP4XEtN8LXN4mnmpTy2nx5