### PR TITLE
Fix autoloader detection to break after first successful load

### DIFF
--- a/reli
+++ b/reli
@@ -25,8 +25,9 @@ $not_loaded = true;
 foreach ([__DIR__ . '/vendor/autoload.php', __DIR__ . '/../../autoload.php'] as $autoload) {
     if (file_exists($autoload)) {
         require $autoload;
+        $not_loaded = false;
+        break;
     }
-    $not_loaded = false;
 }
 
 if ($not_loaded) {


### PR DESCRIPTION
## Summary
Fixed the autoloader initialization logic to properly exit the loop after successfully loading the first available autoload file, preventing unnecessary iteration and ensuring correct state management.

## Key Changes
- Moved `$not_loaded = false;` assignment inside the `if` block to only execute when an autoload file is actually found
- Added `break;` statement after successful autoload to exit the loop immediately
- This ensures the flag is only set to false when autoloading succeeds, and prevents checking additional paths once one is found

## Implementation Details
The previous logic would set `$not_loaded = false` regardless of whether an autoload file was found, and would continue iterating through all paths. The corrected implementation now:
1. Only sets `$not_loaded = false` when `file_exists()` returns true
2. Breaks out of the loop immediately after a successful load
3. Maintains the original intent of the error handling while improving efficiency and correctness

https://claude.ai/code/session_01JiC67HibThMvjKoXTzrYN3