### PR TITLE
Improve documentation layout for tree view screenshots

### DIFF
--- a/docs/tracing/rbt-analyze-and-explore.md
+++ b/docs/tracing/rbt-analyze-and-explore.md
@@ -260,17 +260,43 @@ After that you're in a sandwich-style explorer modelled loosely on
 [speedscope](https://www.speedscope.app/)'s sandwich view.
 
 ### Screenshots
-#### Panes view
-![panes view](../images/rbt-explore-panes.png)
 
-#### Flame view
-![flame view](../images/rbt-explore-flame.png)
+Click any thumbnail for the full-size image.
 
-#### Callers tree view
-![callers tree view](../images/rbt-explore-callers-tree.png)
-
-#### Callees tree view
-![callees tree view](../images/rbt-explore-callees-tree.png)
+<table>
+  <tr>
+    <td align="center" width="50%">
+      <a href="../images/rbt-explore-panes.png">
+        <img src="../images/rbt-explore-panes.png" width="420" alt="panes view">
+      </a>
+      <br>
+      <sub><b>Panes view</b></sub>
+    </td>
+    <td align="center" width="50%">
+      <a href="../images/rbt-explore-flame.png">
+        <img src="../images/rbt-explore-flame.png" width="420" alt="flame view">
+      </a>
+      <br>
+      <sub><b>Flame view</b></sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="50%">
+      <a href="../images/rbt-explore-callers-tree.png">
+        <img src="../images/rbt-explore-callers-tree.png" width="420" alt="callers tree view">
+      </a>
+      <br>
+      <sub><b>Callers tree view</b></sub>
+    </td>
+    <td align="center" width="50%">
+      <a href="../images/rbt-explore-callees-tree.png">
+        <img src="../images/rbt-explore-callees-tree.png" width="420" alt="callees tree view">
+      </a>
+      <br>
+      <sub><b>Callees tree view</b></sub>
+    </td>
+  </tr>
+</table>
 
 ### Layout at a glance
 

--- a/docs/tracing/rbt-analyze-and-explore.md
+++ b/docs/tracing/rbt-analyze-and-explore.md
@@ -261,39 +261,31 @@ After that you're in a sandwich-style explorer modelled loosely on
 
 ### Screenshots
 
-Click any thumbnail for the full-size image.
+#### Panes view
+![panes view](../images/rbt-explore-panes.png)
+
+#### Flame view
+![flame view](../images/rbt-explore-flame.png)
+
+#### Callers / callees tree views
+
+Click either thumbnail for the full-size image.
 
 <table>
   <tr>
     <td align="center" width="50%">
-      <a href="../images/rbt-explore-panes.png">
-        <img src="../images/rbt-explore-panes.png" width="420" alt="panes view">
-      </a>
-      <br>
-      <sub><b>Panes view</b></sub>
-    </td>
-    <td align="center" width="50%">
-      <a href="../images/rbt-explore-flame.png">
-        <img src="../images/rbt-explore-flame.png" width="420" alt="flame view">
-      </a>
-      <br>
-      <sub><b>Flame view</b></sub>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
       <a href="../images/rbt-explore-callers-tree.png">
-        <img src="../images/rbt-explore-callers-tree.png" width="420" alt="callers tree view">
+        <img src="../images/rbt-explore-callers-tree.png" alt="callers tree view">
       </a>
       <br>
-      <sub><b>Callers tree view</b></sub>
+      <sub><b>Callers tree</b></sub>
     </td>
     <td align="center" width="50%">
       <a href="../images/rbt-explore-callees-tree.png">
-        <img src="../images/rbt-explore-callees-tree.png" width="420" alt="callees tree view">
+        <img src="../images/rbt-explore-callees-tree.png" alt="callees tree view">
       </a>
       <br>
-      <sub><b>Callees tree view</b></sub>
+      <sub><b>Callees tree</b></sub>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
Improved the visual presentation of the callers and callees tree view screenshots in the tracing documentation by reorganizing them into a side-by-side table layout with clickable thumbnails.

## Changes
- Consolidated the separate "Callers tree view" and "Callees tree view" sections into a single "Callers / callees tree views" section
- Converted the screenshot layout from stacked vertical format to a responsive two-column table
- Made screenshots clickable links that open full-size images
- Added descriptive labels beneath each thumbnail for better clarity
- Added introductory text explaining the interactive nature of the screenshots
- Added blank line after "Screenshots" heading for improved markdown formatting

## Details
The new table-based layout provides a more compact and visually balanced presentation of the two related tree view screenshots, making it easier for users to compare them side-by-side. The clickable thumbnails improve the documentation's interactivity while maintaining a clean, organized appearance.

https://claude.ai/code/session_01KUpxyVTnKoSWAPeS8ZatuY