### PR TITLE
Improve Docker wrapper setup and FrankenPHP documentation

### DIFF
--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -15,9 +15,21 @@ eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
 eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper --profile=minimal)"
 ```
 
-Add the line to `~/.bashrc` / `~/.zshrc` for persistence. The image tag is
-baked into the emitted wrapper (matching the image the `docker run` pulled),
-so you don't get accidental `:latest` drift.
+For persistence across shells, save the emitted wrapper to a file once
+and `source` it from your rc — pasting the `eval "$(docker run ...)"`
+line into `~/.bashrc` / `~/.zshrc` directly re-runs `docker run` on
+every shell start and breaks shell startup if the Docker daemon is
+down:
+
+```bash
+mkdir -p ~/.local/share/reli
+docker run --rm reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
+echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
+```
+
+The image tag is baked into the emitted wrapper (matching the image
+the `docker run` pulled), so you don't get accidental `:latest` drift —
+re-run the snippet above to upgrade.
 
 ## Profiles
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,9 +76,21 @@ Then, still in the same shell:
 reli --version
 ```
 
-Append the `eval "$(...)"` line to your `~/.bashrc` / `~/.zshrc` to
-keep it. The wrapper baked-in image tag matches the version of reli
-the `docker run` invocation pulled, so there's no `:latest` drift.
+To keep it across shells, **don't** paste the `eval "$(docker run ...)"`
+line into your `~/.bashrc` / `~/.zshrc` directly — that re-runs
+`docker run` on every shell start (slow, and breaks shell startup
+if the Docker daemon is down). Save the wrapper to a file once and
+source that instead:
+
+```bash
+mkdir -p ~/.local/share/reli
+docker run --rm reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
+echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
+```
+
+The wrapper's baked-in image tag matches the version of reli the
+`docker run` invocation pulled, so there's no `:latest` drift —
+re-run the first command above to upgrade.
 
 The wrapper runs each `reli` invocation as a container with
 `--cap-add=SYS_PTRACE --pid=host --network=host`, which gives reli
@@ -159,7 +171,7 @@ php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
 # (-F rbt is implied by the .rbt extension on -o)
-# Use -n (newest) to avoid passing multiple PIDs when several commands match.
+# pgrep -n picks the newest match — avoids passing multiple PIDs when several commands match.
 reli inspector:trace -p "$(pgrep -nf your-script.php)" -o trace.rbt
 ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -120,10 +120,14 @@ sudo reli inspector:daemon \
 ```
 
 For attaching to a single worker (`inspector:trace`), pass the PHP
-worker **TID** rather than the FrankenPHP parent PID:
+worker **TID** rather than the FrankenPHP parent PID. The pattern
+below intentionally excludes `php-main` — that's the bootstrap
+thread, not a worker, and attaching to it produces empty traces /
+"failed to find ZendMM main chunk" on memory commands. See
+[tracing/frankenphp.md](tracing/frankenphp.md) for the full story.
 
 ```bash
-ps -L -p "$(pgrep -o frankenphp)" -o tid,comm | awk '$2 ~ /^php-/'
+ps -L -p "$(pgrep -o frankenphp)" -o tid,comm | awk '$2 ~ /^php-[0-9a-f]+$/'
 #   12345 php-0
 #   12346 php-1
 


### PR DESCRIPTION
This PR improves the documentation for Docker wrapper setup and FrankenPHP tracing to provide clearer guidance and prevent common issues.

## Key Changes

- **Docker wrapper persistence**: Updated `getting-started.md` and `docker-wrapper.md` to recommend saving the wrapper script to a file (`~/.local/share/reli/wrapper.sh`) and sourcing it, rather than pasting the `eval "$(docker run ...)"` line directly into shell rc files. This avoids:
  - Re-running `docker run` on every shell startup (performance issue)
  - Breaking shell startup if the Docker daemon is unavailable
  - Explains that the baked-in image tag prevents `:latest` drift and how to upgrade

- **FrankenPHP worker tracing**: Enhanced `recipes.md` with:
  - Clarification that the bootstrap thread (`php-main`) should be excluded when attaching to workers
  - Explanation of why attaching to the bootstrap thread produces empty traces or "failed to find ZendMM main chunk" errors
  - Updated regex pattern from `/^php-/` to `/^php-[0-9a-f]+$/` to explicitly exclude `php-main`
  - Reference to `tracing/frankenphp.md` for full context

- **Minor clarification**: Updated comment in `getting-started.md` to explain that `pgrep -n` picks the newest match, making the purpose clearer

These changes improve the user experience by preventing common pitfalls and providing better context for advanced use cases.

https://claude.ai/code/session_014mqMJPZZkAi8B5Eunx6eFD