### PR TITLE
Add version pinning note to comparison documentation

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,6 +15,11 @@ and reproducer scripts in [`bench/`](bench/).
 > Blackfire Profiler) come from public docs; everything else is
 > source-verified. Benchmark numbers cited here are summary
 > figures from `bench/RESULTS.md`.
+>
+> *Last reviewed*: 2026-04. Tool versions move; this page pins
+> claims to versions where it can (e.g. php-meminfo v1.1.1,
+> `dd-trace-php` 0.99+, New Relic agent 10.18.0.8) so it can be
+> refreshed deliberately. Re-check before citing.
 
 ## At a glance
 


### PR DESCRIPTION
This PR adds a disclaimer to the comparison documentation clarifying the importance of tool version specificity when referencing the claims made in the document.

## Summary
Updated the introductory note in `docs/comparison.md` to include guidance about version pinning and the need to refresh comparisons over time as tool versions evolve.

## Key changes
- Added a "Last reviewed" timestamp (2026-04) to indicate when the comparison was last validated
- Documented specific tool versions referenced in the comparison (php-meminfo v1.1.1, dd-trace-php 0.99+, New Relic agent 10.18.0.8)
- Added a reminder to re-check claims before citing, acknowledging that tool versions move and comparisons may become outdated

## Details
This change improves the documentation's credibility and usefulness by making it clear that performance comparisons and feature claims are tied to specific versions of the tools being compared. This helps readers understand the context and limitations of the data presented.

https://claude.ai/code/session_01BGqeKUdYe2jnfjbHFH2YSf