### PR TITLE
psalm: typed FFI int-array helpers retire the InvalidCast hot-path baseline

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -71,24 +71,8 @@
       <code><![CDATA[\FFI\CArray<int>|null]]></code>
       <code><![CDATA[\FFI\CArray<int>|null]]></code>
     </MoreSpecificReturnType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_resource($this->fh)]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheWriter.php">
-    <InvalidOperand>
-      <code><![CDATA[getmypid()]]></code>
-    </InvalidOperand>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->fh]]></code>
-      <code><![CDATA[$this->fh]]></code>
-    </InvalidPropertyAssignmentValue>
-    <MixedAssignment>
-      <code><![CDATA[$this->fh]]></code>
-    </MixedAssignment>
-    <PossiblyFalseOperand>
-      <code><![CDATA[getmypid()]]></code>
-    </PossiblyFalseOperand>
     <PossiblyInvalidArgument>
       <code><![CDATA[$data[$elemOffset]]]></code>
     </PossiblyInvalidArgument>
@@ -96,6 +80,9 @@
       <code><![CDATA[unpack('P', $rmemHeader, 16)[1]]]></code>
       <code><![CDATA[unpack('V', $rmemHeader, 12)[1]]]></code>
     </PossiblyInvalidArrayAccess>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[getmypid()]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php">
     <TypeDoesNotContainType>
@@ -124,10 +111,6 @@
      *     examples: array<string, mixed>
      * }>]]></code>
     </MoreSpecificReturnType>
-    <RedundantCondition>
-      <code><![CDATA[$cnt <= 50]]></code>
-      <code><![CDATA[$info['ref_count'] <= 50]]></code>
-    </RedundantCondition>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php">
     <DocblockTypeContradiction>
@@ -141,12 +124,6 @@
     <PropertyTypeCoercion>
       <code><![CDATA[$profiles]]></code>
     </PropertyTypeCoercion>
-  </file>
-  <file src="src/Lib/ByteStream/CDataByteReader.php">
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[assert(is_int($value))]]></code>
-      <code><![CDATA[is_int($value)]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Lib/PhpInternals/Types/Zend/ZendOp.php">
     <PropertyTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -215,9 +215,6 @@
       <code><![CDATA[$this->perNodeClasses]]></code>
       <code><![CDATA[$this->perNodeSizes]]></code>
     </PossiblyNullReference>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$new_classes]]></code>
-    </PropertyTypeCoercion>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php">
     <InvalidOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -149,11 +149,11 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Lib/PhpInternals/Types/Zend/ZendOp.php">
-    <MixedAssignment>
-      <code><![CDATA[$this->op1]]></code>
-      <code><![CDATA[$this->op2]]></code>
-      <code><![CDATA[$this->result]]></code>
-    </MixedAssignment>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->casted_cdata->casted->op1]]></code>
+      <code><![CDATA[$this->casted_cdata->casted->op2]]></code>
+      <code><![CDATA[$this->casted_cdata->casted->result]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="src/Lib/PhpInternals/Types/Zend/ZendOpArray.php">
     <RedundantCondition>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -89,36 +89,6 @@
       <code><![CDATA[unpack('V', $rmemHeader, 12)[1]]]></code>
     </PossiblyInvalidArrayAccess>
   </file>
-  <file src="src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php">
-    <InvalidCast>
-      <code><![CDATA[$allDeg[$i]]]></code>
-      <code><![CDATA[$allDeg[$parent_idx]]]></code>
-      <code><![CDATA[$allPos[$parent_idx]]]></code>
-      <code><![CDATA[$allRowPtr[$i]]]></code>
-      <code><![CDATA[$allRowPtr[$i]]]></code>
-      <code><![CDATA[$nontreeDeg[$i]]]></code>
-      <code><![CDATA[$nontreeDeg[$parent_idx]]]></code>
-      <code><![CDATA[$nontreePos[$parent_idx]]]></code>
-      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
-      <code><![CDATA[$nontreeRowPtr[$i]]]></code>
-      <code><![CDATA[$treeDeg[$i]]]></code>
-      <code><![CDATA[$treeDeg[$parent_idx]]]></code>
-      <code><![CDATA[$treePos[$parent_idx]]]></code>
-      <code><![CDATA[$treeRowPtr[$i]]]></code>
-      <code><![CDATA[$treeRowPtr[$i]]]></code>
-    </InvalidCast>
-    <MixedArgument>
-      <code><![CDATA[$nodeSlots]]></code>
-      <code><![CDATA[$nodeSlots * 4]]></code>
-    </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$nodeSlots]]></code>
-    </MixedOperand>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$nodeSlots]]></code>
-      <code><![CDATA[$nodeSlots]]></code>
-    </PossiblyUndefinedVariable>
-  </file>
   <file src="src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php">
     <TypeDoesNotContainType>
       <code><![CDATA[$key]]></code>
@@ -185,11 +155,15 @@
       <code><![CDATA[$link_id === null]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
+      <code><![CDATA[$ci]]></code>
+      <code><![CDATA[$ci]]></code>
       <code><![CDATA[$ntColIdxData]]></code>
       <code><![CDATA[$ntRowPtrData]]></code>
     </MixedArgument>
     <PropertyTypeCoercion>
       <code><![CDATA[$profiles]]></code>
+      <code><![CDATA[$sccBuf]]></code>
+      <code><![CDATA[$subtreeBuf]]></code>
     </PropertyTypeCoercion>
   </file>
   <file src="src/Lib/ByteStream/CDataByteReader.php">
@@ -227,10 +201,6 @@
     </RedundantCast>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php">
-    <InvalidCast>
-      <code><![CDATA[$this->perNodeClasses[$node_id]]]></code>
-      <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
-    </InvalidCast>
     <PossiblyNullArgument>
       <code><![CDATA[$this->perNodeClasses]]></code>
     </PossiblyNullArgument>
@@ -238,31 +208,20 @@
       <code><![CDATA[$this->perNodeClasses[$node_id]]]></code>
       <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
     </PossiblyNullArrayAccess>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
+    </PossiblyNullOperand>
     <PossiblyNullReference>
       <code><![CDATA[$this->perNodeClasses]]></code>
       <code><![CDATA[$this->perNodeSizes]]></code>
     </PossiblyNullReference>
-    <RedundantCast>
-      <code><![CDATA[(int)Format::NULL_STRING_ID]]></code>
-    </RedundantCast>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$new_classes]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php">
-    <InvalidCast>
-      <code><![CDATA[$old_slots[$i]]]></code>
-      <code><![CDATA[$this->slots[$slot]]]></code>
-      <code><![CDATA[$this->slots[$slot]]]></code>
-    </InvalidCast>
     <InvalidOperand>
       <code><![CDATA[$capacity * self::MAX_LOAD_FACTOR]]></code>
-    </InvalidOperand>
-  </file>
-  <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php">
-    <InvalidOperand>
-      <code><![CDATA[Cast::toFloat($cached_chunks_size) / 1024]]></code>
-      <code><![CDATA[Cast::toFloat($captured_bytes) / 1024]]></code>
-      <code><![CDATA[Cast::toFloat($huge_total_bytes) / 1024]]></code>
-      <code><![CDATA[Cast::toFloat($memory_get_usage_real_size) / 1024]]></code>
-      <code><![CDATA[Cast::toFloat($walked_chunk_bytes) / 1024]]></code>
     </InvalidOperand>
   </file>
   <file src="src/Rbt/Analyze/TraceAggregator.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -63,6 +63,14 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->loadFfiSection($name, 'int32_t', 4)]]></code>
+      <code><![CDATA[$this->loadFfiSection($name, 'int64_t', 8)]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code><![CDATA[\FFI\CArray<int>|null]]></code>
+      <code><![CDATA[\FFI\CArray<int>|null]]></code>
+    </MoreSpecificReturnType>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[is_resource($this->fh)]]></code>
     </RedundantConditionGivenDocblockType>
@@ -95,28 +103,14 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php">
-    <InvalidPropertyFetch>
-      <code><![CDATA[$locRows[$li]->class_id]]></code>
-      <code><![CDATA[$locRows[$li]->location_type_id]]></code>
-      <code><![CDATA[$locRows[$li]->string_value_id]]></code>
-    </InvalidPropertyFetch>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$locIndex]]></code>
+      <code><![CDATA[$locIndex]]></code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[self::getDedupCandidateStatsFallback($reader, $limit)]]></code>
       <code><![CDATA[self::getDedupCandidateStatsFallback($reader, $limit)]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$classId]]></code>
-      <code><![CDATA[$locRows[$li]->location_type_id]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$classId]]></code>
-      <code><![CDATA[$meta['string_value_id']]]></code>
-      <code><![CDATA[$svId]]></code>
-    </MixedAssignment>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$meta]]></code>
-      <code><![CDATA[array{size: int, location_type: ?string, class_name: ?string, string_value_id: ?int}]]></code>
-    </MixedReturnTypeCoercion>
     <MoreSpecificReturnType>
       <code><![CDATA[list<array{
      *     link_name: string,
@@ -130,24 +124,10 @@
      *     examples: array<string, mixed>
      * }>]]></code>
     </MoreSpecificReturnType>
-    <PossiblyNullArgument>
-      <code><![CDATA[$classId]]></code>
-      <code><![CDATA[$locRows[$li]->location_type_id]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$locRows[$li]->class_id]]></code>
-      <code><![CDATA[$locRows[$li]->location_type_id]]></code>
-      <code><![CDATA[$locRows[$li]->string_value_id]]></code>
-    </PossiblyNullPropertyFetch>
     <RedundantCondition>
       <code><![CDATA[$cnt <= 50]]></code>
       <code><![CDATA[$info['ref_count'] <= 50]]></code>
     </RedundantCondition>
-    <UndefinedPropertyFetch>
-      <code><![CDATA[$locRows[$li]->class_id]]></code>
-      <code><![CDATA[$locRows[$li]->location_type_id]]></code>
-      <code><![CDATA[$locRows[$li]->string_value_id]]></code>
-    </UndefinedPropertyFetch>
   </file>
   <file src="src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php">
     <DocblockTypeContradiction>
@@ -157,13 +137,9 @@
     <MixedArgument>
       <code><![CDATA[$ci]]></code>
       <code><![CDATA[$ci]]></code>
-      <code><![CDATA[$ntColIdxData]]></code>
-      <code><![CDATA[$ntRowPtrData]]></code>
     </MixedArgument>
     <PropertyTypeCoercion>
       <code><![CDATA[$profiles]]></code>
-      <code><![CDATA[$sccBuf]]></code>
-      <code><![CDATA[$subtreeBuf]]></code>
     </PropertyTypeCoercion>
   </file>
   <file src="src/Lib/ByteStream/CDataByteReader.php">
@@ -204,17 +180,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$this->perNodeClasses]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$this->perNodeClasses[$node_id]]]></code>
-      <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullOperand>
-      <code><![CDATA[$this->perNodeSizes[$node_id]]]></code>
-    </PossiblyNullOperand>
-    <PossiblyNullReference>
-      <code><![CDATA[$this->perNodeClasses]]></code>
-      <code><![CDATA[$this->perNodeSizes]]></code>
-    </PossiblyNullReference>
   </file>
   <file src="src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php">
     <InvalidOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -230,40 +230,18 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$lines]]></code>
       <code><![CDATA[$lines]]></code>
+      <code><![CDATA[$this->childRows[$i]]]></code>
+      <code><![CDATA[$this->parentRows[$i]]]></code>
+      <code><![CDATA[$this->rows[$i]]]></code>
     </ArgumentTypeCoercion>
     <InvalidArrayOffset>
       <code><![CDATA[$help[$i - 1]]]></code>
-      <code><![CDATA[$row['_class']]]></code>
-      <code><![CDATA[$row['_scc_id']]]></code>
-      <code><![CDATA[$row['_scc_nodes']]]></code>
-      <code><![CDATA[$row['_type']]]></code>
     </InvalidArrayOffset>
-    <InvalidOperand>
-      <code><![CDATA[$cols * 0.3]]></code>
-    </InvalidOperand>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$results]]></code>
-      <code><![CDATA[$this->rows]]></code>
-      <code><![CDATA[$this->rows]]></code>
-      <code><![CDATA[$this->rows]]></code>
-      <code><![CDATA[$this->rows]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedArgument>
-      <code><![CDATA[$className]]></code>
-      <code><![CDATA[$prevNodeId]]></code>
-      <code><![CDATA[$row['_scc_nodes']]]></code>
       <code><![CDATA[$text]]></code>
-      <code><![CDATA[$typeName]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[$parts]]></code>
       <code><![CDATA[$response]]></code>
-      <code><![CDATA[[
-                'id' => $row['_scc_id'] ?? 0,
-                'nodes' => $row['_scc_nodes'],
-                'node_count' => count($row['_scc_nodes']),
-                'total_size' => $row['retained'],
-            ]]]></code>
       <code><![CDATA[array_slice($lines, 1)]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
@@ -271,25 +249,13 @@
       <code><![CDATA[$b['total_size']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$className]]></code>
       <code><![CDATA[$header]]></code>
-      <code><![CDATA[$parts[]]]></code>
-      <code><![CDATA[$prevNodeId]]></code>
       <code><![CDATA[$text]]></code>
-      <code><![CDATA[$this->focusLabel]]></code>
-      <code><![CDATA[$this->focusNodeId]]></code>
-      <code><![CDATA[$this->listModeParam]]></code>
-      <code><![CDATA[$this->listModeParam]]></code>
-      <code><![CDATA[$this->selected]]></code>
-      <code><![CDATA[$this->topRow]]></code>
-      <code><![CDATA[$typeName]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$header]]></code>
       <code><![CDATA[$header]]></code>
       <code><![CDATA[$lines[$lastIdx]]]></code>
-      <code><![CDATA[self::$SPINNER[$this->spinnerFrame]]]></code>
-      <code><![CDATA[self::$SPINNER[$this->spinnerFrame]]]></code>
     </MixedOperand>
     <PossiblyFalseOperand>
       <code><![CDATA[$idx]]></code>

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php
@@ -194,6 +194,8 @@ final class DerivedCacheReader
 
     /**
      * Load a section into an FFI int32 array via chunked fread + memcpy.
+     *
+     * @return \FFI\CArray<int>|null
      */
     public function loadInt32Section(string $name): ?\FFI\CData
     {
@@ -202,6 +204,8 @@ final class DerivedCacheReader
 
     /**
      * Load a section into an FFI int64 array via chunked fread + memcpy.
+     *
+     * @return \FFI\CArray<int>|null
      */
     public function loadInt64Section(string $name): ?\FFI\CData
     {

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheReader.php
@@ -44,6 +44,15 @@ final class DerivedCacheReader
 
     public function __destruct()
     {
+        // The runtime check is required: PHP keeps the value as a
+        // `closed-resource` after the first fclose(), and is_resource()
+        // returns false for that. The docblock-vs-runtime mismatch
+        // (declared `resource`, may actually be `closed-resource` mid-
+        // destruct) is the very thing Psalm flags here, so suppress
+        // narrowly with a comment rather than papering over it with
+        // `resource|closed-resource` — that'd cascade PossiblyInvalid-
+        // Argument complaints across every fseek / fread call below.
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
         if (is_resource($this->fh)) {
             fclose($this->fh);
         }

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheWriter.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/DerivedCacheWriter.php
@@ -39,12 +39,12 @@ final class DerivedCacheWriter
     private int $pos;
     private bool $failed = false;
 
+    /** @param resource $fh */
     private function __construct(
         string $finalPath,
         string $tempPath,
         int $rmemMtime,
         int $rmemSize,
-        /** @var resource */
         mixed $fh,
     ) {
         $this->finalPath = $finalPath;
@@ -81,7 +81,10 @@ final class DerivedCacheWriter
         }
 
         $finalPath = $rmemPath . '.derived';
-        $tempPath = $finalPath . '.tmp.' . getmypid();
+        // getmypid() === false would mean "process info unavailable";
+        // we have no recovery here so fall back to 0 (still produces a
+        // valid path, and any open failure shows up at @fopen below).
+        $tempPath = $finalPath . '.tmp.' . (getmypid() ?: 0);
 
         $fh = @fopen($tempPath, 'wb');
         if ($fh === false) {
@@ -223,8 +226,12 @@ final class DerivedCacheWriter
             return false;
         }
 
-        fclose($this->fh);
+        // Move the handle out of the property before fclose() so Psalm
+        // doesn't see `$this->fh` transit through `closed-resource` (its
+        // declared type is `resource|null`).
+        $fh = $this->fh;
         $this->fh = null;
+        fclose($fh);
 
         // Stale-writer guard: re-stat rmem
         clearstatcache(true, $rmemPath);
@@ -257,8 +264,9 @@ final class DerivedCacheWriter
     private function cleanup(): void
     {
         if ($this->fh !== null) {
-            fclose($this->fh);
+            $fh = $this->fh;
             $this->fh = null;
+            fclose($fh);
         }
         @unlink($this->tempPath);
     }

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/FfiHashTable.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/FfiHashTable.php
@@ -147,8 +147,8 @@ final class FfiHashTable
         $this->mask = $capacity - 1;
         $this->growThreshold = intdiv($capacity * 3, 4);
 
-        $this->hashes = FFIHelper::new("int64_t[{$capacity}]");
-        $this->ids = FFIHelper::new("int32_t[{$capacity}]");
+        $this->hashes = FFIHelper::newInt64Array($capacity);
+        $this->ids = FFIHelper::newInt32Array($capacity);
         $this->offsets = FFIHelper::new("uint64_t[{$capacity}]");
         $this->lengths = FFIHelper::new("uint32_t[{$capacity}]");
 

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/FfiHashTable.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/FfiHashTable.php
@@ -31,15 +31,16 @@ use Reli\Lib\FFI\FFIHelper;
  * Memory: ~28 bytes/slot × capacity (with load factor overhead, effectively
  * ~32 bytes per stored entry). At 10M entries: ~320 MB vs ~4.6 GB for
  * nested PHP arrays.
- *
- * @psalm-suppress InaccessibleMethod
- * @psalm-suppress InvalidCast
  */
 final class FfiHashTable
 {
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $hashes;   // int64_t[capacity]
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $ids;      // int32_t[capacity]
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $offsets;  // uint64_t[capacity]
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $lengths;  // uint32_t[capacity]
 
     private int $capacity;
@@ -74,7 +75,7 @@ final class FfiHashTable
         $slot = $h & $this->mask;
 
         while (true) {
-            if ((int)$this->hashes[$slot] === 0) {
+            if ($this->hashes[$slot] === 0) {
                 // Empty slot — insert here
                 $this->hashes[$slot] = $h;
                 $this->ids[$slot] = $id;
@@ -102,12 +103,12 @@ final class FfiHashTable
         $matches = [];
 
         while (true) {
-            $stored = (int)$this->hashes[$slot];
+            $stored = $this->hashes[$slot];
             if ($stored === 0) {
                 return $matches; // empty slot → end of probe chain
             }
             if ($stored === $h) {
-                $matches[] = [(int)$this->ids[$slot], (int)$this->offsets[$slot], (int)$this->lengths[$slot]];
+                $matches[] = [$this->ids[$slot], $this->offsets[$slot], $this->lengths[$slot]];
             }
             $slot = ($slot + 1) & $this->mask;
         }
@@ -122,8 +123,8 @@ final class FfiHashTable
     public function iterateAll(): \Generator
     {
         for ($i = 0; $i < $this->capacity; $i++) {
-            if ((int)$this->hashes[$i] !== 0) {
-                yield [(int)$this->ids[$i], (int)$this->offsets[$i], (int)$this->lengths[$i]];
+            if ($this->hashes[$i] !== 0) {
+                yield [$this->ids[$i], $this->offsets[$i], $this->lengths[$i]];
             }
         }
     }
@@ -149,8 +150,8 @@ final class FfiHashTable
 
         $this->hashes = FFIHelper::newInt64Array($capacity);
         $this->ids = FFIHelper::newInt32Array($capacity);
-        $this->offsets = FFIHelper::new("uint64_t[{$capacity}]");
-        $this->lengths = FFIHelper::new("uint32_t[{$capacity}]");
+        $this->offsets = FFIHelper::newUint64Array($capacity);
+        $this->lengths = FFIHelper::newUint32Array($capacity);
 
         // hashes are zero-initialized by FFI::new (calloc semantics)
     }
@@ -167,9 +168,9 @@ final class FfiHashTable
         $this->count = 0;
 
         for ($i = 0; $i < $oldCap; $i++) {
-            $h = (int)$oldHashes[$i];
+            $h = $oldHashes[$i];
             if ($h !== 0) {
-                $this->insertRaw($h, (int)$oldIds[$i], (int)$oldOffsets[$i], (int)$oldLengths[$i]);
+                $this->insertRaw($h, $oldIds[$i], $oldOffsets[$i], $oldLengths[$i]);
             }
         }
     }
@@ -180,7 +181,7 @@ final class FfiHashTable
     private function insertRaw(int $sanitizedHash, int $id, int $diskOffset, int $len): void
     {
         $slot = $sanitizedHash & $this->mask;
-        while ((int)$this->hashes[$slot] !== 0) {
+        while ($this->hashes[$slot] !== 0) {
             $slot = ($slot + 1) & $this->mask;
         }
         $this->hashes[$slot] = $sanitizedHash;

--- a/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput;
 
-use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DiskBackedStringDict;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Writer;

--- a/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
@@ -129,7 +129,10 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
             . $this->packString(gmdate('Y-m-d\TH:i:s\Z'));
         $writer->writeSection(Format::SECTION_RUNS, $runs_data, 1);
 
-        // Section 8-9: Per-node sizes and classes for fast report loading.
+        // Sections 8-10: Per-node sizes/classes + canonical map. All three
+        // share the same `$nodeSlots = $maxNodeId + 1` width and run only
+        // when at least one node was emitted; keep them in a single block
+        // so $nodeSlots's scope is unambiguous.
         $maxNodeId = $sink->getMaxNodeId();
         if ($maxNodeId >= 0) {
             $nodeSlots = $maxNodeId + 1;
@@ -149,10 +152,6 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                     $nodeSlots,
                 );
             }
-        }
-
-        // Section 10: Canonical map
-        if ($maxNodeId >= 0) {
             $canonicalMap = $sink->buildCanonicalMap();
             if ($canonicalMap !== null) {
                 $writer->writeSection(
@@ -191,8 +190,6 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
      * - SECTION_TREE_CSR_ROWPTR / COLIDX / LINKNAMES / STRENGTH
      * - SECTION_TREE_PARENTS
      * - SECTION_NONTREE_CSR_ROWPTR / COLIDX
-     *
-     * @psalm-suppress PossiblyInvalidArrayAccess
      */
     private function buildCsrSections(
         Writer $writer,
@@ -208,12 +205,12 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         $nc = $nodeCount + 1; // +1 for sentinel -1 → index $nodeCount
 
         // Allocate degree arrays
-        $treeDeg = FFIHelper::new("int32_t[{$nc}]");
-        $allDeg = FFIHelper::new("int32_t[{$nc}]");
-        $nontreeDeg = FFIHelper::new("int32_t[{$nc}]");
+        $treeDeg = FFIHelper::newInt32Array($nc);
+        $allDeg = FFIHelper::newInt32Array($nc);
+        $nontreeDeg = FFIHelper::newInt32Array($nc);
 
         // Tree parent tracking
-        $treeParents = FFIHelper::new("int32_t[{$nc}]");
+        $treeParents = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $treeParents[$i] = -1;
         }
@@ -248,13 +245,9 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                 $is_tree = ord($data[$off + 12]);
 
                 if ($parent_idx < $nc) {
-                    // (int) on FFI int32_t[] reads: avoid Cast::toInt() in
-                    // this O(edgeCount) loop. Element type is provably int
-                    // at runtime, but Psalm's FFI stub leaves offsetGet as
-                    // CData|null|scalar, so InvalidCast stays in baseline.
-                    $allDeg[$parent_idx] = (int)$allDeg[$parent_idx] + 1;
+                    $allDeg[$parent_idx] = $allDeg[$parent_idx] + 1;
                     if ($is_tree === 1) {
-                        $treeDeg[$parent_idx] = (int)$treeDeg[$parent_idx] + 1;
+                        $treeDeg[$parent_idx] = $treeDeg[$parent_idx] + 1;
                         $treeEdgeCount++;
 
                         // Track tree parent for child
@@ -265,7 +258,7 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                             $treeParents[$child_idx] = $parent_idx;
                         }
                     } else {
-                        $nontreeDeg[$parent_idx] = (int)$nontreeDeg[$parent_idx] + 1;
+                        $nontreeDeg[$parent_idx] = $nontreeDeg[$parent_idx] + 1;
                         $nontreeEdgeCount++;
                     }
                 }
@@ -275,40 +268,38 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
         fclose($fp);
 
         // ---- Build row_ptr from degrees ----
-        $treeRowPtr = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $allRowPtr = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $nontreeRowPtr = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $treeRowPtr = FFIHelper::newInt32Array($nc + 1);
+        $allRowPtr = FFIHelper::newInt32Array($nc + 1);
+        $nontreeRowPtr = FFIHelper::newInt32Array($nc + 1);
 
         $treeRowPtr[0] = 0;
         $allRowPtr[0] = 0;
         $nontreeRowPtr[0] = 0;
-        // O(nc) prefix-sum: keep `(int)` to match the per-edge loops above.
         for ($i = 0; $i < $nc; $i++) {
-            $treeRowPtr[$i + 1] = (int)$treeRowPtr[$i] + (int)$treeDeg[$i];
-            $allRowPtr[$i + 1] = (int)$allRowPtr[$i] + (int)$allDeg[$i];
-            $nontreeRowPtr[$i + 1] = (int)$nontreeRowPtr[$i] + (int)$nontreeDeg[$i];
+            $treeRowPtr[$i + 1] = $treeRowPtr[$i] + $treeDeg[$i];
+            $allRowPtr[$i + 1] = $allRowPtr[$i] + $allDeg[$i];
+            $nontreeRowPtr[$i + 1] = $nontreeRowPtr[$i] + $nontreeDeg[$i];
         }
 
-        // One-shot scalar reads — Cast::toInt() is fine here, only 3 calls.
-        $totalAllEdges = Cast::toInt($allRowPtr[$nc]);
-        $totalTreeEdges = Cast::toInt($treeRowPtr[$nc]);
-        $totalNontreeEdges = Cast::toInt($nontreeRowPtr[$nc]);
+        $totalAllEdges = $allRowPtr[$nc];
+        $totalTreeEdges = $treeRowPtr[$nc];
+        $totalNontreeEdges = $nontreeRowPtr[$nc];
 
         // Allocate col_idx + link_name + strength arrays
-        $allColIdx = FFIHelper::new("int32_t[" . max(1, $totalAllEdges) . "]");
-        $treeColIdx = FFIHelper::new("int32_t[" . max(1, $totalTreeEdges) . "]");
-        $treeLinkNames = FFIHelper::new("int32_t[" . max(1, $totalTreeEdges) . "]");
-        $treeStrength = FFIHelper::new("int8_t[" . max(1, $totalTreeEdges) . "]");
-        $nontreeColIdx = FFIHelper::new("int32_t[" . max(1, $totalNontreeEdges) . "]");
+        $allColIdx = FFIHelper::newInt32Array(max(1, $totalAllEdges));
+        $treeColIdx = FFIHelper::newInt32Array(max(1, $totalTreeEdges));
+        $treeLinkNames = FFIHelper::newInt32Array(max(1, $totalTreeEdges));
+        $treeStrength = FFIHelper::newInt8Array(max(1, $totalTreeEdges));
+        $nontreeColIdx = FFIHelper::newInt32Array(max(1, $totalNontreeEdges));
 
         // Position counters (reuse degree arrays)
-        $treePos = FFIHelper::new("int32_t[{$nc}]");
-        $allPos = FFIHelper::new("int32_t[{$nc}]");
-        $nontreePos = FFIHelper::new("int32_t[{$nc}]");
+        $treePos = FFIHelper::newInt32Array($nc);
+        $allPos = FFIHelper::newInt32Array($nc);
+        $nontreePos = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
-            $treePos[$i] = (int)$treeRowPtr[$i];
-            $allPos[$i] = (int)$allRowPtr[$i];
-            $nontreePos[$i] = (int)$nontreeRowPtr[$i];
+            $treePos[$i] = $treeRowPtr[$i];
+            $allPos[$i] = $allRowPtr[$i];
+            $nontreePos[$i] = $nontreeRowPtr[$i];
         }
 
         // ---- Pass 2: fill col_idx ----
@@ -343,19 +334,18 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                 $strength = ord($data[$off + 13]);
 
                 if ($parent_idx < $nc) {
-                    // All edges — `(int)` for the same hot-loop reasoning.
-                    $pos = (int)$allPos[$parent_idx];
+                    $pos = $allPos[$parent_idx];
                     $allColIdx[$pos] = $child_idx;
                     $allPos[$parent_idx] = $pos + 1;
 
                     if ($is_tree === 1) {
-                        $pos = (int)$treePos[$parent_idx];
+                        $pos = $treePos[$parent_idx];
                         $treeColIdx[$pos] = $child_idx;
                         $treeLinkNames[$pos] = $link_name_id;
                         $treeStrength[$pos] = $strength;
                         $treePos[$parent_idx] = $pos + 1;
                     } else {
-                        $pos = (int)$nontreePos[$parent_idx];
+                        $pos = $nontreePos[$parent_idx];
                         $nontreeColIdx[$pos] = $child_idx;
                         $nontreePos[$parent_idx] = $pos + 1;
                     }

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -283,7 +283,7 @@ final class BinaryReportDataProvider
             return self::getDedupCandidateStatsFallback($reader, $limit);
         }
         $expected = $nodeSizesSlots * 8;
-        $nodeSizes = FFIHelper::new("int64_t[{$nodeSizesSlots}]");
+        $nodeSizes = FFIHelper::newInt64Array($nodeSizesSlots);
         $sizePtr = $reader->getSectionPointer('node_sizes');
         if ($sizePtr !== null) {
             // Zero-copy from mmap
@@ -376,7 +376,7 @@ final class BinaryReportDataProvider
         /** @var \FFI\CData|null $locIndex int32[nodeSizesSlots], -1 = no location */
         $locIndex = null;
         if ($locRows !== null && $nodeSizesSlots > 0) {
-            $locIndex = FFIHelper::new("int32_t[{$nodeSizesSlots}]");
+            $locIndex = FFIHelper::newInt32Array($nodeSizesSlots);
             FFI::memset($locIndex, 0xFF, $nodeSizesSlots * 4); // fill with -1
             for ($i = 0; $i < $locCount; $i++) {
                 $nid = $locRows[$i]->node_id;

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -897,6 +897,15 @@ final class BinaryReportDataProvider
         $edge_count = $reader->getSectionElementCount(Format::SECTION_EDGES);
         $edgeRows = $reader->castSection(Format::SECTION_EDGES, 'EdgeRow');
 
+        /**
+         * @var array<string, array{
+         *     link_name_id: int,
+         *     size: int,
+         *     ref_count: int,
+         *     sample_parent_node_id: int,
+         *     sample_child_node_id: int,
+         * }>
+         */
         $coarse = [];
         if ($edgeRows !== null) {
             for ($i = 0; $i < $edge_count; $i++) {
@@ -975,6 +984,19 @@ final class BinaryReportDataProvider
         usort($candidates, fn (array $a, array $b): int => $b['coarse_total'] <=> $a['coarse_total']);
         $candidates = array_slice($candidates, 0, $candidate_limit);
 
+        /**
+         * @var array<string, array{
+         *     link_name: string,
+         *     size: int,
+         *     sample_parent_node_id: int,
+         *     sample_child_node_id: int,
+         *     sample_location_type: ?string,
+         *     sample_child_node_ids: list<int>,
+         *     seen_children: array<int, true>,
+         *     string_counts: array<string, int>,
+         *     object_samples: list<string>,
+         * }>
+         */
         $groups = [];
         foreach ($candidates as $candidate) {
             $groups[$candidate['key']] = [

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -840,6 +840,8 @@ final class BinaryReportDataProvider
     /**
      * Build a single node's meta on demand from nodeSizes + locIndex/locRows.
      *
+     * @param \FFI\CArray<int>|null $locIndex
+     * @param \FFI\CArray<\FFI\PhpInternals\LocationRow>|null $locRows
      * @return array{size: int, location_type: ?string, class_name: ?string, string_value_id: ?int}
      */
     private static function buildNodeMeta(

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -65,36 +65,51 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private int $nodeCount = 0;
 
     // CSR for tree children
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $treeOffsets;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $treeEdges;
 
     // CSR for strong tree children (tree + strong, for subtree sizes)
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $strongTreeOffsets;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $strongTreeEdges;
 
     // CSR for all children (tree + non-tree)
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $allOffsets;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $allEdges;
 
     // CSR for strong all children (strong tree + non-tree, for SCC)
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $strongAllOffsets;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $strongAllEdges;
 
     // Reverse CSR for all parents
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $revOffsets;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $revEdges;
 
     // Per-node data in FFI
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $ffiNodeSizes;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $ffiSubtreeSizes;
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $ffiNodeToScc;
 
     // Node ID mapping (FFI-backed)
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $indexToNodeFfi;  // int32_t[nodeCount]: CSR index → node_id
 
     // Direct-indexed nodeToIndex: nodeToIndexDirect[node_id + 1] = CSR index
     // (offset by 1 to handle -1 sentinel at slot 0)
     // If node_ids are too sparse, falls back to PHP array.
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $nodeToIndexDirect = null;
     private int $directIndexOffset = 1; // node_id + offset → array index
     private int $directIndexSize = 0;   // size of nodeToIndexDirect array
@@ -110,6 +125,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     // can easily produce 32k+ unique class names, which silently wrapped
     // around when this was int16 and pointed every overflowed node at the
     // wrong dict slot.
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $nodeClassIds; // int32_t[nodeCount], -1 = no class
 
     // Tree-edge link_name index: an int32 per child CSR slot (-1 = no
@@ -128,7 +144,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private array $linkDict = [];
     /** @var array<string, int> link_name → link_id */
     private array $linkDictReverse = [];
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $treeLinkIds = null;     // int32_t[nodeCount], -1 = no tree edge
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $treeParentIdx = null;   // int32_t[nodeCount], -1 = no tree parent
 
     // Per-node context type ("PhpReferenceContext", etc.). Same shape
@@ -137,6 +155,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private array $nodeTypeDict = [];
     /** @var array<string, int> type name → type_id */
     private array $nodeTypeDictReverse = [];
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $nodeTypeIds = null;     // int16_t[nodeCount], -1 = unknown
 
     private bool $subtreeSizesComputed = false;
@@ -146,8 +165,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     // canonIdxFfi[csrIdx] = canonical csrIdx (self for unique nodes).
     // origOffsets + origData form a CSR: originals of canon c are
     // origData[origOffsets[c]..origOffsets[c+1]].
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $canonIdxFfi = null;
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $origOffsets = null;
+    /** @var \FFI\CArray<int> */
     private ?\FFI\CData $origData = null;
 
     /**
@@ -222,7 +244,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         $substrate->nodeCount = count($all_node_ids);
         $nc = $substrate->nodeCount;
-        $substrate->indexToNodeFfi = FFIHelper::new("int32_t[{$nc}]");
+        $substrate->indexToNodeFfi = FFIHelper::newInt32Array($nc);
 
         $idx = 0;
         $minNodeId = PHP_INT_MAX;
@@ -244,35 +266,35 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $substrate->directIndexOffset = -$minNodeId;
             $directSize = $range;
             $substrate->directIndexSize = $directSize;
-            $substrate->nodeToIndexDirect = FFIHelper::new("int32_t[{$directSize}]");
+            $substrate->nodeToIndexDirect = FFIHelper::newInt32Array($directSize);
             for ($i = 0; $i < $directSize; $i++) {
                 $substrate->nodeToIndexDirect[$i] = -1;
             }
             for ($i = 0; $i < $nc; $i++) {
-                $nid = (int)$substrate->indexToNodeFfi[$i];
+                $nid = $substrate->indexToNodeFfi[$i];
                 $slot = $nid + $substrate->directIndexOffset;
                 $substrate->nodeToIndexDirect[$slot] = $i;
             }
         } else {
             $substrate->nodeToIndexPhp = [];
             for ($i = 0; $i < $nc; $i++) {
-                $substrate->nodeToIndexPhp[(int)$substrate->indexToNodeFfi[$i]] = $i;
+                $substrate->nodeToIndexPhp[$substrate->indexToNodeFfi[$i]] = $i;
             }
         }
         unset($all_node_ids);
 
         // Allocate per-node FFI arrays
-        $substrate->ffiNodeSizes = FFIHelper::new("int64_t[{$nc}]");
-        $substrate->ffiSubtreeSizes = FFIHelper::new("int64_t[{$nc}]");
-        $substrate->ffiNodeToScc = FFIHelper::new("int32_t[{$nc}]");
-        $substrate->nodeClassIds = FFIHelper::new("int32_t[{$nc}]");
+        $substrate->ffiNodeSizes = FFIHelper::newInt64Array($nc);
+        $substrate->ffiSubtreeSizes = FFIHelper::newInt64Array($nc);
+        $substrate->ffiNodeToScc = FFIHelper::newInt32Array($nc);
+        $substrate->nodeClassIds = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $substrate->ffiNodeToScc[$i] = -1;
             $substrate->nodeClassIds[$i] = -1;
         }
 
         // ---- Phase 2: Load node types from nodes section ----
-        $substrate->nodeTypeIds = FFIHelper::new("int16_t[{$nc}]");
+        $substrate->nodeTypeIds = FFIHelper::newInt16Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $substrate->nodeTypeIds[$i] = -1;
         }
@@ -297,7 +319,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
             if ($directMap !== null) {
                 $slot = $node_id + $directOffset;
-                $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : (int)$directMap[$slot];
+                $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
             } else {
                 $csrIdx = $phpMap[$node_id] ?? -1;
             }
@@ -340,7 +362,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 // node_id == i (dense), map to CSR index
                 if ($directMap !== null) {
                     $slot = $i + $directOffset;
-                    $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : (int)$directMap[$slot];
+                    $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
                 } else {
                     $csrIdx = $phpMap[$i] ?? -1;
                 }
@@ -430,18 +452,18 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 if (!$sizesLoaded) {
                     if ($directMap !== null) {
                         $slot = $node_id + $directOffset;
-                        $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : (int)$directMap[$slot];
+                        $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
                     } else {
                         $csrIdx = $phpMap[$node_id] ?? -1;
                     }
                     if ($csrIdx >= 0) {
                         /** @psalm-suppress PossiblyUndefinedVariable */
-                        $ffiNodeSizes[$csrIdx] = (int)$ffiNodeSizes[$csrIdx] + (int)$size;
+                        $ffiNodeSizes[$csrIdx] = $ffiNodeSizes[$csrIdx] + (int)$size;
                         /** @psalm-suppress PossiblyUndefinedVariable */
                         $substrate->nodeSizesSum += (int)$size;
 
                         /** @psalm-suppress PossiblyUndefinedVariable */
-                        if ((int)$class_id !== Format::NULL_STRING_ID && (int)$nodeClassIds[$csrIdx] === -1) {
+                        if ((int)$class_id !== Format::NULL_STRING_ID && $nodeClassIds[$csrIdx] === -1) {
                             /** @psalm-suppress PossiblyUndefinedVariable */
                             $className = $dict->lookup((int)$class_id);
                             if ($className !== null) {
@@ -539,39 +561,39 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $substrate->edge_count = $edgeCount;
         $rootParentIdx = $substrate->nodeIdToIndex(-1);
 
-        $substrate->treeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $substrate->strongTreeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $substrate->allOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $substrate->strongAllOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $substrate->revOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $substrate->treeOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $substrate->strongTreeOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $substrate->allOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $substrate->strongAllOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $substrate->revOffsets = FFIHelper::newInt32Array(($nc + 1));
 
         if ($edgeCount === 0) {
-            $substrate->treeEdges = FFIHelper::new("int32_t[1]");
-            $substrate->strongTreeEdges = FFIHelper::new("int32_t[1]");
-            $substrate->allEdges = FFIHelper::new("int32_t[1]");
-            $substrate->strongAllEdges = FFIHelper::new("int32_t[1]");
-            $substrate->revEdges = FFIHelper::new("int32_t[1]");
+            $substrate->treeEdges = FFIHelper::newInt32Array(1);
+            $substrate->strongTreeEdges = FFIHelper::newInt32Array(1);
+            $substrate->allEdges = FFIHelper::newInt32Array(1);
+            $substrate->strongAllEdges = FFIHelper::newInt32Array(1);
+            $substrate->revEdges = FFIHelper::newInt32Array(1);
             $substrate->subtreeSizesComputed = false;
             return $substrate;
         }
 
         // Staging buffers
-        $stageParentIdx = FFIHelper::new("int32_t[{$edgeCount}]");
-        $stageChildIdx = FFIHelper::new("int32_t[{$edgeCount}]");
-        $stageFlags = FFIHelper::new("int8_t[{$edgeCount}]");
+        $stageParentIdx = FFIHelper::newInt32Array($edgeCount);
+        $stageChildIdx = FFIHelper::newInt32Array($edgeCount);
+        $stageFlags = FFIHelper::newInt8Array($edgeCount);
 
-        $substrate->treeLinkIds = FFIHelper::new("int32_t[{$nc}]");
-        $substrate->treeParentIdx = FFIHelper::new("int32_t[{$nc}]");
+        $substrate->treeLinkIds = FFIHelper::newInt32Array($nc);
+        $substrate->treeParentIdx = FFIHelper::newInt32Array($nc);
         for ($k = 0; $k < $nc; $k++) {
             $substrate->treeLinkIds[$k] = -1;
             $substrate->treeParentIdx[$k] = -1;
         }
 
-        $treeDeg = FFIHelper::new("int32_t[{$nc}]");
-        $strongTreeDeg = FFIHelper::new("int32_t[{$nc}]");
-        $allDeg = FFIHelper::new("int32_t[{$nc}]");
-        $strongAllDeg = FFIHelper::new("int32_t[{$nc}]");
-        $revDeg = FFIHelper::new("int32_t[{$nc}]");
+        $treeDeg = FFIHelper::newInt32Array($nc);
+        $strongTreeDeg = FFIHelper::newInt32Array($nc);
+        $allDeg = FFIHelper::newInt32Array($nc);
+        $strongAllDeg = FFIHelper::newInt32Array($nc);
+        $revDeg = FFIHelper::newInt32Array($nc);
 
         $treeCount = 0;
         $strongTreeCount = 0;
@@ -607,9 +629,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
             if ($directMap !== null) {
                 $slot = $parent + $directOffset;
-                $pi = ($slot < 0 || $slot >= $directSize) ? -1 : (int)$directMap[$slot];
+                $pi = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
                 $slot = $child + $directOffset;
-                $ci = ($slot < 0 || $slot >= $directSize) ? -1 : (int)$directMap[$slot];
+                $ci = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
             } else {
                 $pi = $phpMap[$parent] ?? -1;
                 $ci = $phpMap[$child] ?? -1;
@@ -666,17 +688,17 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         unset($treeDeg, $strongTreeDeg, $allDeg, $strongAllDeg, $revDeg);
 
-        $substrate->treeEdges = FFIHelper::new("int32_t[" . max($treeCount, 1) . "]");
-        $substrate->strongTreeEdges = FFIHelper::new("int32_t[" . max($strongTreeCount, 1) . "]");
-        $substrate->allEdges = FFIHelper::new("int32_t[" . max($allCount, 1) . "]");
-        $substrate->strongAllEdges = FFIHelper::new("int32_t[" . max($strongAllCount, 1) . "]");
-        $substrate->revEdges = FFIHelper::new("int32_t[{$edgeCount}]");
+        $substrate->treeEdges = FFIHelper::newInt32Array(max($treeCount, 1));
+        $substrate->strongTreeEdges = FFIHelper::newInt32Array(max($strongTreeCount, 1));
+        $substrate->allEdges = FFIHelper::newInt32Array(max($allCount, 1));
+        $substrate->strongAllEdges = FFIHelper::newInt32Array(max($strongAllCount, 1));
+        $substrate->revEdges = FFIHelper::newInt32Array($edgeCount);
 
-        $treeP = FFIHelper::new("int32_t[{$nc}]");
-        $streeP = FFIHelper::new("int32_t[{$nc}]");
-        $allP = FFIHelper::new("int32_t[{$nc}]");
-        $sallP = FFIHelper::new("int32_t[{$nc}]");
-        $revP = FFIHelper::new("int32_t[{$nc}]");
+        $treeP = FFIHelper::newInt32Array($nc);
+        $streeP = FFIHelper::newInt32Array($nc);
+        $allP = FFIHelper::newInt32Array($nc);
+        $sallP = FFIHelper::newInt32Array($nc);
+        $revP = FFIHelper::newInt32Array($nc);
         for ($k = 0; $k < $nc; $k++) {
             $treeP[$k] = $substrate->treeOffsets[$k];
             $streeP[$k] = $substrate->strongTreeOffsets[$k];
@@ -687,33 +709,33 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         // Second pass: walk staged edges into CSR
         for ($k = 0; $k < $edgeCount; $k++) {
-            $pi = (int)$stageParentIdx[$k];
-            $ci = (int)$stageChildIdx[$k];
-            $flags = (int)$stageFlags[$k];
+            $pi = $stageParentIdx[$k];
+            $ci = $stageChildIdx[$k];
+            $flags = $stageFlags[$k];
             $is_tree = ($flags & 1) !== 0;
             $is_strong = ($flags & 2) !== 0;
 
             if ($is_tree) {
-                $p = (int)$treeP[$pi];
+                $p = $treeP[$pi];
                 $substrate->treeEdges[$p] = $ci;
                 $treeP[$pi] = $p + 1;
                 if ($is_strong) {
-                    $p = (int)$streeP[$pi];
+                    $p = $streeP[$pi];
                     $substrate->strongTreeEdges[$p] = $ci;
                     $streeP[$pi] = $p + 1;
                 }
             }
             if ($pi !== $rootParentIdx) {
-                $p = (int)$allP[$pi];
+                $p = $allP[$pi];
                 $substrate->allEdges[$p] = $ci;
                 $allP[$pi] = $p + 1;
                 if ($is_strong) {
-                    $p = (int)$sallP[$pi];
+                    $p = $sallP[$pi];
                     $substrate->strongAllEdges[$p] = $ci;
                     $sallP[$pi] = $p + 1;
                 }
             }
-            $p = (int)$revP[$ci];
+            $p = $revP[$ci];
             $substrate->revEdges[$p] = $pi;
             $revP[$ci] = $p + 1;
         }
@@ -755,26 +777,26 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $this->edge_count = $treeEdgeCount; // will be updated after nontree
 
         // Allocate and populate tree CSR from raw bytes
-        $this->treeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $this->treeOffsets = FFIHelper::newInt32Array(($nc + 1));
         \FFI::memcpy($this->treeOffsets, $treeRowPtrData, ($nc + 1) * 4);
 
-        $this->treeEdges = FFIHelper::new("int32_t[" . max(1, $treeEdgeCount) . "]");
+        $this->treeEdges = FFIHelper::newInt32Array(max(1, $treeEdgeCount));
         if ($treeEdgeCount > 0) {
             \FFI::memcpy($this->treeEdges, $treeColIdxData, $treeEdgeCount * 4);
         }
 
         // Tree link names
-        $this->treeLinkIds = FFIHelper::new("int32_t[{$nc}]");
+        $this->treeLinkIds = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $this->treeLinkIds[$i] = -1;
         }
         // Populate from the CSR linknames array: for each parent, walk
         // its children and set treeLinkIds[child] = link_name_dict_id
         for ($p = 0; $p < $nc; $p++) {
-            $start = (int)$this->treeOffsets[$p];
-            $end = (int)$this->treeOffsets[$p + 1];
+            $start = $this->treeOffsets[$p];
+            $end = $this->treeOffsets[$p + 1];
             for ($j = $start; $j < $end; $j++) {
-                $child = (int)$this->treeEdges[$j];
+                $child = $this->treeEdges[$j];
                 /** @var array{1: int} */
                 $lid_raw = unpack('V', $treeLinkData, $j * 4);
                 $link_name_id = $lid_raw[1];
@@ -790,48 +812,48 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
 
         // Tree parents
-        $this->treeParentIdx = FFIHelper::new("int32_t[{$nc}]");
+        $this->treeParentIdx = FFIHelper::newInt32Array($nc);
         \FFI::memcpy($this->treeParentIdx, $treeParentsData, $nc * 4);
 
         // Roots: children of the sentinel node (last index)
         $sentinelIdx = $nc - 1;
-        $rstart = (int)$this->treeOffsets[$sentinelIdx];
-        $rend = (int)$this->treeOffsets[$sentinelIdx + 1];
+        $rstart = $this->treeOffsets[$sentinelIdx];
+        $rend = $this->treeOffsets[$sentinelIdx + 1];
         for ($j = $rstart; $j < $rend; $j++) {
-            $child_node_id = (int)$this->indexToNodeFfi[(int)$this->treeEdges[$j]];
+            $child_node_id = $this->indexToNodeFfi[$this->treeEdges[$j]];
             $this->roots[] = $child_node_id;
         }
 
         // Strong tree CSR: filter tree edges by strength == 0
-        $strongTreeDeg = FFIHelper::new("int32_t[{$nc}]");
+        $strongTreeDeg = FFIHelper::newInt32Array($nc);
         $strongTreeCount = 0;
         for ($p = 0; $p < $nc; $p++) {
-            $start = (int)$this->treeOffsets[$p];
-            $end = (int)$this->treeOffsets[$p + 1];
+            $start = $this->treeOffsets[$p];
+            $end = $this->treeOffsets[$p + 1];
             for ($j = $start; $j < $end; $j++) {
                 if (ord($treeStrengthData[$j]) === 0) {
-                    $strongTreeDeg[$p] = (int)$strongTreeDeg[$p] + 1;
+                    $strongTreeDeg[$p] = $strongTreeDeg[$p] + 1;
                     $strongTreeCount++;
                 }
             }
         }
-        $this->strongTreeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $this->strongTreeOffsets = FFIHelper::newInt32Array(($nc + 1));
         $this->strongTreeOffsets[0] = 0;
         for ($i = 0; $i < $nc; $i++) {
-            $this->strongTreeOffsets[$i + 1] = (int)$this->strongTreeOffsets[$i] + (int)$strongTreeDeg[$i];
+            $this->strongTreeOffsets[$i + 1] = $this->strongTreeOffsets[$i] + $strongTreeDeg[$i];
         }
-        $this->strongTreeEdges = FFIHelper::new("int32_t[" . max(1, $strongTreeCount) . "]");
-        $stPos = FFIHelper::new("int32_t[{$nc}]");
+        $this->strongTreeEdges = FFIHelper::newInt32Array(max(1, $strongTreeCount));
+        $stPos = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
-            $stPos[$i] = (int)$this->strongTreeOffsets[$i];
+            $stPos[$i] = $this->strongTreeOffsets[$i];
         }
         for ($p = 0; $p < $nc; $p++) {
-            $start = (int)$this->treeOffsets[$p];
-            $end = (int)$this->treeOffsets[$p + 1];
+            $start = $this->treeOffsets[$p];
+            $end = $this->treeOffsets[$p + 1];
             for ($j = $start; $j < $end; $j++) {
                 if (ord($treeStrengthData[$j]) === 0) {
-                    $pos = (int)$stPos[$p];
-                    $this->strongTreeEdges[$pos] = (int)$this->treeEdges[$j];
+                    $pos = $stPos[$p];
+                    $this->strongTreeEdges[$pos] = $this->treeEdges[$j];
                     $stPos[$p] = $pos + 1;
                 }
             }
@@ -850,9 +872,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         // All-edges CSR = tree + nontree (excluding root-parent edges)
         // Strong all-edges = strong tree + strong nontree (nontree are strong by default)
-        $allDeg = FFIHelper::new("int32_t[{$nc}]");
-        $strongAllDeg = FFIHelper::new("int32_t[{$nc}]");
-        $revDeg = FFIHelper::new("int32_t[{$nc}]");
+        $allDeg = FFIHelper::newInt32Array($nc);
+        $strongAllDeg = FFIHelper::newInt32Array($nc);
+        $revDeg = FFIHelper::newInt32Array($nc);
 
         // Count: tree edges (excluding root parent)
         $rootIdx = $nc - 1; // sentinel
@@ -860,25 +882,25 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             if ($p === $rootIdx) {
                 continue;
             }
-            $start = (int)$this->treeOffsets[$p];
-            $end = (int)$this->treeOffsets[$p + 1];
+            $start = $this->treeOffsets[$p];
+            $end = $this->treeOffsets[$p + 1];
             $deg = $end - $start;
-            $allDeg[$p] = (int)$allDeg[$p] + $deg;
+            $allDeg[$p] = $allDeg[$p] + $deg;
             for ($j = $start; $j < $end; $j++) {
                 if (ord($treeStrengthData[$j]) === 0) {
-                    $strongAllDeg[$p] = (int)$strongAllDeg[$p] + 1;
+                    $strongAllDeg[$p] = $strongAllDeg[$p] + 1;
                 }
-                $ci = (int)$this->treeEdges[$j];
-                $revDeg[$ci] = (int)$revDeg[$ci] + 1;
+                $ci = $this->treeEdges[$j];
+                $revDeg[$ci] = $revDeg[$ci] + 1;
             }
         }
         // Also count root tree edges for reverse
         {
-            $start = (int)$this->treeOffsets[$rootIdx];
-            $end = (int)$this->treeOffsets[$rootIdx + 1];
+            $start = $this->treeOffsets[$rootIdx];
+            $end = $this->treeOffsets[$rootIdx + 1];
         for ($j = $start; $j < $end; $j++) {
-            $ci = (int)$this->treeEdges[$j];
-            $revDeg[$ci] = (int)$revDeg[$ci] + 1;
+            $ci = $this->treeEdges[$j];
+            $revDeg[$ci] = $revDeg[$ci] + 1;
         }
         }
 
@@ -886,20 +908,20 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $allCount = 0;
         $strongAllCount = 0;
         if ($nontreeEdgeCount > 0) {
-            $ntOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+            $ntOffsets = FFIHelper::newInt32Array(($nc + 1));
             \FFI::memcpy($ntOffsets, $ntRowPtrData, ($nc + 1) * 4);
-            $ntEdges = FFIHelper::new("int32_t[" . max(1, $nontreeEdgeCount) . "]");
+            $ntEdges = FFIHelper::newInt32Array(max(1, $nontreeEdgeCount));
             \FFI::memcpy($ntEdges, $ntColIdxData, $nontreeEdgeCount * 4);
 
             for ($p = 0; $p < $nc; $p++) {
-                $start = (int)$ntOffsets[$p];
-                $end = (int)$ntOffsets[$p + 1];
+                $start = $ntOffsets[$p];
+                $end = $ntOffsets[$p + 1];
                 $deg = $end - $start;
-                $allDeg[$p] = (int)$allDeg[$p] + $deg;
-                $strongAllDeg[$p] = (int)$strongAllDeg[$p] + $deg; // nontree are strong
+                $allDeg[$p] = $allDeg[$p] + $deg;
+                $strongAllDeg[$p] = $strongAllDeg[$p] + $deg; // nontree are strong
                 for ($j = $start; $j < $end; $j++) {
-                    $ci = (int)$ntEdges[$j];
-                    $revDeg[$ci] = (int)$revDeg[$ci] + 1;
+                    $ci = $ntEdges[$j];
+                    $revDeg[$ci] = $revDeg[$ci] + 1;
                 }
             }
         }
@@ -908,63 +930,63 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $totalAll = 0;
         $totalStrongAll = 0;
         $totalRev = 0;
-        $this->allOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->strongAllOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->revOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $this->allOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->strongAllOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->revOffsets = FFIHelper::newInt32Array(($nc + 1));
         $this->allOffsets[0] = 0;
         $this->strongAllOffsets[0] = 0;
         $this->revOffsets[0] = 0;
         for ($i = 0; $i < $nc; $i++) {
-            $this->allOffsets[$i + 1] = (int)$this->allOffsets[$i] + (int)$allDeg[$i];
-            $this->strongAllOffsets[$i + 1] = (int)$this->strongAllOffsets[$i] + (int)$strongAllDeg[$i];
-            $this->revOffsets[$i + 1] = (int)$this->revOffsets[$i] + (int)$revDeg[$i];
+            $this->allOffsets[$i + 1] = $this->allOffsets[$i] + $allDeg[$i];
+            $this->strongAllOffsets[$i + 1] = $this->strongAllOffsets[$i] + $strongAllDeg[$i];
+            $this->revOffsets[$i + 1] = $this->revOffsets[$i] + $revDeg[$i];
         }
-        $totalAll = (int)$this->allOffsets[$nc];
-        $totalStrongAll = (int)$this->strongAllOffsets[$nc];
-        $totalRev = (int)$this->revOffsets[$nc];
+        $totalAll = $this->allOffsets[$nc];
+        $totalStrongAll = $this->strongAllOffsets[$nc];
+        $totalRev = $this->revOffsets[$nc];
 
-        $this->allEdges = FFIHelper::new("int32_t[" . max(1, $totalAll) . "]");
-        $this->strongAllEdges = FFIHelper::new("int32_t[" . max(1, $totalStrongAll) . "]");
-        $this->revEdges = FFIHelper::new("int32_t[" . max(1, $totalRev) . "]");
+        $this->allEdges = FFIHelper::newInt32Array(max(1, $totalAll));
+        $this->strongAllEdges = FFIHelper::newInt32Array(max(1, $totalStrongAll));
+        $this->revEdges = FFIHelper::newInt32Array(max(1, $totalRev));
 
-        $allP = FFIHelper::new("int32_t[{$nc}]");
-        $sallP = FFIHelper::new("int32_t[{$nc}]");
-        $revP = FFIHelper::new("int32_t[{$nc}]");
+        $allP = FFIHelper::newInt32Array($nc);
+        $sallP = FFIHelper::newInt32Array($nc);
+        $revP = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
-            $allP[$i] = (int)$this->allOffsets[$i];
-            $sallP[$i] = (int)$this->strongAllOffsets[$i];
-            $revP[$i] = (int)$this->revOffsets[$i];
+            $allP[$i] = $this->allOffsets[$i];
+            $sallP[$i] = $this->strongAllOffsets[$i];
+            $revP[$i] = $this->revOffsets[$i];
         }
 
         // Fill: tree edges (excluding root)
         for ($p = 0; $p < $nc; $p++) {
             if ($p === $rootIdx) {
                 // Still fill reverse for root's children
-                $start = (int)$this->treeOffsets[$p];
-                $end = (int)$this->treeOffsets[$p + 1];
+                $start = $this->treeOffsets[$p];
+                $end = $this->treeOffsets[$p + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $ci = (int)$this->treeEdges[$j];
-                    $rp = (int)$revP[$ci];
+                    $ci = $this->treeEdges[$j];
+                    $rp = $revP[$ci];
                     $this->revEdges[$rp] = $p;
                     $revP[$ci] = $rp + 1;
                 }
                 continue;
             }
-            $start = (int)$this->treeOffsets[$p];
-            $end = (int)$this->treeOffsets[$p + 1];
+            $start = $this->treeOffsets[$p];
+            $end = $this->treeOffsets[$p + 1];
             for ($j = $start; $j < $end; $j++) {
-                $ci = (int)$this->treeEdges[$j];
-                $ap = (int)$allP[$p];
+                $ci = $this->treeEdges[$j];
+                $ap = $allP[$p];
                 $this->allEdges[$ap] = $ci;
                 $allP[$p] = $ap + 1;
 
                 if (ord($treeStrengthData[$j]) === 0) {
-                    $sp = (int)$sallP[$p];
+                    $sp = $sallP[$p];
                     $this->strongAllEdges[$sp] = $ci;
                     $sallP[$p] = $sp + 1;
                 }
 
-                $rp = (int)$revP[$ci];
+                $rp = $revP[$ci];
                 $this->revEdges[$rp] = $p;
                 $revP[$ci] = $rp + 1;
             }
@@ -973,19 +995,19 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // Fill: nontree edges
         if ($nontreeEdgeCount > 0 && isset($ntOffsets) && isset($ntEdges)) {
             for ($p = 0; $p < $nc; $p++) {
-                $start = (int)$ntOffsets[$p];
-                $end = (int)$ntOffsets[$p + 1];
+                $start = $ntOffsets[$p];
+                $end = $ntOffsets[$p + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $ci = (int)$ntEdges[$j];
-                    $ap = (int)$allP[$p];
+                    $ci = $ntEdges[$j];
+                    $ap = $allP[$p];
                     $this->allEdges[$ap] = $ci;
                     $allP[$p] = $ap + 1;
 
-                    $sp = (int)$sallP[$p];
+                    $sp = $sallP[$p];
                     $this->strongAllEdges[$sp] = $ci;
                     $sallP[$p] = $sp + 1;
 
-                    $rp = (int)$revP[$ci];
+                    $rp = $revP[$ci];
                     $this->revEdges[$rp] = $p;
                     $revP[$ci] = $rp + 1;
                 }
@@ -1048,7 +1070,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return 0;
         }
-        return (int)$this->revOffsets[$idx + 1] - (int)$this->revOffsets[$idx];
+        return $this->revOffsets[$idx + 1] - $this->revOffsets[$idx];
     }
 
     #[\Override]
@@ -1064,7 +1086,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return 0;
         }
-        return (int)$this->ffiNodeSizes[$idx];
+        return $this->ffiNodeSizes[$idx];
     }
 
     #[\Override]
@@ -1074,7 +1096,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return 0;
         }
-        return (int)$this->ffiSubtreeSizes[$idx];
+        return $this->ffiSubtreeSizes[$idx];
     }
 
     #[\Override]
@@ -1087,7 +1109,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return true;
         }
-        return (int)$this->canonIdxFfi[$idx] === $idx;
+        return $this->canonIdxFfi[$idx] === $idx;
     }
 
     #[\Override]
@@ -1100,7 +1122,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return $nodeId;
         }
-        $canonIdx = (int)$this->canonIdxFfi[$idx];
+        $canonIdx = $this->canonIdxFfi[$idx];
         return $this->indexToNodeId($canonIdx);
     }
 
@@ -1119,15 +1141,15 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return [$nodeId];
         }
-        $canonIdx = (int)$this->canonIdxFfi[$idx];
-        $oStart = (int)$this->origOffsets[$canonIdx];
-        $oEnd = (int)$this->origOffsets[$canonIdx + 1];
+        $canonIdx = $this->canonIdxFfi[$idx];
+        $oStart = $this->origOffsets[$canonIdx];
+        $oEnd = $this->origOffsets[$canonIdx + 1];
         if ($oEnd <= $oStart) {
             return [$nodeId];
         }
         $group = [];
         for ($i = $oStart; $i < $oEnd; $i++) {
-            $group[] = $this->indexToNodeId((int)$this->origData[$i]);
+            $group[] = $this->indexToNodeId($this->origData[$i]);
         }
         return $group;
     }
@@ -1139,7 +1161,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return null;
         }
-        $classId = (int)$this->nodeClassIds[$idx];
+        $classId = $this->nodeClassIds[$idx];
         if ($classId < 0) {
             return null;
         }
@@ -1156,7 +1178,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return null;
         }
-        $typeId = (int)$this->nodeTypeIds[$idx];
+        $typeId = $this->nodeTypeIds[$idx];
         if ($typeId < 0) {
             return null;
         }
@@ -1173,7 +1195,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return null;
         }
-        $link_id = (int)$this->treeLinkIds[$idx];
+        $link_id = $this->treeLinkIds[$idx];
         if ($link_id < 0) {
             return null;
         }
@@ -1190,11 +1212,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         if ($idx < 0) {
             return null;
         }
-        $parent_idx = (int)$this->treeParentIdx[$idx];
+        $parent_idx = $this->treeParentIdx[$idx];
         if ($parent_idx < 0) {
             return null;
         }
-        $parent_id = (int)$this->indexToNodeFfi[$parent_idx];
+        $parent_id = $this->indexToNodeFfi[$parent_idx];
         return $parent_id === -1 ? null : $parent_id;
     }
 
@@ -1220,8 +1242,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         $n = $this->nodeCount;
         for ($i = 0; $i < $n; $i++) {
-            if ((int)$this->treeLinkIds[$i] === $link_id) {
-                yield (int)$this->indexToNodeFfi[$i];
+            if ($this->treeLinkIds[$i] === $link_id) {
+                yield $this->indexToNodeFfi[$i];
             }
         }
     }
@@ -1243,7 +1265,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     public function iterateNodeSizes(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            yield (int)$this->indexToNodeFfi[$i] => (int)$this->ffiNodeSizes[$i];
+            yield $this->indexToNodeFfi[$i] => $this->ffiNodeSizes[$i];
         }
     }
 
@@ -1252,9 +1274,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     public function iterateSubtreeSizes(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            $size = (int)$this->ffiSubtreeSizes[$i];
+            $size = $this->ffiSubtreeSizes[$i];
             if ($size > 0) {
-                yield (int)$this->indexToNodeFfi[$i] => $size;
+                yield $this->indexToNodeFfi[$i] => $size;
             }
         }
     }
@@ -1264,16 +1286,16 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     public function iterateAllParents(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            $start = (int)$this->revOffsets[$i];
-            $end = (int)$this->revOffsets[$i + 1];
+            $start = $this->revOffsets[$i];
+            $end = $this->revOffsets[$i + 1];
             if ($start < $end) {
                 $parents = [];
                 for ($j = $start; $j < $end; $j++) {
                     // revEdges stores CSR indices (matching the rest of the
                     // CSR arrays); translate back to node_ids on the way out.
-                    $parents[] = (int)$this->indexToNodeFfi[(int)$this->revEdges[$j]];
+                    $parents[] = $this->indexToNodeFfi[$this->revEdges[$j]];
                 }
-                yield (int)$this->indexToNodeFfi[$i] => $parents;
+                yield $this->indexToNodeFfi[$i] => $parents;
             }
         }
     }
@@ -1283,9 +1305,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     public function iterateNodeClasses(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            $classId = (int)$this->nodeClassIds[$i];
+            $classId = $this->nodeClassIds[$i];
             if ($classId >= 0) {
-                yield (int)$this->indexToNodeFfi[$i] => $this->classDict[$classId];
+                yield $this->indexToNodeFfi[$i] => $this->classDict[$classId];
             }
         }
     }
@@ -1295,9 +1317,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     public function iterateNodeToScc(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            $scc_id = (int)$this->ffiNodeToScc[$i];
+            $scc_id = $this->ffiNodeToScc[$i];
             if ($scc_id >= 0) {
-                yield (int)$this->indexToNodeFfi[$i] => $scc_id;
+                yield $this->indexToNodeFfi[$i] => $scc_id;
             }
         }
     }
@@ -1314,7 +1336,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             if ($slot < 0 || $slot >= $this->directIndexSize) {
                 return -1;
             }
-            return (int)$this->nodeToIndexDirect[$slot];
+            return $this->nodeToIndexDirect[$slot];
         }
         return $this->nodeToIndexPhp[$nodeId] ?? -1;
     }
@@ -1324,7 +1346,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
      */
     private function indexToNodeId(int $idx): int
     {
-        return (int)$this->indexToNodeFfi[$idx];
+        return $this->indexToNodeFfi[$idx];
     }
 
     /**
@@ -1340,7 +1362,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         $result = [];
         for ($i = $start; $i < $end; $i++) {
-            $result[] = (int)$this->indexToNodeFfi[(int)$edges[$i]];
+            $result[] = $this->indexToNodeFfi[(int)$edges[$i]];
         }
         return $result;
     }
@@ -1400,7 +1422,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         // Build mapping: assign CSR indices
         $this->nodeCount = count($all_node_ids);
-        $this->indexToNodeFfi = FFIHelper::new("int32_t[{$this->nodeCount}]");
+        $this->indexToNodeFfi = FFIHelper::newInt32Array($this->nodeCount);
 
         $idx = 0;
         $minNodeId = PHP_INT_MAX;
@@ -1424,14 +1446,14 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $this->directIndexOffset = -$minNodeId; // node_id + offset → 0-based slot
             $directSize = $range;
             $this->directIndexSize = $directSize;
-            $this->nodeToIndexDirect = FFIHelper::new("int32_t[{$directSize}]");
+            $this->nodeToIndexDirect = FFIHelper::newInt32Array($directSize);
             // Initialize all to -1
             for ($i = 0; $i < $directSize; $i++) {
                 $this->nodeToIndexDirect[$i] = -1;
             }
             // Fill
             for ($i = 0; $i < $this->nodeCount; $i++) {
-                $nid = (int)$this->indexToNodeFfi[$i];
+                $nid = $this->indexToNodeFfi[$i];
                 $slot = $nid + $this->directIndexOffset;
                 $this->nodeToIndexDirect[$slot] = $i;
             }
@@ -1439,16 +1461,16 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             // Fallback: PHP associative array
             $this->nodeToIndexPhp = [];
             for ($i = 0; $i < $this->nodeCount; $i++) {
-                $this->nodeToIndexPhp[(int)$this->indexToNodeFfi[$i]] = $i;
+                $this->nodeToIndexPhp[$this->indexToNodeFfi[$i]] = $i;
             }
         }
         unset($all_node_ids);
 
         // Allocate per-node FFI arrays
-        $this->ffiNodeSizes = FFIHelper::new("int64_t[{$this->nodeCount}]");
-        $this->ffiSubtreeSizes = FFIHelper::new("int64_t[{$this->nodeCount}]");
-        $this->ffiNodeToScc = FFIHelper::new("int32_t[{$this->nodeCount}]");
-        $this->nodeClassIds = FFIHelper::new("int32_t[{$this->nodeCount}]");
+        $this->ffiNodeSizes = FFIHelper::newInt64Array($this->nodeCount);
+        $this->ffiSubtreeSizes = FFIHelper::newInt64Array($this->nodeCount);
+        $this->ffiNodeToScc = FFIHelper::newInt32Array($this->nodeCount);
+        $this->nodeClassIds = FFIHelper::newInt32Array($this->nodeCount);
 
         // Initialize
         for ($i = 0; $i < $this->nodeCount; $i++) {
@@ -1506,7 +1528,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     $slot = $node_id + $directOffset;
                     $csrIdx = ($slot < 0 || $slot >= $directSize)
                         ? -1
-                        : (int)$directMap[$slot];
+                        : $directMap[$slot];
                 } else {
                     $csrIdx = $phpMap[$node_id] ?? -1;
                 }
@@ -1546,7 +1568,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private function loadNodeTypesFfi(\PDO $db, int $run_id): void
     {
         $nc = $this->nodeCount;
-        $this->nodeTypeIds = FFIHelper::new("int16_t[{$nc}]");
+        $this->nodeTypeIds = FFIHelper::newInt16Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $this->nodeTypeIds[$i] = -1;
         }
@@ -1585,7 +1607,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     $slot = $node_id + $directOffset;
                     $idx = ($slot < 0 || $slot >= $directSize)
                         ? -1
-                        : (int)$directMap[$slot];
+                        : $directMap[$slot];
                 } else {
                     $idx = $phpMap[$node_id] ?? -1;
                 }
@@ -1644,44 +1666,44 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         )->fetchColumn();
         $this->edge_count = $edgeCount;
 
-        $this->treeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->strongTreeOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->allOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->strongAllOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
-        $this->revOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $this->treeOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->strongTreeOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->allOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->strongAllOffsets = FFIHelper::newInt32Array(($nc + 1));
+        $this->revOffsets = FFIHelper::newInt32Array(($nc + 1));
 
         if ($edgeCount === 0) {
-            $this->treeEdges = FFIHelper::new("int32_t[1]");
-            $this->strongTreeEdges = FFIHelper::new("int32_t[1]");
-            $this->allEdges = FFIHelper::new("int32_t[1]");
-            $this->strongAllEdges = FFIHelper::new("int32_t[1]");
-            $this->revEdges = FFIHelper::new("int32_t[1]");
+            $this->treeEdges = FFIHelper::newInt32Array(1);
+            $this->strongTreeEdges = FFIHelper::newInt32Array(1);
+            $this->allEdges = FFIHelper::newInt32Array(1);
+            $this->strongAllEdges = FFIHelper::newInt32Array(1);
+            $this->revEdges = FFIHelper::newInt32Array(1);
             return;
         }
 
         // Staging buffer: written during the SQL pass, read during the
         // CSR fill pass. Flags layout: bit 0 = is_tree, bit 1 = is_strong.
-        $stageParentIdx = FFIHelper::new("int32_t[{$edgeCount}]");
-        $stageChildIdx = FFIHelper::new("int32_t[{$edgeCount}]");
-        $stageFlags = FFIHelper::new("int8_t[{$edgeCount}]");
+        $stageParentIdx = FFIHelper::newInt32Array($edgeCount);
+        $stageChildIdx = FFIHelper::newInt32Array($edgeCount);
+        $stageFlags = FFIHelper::newInt8Array($edgeCount);
 
         // Tree-edge link_name index: int32 per child slot, -1 = no
         // tree edge. Initialised below to -1 in one pass over the
         // CSR slot space, then filled as we walk tree edges. Must
         // stay int32: see the field-declaration comment for the int16
         // wrap-around bug that motivated the widening.
-        $this->treeLinkIds = FFIHelper::new("int32_t[{$nc}]");
-        $this->treeParentIdx = FFIHelper::new("int32_t[{$nc}]");
+        $this->treeLinkIds = FFIHelper::newInt32Array($nc);
+        $this->treeParentIdx = FFIHelper::newInt32Array($nc);
         for ($k = 0; $k < $nc; $k++) {
             $this->treeLinkIds[$k] = -1;
             $this->treeParentIdx[$k] = -1;
         }
 
-        $treeDeg = FFIHelper::new("int32_t[{$nc}]");
-        $strongTreeDeg = FFIHelper::new("int32_t[{$nc}]");
-        $allDeg = FFIHelper::new("int32_t[{$nc}]");
-        $strongAllDeg = FFIHelper::new("int32_t[{$nc}]");
-        $revDeg = FFIHelper::new("int32_t[{$nc}]");
+        $treeDeg = FFIHelper::newInt32Array($nc);
+        $strongTreeDeg = FFIHelper::newInt32Array($nc);
+        $allDeg = FFIHelper::newInt32Array($nc);
+        $strongAllDeg = FFIHelper::newInt32Array($nc);
+        $revDeg = FFIHelper::newInt32Array($nc);
 
         $treeCount = 0;
         $strongTreeCount = 0;
@@ -1736,11 +1758,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     $slot = $parent + $directOffset;
                     $pi = ($slot < 0 || $slot >= $directSize)
                         ? -1
-                        : (int)$directMap[$slot];
+                        : $directMap[$slot];
                     $slot = $child + $directOffset;
                     $ci = ($slot < 0 || $slot >= $directSize)
                         ? -1
-                        : (int)$directMap[$slot];
+                        : $directMap[$slot];
                 } else {
                     $pi = $phpMap[$parent] ?? -1;
                     $ci = $phpMap[$child] ?? -1;
@@ -1800,18 +1822,18 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         unset($treeDeg, $strongTreeDeg, $allDeg, $strongAllDeg, $revDeg);
 
-        $this->treeEdges = FFIHelper::new("int32_t[" . max($treeCount, 1) . "]");
-        $this->strongTreeEdges = FFIHelper::new("int32_t[" . max($strongTreeCount, 1) . "]");
-        $this->allEdges = FFIHelper::new("int32_t[" . max($allCount, 1) . "]");
-        $this->strongAllEdges = FFIHelper::new("int32_t[" . max($strongAllCount, 1) . "]");
-        $this->revEdges = FFIHelper::new("int32_t[{$edgeCount}]");
+        $this->treeEdges = FFIHelper::newInt32Array(max($treeCount, 1));
+        $this->strongTreeEdges = FFIHelper::newInt32Array(max($strongTreeCount, 1));
+        $this->allEdges = FFIHelper::newInt32Array(max($allCount, 1));
+        $this->strongAllEdges = FFIHelper::newInt32Array(max($strongAllCount, 1));
+        $this->revEdges = FFIHelper::newInt32Array($edgeCount);
 
         // Write positions, seeded from the offsets we just computed.
-        $treeP = FFIHelper::new("int32_t[{$nc}]");
-        $streeP = FFIHelper::new("int32_t[{$nc}]");
-        $allP = FFIHelper::new("int32_t[{$nc}]");
-        $sallP = FFIHelper::new("int32_t[{$nc}]");
-        $revP = FFIHelper::new("int32_t[{$nc}]");
+        $treeP = FFIHelper::newInt32Array($nc);
+        $streeP = FFIHelper::newInt32Array($nc);
+        $allP = FFIHelper::newInt32Array($nc);
+        $sallP = FFIHelper::newInt32Array($nc);
+        $revP = FFIHelper::newInt32Array($nc);
         for ($k = 0; $k < $nc; $k++) {
             $treeP[$k] = $this->treeOffsets[$k];
             $streeP[$k] = $this->strongTreeOffsets[$k];
@@ -1823,28 +1845,28 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // Second pass: walk the staged edges and place them into the
         // CSR arrays. No SQL.
         for ($k = 0; $k < $edgeCount; $k++) {
-            $pi = (int)$stageParentIdx[$k];
-            $ci = (int)$stageChildIdx[$k];
-            $flags = (int)$stageFlags[$k];
+            $pi = $stageParentIdx[$k];
+            $ci = $stageChildIdx[$k];
+            $flags = $stageFlags[$k];
             $is_tree = ($flags & 1) !== 0;
             $is_strong = ($flags & 2) !== 0;
 
             if ($is_tree) {
-                $p = (int)$treeP[$pi];
+                $p = $treeP[$pi];
                 $this->treeEdges[$p] = $ci;
                 $treeP[$pi] = $p + 1;
                 if ($is_strong) {
-                    $p = (int)$streeP[$pi];
+                    $p = $streeP[$pi];
                     $this->strongTreeEdges[$p] = $ci;
                     $streeP[$pi] = $p + 1;
                 }
             }
             if ($pi !== $rootParentIdx) {
-                $p = (int)$allP[$pi];
+                $p = $allP[$pi];
                 $this->allEdges[$p] = $ci;
                 $allP[$pi] = $p + 1;
                 if ($is_strong) {
-                    $p = (int)$sallP[$pi];
+                    $p = $sallP[$pi];
                     $this->strongAllEdges[$p] = $ci;
                     $sallP[$pi] = $p + 1;
                 }
@@ -1853,7 +1875,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             // contract csrSlice expects). The previous code stored
             // the raw parent value here, which corrupted getAllParents
             // for every non-root node and crashed on the actual root.
-            $p = (int)$revP[$ci];
+            $p = $revP[$ci];
             $this->revEdges[$p] = $pi;
             $revP[$ci] = $p + 1;
         }
@@ -1885,20 +1907,20 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         while ($stack) {
             [$idx, $processed] = array_pop($stack);
             if ($processed) {
-                $size = (int)$this->ffiNodeSizes[$idx];
-                $start = (int)$this->strongTreeOffsets[$idx];
-                $end = (int)$this->strongTreeOffsets[$idx + 1];
+                $size = $this->ffiNodeSizes[$idx];
+                $start = $this->strongTreeOffsets[$idx];
+                $end = $this->strongTreeOffsets[$idx + 1];
                 for ($i = $start; $i < $end; $i++) {
-                    $size += (int)$this->ffiSubtreeSizes[(int)$this->strongTreeEdges[$i]];
+                    $size += $this->ffiSubtreeSizes[$this->strongTreeEdges[$i]];
                 }
                 $this->ffiSubtreeSizes[$idx] = $size;
                 $visited[$idx] = true;
             } else {
                 $stack[] = [$idx, true];
-                $start = (int)$this->strongTreeOffsets[$idx];
-                $end = (int)$this->strongTreeOffsets[$idx + 1];
+                $start = $this->strongTreeOffsets[$idx];
+                $end = $this->strongTreeOffsets[$idx + 1];
                 for ($i = $start; $i < $end; $i++) {
-                    $childIdx = (int)$this->strongTreeEdges[$i];
+                    $childIdx = $this->strongTreeEdges[$i];
                     if (!isset($visited[$childIdx])) {
                         $stack[] = [$childIdx, false];
                     }
@@ -1943,15 +1965,15 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $nc = $this->nodeCount;
         $indexToNodeFfi = $this->indexToNodeFfi;
 
-        $this->canonIdxFfi = FFIHelper::new("int32_t[{$nc}]");
-        $this->origOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $this->canonIdxFfi = FFIHelper::newInt32Array($nc);
+        $this->origOffsets = FFIHelper::newInt32Array(($nc + 1));
         $canonIdxFfi = $this->canonIdxFfi;
         $origOffsets = $this->origOffsets;
 
         // Pass 1: compute canonIdxFfi and count originals per canonical
-        $origCount = FFIHelper::new("int32_t[{$nc}]");
+        $origCount = FFIHelper::newInt32Array($nc);
         for ($v = 0; $v < $nc; $v++) {
-            $nid = (int)$indexToNodeFfi[$v];
+            $nid = $indexToNodeFfi[$v];
             if ($nid === -1) {
                 $canonIdxFfi[$v] = $v;
                 continue;
@@ -1962,30 +1984,30 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             } else {
                 $canonIdxFfi[$v] = $v;
             }
-            $c = (int)$canonIdxFfi[$v];
-            $origCount[$c] = (int)$origCount[$c] + 1;
+            $c = $canonIdxFfi[$v];
+            $origCount[$c] = $origCount[$c] + 1;
         }
 
         // Pass 2: build origOffsets (prefix sum)
         $origOffsets[0] = 0;
         for ($i = 0; $i < $nc; $i++) {
-            $origOffsets[$i + 1] = (int)$origOffsets[$i] + (int)$origCount[$i];
+            $origOffsets[$i + 1] = $origOffsets[$i] + $origCount[$i];
         }
-        $totalOrig = (int)$origOffsets[$nc];
-        $origData = FFIHelper::new("int32_t[" . max(1, $totalOrig) . "]");
+        $totalOrig = $origOffsets[$nc];
+        $origData = FFIHelper::newInt32Array(max(1, $totalOrig));
 
         // Pass 3: fill origData
-        $origPos = FFIHelper::new("int32_t[{$nc}]");
+        $origPos = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
-            $origPos[$i] = (int)$origOffsets[$i];
+            $origPos[$i] = $origOffsets[$i];
         }
         for ($v = 0; $v < $nc; $v++) {
-            $nid = (int)$indexToNodeFfi[$v];
+            $nid = $indexToNodeFfi[$v];
             if ($nid === -1) {
                 continue;
             }
-            $c = (int)$canonIdxFfi[$v];
-            $p = (int)$origPos[$c];
+            $c = $canonIdxFfi[$v];
+            $p = $origPos[$c];
             $origData[$p] = $v;
             $origPos[$c] = $p + 1;
         }
@@ -2034,16 +2056,16 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         //   active-only reverse CSR is tiny (proportional to active
         //   edges) instead of the full 60M-edge reverse.
 
-        $active = FFIHelper::new("int8_t[{$nc}]");
-        $in_deg = FFIHelper::new("int32_t[{$nc}]");
+        $active = FFIHelper::newInt8Array($nc);
+        $in_deg = FFIHelper::newInt32Array($nc);
 
         // Phase A: compute in-degree and initial active set
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$indexToNodeFfi[$v] === -1) {
+            if ($indexToNodeFfi[$v] === -1) {
                 $active[$v] = 0;
                 continue;
             }
-            $cv = $has_canonical ? (int)$canonIdxFfi[$v] : $v;
+            $cv = $has_canonical ? $canonIdxFfi[$v] : $v;
             if ($cv !== $v) {
                 $active[$v] = 0;
                 continue;
@@ -2052,29 +2074,29 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
             $seen = [];
             if ($has_canonical) {
-                $oStart = (int)$origOffsets[$v];
-                $oEnd = (int)$origOffsets[$v + 1];
+                $oStart = $origOffsets[$v];
+                $oEnd = $origOffsets[$v + 1];
                 for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                    $origIdx = (int)$origData[$oi];
-                    $start = (int)$strongAllOffsets[$origIdx];
-                    $end = (int)$strongAllOffsets[$origIdx + 1];
+                    $origIdx = $origData[$oi];
+                    $start = $strongAllOffsets[$origIdx];
+                    $end = $strongAllOffsets[$origIdx + 1];
                     for ($j = $start; $j < $end; $j++) {
-                        $w = (int)$strongAllEdges[$j];
-                        $cw = (int)$canonIdxFfi[$w];
+                        $w = $strongAllEdges[$j];
+                        $cw = $canonIdxFfi[$w];
                         if ($cw !== $v && !isset($seen[$cw])) {
                             $seen[$cw] = true;
-                            $in_deg[$cw] = (int)$in_deg[$cw] + 1;
+                            $in_deg[$cw] = $in_deg[$cw] + 1;
                         }
                     }
                 }
             } else {
-                $start = (int)$strongAllOffsets[$v];
-                $end = (int)$strongAllOffsets[$v + 1];
+                $start = $strongAllOffsets[$v];
+                $end = $strongAllOffsets[$v + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $w = (int)$strongAllEdges[$j];
+                    $w = $strongAllEdges[$j];
                     if ($w !== $v && !isset($seen[$w])) {
                         $seen[$w] = true;
-                        $in_deg[$w] = (int)$in_deg[$w] + 1;
+                        $in_deg[$w] = $in_deg[$w] + 1;
                     }
                 }
             }
@@ -2083,45 +2105,45 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // Phase A: in-degree queue peeling
         $queue = [];
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$active[$v] !== 0 && (int)$in_deg[$v] === 0) {
+            if ($active[$v] !== 0 && $in_deg[$v] === 0) {
                 $queue[] = $v;
             }
         }
         while ($queue !== []) {
             $v = array_pop($queue);
-            if ((int)$active[$v] === 0) {
+            if ($active[$v] === 0) {
                 continue;
             }
             $active[$v] = 0;
             $seen = [];
             if ($has_canonical) {
-                $oStart = (int)$origOffsets[$v];
-                $oEnd = (int)$origOffsets[$v + 1];
+                $oStart = $origOffsets[$v];
+                $oEnd = $origOffsets[$v + 1];
                 for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                    $origIdx = (int)$origData[$oi];
-                    $start = (int)$strongAllOffsets[$origIdx];
-                    $end = (int)$strongAllOffsets[$origIdx + 1];
+                    $origIdx = $origData[$oi];
+                    $start = $strongAllOffsets[$origIdx];
+                    $end = $strongAllOffsets[$origIdx + 1];
                     for ($j = $start; $j < $end; $j++) {
-                        $w = (int)$strongAllEdges[$j];
-                        $cw = (int)$canonIdxFfi[$w];
-                        if ($cw !== $v && (int)$active[$cw] !== 0 && !isset($seen[$cw])) {
+                        $w = $strongAllEdges[$j];
+                        $cw = $canonIdxFfi[$w];
+                        if ($cw !== $v && $active[$cw] !== 0 && !isset($seen[$cw])) {
                             $seen[$cw] = true;
-                            $in_deg[$cw] = (int)$in_deg[$cw] - 1;
-                            if ((int)$in_deg[$cw] === 0) {
+                            $in_deg[$cw] = $in_deg[$cw] - 1;
+                            if ($in_deg[$cw] === 0) {
                                 $queue[] = $cw;
                             }
                         }
                     }
                 }
             } else {
-                $start = (int)$strongAllOffsets[$v];
-                $end = (int)$strongAllOffsets[$v + 1];
+                $start = $strongAllOffsets[$v];
+                $end = $strongAllOffsets[$v + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $w = (int)$strongAllEdges[$j];
-                    if ($w !== $v && (int)$active[$w] !== 0 && !isset($seen[$w])) {
+                    $w = $strongAllEdges[$j];
+                    if ($w !== $v && $active[$w] !== 0 && !isset($seen[$w])) {
                         $seen[$w] = true;
-                        $in_deg[$w] = (int)$in_deg[$w] - 1;
-                        if ((int)$in_deg[$w] === 0) {
+                        $in_deg[$w] = $in_deg[$w] - 1;
+                        if ($in_deg[$w] === 0) {
                             $queue[] = $w;
                         }
                     }
@@ -2131,40 +2153,40 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         unset($in_deg);
 
         // Phase B: active-only reverse CSR + out-degree peeling
-        $out_deg = FFIHelper::new("int32_t[{$nc}]");
-        $arevDeg = FFIHelper::new("int32_t[{$nc}]");
+        $out_deg = FFIHelper::newInt32Array($nc);
+        $arevDeg = FFIHelper::newInt32Array($nc);
         $active_edge_count = 0;
 
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$active[$v] === 0) {
+            if ($active[$v] === 0) {
                 continue;
             }
             $seen = [];
             if ($has_canonical) {
-                $oStart = (int)$origOffsets[$v];
-                $oEnd = (int)$origOffsets[$v + 1];
+                $oStart = $origOffsets[$v];
+                $oEnd = $origOffsets[$v + 1];
                 for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                    $origIdx = (int)$origData[$oi];
-                    $start = (int)$strongAllOffsets[$origIdx];
-                    $end = (int)$strongAllOffsets[$origIdx + 1];
+                    $origIdx = $origData[$oi];
+                    $start = $strongAllOffsets[$origIdx];
+                    $end = $strongAllOffsets[$origIdx + 1];
                     for ($j = $start; $j < $end; $j++) {
-                        $w = (int)$strongAllEdges[$j];
-                        $cw = (int)$canonIdxFfi[$w];
-                        if ($cw !== $v && (int)$active[$cw] !== 0 && !isset($seen[$cw])) {
+                        $w = $strongAllEdges[$j];
+                        $cw = $canonIdxFfi[$w];
+                        if ($cw !== $v && $active[$cw] !== 0 && !isset($seen[$cw])) {
                             $seen[$cw] = true;
-                            $arevDeg[$cw] = (int)$arevDeg[$cw] + 1;
+                            $arevDeg[$cw] = $arevDeg[$cw] + 1;
                             $active_edge_count++;
                         }
                     }
                 }
             } else {
-                $start = (int)$strongAllOffsets[$v];
-                $end = (int)$strongAllOffsets[$v + 1];
+                $start = $strongAllOffsets[$v];
+                $end = $strongAllOffsets[$v + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $w = (int)$strongAllEdges[$j];
-                    if ($w !== $v && (int)$active[$w] !== 0 && !isset($seen[$w])) {
+                    $w = $strongAllEdges[$j];
+                    if ($w !== $v && $active[$w] !== 0 && !isset($seen[$w])) {
                         $seen[$w] = true;
-                        $arevDeg[$w] = (int)$arevDeg[$w] + 1;
+                        $arevDeg[$w] = $arevDeg[$w] + 1;
                         $active_edge_count++;
                     }
                 }
@@ -2172,47 +2194,47 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $out_deg[$v] = count($seen);
         }
 
-        $arevOffsets = FFIHelper::new("int32_t[" . ($nc + 1) . "]");
+        $arevOffsets = FFIHelper::newInt32Array(($nc + 1));
         $arevOffsets[0] = 0;
         for ($i = 0; $i < $nc; $i++) {
-            $arevOffsets[$i + 1] = (int)$arevOffsets[$i] + (int)$arevDeg[$i];
+            $arevOffsets[$i + 1] = $arevOffsets[$i] + $arevDeg[$i];
         }
-        $arevEdges = FFIHelper::new("int32_t[" . max(1, $active_edge_count) . "]");
-        $arevPos = FFIHelper::new("int32_t[{$nc}]");
+        $arevEdges = FFIHelper::newInt32Array(max(1, $active_edge_count));
+        $arevPos = FFIHelper::newInt32Array($nc);
         for ($i = 0; $i < $nc; $i++) {
-            $arevPos[$i] = (int)$arevOffsets[$i];
+            $arevPos[$i] = $arevOffsets[$i];
         }
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$active[$v] === 0) {
+            if ($active[$v] === 0) {
                 continue;
             }
             $seen = [];
             if ($has_canonical) {
-                $oStart = (int)$origOffsets[$v];
-                $oEnd = (int)$origOffsets[$v + 1];
+                $oStart = $origOffsets[$v];
+                $oEnd = $origOffsets[$v + 1];
                 for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                    $origIdx = (int)$origData[$oi];
-                    $start = (int)$strongAllOffsets[$origIdx];
-                    $end = (int)$strongAllOffsets[$origIdx + 1];
+                    $origIdx = $origData[$oi];
+                    $start = $strongAllOffsets[$origIdx];
+                    $end = $strongAllOffsets[$origIdx + 1];
                     for ($j = $start; $j < $end; $j++) {
-                        $w = (int)$strongAllEdges[$j];
-                        $cw = (int)$canonIdxFfi[$w];
-                        if ($cw !== $v && (int)$active[$cw] !== 0 && !isset($seen[$cw])) {
+                        $w = $strongAllEdges[$j];
+                        $cw = $canonIdxFfi[$w];
+                        if ($cw !== $v && $active[$cw] !== 0 && !isset($seen[$cw])) {
                             $seen[$cw] = true;
-                            $p = (int)$arevPos[$cw];
+                            $p = $arevPos[$cw];
                             $arevEdges[$p] = $v;
                             $arevPos[$cw] = $p + 1;
                         }
                     }
                 }
             } else {
-                $start = (int)$strongAllOffsets[$v];
-                $end = (int)$strongAllOffsets[$v + 1];
+                $start = $strongAllOffsets[$v];
+                $end = $strongAllOffsets[$v + 1];
                 for ($j = $start; $j < $end; $j++) {
-                    $w = (int)$strongAllEdges[$j];
-                    if ($w !== $v && (int)$active[$w] !== 0 && !isset($seen[$w])) {
+                    $w = $strongAllEdges[$j];
+                    if ($w !== $v && $active[$w] !== 0 && !isset($seen[$w])) {
                         $seen[$w] = true;
-                        $p = (int)$arevPos[$w];
+                        $p = $arevPos[$w];
                         $arevEdges[$p] = $v;
                         $arevPos[$w] = $p + 1;
                     }
@@ -2224,23 +2246,23 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // Out-degree queue peeling
         $queue = [];
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$active[$v] !== 0 && (int)$out_deg[$v] === 0) {
+            if ($active[$v] !== 0 && $out_deg[$v] === 0) {
                 $queue[] = $v;
             }
         }
         while ($queue !== []) {
             $v = array_pop($queue);
-            if ((int)$active[$v] === 0) {
+            if ($active[$v] === 0) {
                 continue;
             }
             $active[$v] = 0;
-            $start = (int)$arevOffsets[$v];
-            $end = (int)$arevOffsets[$v + 1];
+            $start = $arevOffsets[$v];
+            $end = $arevOffsets[$v + 1];
             for ($j = $start; $j < $end; $j++) {
-                $cw = (int)$arevEdges[$j];
-                if ((int)$active[$cw] !== 0) {
-                    $out_deg[$cw] = (int)$out_deg[$cw] - 1;
-                    if ((int)$out_deg[$cw] === 0) {
+                $cw = $arevEdges[$j];
+                if ($active[$cw] !== 0) {
+                    $out_deg[$cw] = $out_deg[$cw] - 1;
+                    if ($out_deg[$cw] === 0) {
                         $queue[] = $cw;
                     }
                 }
@@ -2250,9 +2272,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         // Tarjan tables in FFI. -1 in tarjan_index means unvisited;
         // tarjan_on_stack uses 0/1 because int8 is plenty.
-        $tarjan_index = FFIHelper::new("int32_t[{$nc}]");
-        $tarjan_lowlink = FFIHelper::new("int32_t[{$nc}]");
-        $tarjan_on_stack = FFIHelper::new("int8_t[{$nc}]");
+        $tarjan_index = FFIHelper::newInt32Array($nc);
+        $tarjan_lowlink = FFIHelper::newInt32Array($nc);
+        $tarjan_on_stack = FFIHelper::newInt8Array($nc);
         for ($i = 0; $i < $nc; $i++) {
             $tarjan_index[$i] = -1;
             $tarjan_lowlink[$i] = -1;
@@ -2264,11 +2286,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         $sccs = [];
 
         for ($v = 0; $v < $nc; $v++) {
-            if ((int)$active[$v] === 0) {
+            if ($active[$v] === 0) {
                 continue;
             }
-            $cv = $has_canonical ? (int)$canonIdxFfi[$v] : $v;
-            if ((int)$tarjan_index[$cv] !== -1) {
+            $cv = $has_canonical ? $canonIdxFfi[$v] : $v;
+            if ($tarjan_index[$cv] !== -1) {
                 continue;
             }
 
@@ -2286,16 +2308,16 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     if (!isset($canonical_neighbors[$node])) {
                         $neighbors = [];
                         $seen = [];
-                        $oStart = (int)$origOffsets[$node];
-                        $oEnd = (int)$origOffsets[$node + 1];
+                        $oStart = $origOffsets[$node];
+                        $oEnd = $origOffsets[$node + 1];
                         for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                            $origIdx = (int)$origData[$oi];
-                            $start = (int)$strongAllOffsets[$origIdx];
-                            $end = (int)$strongAllOffsets[$origIdx + 1];
+                            $origIdx = $origData[$oi];
+                            $start = $strongAllOffsets[$origIdx];
+                            $end = $strongAllOffsets[$origIdx + 1];
                             for ($j = $start; $j < $end; $j++) {
-                                $w = (int)$strongAllEdges[$j];
-                                $cw = (int)$canonIdxFfi[$w];
-                                if ($cw !== $node && (int)$active[$cw] !== 0 && !isset($seen[$cw])) {
+                                $w = $strongAllEdges[$j];
+                                $cw = $canonIdxFfi[$w];
+                                if ($cw !== $node && $active[$cw] !== 0 && !isset($seen[$cw])) {
                                     $seen[$cw] = true;
                                     $neighbors[] = $cw;
                                 }
@@ -2307,11 +2329,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 } else {
                     $neighbors = [];
                     $seen = [];
-                    $start = (int)$strongAllOffsets[$node];
-                    $end = (int)$strongAllOffsets[$node + 1];
+                    $start = $strongAllOffsets[$node];
+                    $end = $strongAllOffsets[$node + 1];
                     for ($j = $start; $j < $end; $j++) {
-                        $w = (int)$strongAllEdges[$j];
-                        if ($w !== $node && (int)$active[$w] !== 0 && !isset($seen[$w])) {
+                        $w = $strongAllEdges[$j];
+                        if ($w !== $node && $active[$w] !== 0 && !isset($seen[$w])) {
                             $seen[$w] = true;
                             $neighbors[] = $w;
                         }
@@ -2322,7 +2344,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 $found_unvisited = false;
                 for ($i = $ci; $i < $count; $i++) {
                     $w = $neighbors[$i];
-                    $w_index = (int)$tarjan_index[$w];
+                    $w_index = $tarjan_index[$w];
                     if ($w_index === -1) {
                         $call_stack[] = [$node, $i + 1];
                         $tarjan_index[$w] = $index_counter;
@@ -2333,8 +2355,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                         $call_stack[] = [$w, 0];
                         $found_unvisited = true;
                         break;
-                    } elseif ((int)$tarjan_on_stack[$w] !== 0) {
-                        $cur = (int)$tarjan_lowlink[$node];
+                    } elseif ($tarjan_on_stack[$w] !== 0) {
+                        $cur = $tarjan_lowlink[$node];
                         if ($w_index < $cur) {
                             $tarjan_lowlink[$node] = $w_index;
                         }
@@ -2342,7 +2364,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 }
 
                 if (!$found_unvisited) {
-                    if ((int)$tarjan_lowlink[$node] === (int)$tarjan_index[$node]) {
+                    if ($tarjan_lowlink[$node] === $tarjan_index[$node]) {
                         /** @var list<int> $scc CSR indices (canonical) */
                         $scc = [];
                         do {
@@ -2357,8 +2379,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     }
                     if ($call_stack) {
                         $parent_node = $call_stack[count($call_stack) - 1][0];
-                        $cur = (int)$tarjan_lowlink[$parent_node];
-                        $cand = (int)$tarjan_lowlink[$node];
+                        $cur = $tarjan_lowlink[$parent_node];
+                        $cand = $tarjan_lowlink[$node];
                         if ($cand < $cur) {
                             $tarjan_lowlink[$parent_node] = $cand;
                         }
@@ -2373,10 +2395,10 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             foreach ($sccs as &$scc) {
                 $expanded = [];
                 foreach ($scc as $canonical_idx) {
-                    $oStart = (int)$origOffsets[$canonical_idx];
-                    $oEnd = (int)$origOffsets[$canonical_idx + 1];
+                    $oStart = $origOffsets[$canonical_idx];
+                    $oEnd = $origOffsets[$canonical_idx + 1];
                     for ($oi = $oStart; $oi < $oEnd; $oi++) {
-                        $expanded[] = (int)$origData[$oi];
+                        $expanded[] = $origData[$oi];
                     }
                 }
                 $scc = $expanded;
@@ -2389,8 +2411,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // strongAll CSR is only needed for SCC computation.
         // Free it to save ~480 MB on 60M-edge graphs.
         unset($this->strongAllOffsets, $this->strongAllEdges);
-        $this->strongAllOffsets = FFIHelper::new("int32_t[1]");
-        $this->strongAllEdges = FFIHelper::new("int32_t[1]");
+        $this->strongAllOffsets = FFIHelper::newInt32Array(1);
+        $this->strongAllEdges = FFIHelper::newInt32Array(1);
     }
 
     /**
@@ -2413,8 +2435,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
             foreach ($scc_indices as $idx) {
                 $this->ffiNodeToScc[$idx] = $scc_id;
-                $total_size += (int)$this->ffiNodeSizes[$idx];
-                $classId = (int)$this->nodeClassIds[$idx];
+                $total_size += $this->ffiNodeSizes[$idx];
+                $classId = $this->nodeClassIds[$idx];
                 if ($classId >= 0) {
                     $cls = $this->classDict[$classId];
                     $class_counts[$cls] = ($class_counts[$cls] ?? 0) + 1;
@@ -2426,10 +2448,10 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $ext_out = 0;
             foreach ($scc_indices as $idx) {
                 // Reverse edges (parents) — revEdges holds CSR indices.
-                $rStart = (int)$this->revOffsets[$idx];
-                $rEnd = (int)$this->revOffsets[$idx + 1];
+                $rStart = $this->revOffsets[$idx];
+                $rEnd = $this->revOffsets[$idx + 1];
                 for ($j = $rStart; $j < $rEnd; $j++) {
-                    $parentIdx = (int)$this->revEdges[$j];
+                    $parentIdx = $this->revEdges[$j];
                     if ($parentIdx === $rootParentIdx) {
                         continue;
                     }
@@ -2438,10 +2460,10 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     }
                 }
                 // Forward edges (all children)
-                $fStart = (int)$this->allOffsets[$idx];
-                $fEnd = (int)$this->allOffsets[$idx + 1];
+                $fStart = $this->allOffsets[$idx];
+                $fEnd = $this->allOffsets[$idx + 1];
                 for ($j = $fStart; $j < $fEnd; $j++) {
-                    $childIdx = (int)$this->allEdges[$j];
+                    $childIdx = $this->allEdges[$j];
                     if (!isset($scc_set[$childIdx])) {
                         $ext_out++;
                     }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -109,7 +109,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     // Direct-indexed nodeToIndex: nodeToIndexDirect[node_id + 1] = CSR index
     // (offset by 1 to handle -1 sentinel at slot 0)
     // If node_ids are too sparse, falls back to PHP array.
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $nodeToIndexDirect = null;
     private int $directIndexOffset = 1; // node_id + offset → array index
     private int $directIndexSize = 0;   // size of nodeToIndexDirect array
@@ -144,9 +144,9 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private array $linkDict = [];
     /** @var array<string, int> link_name → link_id */
     private array $linkDictReverse = [];
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $treeLinkIds = null;     // int32_t[nodeCount], -1 = no tree edge
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $treeParentIdx = null;   // int32_t[nodeCount], -1 = no tree parent
 
     // Per-node context type ("PhpReferenceContext", etc.). Same shape
@@ -155,7 +155,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     private array $nodeTypeDict = [];
     /** @var array<string, int> type name → type_id */
     private array $nodeTypeDictReverse = [];
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $nodeTypeIds = null;     // int16_t[nodeCount], -1 = unknown
 
     private bool $subtreeSizesComputed = false;
@@ -165,11 +165,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
     // canonIdxFfi[csrIdx] = canonical csrIdx (self for unique nodes).
     // origOffsets + origData form a CSR: originals of canon c are
     // origData[origOffsets[c]..origOffsets[c+1]].
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $canonIdxFfi = null;
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $origOffsets = null;
-    /** @var \FFI\CArray<int> */
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $origData = null;
 
     /**
@@ -860,7 +860,13 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         unset($strongTreeDeg, $stPos);
 
-        // Read nontree CSR
+        // Read nontree CSR. Hoist the data variables out of the guard so
+        // the later `if (nontreeEdgeCount > 0)` block can use them without
+        // tripping a definitely-defined check; nontreeEdgeCount > 0
+        // implies hasSection() was true, so the empty defaults never reach
+        // the FFI::memcpy calls below.
+        $ntRowPtrData = '';
+        $ntColIdxData = '';
         $nontreeEdgeCount = 0;
         if ($reader->hasSection('ntcsr_rowptr')) {
             $ntRowPtrData = $reader->getSectionData('ntcsr_rowptr');

--- a/src/Lib/ByteStream/CDataByteReader.php
+++ b/src/Lib/ByteStream/CDataByteReader.php
@@ -51,9 +51,7 @@ final class CDataByteReader implements ByteReaderInterface
     {
         $result = '';
         for ($i = $offset, $last_offset = $offset + $size; $i < $last_offset; $i++) {
-            $value = $this->source[$i];
-            assert(is_int($value));
-            $result .= chr($value);
+            $result .= chr($this->source[$i]);
         }
         return $result;
     }

--- a/src/Lib/FFI/FFIHelper.php
+++ b/src/Lib/FFI/FFIHelper.php
@@ -63,6 +63,69 @@ final class FFIHelper
     }
 
     /**
+     * Allocate a fixed-size FFI integer array, typed for Psalm so element
+     * access does not need a per-call `(int)` cast. The underlying C type
+     * (`int8_t` / `int32_t` / `int64_t` etc.) determines the storage but
+     * not the PHP-visible element type — every fixed-width integer field
+     * surfaces in PHP as a plain `int` via FFI's automatic conversion, so
+     * `\FFI\CArray<int>` is a faithful PHP-side type.
+     *
+     * The PHP return-type declaration is `\FFI\CData` — the runtime class
+     * is `\FFI\CData` regardless of the C type, and `\FFI\CArray` only
+     * exists as a project-side Psalm stub. The `@return` docblock carries
+     * the templated type for Psalm so callers see int-typed elements.
+     *
+     * Hot-path callers (BinaryMemoryOutput's CSR build, FfiIntSet's
+     * open-addressing slots) use these instead of `FFIHelper::new(...)`
+     * to keep the array element type from collapsing to the wider
+     * `CData|int|float|bool|null|string` union the upstream stub gives
+     * `CData::offsetGet()`.
+     *
+     * @return \FFI\CArray<int>
+     */
+    public static function newInt8Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("int8_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newInt16Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("int16_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newInt32Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("int32_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newInt64Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("int64_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newUint8Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("uint8_t[{$count}]");
+    }
+
+    /**
      * Cast a C pointer to its integer address value.
      *
      * WARNING: Do NOT pass a void* CData to this method. PHP FFI internally

--- a/src/Lib/FFI/FFIHelper.php
+++ b/src/Lib/FFI/FFIHelper.php
@@ -153,6 +153,39 @@ final class FFIHelper
     }
 
     /**
+     * Cast a CData pointer to an `int*` (a `\FFI\CInteger`-shaped view).
+     * Typed wrapper around `cast('int', …)` so callers reading `->cdata`
+     * get a plain int back instead of mixed.
+     *
+     * The PHP-level return type stays `\FFI\CData` because `\FFI\CInteger`
+     * is a project-side Psalm stub (see tools/stubs/ffi/scalar.php), not
+     * a runtime class — declaring it on the signature raises TypeError
+     * the same way `\FFI\CArray` does. The `@return` docblock carries
+     * the narrowed type for Psalm.
+     *
+     * @param CData|CInteger|CPointer $ptr
+     * @return CInteger
+     */
+    public static function castToInt(CData &$ptr): CData
+    {
+        /** @var CInteger */
+        return self::cast('int', $ptr);
+    }
+
+    /**
+     * Cast a CData pointer to a `long*` view. Same role as castToInt
+     * but for the wider integer width some stubbed structs declare.
+     *
+     * @param CData|CInteger|CPointer $ptr
+     * @return CInteger
+     */
+    public static function castToLong(CData &$ptr): CData
+    {
+        /** @var CInteger */
+        return self::cast('long', $ptr);
+    }
+
+    /**
      * Cast a C pointer to its integer address value.
      *
      * WARNING: Do NOT pass a void* CData to this method. PHP FFI internally

--- a/src/Lib/FFI/FFIHelper.php
+++ b/src/Lib/FFI/FFIHelper.php
@@ -126,6 +126,33 @@ final class FFIHelper
     }
 
     /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newUint16Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("uint16_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newUint32Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("uint32_t[{$count}]");
+    }
+
+    /**
+     * @return \FFI\CArray<int>
+     */
+    public static function newUint64Array(int $count): \FFI\CData
+    {
+        /** @var \FFI\CArray<int> */
+        return self::new("uint64_t[{$count}]");
+    }
+
+    /**
      * Cast a C pointer to its integer address value.
      *
      * WARNING: Do NOT pass a void* CData to this method. PHP FFI internally

--- a/src/Lib/PhpInternals/Types/Zend/ZendOp.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOp.php
@@ -102,15 +102,13 @@ final class ZendOp implements LazyDereferencable, CDataDereferencable
         };
     }
 
-    /** @psalm-suppress PropertyTypeCoercion -- CData from FFIHelper::cast is always valid */
     private function getFieldEager(string $field_name): mixed
     {
         assert($this->casted_cdata !== null);
         return match ($field_name) {
-            'op1' => $this->op1 = FFIHelper::cast('int', $this->casted_cdata->casted->op1)->cdata,
-            'op2' => $this->op2 = FFIHelper::cast('int', $this->casted_cdata->casted->op2)->cdata,
-            'result' => $this->result = FFIHelper::cast(
-                'int',
+            'op1' => $this->op1 = FFIHelper::castToInt($this->casted_cdata->casted->op1)->cdata,
+            'op2' => $this->op2 = FFIHelper::castToInt($this->casted_cdata->casted->op2)->cdata,
+            'result' => $this->result = FFIHelper::castToInt(
                 $this->casted_cdata->casted->result
             )->cdata,
             'op1_type' => $this->op1_type = $this->casted_cdata->casted->op1_type,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -554,7 +554,7 @@ final class BinaryContextTreeSink implements ContextTreeSink
         // match and silently leaves every per-node class id as NULL on
         // disk — see `docs/internals/memory-report-t2-3-investigation.md`
         // for the failure trail this caused on the binary report path.
-        $new_classes = \Reli\Lib\FFI\FFIHelper::new("uint32_t[{$new_cap}]");
+        $new_classes = \Reli\Lib\FFI\FFIHelper::newUint32Array($new_cap);
         // Initialize new class slots to NULL_STRING_ID
         for ($i = 0; $i < $new_cap; $i++) {
             $new_classes[$i] = Format::NULL_STRING_ID;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -533,6 +533,10 @@ final class BinaryContextTreeSink implements ContextTreeSink
         }
     }
 
+    /**
+     * @psalm-assert !null $this->perNodeSizes
+     * @psalm-assert !null $this->perNodeClasses
+     */
     private function ensurePerNodeCapacity(int $node_id): void
     {
         if ($node_id > $this->maxNodeId) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -95,7 +95,9 @@ final class BinaryContextTreeSink implements ContextTreeSink
 
     // Per-node size/class accumulators for on-disk sections.
     // FFI int64/int32 arrays, grown as needed.
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $perNodeSizes = null;
+    /** @var \FFI\CArray<int>|null */
     private ?\FFI\CData $perNodeClasses = null;
     private int $perNodeCapacity = 0;
     private int $maxNodeId = -1;
@@ -283,16 +285,14 @@ final class BinaryContextTreeSink implements ContextTreeSink
             }
 
             // Accumulate per-node sizes and classes for on-disk sections.
-            // `(int)` on the FFI int64_t/int32_t reads here is deliberate —
-            // emitNode() is called per location during analysis, so a
-            // PhpCast\Cast::toInt() method dispatch on every iteration
-            // would show up. Element type is provably int at runtime;
-            // the InvalidCast entries are kept in psalm-baseline.xml.
+            // perNodeSizes / perNodeClasses are typed \FFI\CArray<int> via
+            // their property docblocks, so the array reads return int with
+            // no per-iteration Cast::toInt() dispatch.
             $this->ensurePerNodeCapacity($node_id);
-            $this->perNodeSizes[$node_id] = (int)$this->perNodeSizes[$node_id] + $location->size;
+            $this->perNodeSizes[$node_id] = $this->perNodeSizes[$node_id] + $location->size;
             if (
                 $class_id !== Format::NULL_STRING_ID
-                && (int)$this->perNodeClasses[$node_id] === (int)Format::NULL_STRING_ID
+                && $this->perNodeClasses[$node_id] === Format::NULL_STRING_ID
             ) {
                 $this->perNodeClasses[$node_id] = $class_id;
             }
@@ -545,7 +545,7 @@ final class BinaryContextTreeSink implements ContextTreeSink
         while ($new_cap <= $node_id) {
             $new_cap *= 2;
         }
-        $new_sizes = \Reli\Lib\FFI\FFIHelper::new("int64_t[{$new_cap}]");
+        $new_sizes = \Reli\Lib\FFI\FFIHelper::newInt64Array($new_cap);
         // Class slots hold string-dict IDs (unsigned 32-bit, with
         // Format::NULL_STRING_ID = 0xFFFFFFFF reserved for "unset").
         // `uint32_t` is the right type for that representation: a
@@ -611,7 +611,7 @@ final class BinaryContextTreeSink implements ContextTreeSink
         }
 
         $slots = $this->maxNodeId + 1;
-        $map = \Reli\Lib\FFI\FFIHelper::new("int32_t[{$slots}]");
+        $map = \Reli\Lib\FFI\FFIHelper::newInt32Array($slots);
         for ($i = 0; $i < $slots; $i++) {
             $map[$i] = -1;
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
@@ -25,12 +25,11 @@ use Reli\Lib\FFI\FFIHelper;
  * Uses 0 as empty sentinel (no valid memory address is 0).
  * Linear probing with 75% max load factor, grows 2x.
  *
- * The `(int)` casts on `$this->slots[...]` are deliberate: add()/has()
- * are called per memory location during analysis (millions of ops),
- * and the FFI int64_t[] element type is provably int at runtime.
- * PhpCast\Cast::toInt() would be safer in principle but its per-call
- * method dispatch is measurable here. The resulting InvalidCast entries
- * stay in psalm-baseline.xml on purpose.
+ * `$slots` is allocated through `FFIHelper::newInt64Array()`, whose
+ * docblock preserves `\FFI\CArray<int>` for Psalm. Element reads are
+ * therefore typed as int without per-call `Cast::toInt()` dispatch or
+ * hot-path `(int)` casts — important because add()/has() run per
+ * memory location during analysis (millions of ops).
  */
 final class FfiIntSet
 {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/FfiIntSet.php
@@ -34,6 +34,7 @@ use Reli\Lib\FFI\FFIHelper;
  */
 final class FfiIntSet
 {
+    /** @var \FFI\CArray<int> */
     private \FFI\CData $slots;
     private int $capacity;
     private int $mask;
@@ -63,7 +64,7 @@ final class FfiIntSet
 
         $slot = $this->hash($key) & $this->mask;
         while (true) {
-            $stored = (int)$this->slots[$slot];
+            $stored = $this->slots[$slot];
             if ($stored === 0) {
                 $this->slots[$slot] = $key;
                 $this->count++;
@@ -83,7 +84,7 @@ final class FfiIntSet
         }
         $slot = $this->hash($key) & $this->mask;
         while (true) {
-            $stored = (int)$this->slots[$slot];
+            $stored = $this->slots[$slot];
             if ($stored === 0) {
                 return false;
             }
@@ -118,7 +119,7 @@ final class FfiIntSet
         $this->capacity = $capacity;
         $this->mask = $capacity - 1;
         $this->grow_threshold = (int)($capacity * self::MAX_LOAD_FACTOR);
-        $this->slots = FFIHelper::new("int64_t[{$capacity}]");
+        $this->slots = FFIHelper::newInt64Array($capacity);
         // FFI::new uses calloc semantics — slots are zero-initialized
     }
 
@@ -131,7 +132,7 @@ final class FfiIntSet
         $this->count = 0;
 
         for ($i = 0; $i < $old_cap; $i++) {
-            $key = (int)$old_slots[$i];
+            $key = $old_slots[$i];
             if ($key !== 0) {
                 $this->add($key);
             }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -194,11 +194,11 @@ final class MemoryLocationsCollector
             // a float without tripping Psalm's strict int/float operand
             // check (see psalm-058). Cold diagnostic path, called at most
             // once per analyze run.
-            $walked_mb = number_format(Cast::toFloat($walked_chunk_bytes) / 1024 / 1024, 1);
-            $cached_mb = number_format(Cast::toFloat($cached_chunks_size) / 1024 / 1024, 1);
-            $huge_mb = number_format(Cast::toFloat($huge_total_bytes) / 1024 / 1024, 1);
-            $captured_mb = number_format(Cast::toFloat($captured_bytes) / 1024 / 1024, 1);
-            $real_mb = number_format(Cast::toFloat($memory_get_usage_real_size) / 1024 / 1024, 1);
+            $walked_mb = number_format(Cast::toFloat($walked_chunk_bytes) / 1024.0 / 1024.0, 1);
+            $cached_mb = number_format(Cast::toFloat($cached_chunks_size) / 1024.0 / 1024.0, 1);
+            $huge_mb = number_format(Cast::toFloat($huge_total_bytes) / 1024.0 / 1024.0, 1);
+            $captured_mb = number_format(Cast::toFloat($captured_bytes) / 1024.0 / 1024.0, 1);
+            $real_mb = number_format(Cast::toFloat($memory_get_usage_real_size) / 1024.0 / 1024.0, 1);
             fwrite(STDERR, "WARNING: ZendMM chunk walk incomplete — captured {$captured_mb} MB"
                 . " ({$walked_mb} MB in {$walked_chunk_count} chunks"
                 . " + {$cached_mb} MB cached + {$huge_mb} MB huge),"

--- a/src/Rmem/Explore/RmemExploreTui.php
+++ b/src/Rmem/Explore/RmemExploreTui.php
@@ -24,17 +24,51 @@ use Reli\Rbt\Explore\TerminalInterface;
  * Modes:
  * - List: flat list (roots or TopN retained)
  * - Sandwich: parents | focus | children (3-pane)
+ *
+ * @psalm-type Row = array{
+ *     node_id: int,
+ *     retained: int,
+ *     shallow: int,
+ *     label: string,
+ *     link_name?: string|null,
+ *     _class?: string,
+ *     _type?: string,
+ *     _count?: int,
+ *     _scc_id?: int,
+ *     _scc_nodes?: list<int>,
+ *     match_field?: string,
+ * }
  */
 final class RmemExploreTui
 {
     private bool $running = false;
 
     // ---- List mode state ----
-    /** @var list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}> */
+    /**
+     * Rows currently shown in the list pane. The shape is the union of
+     * fields used across all `listMode` values — see the class-level
+     * `@psalm-type Row` for the full layout.
+     *
+     * @var list<Row>
+     */
     private array $rows = [];
     private int $selected = 0;
     private int $topRow = 0;
-    /** @var list<array<string, mixed>> focus stack for list drill-down */
+    /**
+     * Focus stack for list drill-down. Currently never pushed to in
+     * this codebase (the back-from-drill-down branch reads from it but
+     * no path appends), but the typed shape lets the read-side narrow
+     * `array_pop()`'s return so the destructure in goBack() doesn't
+     * widen $this->focusNodeId / focusLabel / topRow / selected to
+     * mixed via array<string, mixed>.
+     *
+     * @var list<array{
+     *     node_id: int,
+     *     label: string,
+     *     selected?: int,
+     *     topRow?: int,
+     * }>
+     */
     private array $focusStack = [];
     private ?int $focusNodeId = null;
     private string $focusLabel = 'Roots';
@@ -43,9 +77,9 @@ final class RmemExploreTui
     private bool $sandwich = false;
     private int $sandwichNodeId = 0;
     private string $sandwichLabel = '';
-    /** @var list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}> */
+    /** @var list<Row> */
     private array $parentRows = [];
-    /** @var list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}> */
+    /** @var list<Row> */
     private array $childRows = [];
     private int $parentSelected = 0;
     private int $parentTopRow = 0;
@@ -126,7 +160,7 @@ final class RmemExploreTui
     private string $addrInput = '';
     private bool $searchPrompt = false;
     private string $searchInput = '';
-    /** @var list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}> */
+    /** @var list<Row> */
     private array $unfilteredRows = [];
     private bool $allEdges = true;
     /** 'retained' | 'link' */
@@ -138,6 +172,7 @@ final class RmemExploreTui
 
     private int $spinnerFrame = 0;
     private string $lastRendered = '';
+    /** @var list<string> */
     private static array $SPINNER = ['⠋','⠙','⠹','⠸','⠼','⠴','⠦','⠧','⠇','⠏'];
     private ?int $queryChildPid = null;
     private ?int $sccBuilderPid = null;
@@ -1188,13 +1223,13 @@ final class RmemExploreTui
      *     sandwichNodeId: int,
      *     sandwichLabel: string,
      *     sandwichHistory: list<array{node_id: int, label: string, pane: string}>,
-     *     rows: list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}>,
+     *     rows: list<Row>,
      *     selected: int,
      *     topRow: int,
      *     focusLabel: string,
      *     listMode: 'normal'|'class_ranking'|'type_ranking'|'class_instances'|'type_instances'|'scc_members',
-     *     parentRows: list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}>,
-     *     childRows: list<array{node_id: int, retained: int, shallow: int, label: string, link_name?: string}>,
+     *     parentRows: list<Row>,
+     *     childRows: list<Row>,
      *     activePane: string,
      * }|null
      */
@@ -1784,7 +1819,9 @@ final class RmemExploreTui
         $sidebarW = 0;
         $sidebarLines = [];
         if ($this->showSidebar && $cols > 80) {
-            $sidebarW = min(40, (int)($cols * 0.3));
+            // intdiv with denominator 10 keeps both operands int (avoids
+            // psalm-058 strict int/float operand check).
+            $sidebarW = min(40, intdiv($cols * 3, 10));
             if ($focusId !== null) {
                 $allSidebarLines = $this->buildSidebarLines($focusId, $sidebarW, $rows + $this->sidebarScroll);
                 // Apply scroll


### PR DESCRIPTION
Continuation of the Psalm baseline cleanup series (#712 → #713 → #714 → #718 → #723). Goal: drive `psalm-baseline.xml` to zero.

After absorbing #727 and #728 into this branch, the full scope is:

## 1. Typed FFI int-array helpers (the InvalidCast root cause)

The 20+ `InvalidCast` entries kept in `psalm-baseline.xml` as "deliberate hot-path tradeoff" all stemmed from one cause: when `FFIHelper::new("int32_t[N]")` returns plain `\FFI\CData`, Psalm widens its `offsetGet` to `CData|null|scalar` and every `\$arr[\$i]` read either takes a `Cast::toInt()` method dispatch (slow on hot loops) or stays a baselined `(int)` cast (silently widens type errors).

Add typed wrappers in `FFIHelper`:

```php
public static function newInt8Array(int \$count):  \FFI\CData; // @return \FFI\CArray<int>
public static function newInt16Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newInt32Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newInt64Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newUint8Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newUint16Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newUint32Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function newUint64Array(int \$count): \FFI\CData; // @return \FFI\CArray<int>
public static function castToInt(\FFI\CData &\$ptr):  \FFI\CData; // @return \FFI\CInteger
public static function castToLong(\FFI\CData &\$ptr): \FFI\CData; // @return \FFI\CInteger
```

The PHP-level return type stays `\FFI\CData` because **`\FFI\CArray` and `\FFI\CInteger` are project-side Psalm stubs, not real PHP classes** — declaring them on the method signature raises `TypeError` at runtime (caught early by `BinaryFormatRoundTripTest`). The `@return …` docblock alone is enough for Psalm to track the templated element type through the call chain.

For the long-lived FFI buffers stored on `\FFI\CData` properties (`FfiIntSet::\$slots`, `FfiCsrGraphSubstrate`'s 22 CSR / canonical / per-node arrays, `BinaryContextTreeSink`'s perNode buffers, `FfiHashTable`'s parallel arrays), add a matching `@var \FFI\CArray<int>[|null]` docblock above each property declaration. Without it the templated type gets erased on the property assignment and `\$this->prop[\$i]` falls back to the wide stub union.

### Effect

- **`BinaryMemoryOutput`**: 15 `InvalidCast` and 8 `buildCsrSections` comments dropped — element reads type as int and the `(int)` casts are gone outright (not just baselined). The per-edge / per-node loops are bare assignments. `@psalm-suppress PossiblyInvalidArrayAccess` on `buildCsrSections()` becomes unnecessary.
- **`FfiCsrGraphSubstrate`**: 251 redundant `(int)` casts stripped via a baseline-driven cleanup script. The hot Tarjan / SCC / Phase walker code is now `\$active[\$v] = 1;` etc. instead of `(int)\$active[\$v] === 1`.
- **`FfiIntSet`, `BinaryContextTreeSink`, `BinaryReportDataProvider`, `FfiHashTable`**: same pattern, smaller scale.

## 2. RmemExploreTui Row shape + focusStack

`RmemExploreTui` populates `\$rows` / `\$parentRows` / `\$childRows` / `\$unfilteredRows` / the saved `preSccState['rows']` with a per-row dictionary that varies by `listMode`:
- normal browsing: `node_id, retained, shallow, label, link_name?`
- class_ranking: same + `_class`, `_count`
- type_ranking: same + `_type`, `_count`
- scc_members: same + `_scc_id`, `_scc_nodes`
- search results: same + `match_field`

The previous shape was the narrow base form, which Psalm rejected at the mode-specific assignment sites — that ate 9 baseline entries on `InvalidPropertyAssignmentValue` plus another ~12 `MixedAssignment` cascading from `\$row['_class']` / `\$row['_scc_nodes']` accesses. Extract a single `@psalm-type Row = array{…all optional fields…}` at the class level and reference it as `@var list<Row>` from every row property and from the nested `preSccState` shape.

Other RmemExploreTui cleanups:
- **`focusStack`** docblock was `array<string, mixed>` so every `array_pop()`-and-destructure widened `\$this->focusNodeId` / `focusLabel` / `selected` / `topRow` to mixed at the read site. Tighten to `array{node_id: int, label: string, selected?: int, topRow?: int}`. (Side observation: nothing in the file actually pushes to `focusStack` — the goBack-from-drill-down branch is currently unreachable in normal flow — but the read site still needs a narrow type to be honest.)
- **`private static array \$SPINNER`** got `@var list<string>` so the status-line `…SPINNER[\$this->spinnerFrame]…` concatenation no longer reads element values as mixed.
- **`\$cols * 0.3`** for the sidebar width tripped Psalm's strict int/float operand check; replace with `intdiv(\$cols * 3, 10)`.

## 3. `\FFI\CArray<T>` propagation through more API boundaries

- **`BinaryReportDataProvider::buildNodeMeta()`** and the LocationRow consumers: `locRows` is now `\FFI\CArray<\FFI\PhpInternals\LocationRow>|null` and `locIndex` is `\FFI\CArray<int>|null`, so `\$locRows[\$li]->location_type_id` etc. carry the right shape from the call site through the helper. Drops the `InvalidPropertyFetch` / `PossiblyNullPropertyFetch` / `UndefinedPropertyFetch` trio at every field read.
- **`DerivedCacheReader::loadInt32Section()`** / **`loadInt64Section()`**: `@return \FFI\CArray<int>|null`. The substrate's `\$sccBuf` / `\$subtreeBuf` locals then assign into the typed `\$ffiSubtreeSizes` / `\$ffiNodeToScc` properties without `PropertyTypeCoercion`.
- **`BinaryContextTreeSink::ensurePerNodeCapacity()`**: `@psalm-assert !null \$this->perNodeSizes` / `\$this->perNodeClasses`. The method always sets both before returning; the assert just encodes that contract for Psalm.
- **`FfiCsrGraphSubstrate`**'s seven nullable `?\FFI\CData` properties: an earlier bulk pass typed them `@var \FFI\CArray<int>` (non-nullable) while the property declaration is nullable. Fix to `\FFI\CArray<int>|null` so the local copies retain narrowing.
- **Nontree-CSR loader**: hoist `\$ntRowPtrData` / `\$ntColIdxData` out of the `hasSection()` guard with empty defaults. Psalm couldn't link the second `if (\$nontreeEdgeCount > 0)` block back to the first guard, so the `FFI::memcpy` calls were flagged `MixedArgument`.

## 4. Misc fixes en route to zero

- **`CDataByteReader::createSliceAsString()`**: drop the `assert(is_int())` that was redundant given `@param CArray<int> \$source`.
- **`DerivedCacheWriter::create()`**: `getmypid()` returns `int|false` and tripped `InvalidOperand` / `PossiblyFalseOperand` on the temp-path concat; use `(getmypid() ?: 0)`.
- **`DerivedCacheWriter::__construct()`**: hoist the `mixed \$fh` parameter's `/** @var resource */` to a method-level `@param resource \$fh` (Psalm did not pick the inline annotation up).
- **`DerivedCacheWriter`** fclose() sites: move the handle into a local before `fclose()` so Psalm doesn't see `\$this->fh` transit through `closed-resource`.
- **`DerivedCacheReader::__destruct()`**: keep the runtime `is_resource()` guard (PHP keeps the value as `closed-resource` after fclose; `is_resource()` returns false for that). Narrow `@psalm-suppress RedundantConditionGivenDocblockType` rather than declaring `resource|closed-resource` on the property — that would cascade `PossiblyInvalidArgument` across every fseek/fread call.
- **`BinaryReportDataProvider::getDedupCandidateStats…()`**: annotate the `\$coarse` and `\$groups` accumulators with `array<string, array{…}>` shapes so `\$info['ref_count']` / `count(\$group['seen_children'])` type as `int` instead of Psalm's narrow-to-literal-zero from the `'ref_count' => 0` / empty-array initializers.
- **`MemoryLocationsCollector`** byte→MB diagnostic divisions: convert each numerator with `Cast::toFloat()` and divide by `1024.0` so the whole expression is float (Psalm's strict int/float operand check also balks on `float / int`). Cold path.
- **`BinaryMemoryOutput`**: the per-node-sizes / per-node-classes / canonical-map block had `\$nodeSlots` defined inside one `if (\$maxNodeId >= 0)` and used inside a separate `if (\$maxNodeId >= 0)`. Psalm couldn't carry the narrowing across the second guard. Merge them.
- **`FFIHelper::cast()`**: drop the unused `@template T of CData` (the return type is plain CData; the template was never applied).

## Numbers

|  | before this PR | after |
|---|---:|---:|
| baseline `<code>` entries | 153 | 72 |
| Psalm errors | 0 | 0 |

Cumulative across the cleanup series (#712 → … → #728): **1023 → 72, 93 % reduction**.

`findUnusedBaselineEntry=true` (set in #712) keeps the surviving entries honest — any future fix that obviates a baseline line will surface as `UnusedBaselineEntry`.

## What's left in the baseline

The 72 entries that remain skew toward "structural refactor required":
- **`RmemMcpCommand`** (4 MixedAssignment) — JSON-decoded mixed; needs an MCP request DTO
- **`RmemExploreTui`** (~19) — remaining mixed/`array<string, mixed>` corners; needs further state-shape work
- **`AnalyzeCommand`** (5) — rbt CLI argument propagation
- **`ZendOp`** (3 `PropertyTypeCoercion`) — `CData &\$ptr` reference invariance, Psalm-internal
- **various 1-2 entry sites** — small one-offs

Those are good candidates for follow-up PRs but each pulls in non-trivial scope, so this PR stops here.

## Test plan

- [x] `psalm` — 0 errors
- [x] `phpcs --standard=PSR12 -n` — clean
- [x] `phpunit tests/Inspector/Output tests/Lib/PhpProcessReader/PhpMemoryReader tests/Rmem` — all touched paths pass; remaining errors are pre-existing sandbox / docker integration failures (per CLAUDE.md "Sandbox-only ptrace failures" + "Known flaky integration tests")
- [x] `phpunit tests/Inspector/Output/MemoryOutput/BinaryFormat` — 32/32 (catches the runtime-type-erasure bug from a first attempt that declared `\FFI\CArray` as the runtime return type)
- [x] dogfooding profile on a 134 MB `.rmem` snapshot — `Cast::toInt` is 0.09 % of CPU time, walltime equal to baseline within noise
- [ ] CI green on the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)