### PR TITLE
Add Docker image publishing workflow and simplify release process

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,26 +1,44 @@
 name: Publish Docker image
 
-# Triggered by the tag push that laminas/automatic-releases performs after a
-# milestone close (see release-on-milestone-closed.yml). Tags are bare semver
-# strings like `0.12.0`, no `v` prefix.
+# Three trigger shapes, three tag shapes:
+#
+#   1. Tag push (e.g. `0.12.0`, set by laminas/automatic-releases on milestone
+#      close). Stable release. Pushes `:0.12.0`, `:0.12`, and `:latest`.
+#      Pre-release tags like `0.12.0-rc1` skip `:latest` and `:0.12`.
+#
+#   2. Push to a release branch matching `[0-9]+.[0-9]+.x` (e.g. `0.12.x`).
+#      Floating dev image. Pushes `:0.12.x-dev` so users can try
+#      not-yet-tagged fixes from the active release line. Never touches
+#      `:latest`.
+#
+#   3. Manual `workflow_dispatch` for any ref (PR branch, feature branch,
+#      SHA). Pushes a SHA-pinned `:manual-sha-<short>` tag — no floating
+#      tags, so PR / experimental builds never overwrite anything stable.
+#      Use this to share a one-off image of a PR with a reviewer or to
+#      reproduce a specific commit's behaviour.
 #
 # Required repo secrets:
 #   DOCKERHUB_USERNAME — Docker Hub account with push access to reliforp/reli-prof
 #   DOCKERHUB_TOKEN    — PAT scoped to that repo
 #
-# `latest` is moved on every stable tag. Pre-release tags (e.g. 0.12.0-rc1)
-# get only their version-specific tags; metadata-action's semver patterns
-# already exclude them from the `latest` / `MAJOR.MINOR` floating tags.
+# Note on `composer install --no-dev` and version reporting: the Dockerfile
+# bakes the source via `COPY . .` and runs composer at build time, so
+# `InstalledVersions::getPrettyVersion()` reflects whatever ref was checked
+# out. Tag builds report the proper semver; branch / dispatch builds report
+# `dev-<branch>` or a commit hash, which is the correct "this is a dev
+# build" signal — don't try to fake the version.
 
 on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
+    branches:
+      - '[0-9]+.[0-9]+.x'
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Existing git tag to (re)publish (e.g. 0.12.0)"
+      ref:
+        description: "Git ref to build (branch name, tag, or full SHA). For PRs, use the head branch name."
         required: true
 
 jobs:
@@ -33,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -52,11 +70,19 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: reliforp/reli-prof
+          # Disable the implicit `:latest` flavor; we add it explicitly
+          # under the right conditions below.
+          flavor: |
+            latest=false
           tags: |
+            # --- Trigger 1: stable tag push -------------------------------
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
+            # --- Trigger 2: release-branch dev push -----------------------
+            type=raw,value=${{ github.ref_name }}-dev,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') }}
+            # --- Trigger 3: manual dispatch (SHA-pinned) ------------------
+            type=sha,prefix=manual-sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -73,5 +99,5 @@ jobs:
       - name: Verify version reported by image
         run: |
           docker run --rm --pull=always \
-            "reliforp/reli-prof:${{ github.event.inputs.tag || github.ref_name }}" \
+            "reliforp/reli-prof:${{ steps.meta.outputs.version }}" \
             --version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Publish Docker image
+
+# Triggered by the tag push that laminas/automatic-releases performs after a
+# milestone close (see release-on-milestone-closed.yml). Tags are bare semver
+# strings like `0.12.0`, no `v` prefix.
+#
+# Required repo secrets:
+#   DOCKERHUB_USERNAME — Docker Hub account with push access to reliforp/reli-prof
+#   DOCKERHUB_TOKEN    — PAT scoped to that repo
+#
+# `latest` is moved on every stable tag. Pre-release tags (e.g. 0.12.0-rc1)
+# get only their version-specific tags; metadata-action's semver patterns
+# already exclude them from the `latest` / `MAJOR.MINOR` floating tags.
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to (re)publish (e.g. 0.12.0)"
+        required: true
+
+jobs:
+  publish:
+    name: Build and push reliforp/reli-prof
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: reliforp/reli-prof
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-publish
+          cache-to: type=gha,mode=max,scope=docker-publish
+
+      - name: Verify version reported by image
+        run: |
+          docker run --rm --pull=always \
+            "reliforp/reli-prof:${{ github.event.inputs.tag || github.ref_name }}" \
+            --version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,12 +21,13 @@ name: Publish Docker image
 #   DOCKERHUB_USERNAME — Docker Hub account with push access to reliforp/reli-prof
 #   DOCKERHUB_TOKEN    — PAT scoped to that repo
 #
-# Note on `composer install --no-dev` and version reporting: the Dockerfile
-# bakes the source via `COPY . .` and runs composer at build time, so
-# `InstalledVersions::getPrettyVersion()` reflects whatever ref was checked
-# out. Tag builds report the proper semver; branch / dispatch builds report
-# `dev-<branch>` or a commit hash, which is the correct "this is a dev
-# build" signal — don't try to fake the version.
+# Why we inject COMPOSER_ROOT_VERSION as a build arg: `.git` is in
+# `.dockerignore` and `composer.json` has no `version` field, so without
+# external help Composer can't infer the root package version inside the
+# build and falls back to `1.0.0+no-version-set`, which makes
+# `reli --version` lie. We compute the right Composer version per trigger
+# (semver tag for stable, `<branch>-dev` alias for floating release-branch
+# builds, `dev-manual-<sha>` for dispatch) and pass it through.
 
 on:
   push:
@@ -52,6 +53,43 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          # metadata-action's `context: git` and our own `git rev-parse`
+          # need the full ref objects, not the shallow default.
+          fetch-depth: 0
+
+      - name: Compute version metadata
+        id: ver
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short HEAD)"
+          case "${{ github.event_name }}" in
+            push)
+              if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+                composer_version="${GITHUB_REF_NAME}"
+              else
+                # Release branch like `0.12.x` becomes the Composer dev
+                # alias `0.12.x-dev`, which is exactly what
+                # `getPrettyVersion` returns when checking out the branch
+                # locally with `.git` available.
+                composer_version="${GITHUB_REF_NAME}-dev"
+              fi
+              ;;
+            workflow_dispatch)
+              # `dev-<branch>` is Composer's canonical "this is a dev
+              # build of branch <branch>" form. `manual-<sha>` as the
+              # synthetic branch name keeps the Docker tag and the
+              # Composer version visibly correlated.
+              composer_version="dev-manual-${short_sha}"
+              ;;
+            *)
+              echo "unsupported event: ${{ github.event_name }}" >&2
+              exit 1
+              ;;
+          esac
+          echo "composer=${composer_version}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "Composer root version: ${composer_version}"
+          echo "Short SHA: ${short_sha}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -67,7 +105,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: reliforp/reli-prof
           # Disable the implicit `:latest` flavor; we add it explicitly
@@ -81,8 +119,9 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
             # --- Trigger 2: release-branch dev push -----------------------
             type=raw,value=${{ github.ref_name }}-dev,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') }}
-            # --- Trigger 3: manual dispatch (SHA-pinned) ------------------
-            type=sha,prefix=manual-sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
+            # --- Trigger 3: manual dispatch (SHA-pinned, sourced from the
+            # actually-checked-out HEAD, not the workflow trigger ref) ----
+            type=raw,value=manual-sha-${{ steps.ver.outputs.short_sha }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -91,6 +130,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            COMPOSER_ROOT_VERSION=${{ steps.ver.outputs.composer }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docker-publish
@@ -98,6 +139,17 @@ jobs:
 
       - name: Verify version reported by image
         run: |
-          docker run --rm --pull=always \
-            "reliforp/reli-prof:${{ steps.meta.outputs.version }}" \
-            --version
+          set -euo pipefail
+          expected='${{ steps.ver.outputs.composer }}'
+          image="reliforp/reli-prof:${{ steps.meta.outputs.version }}"
+          out="$(docker run --rm --pull=always "$image" --version)"
+          echo "$out"
+          case "$out" in
+            *"$expected"*)
+              echo "OK: image reports '$expected'"
+              ;;
+            *)
+              echo "FAIL: expected '$expected' in --version output from $image" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    name: "GIT tag, release & create merge-up PR"
+    name: "GIT tag, release & prepare next milestone"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -16,20 +16,19 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v6
 
+      # 0.x note: laminas/automatic-releases is built around the post-1.0
+      # SemVer workflow where minor bumps are backwards-compatible and patch
+      # releases on an old minor must be merged up into the next minor. In a
+      # 0.x project each minor is effectively a major (BC breaks are allowed),
+      # so the merge-up step would generate noisy / conflicting PRs and is
+      # omitted here. `bump-changelog` is also dropped because this repo does
+      # not ship a CHANGELOG.md in keep-a-changelog format. Re-enable both
+      # once we cut 1.0 (or adopt a CHANGELOG file).
+
       - name: "Release"
         uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:release"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-      - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
           "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
@@ -42,16 +41,6 @@ jobs:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:
           "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-      - name: "Bump Changelog Version On Originating Release Branch"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:bump-changelog"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,16 @@ COPY . .
 # to `1.0.0+no-version-set`. That makes `reli --version` lie. The build arg
 # lets the publish workflow inject the right value (tag for stable builds,
 # `<branch>-dev` alias for floating release-branch builds,
-# `dev-manual-<sha>` for one-off dispatch builds). When unset (local
-# `docker build .`) Composer keeps its usual fallback behaviour.
+# `dev-manual-<sha>` for one-off dispatch builds). For unset / empty arg
+# (local `docker build .`) we don't export the env var at all, so Composer
+# keeps its usual fallback chain (composer.json → COMPOSER_ROOT_VERSION →
+# VCS → `1.0.0+no-version-set`) without an empty string masking the VCS
+# step.
 ARG COMPOSER_ROOT_VERSION
-ENV COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}
-
-RUN composer install --no-dev
+RUN if [ -n "${COMPOSER_ROOT_VERSION}" ]; then \
+        COMPOSER_ROOT_VERSION="${COMPOSER_ROOT_VERSION}" composer install --no-dev; \
+    else \
+        composer install --no-dev; \
+    fi
 
 ENTRYPOINT ["php", "reli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,16 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 WORKDIR /app
 COPY . .
 
+# `.git` is in .dockerignore and composer.json has no `version` field, so
+# without help Composer can't infer the root package version and falls back
+# to `1.0.0+no-version-set`. That makes `reli --version` lie. The build arg
+# lets the publish workflow inject the right value (tag for stable builds,
+# `<branch>-dev` alias for floating release-branch builds,
+# `dev-manual-<sha>` for one-off dispatch builds). When unset (local
+# `docker build .`) Composer keeps its usual fallback behaviour.
+ARG COMPOSER_ROOT_VERSION
+ENV COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}
+
 RUN composer install --no-dev
 
 ENTRYPOINT ["php", "reli"]


### PR DESCRIPTION
## Summary
This PR adds automated Docker image publishing via GitHub Actions and simplifies the release workflow to better suit the 0.x versioning scheme used by this project.

## Key Changes

### New Docker Publishing Workflow
- Added `.github/workflows/docker-publish.yml` to automatically build and publish Docker images to Docker Hub
- Supports three trigger scenarios:
  1. **Tag pushes** (e.g., `0.12.0`): Publishes `:0.12.0`, `:0.12`, and `:latest` tags (`:latest` skipped for pre-releases)
  2. **Release branch pushes** (e.g., `0.12.x`): Publishes `:0.12.x-dev` for development builds
  3. **Manual dispatch**: Publishes SHA-pinned `:manual-sha-<short>` tags for one-off builds (PR previews, reproducing a specific commit). The short SHA is taken from the actually-checked-out HEAD, not the workflow trigger ref.
- Builds multi-platform images for `linux/amd64` and `linux/arm64`
- Verify step asserts that the image's `--version` output contains the expected Composer version, so a misconfigured build can't ship silently
- Uses GitHub Actions cache for faster builds

### Simplified Release Workflow
- Modified `.github/workflows/release-on-milestone-closed.yml` to remove steps incompatible with 0.x versioning:
  - Removed "Create Merge-Up Pull Request" step (0.x minors are effectively majors with BC breaks allowed)
  - Removed "Bump Changelog Version" step (project doesn't use keep-a-changelog format)
- Renamed the job to reflect what now actually runs
- Added explanatory comment documenting why these steps are omitted for 0.x projects
- Retained core release steps: tag creation, release branch management, milestone creation

## Implementation Details
- Docker workflow requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
- Version reporting in Docker images is **forced via `COMPOSER_ROOT_VERSION`** rather than relying on Composer's auto-detection: `.git` is excluded from the build context by `.dockerignore` and `composer.json` carries no `version` field, so without explicit injection Composer would fall back to `1.0.0+no-version-set` and `reli --version` would lie. The publish workflow computes the right value per trigger:
  - Tag builds: the tag itself (`0.12.0`, `0.12.0-rc1`)
  - Release-branch builds: `<branch>-dev` (e.g., `0.12.x-dev`, matching what `getPrettyVersion` returns when working from a local clone)
  - Manual dispatch builds: `dev-manual-<short-sha>`
- The Dockerfile only exports `COMPOSER_ROOT_VERSION` into the `composer install` environment when the build arg is non-empty, so a local `docker build .` without the arg keeps Composer's usual fallback chain unaffected.
- Release workflow changes are backward-compatible and can be re-enabled when the project reaches 1.0 or adopts a CHANGELOG file.

https://claude.ai/code/session_01WCfj6asVSdeR6C8AbvchNf