### PR TITLE
Replace "outer process" with "target process" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Under the hood, reli:
 
 - Parses the ELF binary of the PHP interpreter.
 - Reads the target's memory map from `/proc/<pid>/maps`.
-- Reads memory of the outer process through `ptrace(2)` and `process_vm_readv(2)` via FFI.
+- Reads memory of the target process through `ptrace(2)` and `process_vm_readv(2)` via FFI.
 - Analyses the internal data structures of the PHP VM (aka Zend Engine).
 
 This keeps target-side overhead low in our benchmarks: 1.00–1.06× baseline at typical sampling rates, with profiler CPU spent in the separate reli process. See [docs/bench/RESULTS.md](docs/bench/RESULTS.md) for the numbers.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -94,7 +94,7 @@ When the application hits `memory_limit`, you get a `.dump` file plus a
 Analyse the dump like any other reli memory snapshot:
 
 ```bash
-reli inspector:memory:analyze /tmp/reli-dumps/sidecar-<pid>-<ts>.dump \
+reli inspector:memory:analyze /tmp/reli-dumps/sidecar-<pid>-<datetime>.dump \
     -f binary -o crash.rmem
 reli inspector:memory:report crash.rmem
 ```

--- a/src/Command/Inspector/GetEgAddressCommand.php
+++ b/src/Command/Inspector/GetEgAddressCommand.php
@@ -58,7 +58,7 @@ final class GetEgAddressCommand extends ReliCommand
     public function configure(): void
     {
         $this->setName('inspector:eg_address')
-            ->setDescription('get EG address from an outer process or thread')
+            ->setDescription('get EG address from a target process or thread')
         ;
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -84,7 +84,7 @@ final class GetTraceCommand extends ReliCommand
     public function configure(): void
     {
         $this->setName('inspector:trace')
-            ->setDescription('periodically get call trace from an outer process or thread')
+            ->setDescription('periodically get call trace from a target process or thread')
         ;
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->get_trace_settings_from_console_input->setOptions($this);

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -63,7 +63,7 @@ final class MemoryCommand extends ReliCommand
     public function configure(): void
     {
         $this->setName('inspector:memory')
-            ->setDescription('get memory usage from an outer process')
+            ->setDescription('get memory usage from a target process')
         ;
         $this->memory_profiler_settings_from_console_input->setOptions($this);
         $this->target_process_settings_from_console_input->setOptions($this);


### PR DESCRIPTION
## Summary
Updated documentation and command descriptions to use more accurate and consistent terminology throughout the codebase. The term "outer process" has been replaced with "target process" to better reflect the actual relationship between the profiler and the process being profiled.

## Changes
- **README.md**: Updated the description of how reli reads memory to clarify it reads from the "target process" rather than "outer process"
- **docs/recipes.md**: Fixed example command to use `<datetime>` placeholder instead of `<ts>` for consistency with actual dump file naming
- **Command descriptions**: Updated three inspector command descriptions to use "target process" terminology:
  - `inspector:eg_address`: "get EG address from a target process or thread"
  - `inspector:trace`: "periodically get call trace from a target process or thread"
  - `inspector:memory`: "get memory usage from a target process"

## Details
These changes improve clarity in the documentation and user-facing command descriptions by using terminology that more accurately describes the profiler's relationship with the process being analyzed. The term "target process" is more intuitive than "outer process" for users trying to understand which process is being profiled.

https://claude.ai/code/session_01VF55A85rCasCahYmcSb6Dy