### PR TITLE
Rename RELIMEM dump format to RDUMP

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ A memory graph is reli's PHP heap reconstruction — values (objects, arrays, st
 
 | I want to... | Use | More |
 |---|---|---|
-| Dump now (short stop), analyse offline **(recommended)** | `inspector:memory:dump -p <pid> -o dump.relimem` → `inspector:memory:analyze dump.relimem -f binary -o snap.rmem` | [memory/memory-dump.md](memory/memory-dump.md) |
+| Dump now (short stop), analyse offline **(recommended)** | `inspector:memory:dump -p <pid> -o dump.rdump` → `inspector:memory:analyze dump.rdump -f binary -o snap.rmem` | [memory/memory-dump.md](memory/memory-dump.md) |
 | One-shot live capture (longer stop, one command) | `inspector:memory -p <pid> -f binary -o snap.rmem` | [memory/memory-profiler.md](memory/memory-profiler.md) |
 | From a core file (crashed / post-mortem) | `inspector:coredump` | [memory/coredump.md](memory/coredump.md) |
 

--- a/docs/internals/memory-dump-inspect.md
+++ b/docs/internals/memory-dump-inspect.md
@@ -1,6 +1,6 @@
-# `inspector:memory:dump:inspect` — RELIMEM dump introspection
+# `inspector:memory:dump:inspect` — RDUMP dump introspection
 
-Developer / debugging tool. Reads a `.relimem` file produced by
+Developer / debugging tool. Reads a `.rdump` file produced by
 `inspector:memory:dump` (or by `inspector:sidecar`) and prints its
 header, the captured `/proc/<pid>/maps` snapshot, and the list of
 saved memory regions.
@@ -10,7 +10,7 @@ saved memory regions.
 > itself — verifying what got into a dump, comparing two dumps,
 > investigating analyzer failures. Both the CLI shape and the
 > printed layout are **not a stable interface**: they may change
-> without notice as the RELIMEM container format evolves.
+> without notice as the RDUMP container format evolves.
 > Production / scripting consumers should go through
 > `inspector:memory:analyze` (which produces `.rmem` / `.sqlite` /
 > `.json` with versioned schemas) instead of parsing this output.
@@ -18,7 +18,7 @@ saved memory regions.
 ## Usage
 
 ```bash
-$ ./reli inspector:memory:dump:inspect path/to/snapshot.relimem
+$ ./reli inspector:memory:dump:inspect path/to/snapshot.rdump
 ```
 
 The single positional argument is the dump file. There are no
@@ -30,7 +30,7 @@ Three sections, in order: `Header`, `Memory Map`, `Regions`.
 
 ```
 === Header ===
-  Magic:            RELIMEM
+  Magic:            RDUMP
   Format Version:   2
   PHP Version:      v85
   PID:              23388
@@ -55,11 +55,11 @@ Total: 126 regions, 5.0 MiB
 
 ### Header
 
-The fixed-layout prefix of every `.relimem` file:
+The fixed-layout prefix of every `.rdump` file:
 
 | Field | Type | Meaning |
 |---|---|---|
-| `Magic` | `RELIMEM\0` | Container marker; readers reject anything else. |
+| `Magic` | `RDUMP\0\0\0` | Container marker; readers reject anything else. |
 | `Format Version` | uint32 | `1` for early dumps, `2` adds `RSS at dump`. The inspect command reads either; older formats print `(unavailable)` for newer fields. |
 | `PHP Version` | string | Resolved target version (`v74`, `v85`, …). Used by `inspector:memory:analyze` to pick struct layouts. |
 | `PID` | int64 | Target PID at capture time. Cosmetic only — the analyzer doesn't re-attach. |
@@ -105,7 +105,7 @@ Useful sanity checks against this section:
 Implementation: `src/Command/Inspector/MemoryDumpInspectCommand.php`.
 The on-disk container is read with raw `unpack()` — there's no
 typed parser today, so this file is also the closest thing to a
-RELIMEM v2 schema reference. When you change the dump writer,
+RDUMP v2 schema reference. When you change the dump writer,
 update both that command and this page.
 
 ## See also
@@ -113,4 +113,4 @@ update both that command and this page.
 - [../memory/memory-dump.md](../memory/memory-dump.md) — user-facing
   capture flow and `--include-binary` / `--exclude-heap` semantics.
 - [memory-dump-vs-gcore.md](memory-dump-vs-gcore.md) — why a
-  RELIMEM dump and an ELF core file diverge.
+  RDUMP dump and an ELF core file diverge.

--- a/docs/memory/coredump.md
+++ b/docs/memory/coredump.md
@@ -161,7 +161,7 @@ See `man 5 core` for the full bitmask.
 - [`inspector:memory`](memory-profiler.md) — the live-process
   equivalent. Output format and downstream pipeline are shared.
 - [`inspector:memory:dump`](memory-dump.md) — reli's own compact
-  `.relimem` dump format for offline analysis; prefer it over
+  `.rdump` dump format for offline analysis; prefer it over
   `gcore + inspector:coredump` when the target is still alive and
   reli can attach.
 - [`inspector:memory:report`](memory-report.md) — generate an

--- a/docs/memory/memory-dump.md
+++ b/docs/memory/memory-dump.md
@@ -1,17 +1,17 @@
 # Memory Dump (`inspector:memory:dump`)
 
 Captures a binary snapshot of a PHP process's memory for offline
-analysis. The dump file (`.relimem` format) can later be analyzed with
+analysis. The dump file (`.rdump` format) can later be analyzed with
 `inspector:memory:analyze` on a different machine or at a different time.
 
 ## Quick start
 
 ```bash
 # Dump a running PHP process
-sudo php ./reli inspector:memory:dump --pid=<pid> --output=snapshot.relimem
+sudo php ./reli inspector:memory:dump --pid=<pid> --output=snapshot.rdump
 
 # Analyze the dump (.rmem is the fastest format; every analyser reads it)
-php ./reli inspector:memory:analyze snapshot.relimem -f binary -o snapshot.rmem
+php ./reli inspector:memory:analyze snapshot.rdump -f binary -o snapshot.rmem
 
 # Browse or report on the graph
 php ./reli rmem:explore snapshot.rmem
@@ -80,19 +80,19 @@ can still resolve class names and function signatures.
 
 ```bash
 # To .rmem (recommended — fastest, consumed by every analyser)
-php ./reli inspector:memory:analyze snapshot.relimem \
+php ./reli inspector:memory:analyze snapshot.rdump \
     -f binary -o snapshot.rmem
 
 # To SQLite (for SQL tooling; inspector:memory:report / inspector:memory:compare accept either)
-php ./reli inspector:memory:analyze snapshot.relimem \
+php ./reli inspector:memory:analyze snapshot.rdump \
     -f sqlite3 -o snapshot.sqlite
 
 # To JSON
-php ./reli inspector:memory:analyze snapshot.relimem \
+php ./reli inspector:memory:analyze snapshot.rdump \
     -f json -o snapshot.json
 
 # With dependency root for binary fallback (when --include-binary was not used)
-php ./reli inspector:memory:analyze snapshot.relimem \
+php ./reli inspector:memory:analyze snapshot.rdump \
     -f binary -o snapshot.rmem \
     -r /path/to/target/root
 ```
@@ -101,7 +101,7 @@ php ./reli inspector:memory:analyze snapshot.relimem \
 
 | | `inspector:memory:dump` | `gcore` |
 |---|---|---|
-| Output format | `.relimem` (analyzer-ready) | ELF core (needs post-processing) |
+| Output format | `.rdump` (analyzer-ready) | ELF core (needs post-processing) |
 | Size | Pagemap-filtered (resident pages only) | All writable VMAs |
 | Speed | Comparable or faster | Comparable |
 | PHP awareness | Captures exactly what the analyzer needs | Captures everything blindly |
@@ -114,4 +114,4 @@ php ./reli inspector:memory:analyze snapshot.relimem \
 - [memory-report.md](memory-report.md) — automated analysis reports
 - [watch-command.md](../monitoring/watch-command.md) — condition-triggered dumps
 - [sidecar.md](../monitoring/sidecar.md) — daemon mode for on-demand dumps
-- [internals/memory-dump-inspect.md](../internals/memory-dump-inspect.md) — `inspector:memory:dump:inspect`, a developer tool that prints the `.relimem` header / memory map / region list (output schema is unstable, intended for debugging the capture pipeline itself)
+- [internals/memory-dump-inspect.md](../internals/memory-dump-inspect.md) — `inspector:memory:dump:inspect`, a developer tool that prints the `.rdump` header / memory map / region list (output schema is unstable, intended for debugging the capture pipeline itself)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -39,10 +39,10 @@ Dump now (short stop), analyse offline, look at the prioritised report:
 
 ```bash
 # 1. Take a fast binary dump (target stopped only briefly)
-sudo reli inspector:memory:dump --pid=<pid> --output=worker.relimem
+sudo reli inspector:memory:dump --pid=<pid> --output=worker.rdump
 
 # 2. Analyse the dump into a .rmem snapshot
-reli inspector:memory:analyze worker.relimem -f binary -o worker.rmem
+reli inspector:memory:analyze worker.rdump -f binary -o worker.rmem
 
 # 3. Read the prioritised findings (dominant classes, cycles, choke points, …)
 reli inspector:memory:report worker.rmem

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -153,7 +153,7 @@ sudo php ./reli inspector:memory:dump -p "$(
 )" \
     --php-regex='.*/libphp\.so$' \
     --libpthread-regex='.*/libc\.so.*' \
-    -o ./frankenphp.relimem
+    -o ./frankenphp.rdump
 ```
 
 If the chosen worker has not yet served a request and the

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -28,7 +28,7 @@ final class MemoryDumpInspectCommand extends ReliCommand
         return DockerProfile::Minimal;
     }
 
-    private const MAGIC = "RELIMEM\0";
+    private const MAGIC = "RDUMP\0\0\0";
 
     public function __construct()
     {
@@ -92,7 +92,7 @@ final class MemoryDumpInspectCommand extends ReliCommand
         $region_count = $this->readUint32($fp);
 
         $output->writeln('<info>=== Header ===</info>');
-        $output->writeln("  Magic:            RELIMEM");
+        $output->writeln("  Magic:            RDUMP");
         $output->writeln("  Format Version:   {$format_version}");
         $output->writeln("  PHP Version:      {$php_version}");
         $output->writeln("  PID:              {$pid}");

--- a/src/Command/Inspector/MemoryDumpNormalizeCommand.php
+++ b/src/Command/Inspector/MemoryDumpNormalizeCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Normalize a RELIMEM dump file by merging overlapping regions into
+ * Normalize an RDUMP dump file by merging overlapping regions into
  * a disjoint set. Older dumps may contain duplicate region entries
  * that force the analyzer into O(n) linear scans; this command
  * rewrites them so binary search always works.
@@ -39,11 +39,11 @@ final class MemoryDumpNormalizeCommand extends ReliCommand
     public function configure(): void
     {
         $this->setName('inspector:memory:normalize-dump')
-            ->setDescription('Rewrite a RELIMEM dump with merged disjoint regions')
+            ->setDescription('Rewrite an RDUMP dump with merged disjoint regions')
             ->addArgument(
                 'input',
                 InputArgument::REQUIRED,
-                'path to the input .relimem dump file',
+                'path to the input .rdump dump file',
             )
             ->addArgument(
                 'output',

--- a/src/Inspector/MemoryDump/DumpFileMemoryReader.php
+++ b/src/Inspector/MemoryDump/DumpFileMemoryReader.php
@@ -21,7 +21,7 @@ use Reli\Lib\Process\MemoryReader\MemoryAddressNotInDumpException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 
 /**
- * Offline `MemoryReaderInterface` backed by a RELIMEM dump file.
+ * Offline `MemoryReaderInterface` backed by an RDUMP dump file.
  *
  * Serves remote memory reads out of the dump's region index with a
  * small cache of open file descriptors. When an address is not present

--- a/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
+++ b/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
@@ -17,14 +17,14 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
 
 /**
- * Reads a RELIMEM dump, merges overlapping regions (last-writer-wins
+ * Reads an RDUMP dump, merges overlapping regions (last-writer-wins
  * for overlapping byte ranges), and writes a new dump whose region
  * list is strictly disjoint. This lets DumpFileMemoryReader always
  * use the binary-search fast path.
  */
 final class MemoryDumpNormalizer
 {
-    private const MAGIC = "RELIMEM\0";
+    private const MAGIC = "RDUMP\0\0\0";
 
     /**
      * @return array{original_count: int, merged_count: int, total_bytes: int}

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -29,7 +29,7 @@ use function DI\autowire;
 
 final class MemoryDumpReaderFactory
 {
-    private const MAGIC = "RELIMEM\0";
+    private const MAGIC = "RDUMP\0\0\0";
 
     public function __construct(
         private ContainerBuilder $container_builder,

--- a/src/Inspector/MemoryDump/MemoryDumpWriter.php
+++ b/src/Inspector/MemoryDump/MemoryDumpWriter.php
@@ -17,7 +17,7 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 
 final class MemoryDumpWriter
 {
-    private const MAGIC = "RELIMEM\0";
+    private const MAGIC = "RDUMP\0\0\0";
     private const FORMAT_VERSION = 2;
 
     /**

--- a/tests/Command/Inspector/MemoryDumpCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpCommandTest.php
@@ -145,7 +145,7 @@ class MemoryDumpCommandTest extends BaseTestCase
         $this->assertFileExists($output_path);
         $this->assertGreaterThan(0, filesize($output_path));
         $magic = file_get_contents($output_path, false, null, 0, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
 
         // Verify the dump can be parsed back via MemoryDumpReaderFactory
         $reader_factory = $container->make(MemoryDumpReaderFactory::class);
@@ -185,7 +185,7 @@ class MemoryDumpCommandTest extends BaseTestCase
         // Verify valid dump file
         $this->assertGreaterThan(0, filesize($output_path));
         $magic = file_get_contents($output_path, false, null, 0, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
     }
 
     #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]

--- a/tests/Command/Inspector/SidecarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/SidecarCommandIntegrationTest.php
@@ -149,7 +149,7 @@ class SidecarCommandIntegrationTest extends BaseTestCase
         // Verify dump file
         $this->assertFileExists($response->path);
         $magic = file_get_contents($response->path, false, null, 0, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
         $this->tmp_files[] = $response->path;
 
         // Verify .meta.json

--- a/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
+++ b/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
@@ -65,7 +65,7 @@ class DumpFileMemoryReaderTest extends TestCase
         // in the dump file.
         $fp = fopen($this->tmp_file, 'rb') ?: $this->fail('open failed');
         $magic = fread($fp, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
         // format version (4) + php_version (4 len + body) + pid (8) +
         // eg (8) + cg (8) + rss_bytes (8, v2) + memory_map_count (4) +
         // region_count (4)

--- a/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpOpcacheIntegrationTest.php
@@ -180,7 +180,7 @@ class MemoryDumpOpcacheIntegrationTest extends BaseTestCase
         $fp = fopen($output_path, 'rb');
         $this->assertNotFalse($fp);
         $magic = fread($fp, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
         fclose($fp);
     }
 

--- a/tests/Inspector/MemoryDump/MemoryDumpReaderFactoryTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpReaderFactoryTest.php
@@ -82,7 +82,7 @@ class MemoryDumpReaderFactoryTest extends TestCase
     #[Test]
     public function testInvalidMagicThrows(): void
     {
-        file_put_contents($this->tmp_file, "NOTRELIMEM");
+        file_put_contents($this->tmp_file, "NOTRDUMP\0\0");
 
         $factory = new MemoryDumpReaderFactory(new ContainerBuilder());
 

--- a/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
@@ -127,7 +127,7 @@ class MemoryDumpRoundtripTest extends TestCase
 
         // Skip header
         $magic = fread($fp, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
 
         // version
         $ver = unpack('Vval', fread($fp, 4));

--- a/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
@@ -92,7 +92,7 @@ class MemoryDumpWriterTest extends TestCase
 
         // Magic
         $magic = fread($fp, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
 
         // Format version
         $result = unpack('Vval', fread($fp, 4));
@@ -220,7 +220,7 @@ class MemoryDumpWriterTest extends TestCase
 
         $fp = fopen($this->tmp_file, 'rb');
         $magic = fread($fp, 8);
-        $this->assertSame("RELIMEM\0", $magic);
+        $this->assertSame("RDUMP\0\0\0", $magic);
         fclose($fp);
     }
 


### PR DESCRIPTION
## Summary
Rename the memory dump container format from "RELIMEM" to "RDUMP" throughout the codebase, including documentation, source code, and tests.

## Key Changes
- Updated the magic number constant from `"RELIMEM\0"` to `"RDUMP\0\0\0"` (8 bytes) in all dump file readers and writers
- Changed file extension references from `.relimem` to `.rdump` in documentation and code examples
- Updated all documentation files to use the new format name:
  - `docs/internals/memory-dump-inspect.md`
  - `docs/memory/memory-dump.md`
  - `docs/memory/coredump.md`
  - `docs/README.md`
  - `docs/recipes.md`
  - `docs/tracing/frankenphp.md`
- Updated source code files:
  - `src/Command/Inspector/MemoryDumpInspectCommand.php`
  - `src/Command/Inspector/MemoryDumpNormalizeCommand.php`
  - `src/Inspector/MemoryDump/MemoryDumpWriter.php`
  - `src/Inspector/MemoryDump/MemoryDumpNormalizer.php`
  - `src/Inspector/MemoryDump/MemoryDumpReaderFactory.php`
  - `src/Inspector/MemoryDump/DumpFileMemoryReader.php`
- Updated all test files to expect the new magic number and file extension

## Implementation Details
- The magic number was changed from 8 bytes `"RELIMEM\0"` to `"RDUMP\0\0\0"` (maintaining the 8-byte alignment)
- All references in comments, docstrings, and user-facing output were updated consistently
- The format version and binary structure remain unchanged; only the identifier was renamed

https://claude.ai/code/session_01TgQCYU5DsrwBxwa69gzYKA