### PR TITLE
Change output format flag from -F to -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A taste of what reli looks like in use.
 Capture to `.rbt` in one terminal while running `rbt:analyze` through `watch(1)` in another for a live-refreshing "top of the hot frames" view — the data streams in as samples are taken.
 
 ```bash
-# Terminal A — capture (`-F rbt` is implied by the .rbt extension)
+# Terminal A — capture (`-f rbt` is implied by the .rbt extension)
 $ reli inspector:trace -p <pid> -o trace.rbt
 
 # Terminal B — live analysis, refreshed every 0.2 seconds

--- a/docs/bench/RESULTS.md
+++ b/docs/bench/RESULTS.md
@@ -544,7 +544,7 @@ reli's `.rbt` is a compact binary trace format designed for
 sampling-shaped data; converters to speedscope / pprof / folded
 / callgrind / flamegraph / phpspy text run on demand off the hot
 path. The size numbers in the CPU section and these tables are
-for `-F rbt`; other reli output formats shift more formatting
+for `-f rbt`; other reli output formats shift more formatting
 work onto the PHP-side hot path and produce larger files (target
 wall time is unaffected by the choice of output format).
 

--- a/docs/bench/run-cpu-rates.sh
+++ b/docs/bench/run-cpu-rates.sh
@@ -33,7 +33,7 @@ count_phpspy_stacks() {
 }
 
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
     -o /tmp/cpur-prime.rbt -- /usr/bin/php8.4 -n -r 'usleep(500000);' >/dev/null 2>&1 || true
 
 echo "profiler,rate_hz,depth,target_wall,samples,expected"
@@ -63,7 +63,7 @@ for spec in "${DEPTHS[@]}"; do
 
         # reli
         "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$sleep_ns" \
-            -F rbt -o /tmp/cpur-reli.rbt \
+            -f rbt -o /tmp/cpur-reli.rbt \
             -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/depth.php" "$depth" "$iters" "$work" \
             2>/tmp/cpur-tgt.err >/dev/null
         wall=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/cpur-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')

--- a/docs/bench/run-cpu-samples.sh
+++ b/docs/bench/run-cpu-samples.sh
@@ -35,7 +35,7 @@ count_phpspy_stacks() {
 }
 
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
     -o /tmp/cpus-prime.rbt -- /usr/bin/php8.4 -n -r 'usleep(500000);' >/dev/null 2>&1 || true
 
 echo "profiler,depth,target_wall,samples,expected_at_1khz"
@@ -118,7 +118,7 @@ for spec in "${DEPTHS[@]}"; do
 
     # reli (no stop-process — default)
     "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-        -F rbt -o /tmp/cpus-reli.rbt \
+        -f rbt -o /tmp/cpus-reli.rbt \
         -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/depth.php" "$depth" "$iters" "$work" \
         2>/tmp/cpus-tgt.err >/dev/null
     wall=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/cpus-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')
@@ -128,7 +128,7 @@ for spec in "${DEPTHS[@]}"; do
 
     # reli with -S (stop target during each read — should reduce drops)
     "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -S \
-        -F rbt -o /tmp/cpus-reli-s.rbt \
+        -f rbt -o /tmp/cpus-reli-s.rbt \
         -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/depth.php" "$depth" "$iters" "$work" \
         2>/tmp/cpus-tgt.err >/dev/null
     wall=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/cpus-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')

--- a/docs/bench/run-cpu.sh
+++ b/docs/bench/run-cpu.sh
@@ -61,7 +61,7 @@ echo "profiler,depth,run,target_wall,sampler_user,sampler_sys,sampler_rss_kb"
 
 # Prime reli cache so the analysis-of-binary cost is amortised.
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
     -o /tmp/cpubench-prime.rbt \
     -- /usr/bin/php8.4 -n -r 'usleep(500000);' >/dev/null 2>&1 || true
 
@@ -121,7 +121,7 @@ for spec in "${DEPTHS[@]}"; do
         # `time -v` wraps reli; reli wraps the target.
         /usr/bin/time -v -o /tmp/cpubench-time.txt \
             "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/cpubench-reli.rbt \
+            -f rbt -o /tmp/cpubench-reli.rbt \
             -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/depth.php" "$depth" "$iters" "$work" \
             2>/tmp/cpubench-tgt.err >/dev/null
         wall=$(parse_target_wall /tmp/cpubench-tgt.err)

--- a/docs/bench/run-external.sh
+++ b/docs/bench/run-external.sh
@@ -34,7 +34,7 @@ BENCHES=(
 
 # Prime reli's cache so subsequent runs don't pay startup analysis cost.
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt -o /tmp/bench-reli-prime.rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt -o /tmp/bench-reli-prime.rbt \
     -- /usr/bin/php8.4 -n -r 'usleep(500000);' >/dev/null 2>&1 || true
 echo "# done. running benchmarks." >&2
 
@@ -58,7 +58,7 @@ for b in "${BENCHES[@]}"; do
         echo "phpspy-1khz,${bname},${i},${secs:-NA}"
 
         # ---- reli: launch target itself ----
-        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -F rbt \
+        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -f rbt \
             -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/${script}" $args 2>/tmp/bench-tgt.err
         secs=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/bench-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')

--- a/docs/bench/run-jit.sh
+++ b/docs/bench/run-jit.sh
@@ -94,7 +94,7 @@ done
 
 # External samplers at long targets — target JIT-on, reli's PHP without JIT.
 echo "# priming reli cache (no own-JIT)..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt -o /tmp/bench-reli-prime.rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt -o /tmp/bench-reli-prime.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
 for b in "${LONG_BENCHES[@]}"; do
@@ -115,7 +115,7 @@ for b in "${LONG_BENCHES[@]}"; do
         echo "phpspy-1khz-jit,${bname},${i},${secs:-NA}"
 
         # reli — target JIT on; reli's own PHP runs default (no JIT for reli's process).
-        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -F rbt \
+        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -f rbt \
             -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS "${SCRIPTS_DIR}/${script}" $args 2>/tmp/bench-tgt.err
         secs=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/bench-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')
@@ -123,7 +123,7 @@ for b in "${LONG_BENCHES[@]}"; do
 
         # reli with reli's *own* PHP JIT also on. PHP 8.5 has opcache built in.
         "$RELI_PHP" $RELI_JIT_FLAGS "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/bench-reli.rbt \
+            -f rbt -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS "${SCRIPTS_DIR}/${script}" $args 2>/tmp/bench-tgt.err
         secs=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/bench-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')
         echo "reli-1khz-relijit,${bname},${i},${secs:-NA}"

--- a/docs/bench/run-long.sh
+++ b/docs/bench/run-long.sh
@@ -59,7 +59,7 @@ done
 
 # External samplers.
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt -o /tmp/bench-reli-prime.rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt -o /tmp/bench-reli-prime.rbt \
     -- /usr/bin/php8.4 -n -r 'usleep(500000);' >/dev/null 2>&1 || true
 
 for b in "${BENCHES[@]}"; do
@@ -80,7 +80,7 @@ for b in "${BENCHES[@]}"; do
         echo "phpspy-1khz,${bname},${i},${secs:-NA}"
 
         # reli: launch target itself
-        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -F rbt \
+        "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" -f rbt \
             -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n "${SCRIPTS_DIR}/${script}" $args 2>/tmp/bench-tgt.err
         secs=$(grep -oE 'in [0-9]+\.[0-9]+s' /tmp/bench-tgt.err | tail -1 | awk '{print $2}' | tr -d 's')

--- a/docs/bench/run-output-sizes.sh
+++ b/docs/bench/run-output-sizes.sh
@@ -96,14 +96,14 @@ kill "$spid" 2>/dev/null; wait "$spid" 2>/dev/null || true
 echo "phpspy,laravel-route-${ITERS}@200hz,$(stat -c %s /tmp/outsize-phpspy.out 2>/dev/null || echo 0),phpspy text"
 
 # ---- reli at 200 Hz, plain rbt ----
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -F rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -f rbt \
     -o /tmp/outsize-reli.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
     "${SCRIPTS_DIR}/laravel-route.php" "$ITERS" "$LARAVEL_DIR" >/dev/null 2>&1 || true
 echo "reli-200hz,laravel-route-${ITERS},$(stat -c %s /tmp/outsize-reli.rbt 2>/dev/null || echo 0),rbt binary"
 
 # ---- reli at 200 Hz, compressed rbt (--rbt-compress) ----
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -F rbt --rbt-compress \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -f rbt --rbt-compress \
     -o /tmp/outsize-reli-z.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
     "${SCRIPTS_DIR}/laravel-route.php" "$ITERS" "$LARAVEL_DIR" >/dev/null 2>&1 || true
@@ -116,14 +116,14 @@ echo "reli-200hz-z,laravel-route-${ITERS},$(stat -c %s /tmp/outsize-reli-z.rbt 2
 # leave a 0-byte gzip output).
 
 # reli plain rbt with -S
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -S -F rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -S -f rbt \
     -o /tmp/outsize-reli-S.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
     "${SCRIPTS_DIR}/laravel-route.php" "$ITERS" "$LARAVEL_DIR" >/dev/null 2>&1 || true
 echo "reli-200hz-S,laravel-route-${ITERS},$(stat -c %s /tmp/outsize-reli-S.rbt 2>/dev/null || echo 0),rbt binary -S"
 
 # reli --rbt-compress with -S
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -S -F rbt --rbt-compress \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 5000000 -S -f rbt --rbt-compress \
     -o /tmp/outsize-reli-zS.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
     "${SCRIPTS_DIR}/laravel-route.php" "$ITERS" "$LARAVEL_DIR" >/dev/null 2>&1 || true

--- a/docs/bench/run-realworld-ext.sh
+++ b/docs/bench/run-realworld-ext.sh
@@ -39,7 +39,7 @@ echo "config,bench,run,wall_seconds"
 case "$workload" in
 laravel-route)
     echo "# priming reli cache..." >&2
-    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
         -o /tmp/bench-reli-prime.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
@@ -61,7 +61,7 @@ laravel-route)
 
         # reli — tolerate transient FFI\ParserException
         "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/bench-reli.rbt \
+            -f rbt -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
             "${SCRIPTS_DIR}/laravel-route.php" 2000 "$LARAVEL_DIR" \
             >/dev/null 2>/tmp/bench-tgt.err || true
@@ -72,7 +72,7 @@ laravel-route)
 
 composer-install)
     echo "# priming reli cache..." >&2
-    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
         -o /tmp/bench-reli-prime.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
@@ -105,7 +105,7 @@ composer-install)
         t_start=$(/usr/bin/php8.4 -n -r 'echo microtime(true);')
         COMPOSER_ALLOW_SUPERUSER=1 \
             "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/bench-reli.rbt \
+            -f rbt -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS $COMPOSER_EXTS \
             /usr/local/bin/composer install \
             --no-interaction --prefer-dist --no-dev --no-scripts --quiet \

--- a/docs/bench/run-realworld-interleaved.sh
+++ b/docs/bench/run-realworld-interleaved.sh
@@ -36,7 +36,7 @@ echo "config,bench,run,wall_seconds"
 case "$workload" in
 laravel-route)
     echo "# priming reli cache..." >&2
-    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
         -o /tmp/bench-reli-prime.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
@@ -65,7 +65,7 @@ laravel-route)
 
         # ---- reli ----
         "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/bench-reli.rbt \
+            -f rbt -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
             "${SCRIPTS_DIR}/laravel-route.php" 2000 "$LARAVEL_DIR" \
             >/dev/null 2>/tmp/bench-tgt.err || true
@@ -76,7 +76,7 @@ laravel-route)
 
 composer-install)
     echo "# priming reli cache..." >&2
-    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt \
+    "$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt \
         -o /tmp/bench-reli-prime.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
@@ -123,7 +123,7 @@ composer-install)
         t_start=$(/usr/bin/php8.4 -n -r 'echo microtime(true);')
         COMPOSER_ALLOW_SUPERUSER=1 \
             "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-            -F rbt -o /tmp/bench-reli.rbt \
+            -f rbt -o /tmp/bench-reli.rbt \
             -- /usr/bin/php8.4 -n $JIT_FLAGS $COMPOSER_EXTS \
             /usr/local/bin/composer install \
             --no-interaction --prefer-dist --no-dev --no-scripts --quiet \

--- a/docs/bench/run-realworld.sh
+++ b/docs/bench/run-realworld.sh
@@ -109,7 +109,7 @@ run_composer_inproc() {
 
 # Prime reli cache.
 echo "# priming reli cache..." >&2
-"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -F rbt -o /tmp/bench-reli-prime.rbt \
+"$RELI_PHP" "$RELI" inspector:trace --sleep-ns 10000000 -f rbt -o /tmp/bench-reli-prime.rbt \
     -- /usr/bin/php8.4 -n $JIT_FLAGS -r 'usleep(500000);' >/dev/null 2>&1 || true
 
 echo "config,bench,run,wall_seconds"
@@ -151,7 +151,7 @@ for ((i=1; i<=RUNS_LIGHT; i++)); do
 
     # reli
     "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-        -F rbt -o /tmp/bench-reli.rbt \
+        -f rbt -o /tmp/bench-reli.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS $LARAVEL_EXTS \
         "${SCRIPTS_DIR}/laravel-route.php" 2000 "$LARAVEL_DIR" >/dev/null 2>/tmp/bench-tgt.err \
         || true   # reli can hit a transient FFI\ParserException on fast-moving targets; tolerate
@@ -189,7 +189,7 @@ for ((i=1; i<=RUNS_LIGHT; i++)); do
     t_start=$(/usr/bin/php8.4 -n -r 'echo microtime(true);')
     COMPOSER_ALLOW_SUPERUSER=1 \
         "$RELI_PHP" "$RELI" inspector:trace --sleep-ns "$RELI_SLEEP_NS" \
-        -F rbt -o /tmp/bench-reli.rbt \
+        -f rbt -o /tmp/bench-reli.rbt \
         -- /usr/bin/php8.4 -n $JIT_FLAGS $COMPOSER_EXTS \
         /usr/local/bin/composer install \
         --no-interaction --prefer-dist --no-dev --no-scripts --quiet \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,7 +170,7 @@ Run your workload in one terminal, attach reli from another:
 php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
-# (-F rbt is implied by the .rbt extension on -o)
+# (-f rbt is implied by the .rbt extension on -o)
 # pgrep -n picks the newest match — avoids passing multiple PIDs when several commands match.
 reli inspector:trace -p "$(pgrep -nf your-script.php)" -o trace.rbt
 ```

--- a/docs/inspection/trace-var-command.md
+++ b/docs/inspection/trace-var-command.md
@@ -36,7 +36,7 @@ reli inspector:trace -p <pid> \
   --trace-var='memory::memory_get_peak_usage'
 
 # Binary (rbt) output — annotations ride on SAMPLE_ANNOTATION events
-# (-F rbt is implied by the .rbt extension on -o)
+# (-f rbt is implied by the .rbt extension on -o)
 reli inspector:trace -p <pid> -o trace.rbt \
   --trace-var='global::$counter'
 ```
@@ -79,7 +79,7 @@ For `local::` and `func_static::`, the function name is **required**; use
 
 ## Annotations in each output format
 
-### phpspy text (`-F template:phpspy`, default)
+### phpspy text (`-f template:phpspy`, default)
 
 Annotations appear as `# <spec> = <value>` comment lines **after** the frame
 list, before the blank-line separator:
@@ -120,12 +120,12 @@ and non-ASCII bytes can never break the line-oriented format:
 | unknown type | `(unknown)` |
 | spec not resolved | the annotation line is **omitted** for that sample |
 
-### phpspy with opcode (`-F template:phpspy_with_opcode`)
+### phpspy with opcode (`-f template:phpspy_with_opcode`)
 
 Same shape as plain phpspy, with annotations after the frame list. The
 opcode column on frame lines is unaffected.
 
-### rbt binary (`-F rbt` / `-F rbt-bundled`)
+### rbt binary (`-f rbt` / `-f rbt-bundled`)
 
 Annotations are emitted as `SAMPLE_ANNOTATION` (event type `0x0B`)
 directly following each sample event. Keys and values are interned via
@@ -158,7 +158,7 @@ practical consequences:
   values that are stable over the scales you care about, or use
   `--trace-var-every` to cut the read rate.
 
-### JSON Lines (`-F template:json_lines`)
+### JSON Lines (`-f template:json_lines`)
 
 The `json_lines` template is currently **unchanged** when `--trace-var` is
 set — its JSON shape is stable for `jq`-based consumers. Annotations in
@@ -259,15 +259,15 @@ the loop.
 
 ```bash
 # Per-worker rbt (annotations never leave the worker; zero IPC overhead)
-reli inspector:daemon -P 'php-fpm' -F rbt \
+reli inspector:daemon -P 'php-fpm' -f rbt \
   --trace-var='local::App\Svc::run()$req_id'
 
 # Bundled rbt (annotations ride on PID_SAMPLE + SAMPLE_ANNOTATION)
-reli inspector:daemon -P 'php-fpm' -F rbt-bundled \
+reli inspector:daemon -P 'php-fpm' -f rbt-bundled \
   --trace-var='global::$request_uri'
 
 # Template text (annotations flow over IPC to the controller)
-reli inspector:daemon -P 'php-fpm' -F template:phpspy \
+reli inspector:daemon -P 'php-fpm' -f template:phpspy \
   --trace-var='global::$request_uri'
 ```
 

--- a/docs/internals/design-trace-var-peek.md
+++ b/docs/internals/design-trace-var-peek.md
@@ -353,7 +353,7 @@ The daemon has three output modes (see `DaemonCommand::execute`,
 `src/Command/Inspector/DaemonCommand.php:90`). Each needs a slightly
 different plumbing for annotations:
 
-#### (a) Per-worker `rbt` (`-F rbt`) — simplest
+#### (a) Per-worker `rbt` (`-f rbt`) — simplest
 
 The worker writes directly to its own `worker_<pid>.rbt` file via
 `PhpReaderEntryPoint::writeBinaryTrace()`
@@ -373,7 +373,7 @@ and handles the RLE break case. **Zero IPC changes** — the annotations
 never leave the worker. This is the cleanest path and the one I'd ship
 first.
 
-#### (b) Bundled `rbt-bundled` (`-F rbt-bundled`) — writer extension
+#### (b) Bundled `rbt-bundled` (`-f rbt-bundled`) — writer extension
 
 Workers send `TraceMessage` to the controller; the controller's
 `writeBundledTrace()`

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -21,7 +21,7 @@ mkdir -p ./traces
 # ./traces/, named worker_<reli-worker-pid>.rbt — not one per target PID.
 sudo timeout 60 reli inspector:daemon \
     -P "^php-fpm" \
-    -F rbt -o ./traces/
+    -f rbt -o ./traces/
 
 # List what was written, then browse / report on one of them
 ls ./traces/
@@ -116,7 +116,7 @@ sudo reli inspector:daemon \
     --target-thread-regex='^php-[0-9a-f]+$' \
     --php-regex='.*/libphp\.so$' \
     --libpthread-regex='.*/libc\.so.*' \
-    -F rbt -o ./traces/
+    -f rbt -o ./traces/
 ```
 
 For attaching to a single worker (`inspector:trace`), pass the PHP

--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -558,10 +558,10 @@ Each worker process writes directly to its own file, bypassing IPC for trace dat
 
 ```bash
 # Explicit output directory
-reli inspector:daemon -F rbt -o /path/to/output_dir/ ...
+reli inspector:daemon -f rbt -o /path/to/output_dir/ ...
 
 # Default: auto-creates a session directory under XDG_STATE_HOME
-reli inspector:daemon -F rbt ...
+reli inspector:daemon -f rbt ...
 # -> writes to $XDG_STATE_HOME/reli/daemon-traces/2026-04-09T163012Z_{pid}/
 ```
 
@@ -599,10 +599,10 @@ All traces are collected to the main process and written to a single stream usin
 
 ```bash
 # Explicit output file
-reli inspector:daemon -F rbt-bundled -o combined.rbt ...
+reli inspector:daemon -f rbt-bundled -o combined.rbt ...
 
 # Default: writes to stdout (pipe-friendly)
-reli inspector:daemon -F rbt-bundled ... > combined.rbt
+reli inspector:daemon -f rbt-bundled ... > combined.rbt
 ```
 
 - **Default output**: stdout (same as template modes), so it can be piped
@@ -666,7 +666,7 @@ reli converter:rbt --compress < trace.txt > trace.rbt.gz
 In daemon per-worker mode, `--rbt-compress` gzip-compresses each completed segment and writes concatenated gzip members to a single `.rbt.gz` file per worker:
 
 ```bash
-reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
+reli inspector:daemon -f rbt --rbt-compress -o /path/to/output_dir/ ...
 # Produces worker_{pid}.rbt.gz files with concatenated gzip members
 ```
 
@@ -676,7 +676,7 @@ reli inspector:daemon -F rbt --rbt-compress -o /path/to/output_dir/ ...
 - No raw `.rbt` data touches disk — only compressed data is written
 - Without `--rbt-compress`, output is raw `.rbt` per worker (default, best for recovery/tail)
 
-**Single-shot and bundled modes don't auto-suffix the filename.** Only daemon per-worker mode rewrites the extension, because there reli generates the per-worker filename itself (`worker_{pid}.rbt` → `worker_{pid}.rbt.gz`). In `inspector:trace` and `-F rbt-bundled`, `-o` is treated as the exact output path: `-o foo.rbt --rbt-compress` writes gzip content to a file named `foo.rbt`. `rbt:analyze` auto-detects gzip so the file still works, but external tools (`file`, `tar`) will see a `.rbt`-named gzip blob. Pass `-o foo.rbt.gz` explicitly if you want the extension to match the contents.
+**Single-shot and bundled modes don't auto-suffix the filename.** Only daemon per-worker mode rewrites the extension, because there reli generates the per-worker filename itself (`worker_{pid}.rbt` → `worker_{pid}.rbt.gz`). In `inspector:trace` and `-f rbt-bundled`, `-o` is treated as the exact output path: `-o foo.rbt --rbt-compress` writes gzip content to a file named `foo.rbt`. `rbt:analyze` auto-detects gzip so the file still works, but external tools (`file`, `tar`) will see a `.rbt`-named gzip blob. Pass `-o foo.rbt.gz` explicitly if you want the extension to match the contents.
 
 ### When to use which
 
@@ -689,7 +689,7 @@ Raw `.rbt` is the default for live capture because it supports append-only writi
 
 ### Compression modes by use case
 
-**Daemon per-worker mode** (`inspector:daemon -F rbt --rbt-compress`): each worker writes a single `.rbt.gz` file. Completed segments are gzip-compressed and appended as concatenated gzip members. One file per worker, multiple segments inside.
+**Daemon per-worker mode** (`inspector:daemon -f rbt --rbt-compress`): each worker writes a single `.rbt.gz` file. Completed segments are gzip-compressed and appended as concatenated gzip members. One file per worker, multiple segments inside.
 
 **File rotation via `stream_factory`** (programmatic API): each segment is written to a separate file. With `compress_completed_segments=true`, each file receives exactly one gzip member. The writer closes each stream on rotation.
 

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -57,7 +57,7 @@ from the output destination: writing to a `.rbt` file picks the
 binary format, anything else (including stdout) falls back to the
 configured default template — phpspy text out of the box.
 
-#### Text (default: `-F template:phpspy`)
+#### Text (default: `-f template:phpspy`)
 
 One block per sample, blank-line separated. Each line is
 `<idx> <fqn> <file>:<line>`, deepest frame on top:
@@ -80,7 +80,7 @@ phpspy-compatible tool. Note that the phpspy text format is **much
 larger** than `.rbt` for the same trace — for anything beyond a
 quick look, capture to `.rbt` instead.
 
-#### Binary (`-F rbt`, auto-selected for `-o *.rbt`)
+#### Binary (`-f rbt`, auto-selected for `-o *.rbt`)
 
 Compact append-only binary — typically a few bytes per sample after
 string interning and run-length encoding. Not human-readable;
@@ -123,7 +123,7 @@ Trace every process whose command line matches a regex. Common for
 sudo php ./reli inspector:daemon -P "^/usr/sbin/httpd"
 
 # Per-worker .rbt files (zero IPC overhead between workers)
-sudo php ./reli inspector:daemon -P "^php-fpm" -F rbt -o ./traces/
+sudo php ./reli inspector:daemon -P "^php-fpm" -f rbt -o ./traces/
 ```
 
 Useful flags (in addition to the `inspector:trace` set):
@@ -132,7 +132,7 @@ Useful flags (in addition to the `inspector:trace` set):
 - `-T/--threads <N>` — worker pool size (default 8)
 
 Output modes for `.rbt` come in two flavours: per-worker files
-(`-F rbt -o <dir>/`) which each worker writes independently, or a
+(`-f rbt -o <dir>/`) which each worker writes independently, or a
 single bundled stream. See [binary-trace-format.md](binary-trace-format.md).
 
 ### Sizing `-T`
@@ -142,7 +142,7 @@ roughly to the number of target processes you expect the regex to
 match concurrently:
 
 - **Workers > matched targets**: idle workers stay parked. With
-  `-F rbt -o <dir>/` the per-worker output stream is opened lazily on
+  `-f rbt -o <dir>/` the per-worker output stream is opened lazily on
   the first attach, so workers that never get assigned a target leave
   no `worker_<pid>.rbt` artifact behind. Extra workers are therefore a
   scheduling/resource concern only, not an output-cleanup concern.

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -39,7 +39,7 @@ sudo php ./reli inspector:daemon \
     --target-thread-regex='^php-[0-9a-f]+$' \
     --php-regex='.*/libphp\.so$' \
     --libpthread-regex='.*/libc\.so.*' \
-    -F rbt -o ./traces/
+    -f rbt -o ./traces/
 ```
 
 The same flags work with `inspector:top` for a live view and with

--- a/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/OutputSettings/OutputSettingsFromConsoleInput.php
@@ -32,7 +32,7 @@ final class OutputSettingsFromConsoleInput
         $command
             ->addOption(
                 'output-format',
-                'F',
+                'f',
                 InputOption::VALUE_OPTIONAL,
                 'output format (template:phpspy|template:phpspy_with_opcode|template:json_lines|rbt|rbt-bundled).'
                 . ' Default: when -o ends with .rbt, rbt is selected; otherwise the configured template (phpspy).'


### PR DESCRIPTION
## Summary
This change updates the command-line interface to use the lowercase `-f` flag instead of uppercase `-F` for specifying output format across all reli commands and documentation.

## Changes Made
- **Source code**: Updated `OutputSettingsFromConsoleInput.php` to change the short option for `output-format` from `'F'` to `'f'`
- **Documentation**: Updated all references in documentation files to use `-f` instead of `-F` in:
  - Trace variable inspection documentation
  - Binary trace format documentation
  - Capturing traces guide
  - Benchmark scripts (multiple files)
  - Recipe examples
  - Getting started guide
  - FrankenPHP integration guide
  - Design documentation
  - README and results documentation

## Rationale
This change standardizes the command-line interface by using the more conventional lowercase short option flag. The `-f` flag is more intuitive and aligns with common Unix conventions where `-f` typically denotes "format" or "file" operations.

## Impact
- Users will need to update their scripts and commands to use `-f` instead of `-F` when specifying output format
- All documentation examples now consistently use the new flag
- The change affects all inspector commands that support output format specification (trace, daemon, etc.)

https://claude.ai/code/session_01VF55A85rCasCahYmcSb6Dy