### PR TITLE
Remove memory-output-format option from watch command

### DIFF
--- a/docs/monitoring/watch-command.md
+++ b/docs/monitoring/watch-command.md
@@ -249,13 +249,21 @@ reli inspector:watch -p <pid> \
 
 ### Memory Dump (`--action=memory-dump`)
 
-Captures a binary memory dump (same format as `inspector:memory:dump`) for offline analysis via `inspector:memory:analyze`.
+Captures a binary memory dump (same `.rdump` format as `inspector:memory:dump`) when the trigger fires. The action only writes the raw dump — the watch loop deliberately does **not** run analysis inline (to keep the per-trigger stop time short and to keep cooldown / rate-limit semantics meaningful). Run `inspector:memory:analyze` later to produce a `.rmem` snapshot consumable by `rmem:explore`, `inspector:memory:report`, etc.
 
 ```bash
-reli inspector:watch -p <pid> --memory-usage=256M --action=memory-dump
+# 1. Watch fires and writes raw dumps:
+reli inspector:watch -p <pid> --memory-usage=256M --action=memory-dump \
+  --action-output-dir=/tmp/reli-dumps
+
+# 2. Analyse offline (any time later, on any host):
+reli inspector:memory:analyze /tmp/reli-dumps/watch-<pid>-<timestamp>.rdump \
+  -f binary -o snapshot.rmem
+reli inspector:memory:report snapshot.rmem
+# or: reli rmem:explore snapshot.rmem
 ```
 
-Output files: `<output-dir>/watch-<pid>-<timestamp>.dump`
+Output files: `<action-output-dir>/watch-<pid>-<timestamp>.rdump`.
 
 ### Trace Snapshot (`--action=trace-once`)
 
@@ -354,7 +362,7 @@ Maximum trigger fires per hour (sliding window). Default: 10.
 
 ### Disk Size Limit (`--max-dump-size=<size>`)
 
-Maximum cumulative size of dump files. Default: 1G. Scans existing `watch-*.dump` files in the output directory on startup, so the limit persists across restarts.
+Maximum cumulative size of dump files. Default: 1G. Scans existing `watch-*.rdump` files in the output directory on startup, so the limit persists across restarts.
 
 ```bash
 --max-dump-size=2G --action-output-dir=/var/log/reli/dumps

--- a/src/Inspector/Settings/WatchSettings/WatchSettings.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettings.php
@@ -50,7 +50,6 @@ final class WatchSettings
         public array $actions,
         public ?string $action_exec_command,
         public ?string $log_file,
-        public ?string $memory_output_format,
         public bool $include_binary = false,
         public ?string $memory_limit = null,
         // CPU trigger configs (all optional, added after existing params)

--- a/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInput.php
@@ -137,13 +137,6 @@ final class WatchSettingsFromConsoleInput
                 InputOption::VALUE_REQUIRED,
                 'path to log file for log action',
             )
-            ->addOption(
-                'memory-output-format',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'output format for memory-dump action (json, sqlite3)',
-                'json',
-            )
             // Rate limiting options
             ->addOption(
                 'poll-interval',
@@ -222,7 +215,7 @@ final class WatchSettingsFromConsoleInput
                 'memory-limit',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+                'set PHP memory_limit for the watch process (e.g. 2G, 512M)',
             )
         ;
     }
@@ -332,7 +325,6 @@ final class WatchSettingsFromConsoleInput
             log_file: self::resolveAbsolutePathOrNull(
                 NullableCast::toString($input->getOption('log-file'))
             ),
-            memory_output_format: NullableCast::toString($input->getOption('memory-output-format')),
             include_binary: (bool)$input->getOption('include-binary'),
             memory_limit: NullableCast::toString($input->getOption('memory-limit')),
             cpu_usage_percent: $cpu_usage_percent,

--- a/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/DaemonMemoryDumpAction.php
@@ -68,7 +68,7 @@ final class DaemonMemoryDumpAction implements ActionInterface
         }
 
         $output_path = sprintf(
-            '%s/watch-%d-%s.dump',
+            '%s/watch-%d-%s.rdump',
             rtrim($this->output_dir, '/'),
             $process->pid,
             date('Ymd-His', (int)$event->timestamp),

--- a/src/Inspector/Watch/Action/MemoryDumpAction.php
+++ b/src/Inspector/Watch/Action/MemoryDumpAction.php
@@ -61,7 +61,7 @@ final class MemoryDumpAction implements ActionInterface
         }
 
         $output_path = sprintf(
-            '%s/watch-%d-%s.dump',
+            '%s/watch-%d-%s.rdump',
             rtrim($this->output_dir, '/'),
             $process->pid,
             date('Ymd-His', (int)$event->timestamp),

--- a/src/Inspector/Watch/DiskUsageTracker.php
+++ b/src/Inspector/Watch/DiskUsageTracker.php
@@ -29,7 +29,7 @@ final class DiskUsageTracker
     private function scanExistingFiles(string $dir): void
     {
         $dir = rtrim($dir, '/');
-        foreach (['watch-*.dump', 'sidecar-*.dump'] as $glob) {
+        foreach (['watch-*.rdump', 'sidecar-*.dump'] as $glob) {
             $files = glob($dir . '/' . $glob);
             if ($files === false) {
                 continue;

--- a/tests/Command/Inspector/WatchCommandTest.php
+++ b/tests/Command/Inspector/WatchCommandTest.php
@@ -65,7 +65,6 @@ class WatchCommandTest extends TestCase
         $this->assertTrue($def->hasOption('action-exec-command'));
         $this->assertTrue($def->hasOption('action-output-dir'));
         $this->assertTrue($def->hasOption('log-file'));
-        $this->assertTrue($def->hasOption('memory-output-format'));
     }
 
     public function testHasRateLimitOptions(): void
@@ -106,8 +105,5 @@ class WatchCommandTest extends TestCase
 
         $output_dir = $def->getOption('action-output-dir');
         $this->assertNull($output_dir->getDefault());
-
-        $format = $def->getOption('memory-output-format');
-        $this->assertSame('json', $format->getDefault());
     }
 }

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsFromConsoleInputTest.php
@@ -39,7 +39,6 @@ class WatchSettingsFromConsoleInputTest extends BaseTestCase
             'action-exec-command' => null,
             'action-output-dir' => null,
             'log-file' => null,
-            'memory-output-format' => 'json',
             'poll-interval' => null,
             'cooldown' => null,
             'max-triggers' => null,

--- a/tests/Inspector/Settings/WatchSettings/WatchSettingsTest.php
+++ b/tests/Inspector/Settings/WatchSettings/WatchSettingsTest.php
@@ -40,7 +40,6 @@ class WatchSettingsTest extends TestCase
             actions: ['trace', 'log'],
             action_exec_command: 'echo test',
             log_file: '/tmp/watch.log',
-            memory_output_format: 'sqlite3',
         );
 
         $this->assertSame(500, $settings->poll_interval_ms);
@@ -61,7 +60,6 @@ class WatchSettingsTest extends TestCase
         $this->assertSame(['trace', 'log'], $settings->actions);
         $this->assertSame('echo test', $settings->action_exec_command);
         $this->assertSame('/tmp/watch.log', $settings->log_file);
-        $this->assertSame('sqlite3', $settings->memory_output_format);
     }
 
     public function testDefaults(): void

--- a/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
+++ b/tests/Inspector/Watch/ActionFactoryBuildActionsTest.php
@@ -55,7 +55,6 @@ class ActionFactoryBuildActionsTest extends BaseTestCase
             'actions' => ['log'],
             'action_exec_command' => null,
             'log_file' => null,
-            'memory_output_format' => null,
         ];
         return new WatchSettings(...array_merge($defaults, $overrides));
     }

--- a/tests/Inspector/Watch/ActionFactoryTest.php
+++ b/tests/Inspector/Watch/ActionFactoryTest.php
@@ -52,7 +52,6 @@ class ActionFactoryTest extends BaseTestCase
             'actions' => ['log'],
             'action_exec_command' => null,
             'log_file' => null,
-            'memory_output_format' => null,
         ];
         $merged = array_merge($defaults, $overrides);
         return new WatchSettings(...$merged);

--- a/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
+++ b/tests/Inspector/Watch/Daemon/Controller/PhpWatchControllerTest.php
@@ -198,7 +198,6 @@ final class PhpWatchControllerTest extends BaseTestCase
             actions: ['log'],
             action_exec_command: null,
             log_file: null,
-            memory_output_format: null,
         );
     }
 }

--- a/tests/Inspector/Watch/Daemon/Protocol/Message/WatchMessagesTest.php
+++ b/tests/Inspector/Watch/Daemon/Protocol/Message/WatchMessagesTest.php
@@ -104,7 +104,6 @@ class WatchMessagesTest extends TestCase
             actions: ['log'],
             action_exec_command: null,
             log_file: null,
-            memory_output_format: null,
         );
     }
 }

--- a/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
+++ b/tests/Inspector/Watch/Daemon/Worker/PhpWatchEntryPointRunTest.php
@@ -56,7 +56,6 @@ class PhpWatchEntryPointRunTest extends TestCase
                 actions: [],
                 action_exec_command: null,
                 log_file: null,
-                memory_output_format: null,
             ),
             trace_loop_settings: new TraceLoopSettings(
                 sleep_nano_seconds: 1000,

--- a/tests/Inspector/Watch/DiskUsageTrackerTest.php
+++ b/tests/Inspector/Watch/DiskUsageTrackerTest.php
@@ -64,8 +64,8 @@ class DiskUsageTrackerTest extends TestCase
         mkdir($dir);
 
         // Create existing dump files
-        file_put_contents($dir . '/watch-123-20260330.dump', str_repeat('x', 300));
-        file_put_contents($dir . '/watch-456-20260330.dump', str_repeat('x', 200));
+        file_put_contents($dir . '/watch-123-20260330.rdump', str_repeat('x', 300));
+        file_put_contents($dir . '/watch-456-20260330.rdump', str_repeat('x', 200));
         // Non-matching file should be ignored
         file_put_contents($dir . '/other.txt', str_repeat('x', 999));
 
@@ -73,14 +73,14 @@ class DiskUsageTrackerTest extends TestCase
         $this->assertSame(500, $tracker->getTotalBytes());
 
         // Adding more should accumulate
-        file_put_contents($dir . '/watch-789-20260330.dump', str_repeat('x', 400));
-        $tracker->recordFile($dir . '/watch-789-20260330.dump');
+        file_put_contents($dir . '/watch-789-20260330.rdump', str_repeat('x', 400));
+        $tracker->recordFile($dir . '/watch-789-20260330.rdump');
         $this->assertSame(900, $tracker->getTotalBytes());
         $this->assertTrue($tracker->canWrite());
 
         // Over limit
-        file_put_contents($dir . '/watch-999-20260330.dump', str_repeat('x', 200));
-        $tracker->recordFile($dir . '/watch-999-20260330.dump');
+        file_put_contents($dir . '/watch-999-20260330.rdump', str_repeat('x', 200));
+        $tracker->recordFile($dir . '/watch-999-20260330.rdump');
         $this->assertFalse($tracker->canWrite());
 
         // Cleanup

--- a/tests/Inspector/Watch/TriggerFactoryTest.php
+++ b/tests/Inspector/Watch/TriggerFactoryTest.php
@@ -47,7 +47,6 @@ class TriggerFactoryTest extends TestCase
             'actions' => ['log'],
             'action_exec_command' => null,
             'log_file' => null,
-            'memory_output_format' => null,
         ];
         $merged = array_merge($defaults, $overrides);
         return new WatchSettings(...$merged);

--- a/tests/Inspector/Watch/WatchPipelineTest.php
+++ b/tests/Inspector/Watch/WatchPipelineTest.php
@@ -182,7 +182,6 @@ class WatchPipelineTest extends TestCase
             actions: ['log'],
             action_exec_command: null,
             log_file: null,
-            memory_output_format: null,
         );
 
         $triggers = $factory->build($settings);


### PR DESCRIPTION
## Summary
Removes the `--memory-output-format` CLI option from the `inspector:watch` command and simplifies the memory dump workflow. The watch command now only captures raw `.rdump` format dumps, with analysis deferred to the `inspector:memory:analyze` command for offline processing.

## Key Changes
- **Removed CLI option**: Deleted `--memory-output-format` option (which previously supported `json` and `sqlite3` formats) from `WatchSettingsFromConsoleInput`
- **Removed settings property**: Deleted `memory_output_format` property from `WatchSettings` class
- **Updated documentation**: Enhanced `watch-command.md` to clarify the two-step workflow:
  1. Watch fires and writes raw `.rdump` dumps to `--action-output-dir`
  2. User runs `inspector:memory:analyze` offline to produce `.rmem` snapshots for analysis
- **Updated tests**: Removed all references to `memory_output_format` from test fixtures and assertions across 8 test files

## Implementation Details
The change simplifies the watch command by removing output format flexibility at trigger time. This aligns with the design goal of keeping per-trigger stop time short and maintaining meaningful cooldown/rate-limit semantics. Format conversion is now explicitly a separate offline step, making the workflow clearer and the watch daemon lighter.

https://claude.ai/code/session_01CXoesMgPqnXEFzyMBA6WbW