### PR TITLE
Isolate cap_sys_ptrace on a separate php-ptrace binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM php:8.5-cli
 
-# libcap2-bin provides setcap; the file-capability set on /usr/local/bin/php
-# lets reli use CAP_SYS_PTRACE when the container is run as a non-root
-# `--user` (the normal mode under docker:print-wrapper). Without it, the
-# capability is in the bounding set only and memory reads fail with EPERM.
+# libcap2-bin provides setcap; the actual `setcap` invocation is deferred to
+# the final RUN below — see the comment there for why.
 RUN apt-get update && apt-get install -y \
       libffi-dev \
       libzip-dev \
@@ -11,7 +9,6 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install ffi \
     && docker-php-ext-install pcntl \
     && docker-php-ext-install zip \
-    && setcap cap_sys_ptrace=eip /usr/local/bin/php \
     && rm -rf /var/lib/apt/lists/*
 
 # Compile out bare assert() calls in the production image. The reli codebase
@@ -47,5 +44,28 @@ RUN if [ -n "${COMPOSER_ROOT_VERSION}" ]; then \
     else \
         composer install --no-dev; \
     fi
+
+# Build a setcap'd shadow copy of the PHP binary at /usr/local/bin/php-ptrace.
+# Wrappers that actually need ptrace (docker:print-wrapper --profile=full)
+# override the container entrypoint to invoke this binary; that copy carries
+# cap_sys_ptrace=eip, so ptrace works under `--user <non-root>` even though
+# Linux strips effective caps at exec for non-zero uid.
+#
+# /usr/local/bin/php itself is left untouched on purpose. A binary with `=eip`
+# file capabilities returns EPERM from execve() in any environment whose
+# bounding set lacks the requested cap (default Docker, BuildKit, k8s without
+# explicit cap-add, etc.). Putting the cap on /usr/local/bin/php would force
+# every `docker run reliforp/reli-prof <cmd>` invocation to require
+# `--cap-add=SYS_PTRACE`, even for offline-only commands like rbt:analyze
+# / inspector:memory:report / converter:* that never touch a live process.
+# A separate php-ptrace binary keeps the default ENTRYPOINT path usable
+# without extra caps and confines the regression to the wrapper-emitted
+# command line, which already passes --cap-add=SYS_PTRACE.
+#
+# Why `cp` and not `ln`: file capabilities are stored as xattrs on the
+# inode, so a hardlink would silently apply the cap to /usr/local/bin/php
+# as well, defeating the split. A real copy gives us a separate inode.
+RUN cp -p /usr/local/bin/php /usr/local/bin/php-ptrace \
+    && setcap cap_sys_ptrace=eip /usr/local/bin/php-ptrace
 
 ENTRYPOINT ["php", "reli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,9 @@ RUN if [ -n "${COMPOSER_ROOT_VERSION}" ]; then \
 RUN cp -p /usr/local/bin/php /usr/local/bin/php-ptrace \
     && setcap cap_sys_ptrace=eip /usr/local/bin/php-ptrace
 
-ENTRYPOINT ["php", "reli"]
+# Absolute path on purpose. The wrapper emitted by docker:print-wrapper
+# overrides WORKDIR to the host's $PWD (so bind-mounted input/output paths
+# resolve naturally), and PHP CLI does not search PATH for script
+# arguments — a relative `reli` would fail to open whenever the host CWD
+# is not the reli source tree.
+ENTRYPOINT ["php", "/app/reli"]

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -122,8 +122,10 @@ final class PrintWrapperCommand extends ReliCommand
 # capability set at exec, so --cap-add=SYS_PTRACE alone would still leave
 # ptrace returning EPERM; the file capability on /usr/local/bin/php-ptrace
 # raises CAP_SYS_PTRACE back into the effective set on each invocation.
-# Overriding the entrypoint also drops the image's `php reli` ENTRYPOINT,
-# so we re-supply the `reli` script path explicitly below.
+# Overriding the entrypoint also drops the image's `php /app/reli`
+# ENTRYPOINT, so we re-supply the absolute script path explicitly below.
+# Absolute path matters because `-w "$PWD"` puts the container CWD at the
+# host's working dir, and PHP CLI does not search PATH for script args.
 {{NAME}}() {
     local tty=
     [ -t 0 ] && [ -t 1 ] && tty=-t
@@ -163,7 +165,7 @@ final class PrintWrapperCommand extends ReliCommand
         -e XDG_CACHE_HOME="${scratch}/cache" \
         -e XDG_RUNTIME_DIR="${scratch}/runtime" \
         ${RELI_DOCKER_EXTRA_ARGS:-} \
-        {{IMAGE}} reli "$@"
+        {{IMAGE}} /app/reli "$@"
 }
 
 reli_assert_scratch_safe() {

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -116,6 +116,14 @@ final class PrintWrapperCommand extends ReliCommand
 # Runs reli in a container with the capabilities needed to attach to host
 # PHP processes (ptrace, pid=host, network=host). Files written by the
 # container to bind-mounted paths are owned by the host user via --user.
+#
+# --entrypoint selects the setcap'd PHP binary baked into the image
+# (see Dockerfile). When --user is non-root the kernel zeroes the effective
+# capability set at exec, so --cap-add=SYS_PTRACE alone would still leave
+# ptrace returning EPERM; the file capability on /usr/local/bin/php-ptrace
+# raises CAP_SYS_PTRACE back into the effective set on each invocation.
+# Overriding the entrypoint also drops the image's `php reli` ENTRYPOINT,
+# so we re-supply the `reli` script path explicitly below.
 {{NAME}}() {
     local tty=
     [ -t 0 ] && [ -t 1 ] && tty=-t
@@ -142,6 +150,7 @@ final class PrintWrapperCommand extends ReliCommand
     fi
 
     docker run --rm -i ${tty} \
+        --entrypoint /usr/local/bin/php-ptrace \
         --cap-add=SYS_PTRACE \
         --security-opt=apparmor=unconfined \
         --pid=host \
@@ -154,7 +163,7 @@ final class PrintWrapperCommand extends ReliCommand
         -e XDG_CACHE_HOME="${scratch}/cache" \
         -e XDG_RUNTIME_DIR="${scratch}/runtime" \
         ${RELI_DOCKER_EXTRA_ARGS:-} \
-        {{IMAGE}} "$@"
+        {{IMAGE}} reli "$@"
 }
 
 reli_assert_scratch_safe() {

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -105,22 +105,24 @@ class PrintWrapperCommandTest extends TestCase
     public function testImageOverrideChangesImageReference(): void
     {
         // Default profile is full, which overrides --entrypoint and so has
-        // to re-supply the `reli` script path explicitly after the image.
+        // to re-supply the absolute reli script path after the image.
+        // Absolute (not bare `reli`) so `-w "$PWD"` does not point PHP at
+        // a host CWD that has no `reli` next to it.
         $out = $this->runWrapper(['--image' => 'myreg/reli:custom']);
-        $this->assertStringContainsString('myreg/reli:custom reli "$@"', $out);
+        $this->assertStringContainsString('myreg/reli:custom /app/reli "$@"', $out);
     }
 
     public function testMinimalProfileImageOverridePassesArgsToEntrypoint(): void
     {
-        // Minimal profile keeps the image's `php reli` ENTRYPOINT, so the
+        // Minimal profile keeps the image's `php /app/reli` ENTRYPOINT, so
         // user-supplied args go straight after the image reference with no
-        // extra `reli` token in front.
+        // extra script-path token in front.
         $out = $this->runWrapper([
             '--profile' => 'minimal',
             '--image' => 'myreg/reli:custom',
         ]);
         $this->assertStringContainsString('myreg/reli:custom "$@"', $out);
-        $this->assertStringNotContainsString('myreg/reli:custom reli "$@"', $out);
+        $this->assertStringNotContainsString('myreg/reli:custom /app/reli "$@"', $out);
     }
 
     public function testUnknownProfileReturnsNonZero(): void

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -59,6 +59,7 @@ class PrintWrapperCommandTest extends TestCase
         $this->assertStringContainsString('full profile', $out);
         $this->assertStringContainsString("reli() {", $out);
         $this->assertStringContainsString('--cap-add=SYS_PTRACE', $out);
+        $this->assertStringContainsString('--entrypoint /usr/local/bin/php-ptrace', $out);
         $this->assertStringContainsString('--pid=host', $out);
         $this->assertStringContainsString('--network=host', $out);
         $this->assertStringContainsString('reli_assert_scratch_safe()', $out);
@@ -80,6 +81,7 @@ class PrintWrapperCommandTest extends TestCase
         $this->assertStringContainsString('--read-only', $out);
         $this->assertStringContainsString('--tmpfs /tmp', $out);
         $this->assertStringNotContainsString('--cap-add=SYS_PTRACE', $out);
+        $this->assertStringNotContainsString('--entrypoint', $out);
         $this->assertStringNotContainsString('--pid=host', $out);
         $this->assertStringNotContainsString('reli_assert_scratch_safe', $out);
     }
@@ -102,8 +104,23 @@ class PrintWrapperCommandTest extends TestCase
 
     public function testImageOverrideChangesImageReference(): void
     {
+        // Default profile is full, which overrides --entrypoint and so has
+        // to re-supply the `reli` script path explicitly after the image.
         $out = $this->runWrapper(['--image' => 'myreg/reli:custom']);
+        $this->assertStringContainsString('myreg/reli:custom reli "$@"', $out);
+    }
+
+    public function testMinimalProfileImageOverridePassesArgsToEntrypoint(): void
+    {
+        // Minimal profile keeps the image's `php reli` ENTRYPOINT, so the
+        // user-supplied args go straight after the image reference with no
+        // extra `reli` token in front.
+        $out = $this->runWrapper([
+            '--profile' => 'minimal',
+            '--image' => 'myreg/reli:custom',
+        ]);
         $this->assertStringContainsString('myreg/reli:custom "$@"', $out);
+        $this->assertStringNotContainsString('myreg/reli:custom reli "$@"', $out);
     }
 
     public function testUnknownProfileReturnsNonZero(): void


### PR DESCRIPTION
## Summary
- **Fixes**: every run of the `Publish Docker image` workflow has failed since it was added (10/10 runs). Latest example: https://github.com/reliforp/reli-prof/actions/runs/25127319990
- The build dies at `composer install --no-dev` with:
  ```
  env: 'php': Operation not permitted
  ERROR: ... did not complete successfully: exit code: 126
  ```

## Root cause

A binary with `=eip` file capabilities returns `EPERM` from `execve()` in any environment whose bounding set lacks the requested cap. The GitHub-hosted runner's BuildKit sandbox excludes `CAP_SYS_PTRACE`, so the moment we applied `setcap cap_sys_ptrace=eip /usr/local/bin/php` (5b6689cc), every subsequent `php` invocation in the build started failing. Composer's shebang is `#!/usr/bin/env php`, which is why the failure surfaces at the composer step.

A more permissive local Docker daemon may not enforce the same bounding-set restriction at build time, which is how this slipped past local testing on `5b6689cc`.

## Why not just move setcap to the final RUN

Moving `setcap` to the very last `RUN` does unblock CI (BuildKit no longer needs to exec the setcap'd binary mid-build), but it introduces a runtime regression: every `docker run reliforp/reli-prof <cmd>` would then require `--cap-add=SYS_PTRACE`, because Docker's default bounding set lacks `SYS_PTRACE` and the very first `php /app/reli` exec would fail with the same `EPERM`. Offline-only commands like `rbt:analyze`, `inspector:memory:report`, and `converter:*` would suddenly require the cap even though they never touch a live process.

## Fix

### 1. Isolate the file capability on a shadow binary (`603dab1b`)

Build a setcap'd shadow copy of the PHP binary at `/usr/local/bin/php-ptrace` (a real `cp` rather than a hardlink — file capabilities are stored as xattrs on the inode, so a hardlink would silently apply the cap to `/usr/local/bin/php` as well).

- Default ENTRYPOINT keeps using the clean `/usr/local/bin/php`. Any `docker run` that doesn't need ptrace runs without `--cap-add` — same behaviour as before 5b6689cc.
- `docker:print-wrapper --profile=full` (which is the case that *needs* the cap, because it pairs `--cap-add=SYS_PTRACE` with `--user <non-root>` for host-uid output ownership) now adds `--entrypoint=/usr/local/bin/php-ptrace` so it picks up the setcap'd copy. Linux still zeroes the effective set at non-root exec, but the file capability promotes `CAP_SYS_PTRACE` back into the effective set on the new process.

### 2. Pin the reli script path to `/app/reli` everywhere (`d07d5100`, addresses ChatGPT review)

Once `--entrypoint` is in play, the image's ENTRYPOINT array is dropped, so the wrapper has to re-supply the script path. PHP CLI does **not** search `PATH` for script arguments, and the wrapper sets `-w "$PWD"` (host's working dir) for bind-mount ergonomics — so a bare `reli` arg would resolve to `$PWD/reli`, which is essentially never the right file outside the reli source tree.

- `Dockerfile` ENTRYPOINT changes from `["php", "reli"]` to `["php", "/app/reli"]`. Plain `docker run reliforp/reli-prof <cmd>` is unaffected (image WORKDIR is `/app`, both forms resolve identically when WORKDIR is unchanged), but the absolute form is robust against any `-w` override.
- The full wrapper emits `{{IMAGE}} /app/reli "$@"` after the image reference, matching the same absolute path.
- `minimal` profile (`reli-view`) keeps relying on the image's ENTRYPOINT, so it picks up the new `/app/reli` automatically without needing to mention it on the wrapper command line.

## Test plan
- [x] `php vendor/bin/phpunit --filter PrintWrapperCommandTest` — 9/9 green.
  - New: `--entrypoint /usr/local/bin/php-ptrace` assertion in the full-profile happy-path.
  - New: `testMinimalProfileImageOverridePassesArgsToEntrypoint` — minimal profile must **not** emit `image /app/reli "$@"` (it relies on the image ENTRYPOINT).
  - Updated: `testImageOverrideChangesImageReference` now asserts `image /app/reli "$@"` for the full profile.
- [x] `phpcs --standard=PSR12 src/Command/Docker tests/Command/Docker` clean.
- [x] `psalm` on `PrintWrapperCommand.php` — no errors.
- [x] CI: `Publish Docker image` workflow on the merge to `0.12.x` completes (both `linux/amd64` and `linux/arm64`).
- [ ] CI verify step: `docker run --rm reliforp/reli-prof:<tag> --version` reports the expected version. (This invokes the clean `/usr/local/bin/php` ENTRYPOINT — proves the offline path still works without `--cap-add` and proves the new absolute `/app/reli` resolves under default WORKDIR.)
- [ ] After merge, manual sanity-check: `eval "$(docker run --rm reliforp/reli-prof:0.12.x-dev docker:print-wrapper)"; reli inspector:trace -p <pid>` against a host PHP process (proves the wrapper's `--entrypoint` switch + setcap actually grants effective `CAP_SYS_PTRACE` under non-root `--user`, and that `/app/reli` resolves with `-w "$PWD"`).

## Follow-up (not in this PR)

The 2-binary split is a near-term shape; a cleaner long-term option is to drop the shadow binary entirely, set `cap_sys_ptrace=p` (no effective bit) on the real `/usr/local/bin/php`, and have reli itself raise the cap from permitted into effective via `capset(2)` on attach paths. That removes the `--entrypoint` plumbing and lets us print a friendly error when caps aren't available, but needs FFI work that isn't worth blocking the 0.12.0 release on. Tracking as a post-0.12.0 task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)