### PR TITLE
Documentation improvements: client install, format flag, and clarifications

### DIFF
--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -170,7 +170,7 @@ And the output is like below. The target process is [psalm](https://github.com/v
                         "object_properties": {
                             "#node_id": 5,
                             "#type": "ObjectPropertiesContext",
-                            "#count": 24
+                            "#count": 24,
                             "config": {
                                 "#node_id": 6,
                                 "#type": "ObjectContext",

--- a/docs/memory/rmem-explore-and-serve.md
+++ b/docs/memory/rmem-explore-and-serve.md
@@ -300,6 +300,7 @@ reli rmem:serve output.rmem
 reli rmem:serve output.rmem --socket=/tmp/my-rmem.sock
 
 # Auto-shutdown after 30 minutes of inactivity
+# (default: 3600s = 1 hour; pass 0 to keep the server up indefinitely)
 reli rmem:serve output.rmem --timeout=1800
 ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -83,6 +83,21 @@ reli inspector:sidecar --output-dir=/tmp/reli-dumps
 # --socket explicitly — see docs/monitoring/sidecar.md.
 ```
 
+Install the FFI-free client package in your application (the
+standalone client mirror; downgraded to PHP 7.0+ so it runs anywhere
+your application does):
+
+```bash
+# Until the first tagged release, the package is dev-main only —
+# requires "minimum-stability": "dev" + "prefer-stable": true in composer.json.
+composer require reliforp/reli-prof-sidecar-client:dev-main
+```
+
+Other install paths (full `reliforp/reli-prof` or vendoring the three
+client files) are documented in
+[monitoring/sidecar.md § Client Library](monitoring/sidecar.md#client-library);
+the standalone package is the recommended one.
+
 ```php
 // In your application bootstrap (index.php / bin/console / …)
 \Reli\Sidecar\Client\MemoryLimitHandler::register();

--- a/docs/tracing/binary-trace-format.md
+++ b/docs/tracing/binary-trace-format.md
@@ -618,7 +618,7 @@ reli inspector:daemon -f rbt-bundled ... > combined.rbt
 
 ## Output Format Selection
 
-The `--output-format` (`-F`) option selects the output format for `inspector:trace` and `inspector:daemon`:
+The `--output-format` (`-f`) option selects the output format for `inspector:trace` and `inspector:daemon`:
 
 | Value | Description |
 |-------|-------------|


### PR DESCRIPTION
This PR improves the documentation with several clarifications and corrections across multiple guides.

**Key changes:**

- **recipes.md**: Added comprehensive installation instructions for the FFI-free standalone client package (`reliforp/reli-prof-sidecar-client`), including composer requirements and references to alternative installation methods documented in the monitoring guide.

- **binary-trace-format.md**: Corrected the output format option flag from `-F` to `-f` in the documentation for `inspector:trace` and `inspector:daemon` commands.

- **rmem-explore-and-serve.md**: Added clarification comment explaining the default timeout value (3600s = 1 hour) and the option to pass 0 to keep the server running indefinitely.

- **memory-profiler.md**: Fixed JSON formatting by adding a missing comma in the example output.

These changes improve clarity for users setting up the sidecar client, using the CLI tools, and configuring the rmem server.

https://claude.ai/code/session_01NwPoNuXHMwKFjpfUnQqLPN