### PR TITLE
Relocate the setcap'd PHP copy to /opt/reli/php-ptrace/php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN if [ -n "${COMPOSER_ROOT_VERSION}" ]; then \
         composer install --no-dev; \
     fi
 
-# Build a setcap'd shadow copy of the PHP binary at /usr/local/bin/php-ptrace.
+# Build a setcap'd shadow copy of the PHP binary at /opt/reli/php-ptrace/php.
 # Wrappers that actually need ptrace (docker:print-wrapper --profile=full)
 # override the container entrypoint to invoke this binary; that copy carries
 # cap_sys_ptrace=eip, so ptrace works under `--user <non-root>` even though
@@ -58,15 +58,27 @@ RUN if [ -n "${COMPOSER_ROOT_VERSION}" ]; then \
 # every `docker run reliforp/reli-prof <cmd>` invocation to require
 # `--cap-add=SYS_PTRACE`, even for offline-only commands like rbt:analyze
 # / inspector:memory:report / converter:* that never touch a live process.
-# A separate php-ptrace binary keeps the default ENTRYPOINT path usable
+# A separate ptrace-enabled binary keeps the default ENTRYPOINT path usable
 # without extra caps and confines the regression to the wrapper-emitted
 # command line, which already passes --cap-add=SYS_PTRACE.
+#
+# Why the basename stays `php` and the variant goes in the directory: when
+# reli attaches to a process started from this binary, it filters
+# /proc/<pid>/maps lines through TargetPhpSettings::PHP_REGEX_DEFAULT, which
+# is anchored on `(php|php-fpm)` (with optional version) or `libphp*.so`.
+# A binary literally named `php-ptrace` does not match — dogfooding (reli
+# attached to wrapper-launched reli) then fails inside fingerprint creation
+# with "regex matched nothing". Putting the file at `/opt/reli/php-ptrace/php`
+# keeps the basename `php` (default regex hits) while still labelling the
+# variant in the directory name, so `ps` / `--entrypoint` output reads as
+# `/opt/reli/php-ptrace/php` and the role is obvious.
 #
 # Why `cp` and not `ln`: file capabilities are stored as xattrs on the
 # inode, so a hardlink would silently apply the cap to /usr/local/bin/php
 # as well, defeating the split. A real copy gives us a separate inode.
-RUN cp -p /usr/local/bin/php /usr/local/bin/php-ptrace \
-    && setcap cap_sys_ptrace=eip /usr/local/bin/php-ptrace
+RUN mkdir -p /opt/reli/php-ptrace \
+    && cp -p /usr/local/bin/php /opt/reli/php-ptrace/php \
+    && setcap cap_sys_ptrace=eip /opt/reli/php-ptrace/php
 
 # Absolute path on purpose. The wrapper emitted by docker:print-wrapper
 # overrides WORKDIR to the host's $PWD (so bind-mounted input/output paths

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -120,8 +120,11 @@ final class PrintWrapperCommand extends ReliCommand
 # --entrypoint selects the setcap'd PHP binary baked into the image
 # (see Dockerfile). When --user is non-root the kernel zeroes the effective
 # capability set at exec, so --cap-add=SYS_PTRACE alone would still leave
-# ptrace returning EPERM; the file capability on /usr/local/bin/php-ptrace
+# ptrace returning EPERM; the file capability on /opt/reli/php-ptrace/php
 # raises CAP_SYS_PTRACE back into the effective set on each invocation.
+# The basename is `php` (not `php-ptrace`) so reli's default --php-regex
+# still matches /proc/<pid>/maps lines for processes started from this
+# binary — important when one wrapper-launched reli attaches to another.
 # Overriding the entrypoint also drops the image's `php /app/reli`
 # ENTRYPOINT, so we re-supply the absolute script path explicitly below.
 # Absolute path matters because `-w "$PWD"` puts the container CWD at the
@@ -152,7 +155,7 @@ final class PrintWrapperCommand extends ReliCommand
     fi
 
     docker run --rm -i ${tty} \
-        --entrypoint /usr/local/bin/php-ptrace \
+        --entrypoint /opt/reli/php-ptrace/php \
         --cap-add=SYS_PTRACE \
         --security-opt=apparmor=unconfined \
         --pid=host \

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -59,7 +59,7 @@ class PrintWrapperCommandTest extends TestCase
         $this->assertStringContainsString('full profile', $out);
         $this->assertStringContainsString("reli() {", $out);
         $this->assertStringContainsString('--cap-add=SYS_PTRACE', $out);
-        $this->assertStringContainsString('--entrypoint /usr/local/bin/php-ptrace', $out);
+        $this->assertStringContainsString('--entrypoint /opt/reli/php-ptrace/php', $out);
         $this->assertStringContainsString('--pid=host', $out);
         $this->assertStringContainsString('--network=host', $out);
         $this->assertStringContainsString('reli_assert_scratch_safe()', $out);


### PR DESCRIPTION
## Summary

Follow-up to #740. Moves the ptrace-enabled PHP shadow binary from `/usr/local/bin/php-ptrace` to `/opt/reli/php-ptrace/php` so that reli's default `--php-regex` recognises processes launched from it.

## Problem

#740 introduced a setcap'd shadow copy at `/usr/local/bin/php-ptrace`. The wrapper (full profile) starts the container with `--entrypoint /usr/local/bin/php-ptrace`, so `/proc/<pid>/maps` for a wrapper-launched reli shows `/usr/local/bin/php-ptrace` everywhere PHP is mapped.

When another reli (also via the wrapper) attaches to that target, it filters those maps through `TargetPhpSettings::PHP_REGEX_DEFAULT`:

```
.*/((php|php-fpm)(7\.?[01234]|8\.?[012345])?|libphp[78]?.*\.so)$
```

The trailing `$` after `(php|php-fpm)(<version>)?` requires the basename to end in `php` or `php-fpm` (with optional version) — `php-ptrace` matches nothing. The result is the user-visible failure:

```
$ reli i:tr -p <wrapper-launched-pid> -vvv

In ProcessModuleMemoryMap.php line 117:

  [RuntimeException]
  ProcessModuleMemoryMap::getBaseAddress called on a map with no memory areas;
  the regex used to filter /proc/{pid}/maps matched nothing

Exception trace:
  at /app/src/Lib/Process/MemoryMap/ProcessModuleMemoryMap.php:117
 ...
 Reli\Lib\PhpProcessReader\PhpVersionDetector->decidePhpVersion() at /app/src/Command/Inspector/GetTraceCommand.php:142
 ...
```

i.e. dogfooding (reli attached to wrapper-launched reli) is broken on the default command line.

## Fix

Place the setcap'd copy at `/opt/reli/php-ptrace/php` instead. Basename = `php`, so the default regex matches; directory name still labels the variant clearly so `ps` / `--entrypoint` output reads as `/opt/reli/php-ptrace/php` and the ptrace role is obvious to a reader.

Changes:
- `Dockerfile`: `RUN mkdir -p /opt/reli/php-ptrace && cp -p /usr/local/bin/php /opt/reli/php-ptrace/php && setcap cap_sys_ptrace=eip /opt/reli/php-ptrace/php`. Comment expanded to explain why basename = `php` and why the variant goes in the directory.
- `PrintWrapperCommand.php` (full profile): `--entrypoint /usr/local/bin/php-ptrace` → `--entrypoint /opt/reli/php-ptrace/php`. Comment notes the regex-compat reason.
- `PrintWrapperCommandTest.php`: `--entrypoint` assertion path updated.

Default ENTRYPOINT (`["php", "/app/reli"]` → `/usr/local/bin/php`) and minimal-profile wrapper are unaffected.

## Test plan
- [x] `php vendor/bin/phpunit --filter PrintWrapperCommandTest` — 9/9 green.
- [x] `phpcs --standard=PSR12 src/Command/Docker tests/Command/Docker` clean.
- [x] `psalm` on `PrintWrapperCommand.php` — no errors.
- [ ] CI: `Publish Docker image` workflow on the merge to `0.12.x` completes (linux/amd64 + linux/arm64).
- [ ] After merge, manual sanity-check: `eval "$(docker run --rm --pull=always reliforp/reli-prof:0.12.x-dev docker:print-wrapper)"` to refresh the shell function, then run `reli i:tr -p <pid-of-another-wrapper-launched-reli>` (no `--php-regex` override). Should attach successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)