### PR TITLE
Refresh docker-wrapper Security section for the /opt/reli/php-ptrace/php split

### DIFF
--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -140,9 +140,19 @@ privilege:
 - `--network=host` lets the container bind directly on host interfaces.
 - `--security-opt=apparmor=unconfined` removes AppArmor constraints.
 
-Inside the container, reli runs as the host user (`--user $(id -u):$(id -g)`);
-`CAP_SYS_PTRACE` is made effective via file capabilities on
-`/usr/local/bin/php` in the image (installed at build time).
+Inside the container, reli runs as the host user (`--user $(id -u):$(id -g)`).
+Linux zeroes the effective capability set at exec for non-zero uids, so
+`--cap-add=SYS_PTRACE` alone would still leave ptrace returning `EPERM`.
+The wrapper works around that by setting `--entrypoint /opt/reli/php-ptrace/php`,
+selecting a shadow copy of the PHP binary that carries `cap_sys_ptrace=eip`
+as a file capability — on exec the kernel re-promotes `CAP_SYS_PTRACE` into
+the effective set. The default ENTRYPOINT (`/usr/local/bin/php`) is
+intentionally left clean, so plain `docker run reliforp/reli-prof <cmd>`
+for offline-only commands (`rbt:analyze`, `inspector:memory:report`,
+`converter:*`, …) works without `--cap-add`. The shadow copy's basename is
+`php` (the variant tag is in the directory name), so reli's default
+`--php-regex` matches `/proc/<pid>/maps` for processes started from it —
+relevant when one wrapper-launched reli attaches to another.
 
 Trust the wrapper accordingly: the Full profile is fine for
 single-user laptops and dedicated CI runners, but think twice on


### PR DESCRIPTION
## Summary

A paragraph in `docs/docker-wrapper.md`'s Security section was describing the world before PR #740 / #742:

> Inside the container, reli runs as the host user (`--user $(id -u):$(id -g)`); `CAP_SYS_PTRACE` is made effective via file capabilities on `/usr/local/bin/php` in the image (installed at build time).

That was correct in the original `5b6689cc` shape, where the cap was set on `/usr/local/bin/php` itself. As of #740 + #742 the layout is different:

- `/usr/local/bin/php` is **clean (no caps)** — so plain `docker run reliforp/reli-prof <cmd>` works without `--cap-add` for offline-only commands like `rbt:analyze` (this regressed in #740 itself and was the reason for the 2-binary split).
- The setcap'd shadow copy lives at **`/opt/reli/php-ptrace/php`**, selected by the wrapper via `--entrypoint /opt/reli/php-ptrace/php`.
- The shadow copy's basename is `php` (the variant tag is in the directory name) so reli's default `--php-regex` still hits when one wrapper-launched reli attaches to another (this was the #742 motivation).

## Fix

Rewrite the paragraph to match the actual mechanism:

1. Why `--cap-add=SYS_PTRACE` alone isn't enough under non-root `--user` (Linux zeroes the effective set at exec for non-zero uids).
2. How `--entrypoint /opt/reli/php-ptrace/php` selects the setcap'd binary so the kernel re-promotes the cap into the effective set.
3. Why the default ENTRYPOINT (`/usr/local/bin/php`) is left clean — offline-only commands run via plain `docker run` without `--cap-add`.
4. Why the shadow copy's basename is `php` — default `--php-regex` keeps matching when one wrapper-launched reli attaches to another.

## Verification

Re-installed the wrapper from `reliforp/reli-prof:0.12.x-dev` and walked every showcase command in the README plus the getting-started smoke test through it. This paragraph was the only thing that drifted:

| README section | Command | Result |
|---|---|---|
| Showcase #1 | `reli inspector:trace -p \$PID -o trace.rbt` + `rbt:analyze --last --last-depth=10 --top=10 --sections="tail,self+total" ...` | OK |
| Showcase #2 | `reli rbt:explore --help` | OK (TUI explorer help renders correctly) |
| Showcase #3 | `inspector:memory:dump` → `inspector:memory:analyze -f binary` → `rmem:viz` → `wrote snapshot.rmem.viz.html` | OK |
| Showcase #4 | `inspector:memory:report` + `inspector:memory:compare` | OK |
| getting-started smoke test | `reli inspector:trace -- php -r "for(;;){usleep(10000);}"` | OK |
| `reli --version` | | `reli 0.12.x-dev` |

Also checked all 17 README link targets exist (`docs/getting-started.md`, `docs/README.md`, the tracing/* and memory/* guides, the four images, `docs/troubleshooting.md`, `docs/bench/RESULTS.md`, `docs/comparison.md`) — no broken links.

## Test plan
- [x] Confirm the new paragraph matches the running image's behaviour: `docker run --rm --entrypoint sh reliforp/reli-prof:0.12.x-dev -c 'getcap /usr/local/bin/php /opt/reli/php-ptrace/php'` returns only `/opt/reli/php-ptrace/php cap_sys_ptrace=eip` (the default `/usr/local/bin/php` shows no caps).
- [ ] Reviewer reads the rewritten paragraph and confirms the explanation flows naturally without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)