### PR TITLE
Raise PHP memory_limit to 256M in the published Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,21 @@ RUN apt-get update && apt-get install -y \
 # the type-narrowing asserts still fire during phpunit.
 RUN echo 'zend.assertions=-1' > /usr/local/etc/php/conf.d/zz-assertions.ini
 
+# Bump PHP's runtime memory_limit. Several reli commands (notably
+# inspector:peek-var, but also the eager symbol-resolver path used by
+# inspector:trace / inspector:memory:* on first attach) read the target
+# binary fully into a PHP string via FFI::string. With phpenv-style or
+# debug-info-bearing PHP builds, the target binary is comfortably 50-100 MB,
+# and at PHP's default 128 MB memory_limit the FFI buffer + PHP string copies
+# during ELF parsing push past the cap and fault as
+# "Allowed memory size of 134217728 bytes exhausted ... in NativeFileReader".
+# 256M gives enough headroom for those host PHP shapes without making the
+# image's per-invocation memory footprint unreasonable. Longer-term, the
+# individual commands should grow `--memory-limit` flags and the symbol
+# resolver should stream rather than buffer the whole binary, at which
+# point this default can shrink again.
+RUN echo 'memory_limit=256M' > /usr/local/etc/php/conf.d/zz-memory.ini
+
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Stop-gap fix for the OOM surfaced by `inspector:peek-var` (and the same code path reached on first-attach by `inspector:trace` / `inspector:memory:*`) when the target's PHP binary is large enough to exceed the image's default 128 MB `memory_limit` while reli's symbol resolver buffers it into a PHP string.

## Reproduction

```
$ reli inspector:peek-var -p <pid> --var='memory::memory_get_usage'
Fatal error: Allowed memory size of 134217728 bytes exhausted
  (tried to allocate 1052672 bytes) in /app/src/Lib/File/NativeFileReader.php on line 144
Stack:
  #0 FFI::string(uint8_t[1048576], 1048576)
  #1 NativeFileReader->readKnownSize(4, 77397728)        ← 73 MB binary
  #2 NativeFileReader->readAll('/proc/<pid>/r...')       ← read via /proc/<pid>/root
  #3 Elf64LazyParseSymbolResolver->readBinaryOnce()
  ...
```

Surfaced against a phpenv-built host PHP (binary ~73 MB on this machine — debug info / extra extensions). 1 MB FFI buffers copied into PHP strings during ELF parse cumulatively push past PHP's default 128 MB cap.

## Fix

Add a tiny `/usr/local/etc/php/conf.d/zz-memory.ini` snippet at image build time setting `memory_limit=256M`, alongside the existing `zz-assertions.ini`. Loads after the base `php.ini` so the bumped value wins.

256M gives enough headroom for the big-PHP shapes we've seen (phpenv, debug-info, extension-heavy distro builds) without making the image's per-invocation memory footprint unreasonable.

## Why this is a stop-gap

Two follow-ups that should land later (separately, post-0.12.0):

1. **Per-command `--memory-limit` flag** so users can crank it up further when needed without rebuilding the image. `inspector:memory:*` already takes one; the trace / peek-var / watch family doesn't yet.
2. **Streaming symbol resolver** — `Elf64LazyParseSymbolResolver->readBinaryOnce()` currently buffers the whole binary into PHP via `FFI::string`. Switching it to chunked read/parse would erase the issue at the source, and let the default come back down to 128 MB.

When (2) lands, this commit can be reverted; (1) is independent and complementary.

## Test plan
- [ ] CI: `Publish Docker image` workflow on the merge to `0.12.x` completes (linux/amd64 + linux/arm64).
- [ ] After merge, manual:
  - [ ] Refresh wrapper (`eval "$(docker run --rm --pull=always reliforp/reli-prof:0.12.x-dev d:p --image=reliforp/reli-prof:0.12.x-dev)"`).
  - [ ] `docker run --rm reliforp/reli-prof:0.12.x-dev -d memory_limit -d -d -i 'memory_limit'` (or simply `php -i | grep memory_limit` via shell entrypoint) to confirm the new ini value is picked up.
  - [ ] Re-run `reli inspector:peek-var -p <pid> --var='memory::memory_get_usage'` against the same host PHP that previously OOM'd; should now return a value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)