### PR TITLE
Drop sudo from `sudo reli ...` examples in recipes.md

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -19,7 +19,7 @@ mkdir -p ./traces
 # Attach to every worker matching the regex for ~60s.
 # The daemon writes one .rbt per *reli worker* (-T, default 8) into
 # ./traces/, named worker_<reli-worker-pid>.rbt — not one per target PID.
-sudo timeout 60 reli inspector:daemon \
+timeout 60 reli inspector:daemon \
     -P "^php-fpm" \
     -f rbt -o ./traces/
 
@@ -39,7 +39,7 @@ Dump now (short stop), analyse offline, look at the prioritised report:
 
 ```bash
 # 1. Take a fast binary dump (target stopped only briefly)
-sudo reli inspector:memory:dump --pid=<pid> --output=worker.rdump
+reli inspector:memory:dump --pid=<pid> --output=worker.rdump
 
 # 2. Analyse the dump into a .rmem snapshot
 reli inspector:memory:analyze worker.rdump -f binary -o worker.rmem
@@ -126,7 +126,7 @@ flags do the work:
 
 ```bash
 # Daemon mode: discover workers automatically, skip Caddy / Go threads
-sudo reli inspector:daemon \
+reli inspector:daemon \
     -P frankenphp \
     --target-thread-regex='^php-[0-9a-f]+$' \
     --php-regex='.*/libphp\.so$' \
@@ -148,7 +148,7 @@ ps -L -p "$(pgrep -o frankenphp)" -o tid,comm | awk '$2 ~ /^php-[0-9a-f]+$/'
 # (FrankenPHP names worker threads with a hex suffix; the regex above also
 #  excludes `php-main`, the bootstrap thread.)
 
-sudo reli inspector:trace -p 12345 \
+reli inspector:trace -p 12345 \
     --php-regex='.*/libphp\.so$' \
     --libpthread-regex='.*/libc\.so.*' \
     -o trace.rbt


### PR DESCRIPTION
## Summary

`docs/recipes.md` mixes its own preamble — bare `reli ...` means the Docker wrapper, `./reli ...` for native — by prefixing `sudo` to four wrapper-form invocations:

| Line | Recipe | Before |
|---|---|---|
| 22 | Profile a php-fpm pool for 60s | `sudo timeout 60 reli inspector:daemon ...` |
| 42 | Investigate memory growth in a worker | `sudo reli inspector:memory:dump ...` |
| 129 | Profile FrankenPHP workers (daemon) | `sudo reli inspector:daemon ...` |
| 151 | Profile FrankenPHP workers (single TID) | `sudo reli inspector:trace -p 12345 ...` |

`sudo reli` doesn't work and isn't needed:

1. **It would fail.** `reli` is a shell function emitted by `docker:print-wrapper`. `sudo` only runs binaries, so the literal `sudo reli ...` errors out as `sudo: reli: command not found` on most setups.
2. **It would defeat the wrapper's design even if it ran.** Routing the wrapper through sudo would set `--user 0:0` inside the container and emit root-owned files into the bind-mounted host cwd. The wrapper already requests `--cap-add=SYS_PTRACE` and selects the setcap'd PHP binary via `--entrypoint`, so ptrace works under the host user — sudo provides nothing extra and breaks output-ownership.

Native-checkout users still need sudo (or setcap on host php) for ptrace, but that's already covered by the recipes preamble's pointer to `getting-started.md`, which explicitly says "On a native install you need either to run reli as root (`sudo`) or set `CAP_SYS_PTRACE`...". So the recipes themselves can stay terse.

## Fix

Drop the four `sudo` prefixes. No other changes — the surrounding `timeout 60 reli ...` form (recipe §1) and the FrankenPHP regex flags are unchanged.

## Test plan
- [x] `grep -n '^sudo \|^\s*sudo ' docs/recipes.md` returns nothing after the change.
- [x] Diff is exactly 4 lines (one `sudo` prefix removed each).
- [ ] Visual review: each recipe still parses end-to-end as a copy-pasteable wrapper invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)