### PR TITLE
Pre-create runtime/state/cache subdirs of the wrapper scratch dir

### DIFF
--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -148,6 +148,16 @@ final class PrintWrapperCommand extends ReliCommand
         return 2
     fi
     mkdir -m 0700 -p "$scratch" || return $?
+    # Pre-create the XDG_* sub-paths the docker run below points at.
+    # `inspector:sidecar` (and any other consumer that resolves a default
+    # path under $XDG_RUNTIME_DIR) checks `is_dir(parent)` before binding;
+    # without this `runtime/` mkdir the default sidecar socket path fails
+    # immediately with "XDG_RUNTIME_DIR is not set or not a directory".
+    # `state/` and `cache/` are auto-created on demand by other commands,
+    # but we make them up front for symmetry so the XDG_* triple inside
+    # the container always points at real directories.
+    mkdir -m 0700 -p "$scratch/runtime" "$scratch/state" "$scratch/cache" \
+        || return $?
     local reason
     if ! reason=$(reli_assert_scratch_safe "$scratch"); then
         echo "{{NAME}}: scratch dir $scratch failed safety check: $reason" >&2

--- a/tests/Command/Docker/PrintWrapperCommandTest.php
+++ b/tests/Command/Docker/PrintWrapperCommandTest.php
@@ -64,6 +64,14 @@ class PrintWrapperCommandTest extends TestCase
         $this->assertStringContainsString('--network=host', $out);
         $this->assertStringContainsString('reli_assert_scratch_safe()', $out);
         $this->assertStringContainsString('reliforp/reli-prof:', $out);
+        // XDG sub-paths the wrapper points -e env vars at must be
+        // created up front so e.g. `inspector:sidecar`'s default
+        // socket-path resolver finds $XDG_RUNTIME_DIR pointing at a
+        // real directory.
+        $this->assertStringContainsString(
+            'mkdir -m 0700 -p "$scratch/runtime" "$scratch/state" "$scratch/cache"',
+            $out,
+        );
     }
 
     public function testFullProfileIsDefault(): void


### PR DESCRIPTION
## Summary

`docker:print-wrapper`'s full profile sets:

```
-e HOME="${scratch}" \
-e XDG_STATE_HOME="${scratch}/state" \
-e XDG_CACHE_HOME="${scratch}/cache" \
-e XDG_RUNTIME_DIR="${scratch}/runtime" \
```

…but only `mkdir -p`'s `\$scratch` itself, leaving the three sub-paths non-existent until something inside the container creates them. `inspector:sidecar` resolves its default socket path via `SocketPathResolver`, which calls `is_dir(\$XDG_RUNTIME_DIR)` and aborts otherwise — so the documented one-liner from `monitoring/sidecar.md`:

```
$ reli inspector:sidecar --output-dir=/tmp/reli-dumps
```

…always fails out of the box on a wrapper-installed `reli`:

```
In SocketPathResolver.php line 51:
  Cannot resolve default sidecar socket path: XDG_RUNTIME_DIR is not set
  or not a directory. Pass --socket explicitly (or set RELI_SIDECAR_SOCKET)
  to a user-owned 0700 parent dir.
```

even though the doc explicitly says the default works when `XDG_RUNTIME_DIR` is set. The wrapper *is* setting it — it's just pointing at a path nobody created.

## Reproduction

Inside the container, before this change:

```
$ docker run --rm --user "$(id -u):$(id -g)" --entrypoint sh \
    -v "${XDG_RUNTIME_DIR}/reli-docker:${XDG_RUNTIME_DIR}/reli-docker" \
    -e XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}/reli-docker/runtime" \
    reliforp/reli-prof:0.12.x-dev \
    -c 'echo "container XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"; ls -la "$XDG_RUNTIME_DIR" 2>&1'
container XDG_RUNTIME_DIR=/run/user/1000/reli-docker/runtime
ls: cannot access '/run/user/1000/reli-docker/runtime': No such file or directory
```

## Fix

Add a `mkdir -m 0700 -p \"\$scratch/runtime\" \"\$scratch/state\" \"\$scratch/cache\"` right after the existing `mkdir -m 0700 -p \"\$scratch\"`. The new subdirs match the three XDG_* env vars the wrapper exports, so the triple always points at real directories no matter which command the user runs first.

## Verification

After this change, sourcing the emitted wrapper into a fresh shell:

```
$ rm -rf \"\$XDG_RUNTIME_DIR/reli-docker\"
$ source /tmp/wrapper.sh
$ reli inspector:sidecar --output-dir=/tmp/reli-dumps
[sidecar] Listening on /run/user/1000/reli-docker/runtime/reli/sidecar.sock
```

…matching the banner format the doc claims.

`\$scratch` itself ends up containing all three sub-paths at 0700:

```
$ ls -la \"\$XDG_RUNTIME_DIR/reli-docker/\"
drwx------ 5 sji sji 100 ... .
drwx------ 2 sji sji  40 ... cache
drwx------ 2 sji sji  40 ... runtime
drwx------ 3 sji sji  60 ... state
```

The minimal-profile wrapper does not export XDG_* env vars and is unaffected.

## Test plan
- [x] `php vendor/bin/phpunit --filter PrintWrapperCommandTest` — 9/9 green; `testFullProfileEmitsReliFunction` gains an assertion that the new `mkdir` line is present in the full-profile output.
- [x] `phpcs --standard=PSR12 src/Command/Docker tests/Command/Docker` clean.
- [x] `psalm` on `PrintWrapperCommand.php` — no errors.
- [x] Functional: emitted wrapper sourced into a fresh bash creates `\$scratch/{runtime,state,cache}` at 0700, and `inspector:sidecar` with no `--socket` override binds successfully.
- [ ] CI: `Publish Docker image` workflow on the merge to `0.12.x` completes (the wrapper is emitted at runtime by the image, so the image itself doesn't change shape — but reviewers may want to confirm the verify step still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)