### PR TITLE
Fall back to default_static_members_table when the runtime slot is unmaterialized

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php
@@ -259,37 +259,55 @@ final class ZendClassEntry implements LazyDereferencable, PointedTypeResolverAwa
         ZendTypeReader $type_reader,
         int $map_ptr_base,
     ): iterable {
-        if ($this->default_static_members_count === 0 or is_null($this->static_members_table)) {
+        if ($this->default_static_members_count === 0) {
             return;
         }
 
         if (!isset($this->static_properties_table_cache)) {
             $property_count = $this->default_static_members_count;
             $table_size = $property_count * $type_reader->sizeOf(Zval::getCTypeName());
-            $raw_ptr = $this->static_members_table->address;
-            if ($map_ptr_base !== 0) {
-                // PHP 8.2+: MAP_PTR offset resolution
-                $table_address = $type_reader->resolveMapPtr(
-                    $map_ptr_base,
-                    $raw_ptr,
-                    $dereferencer,
-                );
-            } elseif (
-                !$type_reader->isPhpVersionLowerThan(
-                    \Reli\Lib\PhpInternals\ZendTypeReader::V74,
-                )
-            ) {
-                // PHP 7.4-8.1: static_members_table__ptr is zval**
-                // (double pointer), deref once
-                $ptr = new Pointer(RawInt64::class, $raw_ptr, 8);
-                $table_address = $dereferencer->deref($ptr)->value;
-            } else {
-                // PHP 7.0-7.3: static_members_table__ptr is zval*
-                // (direct pointer to table)
-                $table_address = $raw_ptr;
+            // Try the runtime static_members_table first. PHP 7.4+
+            // allocates this lazily — until a static of this class is
+            // read or written for the first time, the C struct's
+            // `static_members_table__ptr` field can be NULL outright
+            // (untouched user-defined class), or it can be non-NULL
+            // but with a MAP_PTR / single-deref slot that resolves to
+            // 0. In both cases we fall through to the class entry's
+            // default_static_members_table, which holds the
+            // compile-time defaults that PHP would copy from on first
+            // access — so values match what an in-process
+            // `ClassName::$prop` read would see before any
+            // modification.
+            $table_address = 0;
+            if (!is_null($this->static_members_table)) {
+                $raw_ptr = $this->static_members_table->address;
+                if ($map_ptr_base !== 0) {
+                    // PHP 8.2+: MAP_PTR offset resolution
+                    $table_address = $type_reader->resolveMapPtr(
+                        $map_ptr_base,
+                        $raw_ptr,
+                        $dereferencer,
+                    );
+                } elseif (
+                    !$type_reader->isPhpVersionLowerThan(
+                        \Reli\Lib\PhpInternals\ZendTypeReader::V74,
+                    )
+                ) {
+                    // PHP 7.4-8.1: static_members_table__ptr is zval**
+                    // (double pointer), deref once
+                    $ptr = new Pointer(RawInt64::class, $raw_ptr, 8);
+                    $table_address = $dereferencer->deref($ptr)->value;
+                } else {
+                    // PHP 7.0-7.3: static_members_table__ptr is zval*
+                    // (direct pointer to table)
+                    $table_address = $raw_ptr;
+                }
             }
             if ($table_address === 0) {
-                return;
+                if ($this->default_static_members_table === null) {
+                    return;
+                }
+                $table_address = $this->default_static_members_table->address;
             }
             $properties_table_pointer = new Pointer(
                 ZvalArray::class,

--- a/tests/Inspector/Watch/VariableReaderIntegrationTest.php
+++ b/tests/Inspector/Watch/VariableReaderIntegrationTest.php
@@ -411,6 +411,115 @@ class VariableReaderIntegrationTest extends BaseTestCase
     }
 
     /**
+     * In PHP 7.4+ the runtime static_members_table for a class is
+     * allocated lazily — it stays unset until any static property of
+     * the class is read or written for the first time. A class declared
+     * but whose statics are never touched therefore has a NULL runtime
+     * pointer (zero MAP_PTR slot on PHP 8.2+, zero double-deref on
+     * 7.4-8.1) even though the class itself is registered in
+     * EG(class_table) and the compile-time defaults are sitting in
+     * default_static_members_table. The reader falls back to the
+     * defaults table in that case.
+     */
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testReadStaticPropertyOfUntouchedClass(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $memory_reader = new MemoryReader();
+        $zend_type_reader_creator = new ZendTypeReaderCreator();
+
+        // Deliberately do NOT touch UntouchedCache::$* anywhere. The
+        // class is declared at file scope (so it is in
+        // EG(class_table) by the time the script is paused) but no
+        // static of it is read or written, leaving the runtime
+        // static_members_table slot zero on PHP 7.4+.
+        $target_script = <<<'CODE'
+            <?php
+            class UntouchedCache {
+                public static $size = 42;
+                public static $name = "default";
+                public static $items = array(1, 2, 3);
+            }
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+
+        $php_globals_finder = $this->createGlobalsFinder(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+        $eg_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $cg_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $variable_reader = new VariableReader(
+            $memory_reader,
+            $zend_type_reader_creator,
+        );
+
+        $specs = [
+            VariableSpec::parse('static::UntouchedCache::$size'),
+            VariableSpec::parse('static::UntouchedCache::$name'),
+            VariableSpec::parse('static::UntouchedCache::$items'),
+        ];
+        $results = $variable_reader->readVariables(
+            $specs,
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+            $cg_address,
+        );
+
+        $key_size = 'static::UntouchedCache::$size';
+        $this->assertArrayHasKey($key_size, $results);
+        $this->assertSame(
+            VariableValue::TYPE_LONG,
+            $results[$key_size]->type,
+        );
+        $this->assertSame(42, $results[$key_size]->scalar_value);
+
+        $key_name = 'static::UntouchedCache::$name';
+        $this->assertArrayHasKey($key_name, $results);
+        $this->assertSame(
+            VariableValue::TYPE_STRING,
+            $results[$key_name]->type,
+        );
+        $this->assertSame(
+            'default',
+            $results[$key_name]->scalar_value,
+        );
+
+        $key_items = 'static::UntouchedCache::$items';
+        $this->assertArrayHasKey($key_items, $results);
+        $this->assertSame(
+            VariableValue::TYPE_ARRAY,
+            $results[$key_items]->type,
+        );
+        $this->assertSame(3, $results[$key_items]->array_count);
+    }
+
+    /**
      * Nested array and object property access tests.
      * Note: $GLOBALS entries use IS_INDIRECT in PHP 8.1+,
      * and nested hash table traversal for sub-keys requires


### PR DESCRIPTION
## Summary

`inspector:peek-var --var='static::C::\$prop'` (and the same thing through `inspector:trace --trace-var=...` / `inspector:watch --watch-var=...`) returned `<not found>` for any class whose statics had never been read or written, even when the class itself was clearly defined in `EG(class_table)`.

### Reproduction (PHP 8.4)

```php
<?php
class Untouched { public static int \$entries = 11111; }
class Touched   { public static int \$entries = 22222; }
Touched::\$entries++;        // ← only diff
while (true) { usleep(100000); }
```

```
$ reli inspector:peek-var -p \$PID \
    --var='static::Untouched::\$entries' \
    --var='static::Touched::\$entries'
static::Untouched::\$entries = <not found>     # ← bug
static::Touched::\$entries   = (int) 22223
```

The two classes are byte-for-byte identical at the source level; the only difference is one statement that touches the static at script startup.

## Root cause

PHP 7.4+ allocates the runtime `static_members_table` **lazily**. Until the first read or write of any static of the class, the C struct's `static_members_table__ptr` field is either:

- **NULL outright**, on PHP 8.4 user-defined classes that have never been touched (confirmed via on-the-fly stderr probes against the running target);
- non-NULL but with a MAP_PTR / single-deref slot that resolves to 0 on other 7.4+ shapes.

Reli's `getStaticPropertyIterator` (in `src/Lib/PhpInternals/Types/Zend/ZendClassEntry.php`) was bailing out in both paths:

```php
if ($default_static_members_count === 0
    or is_null($static_members_table)) {
    return;     // ← path 1: \"no runtime ptr at all\"
}
...
if (\$table_address === 0) {
    return;     // ← path 2: \"runtime ptr exists but resolves to 0\"
}
```

…even though the compile-time defaults are sitting next door in `zend_class_entry::default_static_members_table`, and reading from there gives byte-identical values to what PHP would copy in on first access.

## Fix

Restructure the iterator so the runtime path stays primary, and we fall back to `default_static_members_table` whenever the runtime is absent or resolves to 0:

- `default_static_members_count == 0` still short-circuits (no statics to read at all — the only legitimate empty case).
- `static_members_table === null` no longer returns immediately. We leave `\$table_address = 0` and fall through to the fallback check.
- `\$table_address === 0` (post-MAP_PTR / post-deref) tries the defaults pointer; only returns empty when neither runtime nor defaults are available.

The defaults table format (`ZvalArray` of `default_static_members_count` slots) is the same shape as the runtime table, so no other code in the iterator changes — `iteratePropertyInfo()` returns the same offsets, and `\$this->static_properties_table_cache[\$real_offset]` still works.

## Affected commands

Every consumer of `ZendClassEntry::getStaticPropertyIterator`:

- `inspector:peek-var --var='static::...'`
- `inspector:trace --trace-var='static::...'`
- `inspector:watch --watch-var='static::...:op:val'`

Before this fix, any of these failed silently against statics that no code path in the running script had touched yet — common for config-style class constants, pre-bootstrap caches, and anything that the application reads through a different access path.

## Test

A new `testReadStaticPropertyOfUntouchedClass` integration test mirrors the existing `testReadStaticProperty`, but its target script deliberately omits the `AppCache::\$size;` line that was making the previous test pass on PHP 7.4+. It exercises int / string / array defaults across all supported target PHP versions:

```php
class UntouchedCache {
    public static \$size = 42;
    public static \$name = \"default\";
    public static \$items = array(1, 2, 3);
}
fputs(STDOUT, \"ready\n\");
fgets(STDIN);
```

then asserts the reader returns `42`, `\"default\"`, and an array with three elements respectively.

## Verified

Against the published docker target images for PHP 7.4 / 8.0 / 8.4 (skipping the pre-existing flaky `WithOpcachePreload` test, which fails identically on the unmodified base — confirmed via `git stash`):

```
RELI_TEST_PHP_TARGETS=v74 phpunit --filter StaticProperty ...  4/4 OK (36 assertions)
RELI_TEST_PHP_TARGETS=v80 phpunit --filter StaticProperty ...  4/4 OK (36 assertions)
RELI_TEST_PHP_TARGETS=v84 phpunit --filter StaticProperty ...  4/4 OK (36 assertions)
RELI_TEST_PHP_TARGETS=v84 phpunit VariableReaderIntegrationTest  10/10 OK (103 assertions)
RELI_TEST_PHP_TARGETS=v84 phpunit PeekVarCommandIntegrationTest  6/6  OK (31 assertions)
```

phpcs and psalm clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)