### PR TITLE
Fix memory analyze command format flag in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Render the heap as a standalone HTML file — Circle Pack, Treemap, Sunburst, 3D
 ```bash
 # Recommended for production: short stop, then offline analysis.
 $ reli inspector:memory:dump -p <pid> -o snapshot.rdump
-$ reli inspector:memory:analyze snapshot.rdump -f binary -o snapshot.rmem
+$ reli inspector:memory:analyze snapshot.rdump -f rmem -o snapshot.rmem
 
 # Standalone HTML
 $ reli rmem:viz snapshot.rmem
@@ -90,7 +90,7 @@ Capture a snapshot and get a prioritised report back — dominant classes, cycle
 ```bash
 # Recommended for production: short stop, then offline analysis.
 $ reli inspector:memory:dump -p <pid> -o snapshot.rdump
-$ reli inspector:memory:analyze snapshot.rdump -f binary -o snapshot.rmem
+$ reli inspector:memory:analyze snapshot.rdump -f rmem -o snapshot.rmem
 $ reli inspector:memory:report snapshot.rmem
 ```
 


### PR DESCRIPTION
## Summary
Updated the README documentation to correct the format flag used in the `inspector:memory:analyze` command from `binary` to `rmem`.

## Changes
- Updated two command examples in the README that demonstrate memory snapshot analysis workflow
- Changed the `-f binary` flag to `-f rmem` in both the "Render the heap as a standalone HTML file" and "Capture a snapshot and get a prioritised report back" sections
- This ensures the documentation accurately reflects the correct format option for analyzing memory dumps

## Details
The format flag should be `rmem` (not `binary`) when analyzing `.rdump` snapshot files to produce `.rmem` output files. This correction ensures users following the documentation will use the correct command syntax.

https://claude.ai/code/session_01Ksf4VT5pHkFRBYmfd19Aks