### PR TITLE
docs(frankenphp): the php-main failure mode varies by build

### DIFF
--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -67,10 +67,23 @@ sudo php ./reli inspector:trace -p 12345 \
 A few realities on FrankenPHP that the snippet above is built around:
 
 - **Skip `php-main`.** It also matches `^php-` but is the
-  bootstrap thread — its executor globals do not point at a
-  populated request heap, so memory commands fail with
-  "failed to find ZendMM main chunk". `^php-[0-9a-f]+$` excludes
-  it.
+  bootstrap thread: FrankenPHP's `php_main` initialises the TSRM
+  subsystem itself but never calls `ts_resource(0)` for the
+  bootstrap thread, and `php-main` does not service requests
+  that would populate TSRM later. The exact error reli prints
+  depends on the FrankenPHP / PHP build:
+  - On current builds (verified against `dunglas/frankenphp:latest`
+    PHP 8.5 and `dunglas/frankenphp:php8.3` as of 2026-04), the
+    brute-force TLS scan returns nothing and the call fails at
+    TSRM resolution with `_tsrm_ls_cache slot is uninitialized
+    -- typical of an idle FrankenPHP worker`.
+  - On older builds where reli's scan happened to land on a
+    neighbouring thread's TLS pattern, the call progressed past
+    TSRM and failed downstream with `failed to find ZendMM main
+    chunk` instead.
+
+  In either case the recovery is the same: `^php-[0-9a-f]+$`
+  excludes `php-main` and selects a hex-named worker.
 - **First attach is slower than subsequent ones.** The first attach
   to a given `libphp.so` parses the dynamic symbol table, reads
   PT_TLS, and brute-forces `_tsrm_ls_cache` out of the TLS block.


### PR DESCRIPTION
## Summary

Walked the FrankenPHP recipe in `docs/tracing/frankenphp.md` against `dunglas/frankenphp:latest` (PHP 8.5) and `dunglas/frankenphp:php8.3` and found the "Skip `php-main`" bullet was still asserting a failure mode the current images do not produce.

The bullet said:

> its executor globals do not point at a populated request heap, so memory commands fail with "failed to find ZendMM main chunk".

But both images, on every attempt, print the TSRM-uninitialized error instead:

```
In PhpGlobalsFinder.php line 372:
  executor_globals not found via TSRM on TID <n>. The binary is
  ZTS (PT_TLS present) but this thread's _tsrm_ls_cache slot is
  uninitialized -- typical of an idle FrankenPHP worker.
```

## Why current behaviour differs from the documented one

Reading `frankenphp.c` (HEAD = `eeaab63`, 2026-04-24):

- `php_thread` (the routine that backs the `php-<hex>` worker threads) calls `(void)ts_resource(0)` at thread startup. Added in `fb23c646` (2024-07-26, "perf: cgi-mode 1700% improvement").
- `php_main` (the bootstrap thread that gets the `php-main` name) calls `php_tsrm_startup_ex` / `php_tsrm_startup` to bring up the TSRM **subsystem itself**, then `sapi_startup`. It does **not** call `ts_resource(0)` for the bootstrap thread, and `php-main` is the thread that orchestrates Caddy / signals worker threads — not one that handles PHP requests. So the per-thread TSRM resource on which `_tsrm_ls_cache` depends never gets allocated.

The earlier "ZendMM main chunk" wording was added in `c35080c0` and tightened in `f45da8bf` against `dunglas/frankenphp:php8.3` of that era, when reli's brute-force TLS scan happened to land on a pattern from a neighbouring thread's TLS block. That let TSRM resolution succeed by accident on `php-main` and pushed the failure one stage further (down to ZendMM-main-chunk lookup, which then legitimately failed because php-main never sets up a request scope). Today's images don't reproduce that happy accident — TSRM resolution itself fails first.

## Fix

Soften the bullet the same way `781d6c34` did for idle hex workers: keep the recommendation (`^php-[0-9a-f]+$` excludes `php-main`, target a hex-named worker) and explicitly note that the failure message varies by build, with both messages quoted so a doc search for either string hits this section.

```diff
 - **Skip `php-main`.** It also matches `^php-` but is the
-  bootstrap thread — its executor globals do not point at a
-  populated request heap, so memory commands fail with
-  "failed to find ZendMM main chunk". `^php-[0-9a-f]+$` excludes
-  it.
+  bootstrap thread: FrankenPHP's `php_main` initialises the TSRM
+  subsystem itself but never calls `ts_resource(0)` for the
+  bootstrap thread, and `php-main` does not service requests
+  that would populate TSRM later. The exact error reli prints
+  depends on the FrankenPHP / PHP build:
+  - On current builds (verified against `dunglas/frankenphp:latest`
+    PHP 8.5 and `dunglas/frankenphp:php8.3` as of 2026-04), the
+    brute-force TLS scan returns nothing and the call fails at
+    TSRM resolution with `_tsrm_ls_cache slot is uninitialized
+    -- typical of an idle FrankenPHP worker`.
+  - On older builds where reli's scan happened to land on a
+    neighbouring thread's TLS pattern, the call progressed past
+    TSRM and failed downstream with `failed to find ZendMM main
+    chunk` instead.
+
+  In either case the recovery is the same: `^php-[0-9a-f]+$`
+  excludes `php-main` and selects a hex-named worker.
```

The other ZendMM-main-chunk reference in this file (line ~113, "TSRM-resolved cold worker in regular mode still fails downstream with 'failed to find ZendMM main chunk' because the request scope hasn't been set up") is a separate case — it documents the **non-main** worker path in **regular per-request mode**, which is unaffected by this issue and stays as-is.

Pure documentation fix; no code change.

## Verification

- `dunglas/frankenphp:latest` (PHP 8.5.5) — `inspector:memory:dump -p $(php-main TID) ...` prints the TSRM-uninitialized error.
- `dunglas/frankenphp:php8.3` (current) — same TSRM-uninitialized error against `php-main` even with hex workers warmed by traffic.
- Both reli targets resolve fine against warm `php-<hex>` workers, confirming the issue is specific to `php-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)