### PR TITLE
Improve documentation clarity and error messaging

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,12 +185,14 @@ php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
 # (-f rbt is implied by the .rbt extension on -o)
-# pgrep -fx matches the full command line exactly — avoids picking up the
-# enclosing shell (whose own /proc/<pid>/cmdline can contain "your-script.php"
-# when this line is run via `bash -c`, a Make rule, an editor task runner, etc).
+# pgrep -nfx matches the newest process whose full command line is exactly
+# `php ./your-script.php` -- the `x` avoids picking up the enclosing shell
+# (whose own /proc/<pid>/cmdline can contain "your-script.php" when this line
+# is run via `bash -c`, a Make rule, an editor task runner, etc), and the `n`
+# keeps the result to one PID even if you ran the script more than once.
 # Plain `pgrep -nf your-script.php` works in an interactive shell but silently
 # returns the wrong PID inside those wrappers.
-reli inspector:trace -p "$(pgrep -fx 'php ./your-script.php')" -o trace.rbt
+reli inspector:trace -p "$(pgrep -nfx 'php ./your-script.php')" -o trace.rbt
 ```
 
 The target process must be reachable with `ptrace(2)`. Under the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,8 +185,12 @@ php ./your-script.php
 
 # Terminal B: attach and capture for ~10 s, then Ctrl-C
 # (-f rbt is implied by the .rbt extension on -o)
-# pgrep -n picks the newest match — avoids passing multiple PIDs when several commands match.
-reli inspector:trace -p "$(pgrep -nf your-script.php)" -o trace.rbt
+# pgrep -fx matches the full command line exactly — avoids picking up the
+# enclosing shell (whose own /proc/<pid>/cmdline can contain "your-script.php"
+# when this line is run via `bash -c`, a Make rule, an editor task runner, etc).
+# Plain `pgrep -nf your-script.php` works in an interactive shell but silently
+# returns the wrong PID inside those wrappers.
+reli inspector:trace -p "$(pgrep -fx 'php ./your-script.php')" -o trace.rbt
 ```
 
 The target process must be reachable with `ptrace(2)`. Under the

--- a/docs/memory/coredump.md
+++ b/docs/memory/coredump.md
@@ -54,7 +54,7 @@ and `rmem:mcp` read `.rmem` only.
 The output of `inspector:coredump` uses the same
 [`MemoryProfilerSettings`](../../src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php)
 as `inspector:memory`, so every output format (`json`, `sqlite3`,
-`binary`, `mysql`, `postgresql`, `report`, `report-json`) is supported.
+`rmem`, `mysql`, `postgresql`, `report`, `report-json`) is supported.
 Which downstream tool you can feed depends on the format:
 
 - `inspector:memory:report` and `inspector:memory:compare` accept

--- a/docs/memory/memory-dump.md
+++ b/docs/memory/memory-dump.md
@@ -47,12 +47,11 @@ that the dump may contain inconsistent state.
 ## Options
 
 ```
---pid, -p           Target process PID (or pass a `cmd` after `--` to spawn one)
---output, -o        Output file path
---stop-process      Stop the target during dump (default: on)
---no-stop-process   Don't stop the target
---include-binary    Include read-only binary segments (self-contained dump)
---exclude-heap      Exclude [heap] and anonymous mmap regions (see below)
+--pid, -p                          Target process PID (or pass a `cmd` after `--` to spawn one)
+--output, -o                       Output file path
+--stop-process | --no-stop-process Stop the target during dump (default: on)
+--include-binary                   Include read-only binary segments (self-contained dump)
+--exclude-heap                     Exclude [heap] and anonymous mmap regions (see below)
 ```
 
 `./reli inspector:memory:dump --help` is the source of truth for the
@@ -117,4 +116,10 @@ php ./reli inspector:memory:analyze snapshot.rdump \
 - [memory-report.md](memory-report.md) — automated analysis reports
 - [watch-command.md](../monitoring/watch-command.md) — condition-triggered dumps
 - [sidecar.md](../monitoring/sidecar.md) — daemon mode for on-demand dumps
-- [internals/memory-dump-inspect.md](../internals/memory-dump-inspect.md) — `inspector:memory:dump:inspect`, a developer tool that prints the `.rdump` header / memory map / region list (output schema is unstable, intended for debugging the capture pipeline itself)
+
+For developers debugging the capture pipeline itself,
+`inspector:memory:dump:inspect` prints the `.rdump` header, memory
+map, and region list. Its output schema is unstable and is **not**
+intended for end-user analysis (use `inspector:memory:analyze` /
+`inspector:memory:report` for that). Notes:
+[internals/memory-dump-inspect.md](../internals/memory-dump-inspect.md).

--- a/docs/memory/memory-profiler-database.md
+++ b/docs/memory/memory-profiler-database.md
@@ -45,10 +45,10 @@ psql reli_memory -c "SELECT * FROM location_types_summary ORDER BY memory_usage 
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--output-format` | `-f` | Output format: `json` (default), `binary` (`.rmem`), `sqlite3`, `mysql`, `postgresql`, `report`, `report-json` |
-| `--output` | `-o` | Output file path (required for `binary` / `sqlite3` / `report-json`) |
+| `--output-format` | `-f` | Output format: `json` (default), `rmem` (`.rmem`), `sqlite3`, `mysql`, `postgresql`, `report`, `report-json` |
+| `--output` | `-o` | Output file path (required for `rmem` / `sqlite3` / `report-json`) |
 
-This page focuses on `sqlite3` / `mysql` / `postgresql`. `binary` (`.rmem`) is the primary storage format — see the note at the top of the page. `report` / `report-json` emit a findings report directly; see [memory-report.md](memory-report.md).
+This page focuses on `sqlite3` / `mysql` / `postgresql`. `rmem` (`.rmem`) is the primary storage format — see the note at the top of the page. `report` / `report-json` emit a findings report directly; see [memory-report.md](memory-report.md).
 
 ### Database connection (for `mysql` / `postgresql`)
 

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -45,8 +45,8 @@ recommended install paths (Docker wrapper, Composer, Git).
 flag list and defaults. The flags you most often reach for:
 
 - `-p, --pid <PID>` — target process id (or pass a `cmd` after `--` to spawn one)
-- `-f, --output-format <fmt>` — `json` (default), `sqlite3`, `binary` (`.rmem`),
-  `report`, `report-json`, `mysql`, `postgresql`. `binary` / `sqlite3` /
+- `-f, --output-format <fmt>` — `json` (default), `sqlite3`, `rmem` (`.rmem`),
+  `report`, `report-json`, `mysql`, `postgresql`. `rmem` / `sqlite3` /
   `mysql` / `postgresql` require `-o` (or `--db-*`).
 - `-o, --output <path>` — write to a file instead of stdout
 - `--pretty-print` — pretty-print the JSON output (default: off)

--- a/docs/tracing/capturing-traces.md
+++ b/docs/tracing/capturing-traces.md
@@ -161,12 +161,18 @@ UNIX-`top`-style aggregated view, updated live as samples come in.
 Useful as a quick "what is this pool doing right now?" check:
 
 ```bash
+# Across a pool of processes
 sudo php ./reli inspector:top -P "^php-fpm"
+
+# Or against a single PID — same output, no regex needed
+sudo php ./reli inspector:top -p <pid>
 ```
 
-Flags are the regex/pool subset of `inspector:daemon`:
-`-P/--target-regex`, `-T/--threads`, `-d/--depth`, `-s/--sleep-ns`,
-`--with-native-trace`.
+`-p` and `-P` are interchangeable target selectors here (the `--help`
+text marks `-P` as required, but `-p <pid>` is also accepted and goes
+through the same aggregation path). Other flags are the regex/pool
+subset of `inspector:daemon`: `-T/--threads`, `-d/--depth`,
+`-s/--sleep-ns`, `--with-native-trace`.
 
 ## `inspector:eg_address`
 

--- a/docs/tracing/frankenphp.md
+++ b/docs/tracing/frankenphp.md
@@ -23,7 +23,7 @@ shapes — see [Memory and watch commands](#memory-and-watch-commands).
 
 | Flag | Value | Why |
 |---|---|---|
-| `--php-regex` | `.*/libphp\.so$` | PHP is loaded as a shared library; the default (`/php$`) never matches |
+| `--php-regex` | `.*/libphp\.so$` | PHP is loaded as a shared library. The default regex would match `libphp.so` on its own, but the tighter pattern is recommended on FrankenPHP to pin the resolver to libphp without relying on the `libphp[78]?.*\.so$` branch of the default and to avoid accidental matches against other `.so`s that happen to fit it. |
 | `--libpthread-regex` | `.*/libc\.so.*` | pthread functions live in libc, not in a separate libpthread |
 | `--target-thread-regex` (daemon/top/watch) | `^php-[0-9a-f]+$` | Restricts sampling to PHP worker threads; see [Thread filtering](#thread-filtering) |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## "regex used to filter /proc/{pid}/maps matched nothing" / "php module not found"
 
-Both of these surface the same root cause: reli's default `--php-regex` (`/php$`) did not match any module in the target's `/proc/<pid>/maps`. Distro builds with versioned binary names (`php8.4`, `php8.5`), embedded interpreters (FrankenPHP's `libphp.so`), and any other non-standard layout will hit this. Use `--php-regex` to specify the executable (or shared object) that contains the PHP interpreter:
+Both of these surface the same root cause: reli's default `--php-regex` did not match any module in the target's `/proc/<pid>/maps`. The default is wide enough to cover unversioned (`php`, `php-fpm`), versioned (`php7.4`, `php8.4`, `php-fpm8.4`), and shared-library (`libphp.so`, `libphp7.so`, `libphp8.so`) layouts, but anything else — a custom `php-cli-foo` rename, a build whose libphp is named without the `libphp` prefix, or a target that mounts the interpreter at a non-standard path — will hit this. Use `--php-regex` to specify the executable (or shared object) that contains the PHP interpreter:
 
 ```bash
 # Inspect the target's maps to see what to match against

--- a/src/Rbt/Explore/Terminal.php
+++ b/src/Rbt/Explore/Terminal.php
@@ -63,7 +63,7 @@ final class Terminal implements TerminalInterface
         $out = @fopen('/dev/tty', 'wb');
         if ($in === false || $out === false) {
             throw new \RuntimeException(
-                'rbt:explore requires a terminal — /dev/tty could not be opened.'
+                'a terminal is required — /dev/tty could not be opened.'
             );
         }
         $this->tty_in = $in;


### PR DESCRIPTION
This PR improves documentation clarity across multiple guides and refines error messaging in the codebase.

## Key Changes

**Documentation improvements:**
- Reformatted the memory dump options table for better readability and alignment
- Consolidated `--stop-process` and `--no-stop-process` into a single option line
- Rewrote the `inspector:memory:dump:inspect` reference to clarify it's a developer tool with unstable output, not for end-user analysis
- Enhanced `inspector:top` documentation with concrete examples showing both pool (`-P`) and single PID (`-p`) usage patterns
- Clarified the `pgrep` command in getting-started guide to use `-fx` (full command line match) instead of `-nf`, with explanation of why this matters in different execution contexts (interactive shell vs. Make rules, editor task runners, etc.)
- Replaced terminology "binary" with "rmem" throughout memory profiler documentation for consistency and clarity
- Expanded FrankenPHP `--php-regex` documentation to explain why the tighter pattern is recommended
- Rewrote troubleshooting guide's regex matching explanation to be more comprehensive about what the default pattern covers and what edge cases require custom configuration

**Source code changes:**
- Updated error message in `src/Rbt/Explore/Terminal.php` to be more concise: changed from "rbt:explore requires a terminal" to "a terminal is required" for better generality

## Rationale

These changes improve user experience by:
1. Making documentation more scannable and easier to follow
2. Providing concrete examples for common use cases
3. Clarifying tool purposes and output stability guarantees
4. Explaining the "why" behind recommended practices (e.g., pgrep flags)
5. Standardizing terminology across related documentation
6. Making error messages more general and less tool-specific

https://claude.ai/code/session_0195np8t2FCew7zpA4M7pf8m