### PR TITLE
Support `inspector:coredump -f rmem` (binary streaming output)

### DIFF
--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\MemoryOutputFactory;
 use Reli\Inspector\Settings\MemoryProfilerSettings\MemoryProfilerSettings;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\CollectedMemories;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
@@ -60,6 +61,41 @@ final class CoreDumpReader
             $target_php_settings_version_decided
         );
 
+        if (MemoryOutputFactory::isRmemFormat($memory_profiler_settings)) {
+            $this->readBinary(
+                $process_specifier,
+                $target_php_settings_version_decided,
+                $eg_address,
+                $cg_address,
+                $bg_address,
+                $memory_profiler_settings,
+            );
+            return;
+        }
+
+        $this->readPdo(
+            $process_specifier,
+            $target_php_settings_version_decided,
+            $eg_address,
+            $cg_address,
+            $bg_address,
+            $memory_profiler_settings,
+        );
+    }
+
+    /**
+     * Original PDO-based streaming path (SQLite / MySQL / PostgreSQL / JSON / report).
+     *
+     * @param TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
+     */
+    private function readPdo(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        int $eg_address,
+        int $cg_address,
+        ?int $bg_address,
+        MemoryProfilerSettings $memory_profiler_settings,
+    ): void {
         $output_factory = new MemoryOutputFactory();
         [$pdo_output, $sink, $run_id, $db, $temp_path] = $output_factory->createStreamingSink(
             $memory_profiler_settings,
@@ -68,7 +104,7 @@ final class CoreDumpReader
         try {
             $collected_memories = $this->memory_locations_collector->collectAll(
                 $process_specifier,
-                $target_php_settings_version_decided,
+                $target_php_settings,
                 $eg_address,
                 $cg_address,
                 $memory_profiler_settings->memory_exhaustion_error_details,
@@ -102,34 +138,11 @@ final class CoreDumpReader
                 ? $analyzed_regions->summary->correctedToArray($region_sums)
                 : $analyzed_regions->summary->toArray();
 
-            $summary = [
-                $summary_base
-                + [
-                    'memory_get_usage' => $collected_memories->memory_get_usage_size,
-                    'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
-                    'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
-                    'memory_limit' => $collected_memories->memory_limit,
-                    'cached_chunks_size' => $collected_memories->cached_chunks_size,
-                    'chunks_count' => $collected_memories->chunks_count,
-                    'peak_chunks_count' => $collected_memories->peak_chunks_count,
-                    'cached_chunks_count' => $collected_memories->cached_chunks_count,
-                    'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
-                    'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
-                    'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
-                    'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
-                ]
-                + [
-                    'heap_memory_analyzed_percentage' =>
-                        (float)$summary_base['zend_mm_heap_usage']
-                        /
-                        (float)$collected_memories->memory_get_usage_size * 100.0
-                    ,
-                ]
-                + [
-                    'php_version' => $target_php_settings_version_decided->php_version,
-                    'analyzer' => ReliProfiler::toolSignature(),
-                ]
-            ];
+            $summary = $this->buildSummary(
+                $summary_base,
+                $collected_memories,
+                $target_php_settings,
+            );
 
             unset($collected_memories, $analyzed_regions, $region_analyzer);
 
@@ -156,5 +169,117 @@ final class CoreDumpReader
                 @unlink($temp_path);
             }
         }
+    }
+
+    /**
+     * Binary (.rmem) streaming path.
+     *
+     * Collects with a BinaryContextTreeSink that streams to temp files,
+     * then assembles the final .rmem. No SQLite intermediate. Mirrors
+     * the readBinary path in MemoryDumpReader so a coredump-driven
+     * pipeline produces the exact same .rmem layout downstream tools
+     * (`rmem:explore`, `rmem:query`, `rmem:serve`, `rmem:mcp`,
+     * `inspector:memory:report`, `inspector:memory:compare`) consume.
+     *
+     * @param TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
+     */
+    private function readBinary(
+        ProcessSpecifier $process_specifier,
+        TargetPhpSettings $target_php_settings,
+        int $eg_address,
+        int $cg_address,
+        ?int $bg_address,
+        MemoryProfilerSettings $memory_profiler_settings,
+    ): void {
+        $output_factory = new MemoryOutputFactory();
+        [$binary_output, $sink] = $output_factory->createBinaryStreamingSink(
+            $memory_profiler_settings,
+        );
+
+        $collected_memories = $this->memory_locations_collector->collectAll(
+            $process_specifier,
+            $target_php_settings,
+            $eg_address,
+            $cg_address,
+            $memory_profiler_settings->memory_exhaustion_error_details,
+            $bg_address,
+            $sink,
+        );
+
+        // RegionBoundaries is already set on the sink by collectAll()
+        // (MemoryLocationsCollector builds it from chunk/huge/vm_stack/
+        // compiler_arena before the emit loop starts), so all locations
+        // are written with correct region_id inline — no backfill needed.
+
+        $region_analyzer = new RegionAnalyzer(
+            $collected_memories->chunk_memory_locations,
+            $collected_memories->huge_memory_locations,
+            $collected_memories->vm_stack_memory_locations,
+            $collected_memories->compiler_arena_memory_locations,
+        );
+
+        $analyzed_regions = $region_analyzer->analyze(
+            $collected_memories->memory_locations,
+        );
+
+        // Region sums come from the location temp file rather than a
+        // SQL DB on this path; correctedToArray() applies them when
+        // available, falling back to the uncorrected analyser summary.
+        $region_sums = $sink->computeRegionSumsAndOverhead()['sums'];
+        $summary_base = $region_sums !== []
+            ? $analyzed_regions->summary->correctedToArray($region_sums)
+            : $analyzed_regions->summary->toArray();
+
+        $summary = $this->buildSummary(
+            $summary_base,
+            $collected_memories,
+            $target_php_settings,
+        );
+
+        unset($collected_memories, $analyzed_regions, $region_analyzer);
+
+        $binary_output->finalizeStreaming($sink, $summary);
+    }
+
+    /**
+     * Build the summary array shared by both PDO and rmem paths.
+     *
+     * @param array<string, mixed> $summary_base
+     * @param TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_php_settings
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildSummary(
+        array $summary_base,
+        CollectedMemories $collected_memories,
+        TargetPhpSettings $target_php_settings,
+    ): array {
+        return [
+            $summary_base
+            + [
+                'memory_get_usage' => $collected_memories->memory_get_usage_size,
+                'memory_get_real_usage' => $collected_memories->memory_get_usage_real_size,
+                'memory_get_peak_usage' => $collected_memories->memory_get_peak_usage,
+                'memory_limit' => $collected_memories->memory_limit,
+                'cached_chunks_size' => $collected_memories->cached_chunks_size,
+                'chunks_count' => $collected_memories->chunks_count,
+                'peak_chunks_count' => $collected_memories->peak_chunks_count,
+                'cached_chunks_count' => $collected_memories->cached_chunks_count,
+                'last_chunks_delete_boundary' => $collected_memories->last_chunks_delete_boundary,
+                'last_chunks_delete_count' => $collected_memories->last_chunks_delete_count,
+                'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
+                'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
+            ]
+            + [
+                'heap_memory_analyzed_percentage' =>
+                    (float)$summary_base['zend_mm_heap_usage']
+                    /
+                    (float)$collected_memories->memory_get_usage_size * 100.0
+                ,
+            ]
+            + [
+                'php_version' => $target_php_settings->php_version,
+                'analyzer' => ReliProfiler::toolSignature(),
+            ]
+        ];
     }
 }

--- a/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
+++ b/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
@@ -174,6 +174,96 @@ class CoreDumpReaderIntegrationTest extends BaseTestCase
         $this->assertGreaterThanOrEqual(0, $summary['chunks_mostly_empty_count']);
     }
 
+    /**
+     * `inspector:coredump -f rmem` previously failed at the
+     * `BinaryMemoryOutput::output()` boundary (BinaryMemoryOutput
+     * only supports the streaming sink path, but the coredump
+     * reader was always going through the PDO temp-DB path and
+     * then asking the factory for a non-streaming output).
+     * CoreDumpReader now branches on isRmemFormat() and uses
+     * createBinaryStreamingSink() / finalizeStreaming(),
+     * mirroring the pattern in MemoryDumpReader.
+     */
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testReadFromCoreDumpToRmem(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        ini_set('memory_limit', '2G');
+
+        // ZTS PHP 8.2+: same skip rationale as testReadFromCoreDump.
+        if (
+            str_contains($docker_image_name, '-zts')
+            && $php_version >= 'v82'
+        ) {
+            $this->markTestSkipped(
+                'ZTS PHP 8.2+ coredump: _tsrm_ls_cache not found in TLS block'
+            );
+        }
+
+        $target_script = <<<'CODE'
+            <?php
+            $data = array_fill(0, 1000, str_repeat('x', 100));
+            $obj = new stdClass();
+            $obj->items = range(1, 50);
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $this->core_file = $this->takeCoreDump($pid);
+        $this->assertFileExists($this->core_file);
+
+        $integer_reader = new LittleEndianReader();
+        $elf64_parser = new Elf64Parser($integer_reader);
+        $container_builder = new ContainerBuilder();
+        $factory = new CoreDumpReaderFactory($container_builder, $elf64_parser);
+
+        $path_mapping = ['/' => "/proc/{$pid}/root"];
+        $core_dump_reader = $factory->createFromPath($this->core_file, $path_mapping);
+
+        // Output format: rmem (.rmem binary) — exercises the
+        // createBinaryStreamingSink / finalizeStreaming path.
+        $this->output_file = tempnam('/tmp/reli-test', 'coredump-test-rmem-');
+        $target_php_settings = new TargetPhpSettings(
+            php_version: $php_version,
+        );
+        $memory_profiler_settings = new MemoryProfilerSettings(
+            stop_process: false,
+            pretty_print: false,
+            output_format: 'rmem',
+            output_path: $this->output_file,
+        );
+
+        $core_dump_reader->read(
+            $pid,
+            $target_php_settings,
+            $memory_profiler_settings,
+        );
+
+        // Verify the output is a real .rmem file: non-empty, starts
+        // with the RMEM magic. Full structural validation is covered
+        // by the BinaryFormat reader tests; here we just guard against
+        // a zero-byte file or a regression to "BinaryMemoryOutput
+        // does not support the non-streaming output() path".
+        $this->assertFileExists($this->output_file);
+        $size = filesize($this->output_file);
+        $this->assertNotFalse($size);
+        $this->assertGreaterThan(0, $size);
+
+        $magic = file_get_contents($this->output_file, false, null, 0, 4);
+        $this->assertSame('RMEM', $magic);
+    }
+
     private function takeCoreDump(int $pid): string
     {
         // Include all memory pages in the coredump (file-backed pages are needed


### PR DESCRIPTION
## Summary

`inspector:coredump <core-file> --pid <pid> -f rmem -o snapshot.rmem` — the typical post-mortem flow recommended in `docs/memory/coredump.md`'s Quick Start — always died at the `BinaryMemoryOutput` boundary:

```
In BinaryMemoryOutput.php line 49:
  BinaryMemoryOutput does not support the non-streaming output()
  path. Use createStreamingSink() + finalizeStreaming() instead.
```

That left the doc-promised pipeline `coredump → .rmem → rmem:explore / rmem:query / rmem:serve / rmem:mcp / inspector:memory:report` completely broken. `-f json` / `-f sqlite3` / `-f report` / `-f report-json` worked, but the rmem-only analysers (`rmem:explore` etc.) had no path in from a core file.

## Root cause

`CoreDumpReader::read` was unconditionally going through the PDO temp-DB streaming path (`MemoryOutputFactory::createStreamingSink`) and then, when a temp DB was used, asking the factory for a final-format `MemoryOutput` and calling `->output($result)`. For `-f rmem` the factory returns a `BinaryMemoryOutput` whose `output()` is a deliberate stub: the binary format only supports streaming via `createStreamingSink() / finalizeStreaming()`.

`MemoryDumpReader` already split into a `readBinary()` / `readPdo()` pair months ago (`isRmemFormat()` branch at the top), but `CoreDumpReader` never got the same treatment.

## Fix

Mirror the pattern in `MemoryDumpReader`:

1. The top-level `CoreDumpReader::read` resolves PHP version + EG/CG/BG addresses once and dispatches to `readBinary()` (when `MemoryOutputFactory::isRmemFormat()`) or `readPdo()`.
2. The new `readBinary()` wires up a `BinaryContextTreeSink` directly via `createBinaryStreamingSink()`, runs the same `MemoryLocationsCollector::collectAll()` flow, and finalises with `$binary_output->finalizeStreaming($sink, $summary)`. Region sums come from `$sink->computeRegionSumsAndOverhead()` instead of `RegionsSummary::queryRegionSums($db, $run_id)` — there is no SQL DB on the rmem path.
3. The summary-build prelude (`memory_get_usage`, `chunks_count`, `heap_memory_analyzed_percentage`, …) is factored into a private `buildSummary()` helper that both paths consume, so the two paths emit byte-identical metadata.

The PDO path behaviour is unchanged — non-rmem formats continue to flow through exactly the same code as before.

## Verification

End-to-end against a host PHP process snapshotted with `gcore`:

```
$ ./reli inspector:coredump /tmp/cd-core.<pid> --pid <pid> \
    -f rmem -o /tmp/cd.rmem
$ ls -la /tmp/cd.rmem
-rw-rw-r-- 1 sji sji 3414812 ... /tmp/cd.rmem
$ ./reli rmem:query /tmp/cd.rmem --check-integrity
Checking string_dict... OK
OK nodes: 30639 elements × 16 = 490224 bytes, section has 490224
OK edges: 36015 elements × 16 = 576240 bytes, section has 576240
OK locations: 16557 elements × 48 = 794736 bytes, section has 794736
OK node_sizes / node_classes
$ ./reli inspector:memory:report /tmp/cd.rmem
=== Overview === ... full report ...
```

Regression-checked the other formats against the same core in the same session — `-f json` / `-f sqlite3 -o cd.db` / `-f report` / `-f report-json` all produce the same shape they did before this PR.

## Test

New `testReadFromCoreDumpToRmem` integration test mirrors the existing `testReadFromCoreDump` exactly — same data provider, same target script, same `gcore` capture, same ZTS-PHP-8.2+ skip — but exercises `output_format: 'rmem'` and asserts:

- the output file is non-empty
- the file starts with the `RMEM` magic (`Format::MAGIC`), guarding against a regression to "BinaryMemoryOutput does not support the non-streaming output() path"

Both `Group('target-version')` and `Group('coredump')` so it picks up the same CI matrix the JSON variant runs under.

(Couldn't execute the integration test in this dev sandbox — `/tmp/reli-test/` happens to be root-owned here from a prior root-running test, blocking gcore output. Manual end-to-end verification was done against a non-Docker host PHP target as shown above; CI runs in a fresh env where the test path is writable.)

## Test plan
- [x] `phpcs --standard=PSR12 src/Inspector/CoreDumpReader/CoreDumpReader.php tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php` clean (3 docblock-line warnings inherited from `MemoryDumpReader`-style `@param TargetPhpSettings<value-of<...>>` annotations; the existing file has the same pattern).
- [x] `psalm` on `CoreDumpReader.php` — no errors.
- [x] Manual end-to-end: gcore → coredump -f rmem → rmem:query --check-integrity → inspector:memory:report.
- [x] Manual regression: gcore → coredump -f sqlite3 / -f json / -f report / -f report-json all still produce the same outputs.
- [ ] CI: `target-version` group runs `testReadFromCoreDump` and the new `testReadFromCoreDumpToRmem` against every supported PHP version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)