### PR TITLE
Make `inspector:coredump` work post-mortem (readlink fail-soft for NTS)

### DIFF
--- a/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
+++ b/src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php
@@ -91,22 +91,30 @@ final class PhpSymbolReaderCreator
 
         $root_link_map_address = null;
         if (!is_null($libpthread_symbol_reader)) {
-            $executable_path = readlink("/proc/{$pid}/exe");
-            if ($executable_path === false) {
-                throw new ProcessSymbolReaderException('failed to readlink /proc/' . $pid . '/exe');
+            // We use the executable path here only to obtain the
+            // root link-map address for TLS resolution (ZTS targets,
+            // libthread_db). NTS targets do not consult this — they
+            // resolve `executor_globals` via static symbol lookup —
+            // so a missing executable path is recoverable downstream
+            // for NTS even though it disables the TLS path. Make this
+            // step fail-soft so post-mortem core analysis (where
+            // /proc/<pid>/exe no longer exists) keeps progressing for
+            // the NTS case; ZTS readers will fail later when they try
+            // to walk the link map.
+            $executable_path = @readlink("/proc/{$pid}/exe");
+            if ($executable_path !== false) {
+                $full_executable_path = "/proc/{$pid}/root{$executable_path}";
+                $main_executable_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
+                    $pid,
+                    $process_memory_map,
+                    $executable_path,
+                    $full_executable_path,
+                    $libpthread_symbol_reader,
+                );
+                if (!is_null($main_executable_reader)) {
+                    $root_link_map_address = $main_executable_reader->getLinkMapAddress();
+                }
             }
-            $full_executable_path = "/proc/{$pid}/root{$executable_path}";
-            $main_executable_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(
-                $pid,
-                $process_memory_map,
-                $executable_path,
-                $full_executable_path,
-                $libpthread_symbol_reader,
-            );
-            if (is_null($main_executable_reader)) {
-                throw new ProcessSymbolReaderException('main executable not found');
-            }
-            $root_link_map_address = $main_executable_reader->getLinkMapAddress();
         }
 
         $php_symbol_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(


### PR DESCRIPTION
## Summary

`docs/memory/coredump.md` advertises `inspector:coredump` as the post-mortem counterpart to `inspector:memory:dump`, explicitly including:

> **The process has already died**: you have a core file (from the kernel `core_pattern`, `systemd-coredump`, Docker runtime dump, cloud platform artifact, CI sidecar, etc.) but no live PID to attach to.

In practice the call always died before touching the core file when `/proc/<pid>/` was gone:

```
$ ./reli inspector:coredump <core> --pid <dead-pid> -r / -f rmem -o snap.rmem
PHP Warning:  readlink(): No such file or directory in
  src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php on line 94

In PhpSymbolReaderCreator.php line 96:
  failed to readlink /proc/<dead-pid>/exe
```

`--dependency-root` did not bypass this: the readlink target is `/proc/<pid>/exe` directly, not a path that goes through `MappedPathResolver`. The existing `testReadFromCoreDump` integration test only happens to pass because `runScriptViaContainer` keeps the target alive in a running container during the test.

## Why the readlink was load-bearing only on the ZTS path

`PhpSymbolReaderCreator::create` resolves a libpthread / libc reader (used as a `libthread_db` source) and then, when one is available, does:

```php
$executable_path = readlink("/proc/{$pid}/exe");
if ($executable_path === false) {
    throw new ProcessSymbolReaderException(...);
}
$full_executable_path = "/proc/{$pid}/root{$executable_path}";
$main_executable_reader = $this->process_module_symbol_reader_creator->createModuleReaderByNameRegex(...);
if (is_null($main_executable_reader)) {
    throw new ProcessSymbolReaderException(...);
}
$root_link_map_address = $main_executable_reader->getLinkMapAddress();
```

The result `$root_link_map_address` is consumed exactly once, in `ProcessModuleSymbolReaderCreator::createModuleReaderByNameRegex`:

```php
if (!is_null($libpthread_symbol_reader) and !is_null($root_link_map_address)) {
    // ... build LibThreadDbTlsFinder, walk link_map, locate TLS block ...
}
```

That guard is the **TLS-resolution branch** — needed only by ZTS targets, where `executor_globals` is per-thread TLS. NTS targets resolve `executor_globals` via static symbol lookup and don't consult `$root_link_map_address` at all.

But the throw was making the entire call fail for NTS too: `resolveThreadDbReader` always returns non-null in practice (libc is mapped in every PHP process), so the readlink was reached for every target shape.

## Fix

Make the readlink + main-executable lookup fail-soft: when readlink fails (or the main-executable module isn't findable in the memory map), skip the link-map step and leave `$root_link_map_address` at `null`. Downstream:

- **NTS targets** — TLS branch is skipped (it was already null-guarded); the static-symbol-based path that finds `executor_globals` runs unchanged. Post-mortem analysis succeeds.
- **ZTS targets with live `/proc/<pid>/`** — readlink succeeds, link-map address is populated, behaviour identical to before.
- **ZTS targets without live `/proc/<pid>/`** — TLS finder is now reached with `$root_link_map_address = null` and reports "no link map" instead of "failed to readlink". Both are equivalent failures (you can't TLS-resolve without the link map), but the new error surfaces the actual blocker (TLS) rather than a misleading filesystem complaint.

## Verification

End-to-end against an **apport-saved system coredump** for a PHP CLI process killed by `SIGABRT` ~10 minutes before the analyzer ran (the original PID was long gone, no `/proc/<pid>/*` anywhere on the host):

```
$ kill -SIGSEGV $TARGET_PID    # apport intercepts, writes ELF core to
                               # /var/lib/apport/coredump/core.<...>
$ ls -la /var/lib/apport/coredump/core._home_sji__phpenv_<...>.crash
... ELF 64-bit LSB core file, x86-64, version 1 (SYSV), SVR4-style,
    from 'php /tmp/cd-syscrash.php' ...

$ ./reli inspector:coredump <core> --pid <dead-pid> -r / -f rmem \
      -o /tmp/cd-sys.rmem
$ ./reli rmem:query /tmp/cd-sys.rmem --check-integrity
Checking string_dict... OK
OK nodes: 30639 ... OK edges: 36015 ... OK locations: 16557 ...

$ ./reli inspector:memory:report /tmp/cd-sys.rmem
====================================
 reli-prof Memory Analysis Report
====================================
=== Overview ===
  Captured: ...
  Heap: 481.80 KB (83.1% analyzed)
  Call Stack at capture:
    ...
```

All four other output formats (`json` / `sqlite3` / `report` / `report-json`) also now work end-to-end on the dead-PID system core.

Live-PID `gcore` flows (the case the existing integration test covers) are unaffected — the readlink succeeds and the link-map step runs as before. Linted clean (`phpcs --standard=PSR12`) and Psalm clean.

## Relationship to PR #752

PR #752 makes `inspector:coredump -f rmem` produce a real `.rmem` file instead of throwing at `BinaryMemoryOutput::output()`. That fix is necessary but not sufficient for the post-mortem use case — without the readlink fix in this PR, every `-f *` path still aborts before reaching the output stage when the target PID is dead.

The two PRs are independent (they touch disjoint files), apply cleanly against `0.12.x`, and can land in either order. Together they restore the post-mortem flow `coredump → .rmem → rmem:explore / rmem:query / rmem:serve / rmem:mcp / inspector:memory:report` that `docs/memory/coredump.md` describes.

## Test plan
- [x] `phpcs --standard=PSR12 src/Lib/PhpProcessReader/PhpSymbolReaderCreator.php` clean.
- [x] `psalm` on the touched file — no errors.
- [x] Manual end-to-end: apport-saved ELF core (process dead, no `/proc/<pid>/*`) → `inspector:coredump` succeeds for all five formats (`rmem` / `json` / `sqlite3` / `report` / `report-json`) → `rmem:query --check-integrity` passes → `inspector:memory:report` produces a normal report.
- [x] Manual regression: gcore'd live PID still works for all five formats.
- [ ] CI: `target-version` group's `testReadFromCoreDump` (and `testReadFromCoreDumpToRmem` from #752, after that lands) keep passing — they continue to use the live-PID path that this change leaves unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)