### PR TITLE
Add --memory-limit option to all commands

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,7 +102,9 @@ Every top-level command accepts `--memory-limit` for this:
 ./reli rmem:explore huge.rmem --memory-limit=4G
 ```
 
-Prefer `--memory-limit=2G` over `php -d memory_limit=2G ./reli …`: the option goes through `ini_set` after bootstrap, so it survives any inner reli launches (e.g. `inspector:trace -- php ./reli ...`) and is visible in `--help`.
+`--memory-limit=2G` is generally what you want: it shows up in `--help`, works through the Docker wrapper, and (for daemon-style commands) is propagated to the spawned worker processes via the `RELI_MEMORY_LIMIT` env var so the readers raise their limit too. Use `php -d memory_limit=2G ./reli ...` only when reli is dying *before* it parses options — e.g. during PHP startup or `composer` autoload.
+
+> `--memory-limit` only affects the current reli invocation. If you launch a *separate* reli process from inside another (e.g. `inspector:trace -- php ./reli inspector:trace ...`), pass `--memory-limit` to that inner command separately — `ini_set` does not cross the `proc_open` boundary, and `--` arguments are not interpreted by the outer reli.
 
 For the sidecar specifically, the value also has a sizing rule (target heap + ~80 MB headroom) — see [monitoring/sidecar.md § Sizing `--memory-limit`](monitoring/sidecar.md#sizing---memory-limit).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,6 +82,30 @@ Recovery:
 
 > **Note:** older versions of reli could persist `has_tsrm_ls_cache: false` for a ZTS binary the first time an idle worker was hit. The current code re-checks the binary's PT_TLS on every cache read and drops the entry if the binary is in fact ZTS, so upgraders do not need to `./reli cache:clear` — the stale entry self-heals on the next attach.
 
+## "Allowed memory size of N bytes exhausted" — reli itself OOMs
+
+reli analyses the target's binaries and heap inside its own PHP process, so it is bound by its own `memory_limit`. Big targets — FrankenPHP / statically-linked `libphp` (tens of thousands of ELF symbols), large `.rmem` snapshots, multi-GB ZendMM heaps — can blow past the default limit during cold attach or analysis. The symptom is a fatal `Allowed memory size of … bytes exhausted` from reli, **not** from the target.
+
+Every top-level command accepts `--memory-limit` for this:
+
+```bash
+# Trace commands (cold-attach a big binary)
+./reli inspector:trace -p <tid> --memory-limit=2G ...
+./reli inspector:daemon --target-regex=... --memory-limit=2G
+
+# Memory analysis
+./reli inspector:memory -p <pid> --memory-limit=4G
+./reli inspector:memory:analyze dump.rdump --memory-limit=4G
+
+# Post-processing big traces / snapshots
+./reli rbt:analyze --memory-limit=2G < big.rbt
+./reli rmem:explore huge.rmem --memory-limit=4G
+```
+
+Prefer `--memory-limit=2G` over `php -d memory_limit=2G ./reli …`: the option goes through `ini_set` after bootstrap, so it survives any inner reli launches (e.g. `inspector:trace -- php ./reli ...`) and is visible in `--help`.
+
+For the sidecar specifically, the value also has a sizing rule (target heap + ~80 MB headroom) — see [monitoring/sidecar.md § Sizing `--memory-limit`](monitoring/sidecar.md#sizing---memory-limit).
+
 ## Something seems stale after a PHP upgrade or container rebuild.
 
 reli caches expensive binary-analysis results (ELF symbol resolution, ZTS TLS offsets, PHP version detection) under `~/.cache/reli/binary-analysis/`. If you suspect a stale entry is being served — after upgrading the target PHP, rebuilding a container image, or any other "shouldn't that have worked?" moment — drop or bypass the cache:

--- a/src/Command/Cache/ClearCommand.php
+++ b/src/Command/Cache/ClearCommand.php
@@ -17,6 +17,7 @@ use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class ClearCommand extends ReliCommand
@@ -38,12 +39,23 @@ final class ClearCommand extends ReliCommand
     {
         $this->setName('cache:clear')
             ->setDescription('clear the binary analysis cache')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $count = $this->binary_analysis_cache->clear();
         $output->writeln("cleared {$count} cached entries");
         return 0;

--- a/src/Command/Cache/ClearCommand.php
+++ b/src/Command/Cache/ClearCommand.php
@@ -17,7 +17,6 @@ use Reli\Lib\Elf\Process\BinaryAnalysisCache;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class ClearCommand extends ReliCommand
@@ -39,23 +38,14 @@ final class ClearCommand extends ReliCommand
     {
         $this->setName('cache:clear')
             ->setDescription('clear the binary analysis cache')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $count = $this->binary_analysis_cache->clear();
         $output->writeln("cleared {$count} cached entries");
         return 0;

--- a/src/Command/Converter/CallgrindCommand.php
+++ b/src/Command/Converter/CallgrindCommand.php
@@ -18,6 +18,7 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class CallgrindCommand extends ReliCommand
@@ -33,12 +34,23 @@ final class CallgrindCommand extends ReliCommand
     {
         $this->setName('converter:callgrind')
             ->setDescription('convert traces to the callgrind file format (auto-detects rbt or phpspy input)')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $reader = new TraceInputReader();
         $output->writeln('# format callgrind');
         $output->writeln('events: Samples');

--- a/src/Command/Converter/CallgrindCommand.php
+++ b/src/Command/Converter/CallgrindCommand.php
@@ -18,7 +18,6 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class CallgrindCommand extends ReliCommand
@@ -34,23 +33,14 @@ final class CallgrindCommand extends ReliCommand
     {
         $this->setName('converter:callgrind')
             ->setDescription('convert traces to the callgrind file format (auto-detects rbt or phpspy input)')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $reader = new TraceInputReader();
         $output->writeln('# format callgrind');
         $output->writeln('events: Samples');

--- a/src/Command/Converter/FlameGraphCommand.php
+++ b/src/Command/Converter/FlameGraphCommand.php
@@ -20,6 +20,7 @@ use Reli\Command\ReliCommand;
 use Reli\Converter\PhpSpyCompatibleFormatter;
 use Reli\Converter\TraceInputReader;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class FlameGraphCommand extends ReliCommand
@@ -41,12 +42,23 @@ final class FlameGraphCommand extends ReliCommand
     {
         $this->setName('converter:flamegraph')
             ->setDescription('convert traces to flamegraph SVG (auto-detects rbt or phpspy input)')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $tools_path = Cast::toString($this->config->get('paths.tools'));
 
         $flamegraph = "{$tools_path}/flamegraph/flamegraph.pl";

--- a/src/Command/Converter/FlameGraphCommand.php
+++ b/src/Command/Converter/FlameGraphCommand.php
@@ -20,7 +20,6 @@ use Reli\Command\ReliCommand;
 use Reli\Converter\PhpSpyCompatibleFormatter;
 use Reli\Converter\TraceInputReader;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class FlameGraphCommand extends ReliCommand
@@ -42,23 +41,14 @@ final class FlameGraphCommand extends ReliCommand
     {
         $this->setName('converter:flamegraph')
             ->setDescription('convert traces to flamegraph SVG (auto-detects rbt or phpspy input)')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $tools_path = Cast::toString($this->config->get('paths.tools'));
 
         $flamegraph = "{$tools_path}/flamegraph/flamegraph.pl";

--- a/src/Command/Converter/FoldedCommand.php
+++ b/src/Command/Converter/FoldedCommand.php
@@ -18,7 +18,6 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class FoldedCommand extends ReliCommand
@@ -34,23 +33,14 @@ final class FoldedCommand extends ReliCommand
     {
         $this->setName('converter:folded')
             ->setDescription('convert traces to folded stacks format (auto-detects rbt or phpspy input)')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $reader = new TraceInputReader();
         $formatter = new FoldedStacksFormatter();
 

--- a/src/Command/Converter/FoldedCommand.php
+++ b/src/Command/Converter/FoldedCommand.php
@@ -18,6 +18,7 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class FoldedCommand extends ReliCommand
@@ -33,12 +34,23 @@ final class FoldedCommand extends ReliCommand
     {
         $this->setName('converter:folded')
             ->setDescription('convert traces to folded stacks format (auto-detects rbt or phpspy input)')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $reader = new TraceInputReader();
         $formatter = new FoldedStacksFormatter();
 

--- a/src/Command/Converter/PhpspyCommand.php
+++ b/src/Command/Converter/PhpspyCommand.php
@@ -18,7 +18,6 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PhpspyCommand extends ReliCommand
@@ -34,23 +33,14 @@ final class PhpspyCommand extends ReliCommand
     {
         $this->setName('converter:phpspy')
             ->setDescription('convert traces to phpspy-compatible text (auto-detects rbt or phpspy input)')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $reader = new TraceInputReader();
         $formatter = new PhpSpyCompatibleFormatter();
 

--- a/src/Command/Converter/PhpspyCommand.php
+++ b/src/Command/Converter/PhpspyCommand.php
@@ -18,6 +18,7 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PhpspyCommand extends ReliCommand
@@ -33,12 +34,23 @@ final class PhpspyCommand extends ReliCommand
     {
         $this->setName('converter:phpspy')
             ->setDescription('convert traces to phpspy-compatible text (auto-detects rbt or phpspy input)')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $reader = new TraceInputReader();
         $formatter = new PhpSpyCompatibleFormatter();
 

--- a/src/Command/Converter/PprofCommand.php
+++ b/src/Command/Converter/PprofCommand.php
@@ -18,6 +18,7 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PprofCommand extends ReliCommand
@@ -33,12 +34,23 @@ final class PprofCommand extends ReliCommand
     {
         $this->setName('converter:pprof')
             ->setDescription('convert traces to pprof protobuf (auto-detects rbt or phpspy input)')
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $reader = new TraceInputReader();
         $encoder = new PprofEncoder();
 

--- a/src/Command/Converter/PprofCommand.php
+++ b/src/Command/Converter/PprofCommand.php
@@ -18,7 +18,6 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PprofCommand extends ReliCommand
@@ -34,23 +33,14 @@ final class PprofCommand extends ReliCommand
     {
         $this->setName('converter:pprof')
             ->setDescription('convert traces to pprof protobuf (auto-detects rbt or phpspy input)')
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $reader = new TraceInputReader();
         $encoder = new PprofEncoder();
 

--- a/src/Command/Converter/RbtCommand.php
+++ b/src/Command/Converter/RbtCommand.php
@@ -54,12 +54,23 @@ final class RbtCommand extends ReliCommand
                 InputOption::VALUE_NONE,
                 'Gzip-compress the output (.rbt.gz)',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $sampling_period = (int)$input->getOption('sampling-period');
         $has_timestamps = $input->getOption('rbt-timestamps') === 'delta';
         $compress = (bool)$input->getOption('compress');

--- a/src/Command/Converter/RbtCommand.php
+++ b/src/Command/Converter/RbtCommand.php
@@ -54,23 +54,14 @@ final class RbtCommand extends ReliCommand
                 InputOption::VALUE_NONE,
                 'Gzip-compress the output (.rbt.gz)',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $sampling_period = (int)$input->getOption('sampling-period');
         $has_timestamps = $input->getOption('rbt-timestamps') === 'delta';
         $compress = (bool)$input->getOption('compress');

--- a/src/Command/Converter/SpeedscopeCommand.php
+++ b/src/Command/Converter/SpeedscopeCommand.php
@@ -19,7 +19,6 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class SpeedscopeCommand extends ReliCommand
@@ -44,22 +43,13 @@ final class SpeedscopeCommand extends ReliCommand
             ->setDescription('convert traces to the speedscope file format (auto-detects rbt or phpspy input)')
         ;
         $this->settings_from_console_input->setOptions($this);
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $settings = $this->settings_from_console_input->createSettings($input);
         $reader = new TraceInputReader();
 

--- a/src/Command/Converter/SpeedscopeCommand.php
+++ b/src/Command/Converter/SpeedscopeCommand.php
@@ -19,6 +19,7 @@ use Reli\Converter\TraceInputReader;
 use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class SpeedscopeCommand extends ReliCommand
@@ -43,11 +44,22 @@ final class SpeedscopeCommand extends ReliCommand
             ->setDescription('convert traces to the speedscope file format (auto-detects rbt or phpspy input)')
         ;
         $this->settings_from_console_input->setOptions($this);
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $settings = $this->settings_from_console_input->createSettings($input);
         $reader = new TraceInputReader();
 

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -62,23 +62,14 @@ final class PrintWrapperCommand extends ReliCommand
                 'target shell dialect (bash|zsh|posix) — currently informational',
                 'bash',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $profile = DockerProfile::tryFrom((string)$input->getOption('profile'));
         if ($profile === null) {
             $output->writeln(

--- a/src/Command/Docker/PrintWrapperCommand.php
+++ b/src/Command/Docker/PrintWrapperCommand.php
@@ -62,12 +62,23 @@ final class PrintWrapperCommand extends ReliCommand
                 'target shell dialect (bash|zsh|posix) — currently informational',
                 'bash',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $profile = DockerProfile::tryFrom((string)$input->getOption('profile'));
         if ($profile === null) {
             $output->writeln(

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -78,22 +78,13 @@ final class CoreDumpCommand extends ReliCommand
             'dependency root directory'
         );
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -80,11 +80,22 @@ final class DaemonCommand extends ReliCommand
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $no_cache = (bool)$input->getOption('no-cache');
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);

--- a/src/Command/Inspector/DaemonCommand.php
+++ b/src/Command/Inspector/DaemonCommand.php
@@ -80,22 +80,13 @@ final class DaemonCommand extends ReliCommand
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $no_cache = (bool)$input->getOption('no-cache');
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);

--- a/src/Command/Inspector/GetEgAddressCommand.php
+++ b/src/Command/Inspector/GetEgAddressCommand.php
@@ -63,6 +63,12 @@ final class GetEgAddressCommand extends ReliCommand
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     /**
@@ -75,6 +81,11 @@ final class GetEgAddressCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/GetEgAddressCommand.php
+++ b/src/Command/Inspector/GetEgAddressCommand.php
@@ -63,12 +63,7 @@ final class GetEgAddressCommand extends ReliCommand
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     /**
@@ -81,11 +76,7 @@ final class GetEgAddressCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -92,12 +92,7 @@ final class GetTraceCommand extends ReliCommand
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     /**
@@ -110,11 +105,7 @@ final class GetTraceCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/GetTraceCommand.php
+++ b/src/Command/Inspector/GetTraceCommand.php
@@ -92,6 +92,12 @@ final class GetTraceCommand extends ReliCommand
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->output_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     /**
@@ -104,6 +110,11 @@ final class GetTraceCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -60,12 +60,7 @@ final class MemoryAnalyzeCommand extends ReliCommand
             'dependency root directory (for read-only segment fallback)'
         );
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
         $this->addOption(
             'read-buffer',
             null,
@@ -84,11 +79,7 @@ final class MemoryAnalyzeCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -69,22 +69,13 @@ final class MemoryCommand extends ReliCommand
         $this->target_process_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryCompareCommand.php
+++ b/src/Command/Inspector/MemoryCompareCommand.php
@@ -102,12 +102,7 @@ final class MemoryCompareCommand extends ReliCommand
             'run all analysis passes for both snapshots (default: off)',
             false,
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
         $this->addOption(
             'ffi-csr',
             null,
@@ -132,11 +127,7 @@ final class MemoryCompareCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
 
         Log::info('start memory:compare command');
 

--- a/src/Command/Inspector/MemoryDbOptimizeCommand.php
+++ b/src/Command/Inspector/MemoryDbOptimizeCommand.php
@@ -45,23 +45,14 @@ final class MemoryDbOptimizeCommand extends ReliCommand
                 InputOption::VALUE_REQUIRED,
                 'run ID to materialize (default: all runs)',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
 
         $db_path = $input->getArgument('db-path');
         assert(is_string($db_path));

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -71,12 +71,7 @@ final class MemoryDumpCommand extends ReliCommand
             InputOption::VALUE_NONE,
             'disable the binary analysis cache',
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
@@ -84,11 +79,7 @@ final class MemoryDumpCommand extends ReliCommand
         InputInterface $input,
         OutputInterface $output,
     ): int {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -18,7 +18,6 @@ use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class MemoryDumpInspectCommand extends ReliCommand
@@ -47,22 +46,13 @@ final class MemoryDumpInspectCommand extends ReliCommand
             InputArgument::REQUIRED,
             'path to the memory dump file'
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         /** @var string $dump_file */
         $dump_file = $input->getArgument('dump-file');
 

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -18,6 +18,7 @@ use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class MemoryDumpInspectCommand extends ReliCommand
@@ -46,11 +47,22 @@ final class MemoryDumpInspectCommand extends ReliCommand
             InputArgument::REQUIRED,
             'path to the memory dump file'
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         /** @var string $dump_file */
         $dump_file = $input->getArgument('dump-file');
 

--- a/src/Command/Inspector/MemoryDumpNormalizeCommand.php
+++ b/src/Command/Inspector/MemoryDumpNormalizeCommand.php
@@ -19,6 +19,7 @@ use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -50,12 +51,23 @@ final class MemoryDumpNormalizeCommand extends ReliCommand
                 InputArgument::OPTIONAL,
                 'path for the output file (default: overwrite input)',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $input_path = (string) $input->getArgument('input');
         /** @var string|null $output_arg */
         $output_arg = $input->getArgument('output');

--- a/src/Command/Inspector/MemoryDumpNormalizeCommand.php
+++ b/src/Command/Inspector/MemoryDumpNormalizeCommand.php
@@ -19,7 +19,6 @@ use Reli\Command\DockerProfile;
 use Reli\Command\ReliCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -51,23 +50,14 @@ final class MemoryDumpNormalizeCommand extends ReliCommand
                 InputArgument::OPTIONAL,
                 'path for the output file (default: overwrite input)',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $input_path = (string) $input->getArgument('input');
         /** @var string|null $output_arg */
         $output_arg = $input->getArgument('output');

--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -80,12 +80,7 @@ final class MemoryReportCommand extends ReliCommand
             'run all analysis passes (default: on; --no-full-analysis to limit for very large snapshots)',
             true,
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
         // Advanced / tuning options.
         // These mostly matter on large snapshots (multi-GB SQLite, OOM, slow
         // substrate load). The help text below is a one-liner each; the
@@ -161,11 +156,7 @@ final class MemoryReportCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
 
         Log::info('start memory:report command');
 

--- a/src/Command/Inspector/PeekVarCommand.php
+++ b/src/Command/Inspector/PeekVarCommand.php
@@ -89,11 +89,22 @@ final class PeekVarCommand extends ReliCommand
             InputOption::VALUE_NONE,
             'disable the binary analysis cache',
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/PeekVarCommand.php
+++ b/src/Command/Inspector/PeekVarCommand.php
@@ -89,22 +89,13 @@ final class PeekVarCommand extends ReliCommand
             InputOption::VALUE_NONE,
             'disable the binary analysis cache',
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -93,22 +93,13 @@ final class TopLikeCommand extends ReliCommand
         $this->trace_loop_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $target_regex = $input->getOption('target-regex');
         if ($target_regex !== null) {
             return $this->executeDaemonMode($input, $output);

--- a/src/Command/Inspector/TopLikeCommand.php
+++ b/src/Command/Inspector/TopLikeCommand.php
@@ -93,11 +93,22 @@ final class TopLikeCommand extends ReliCommand
         $this->trace_loop_settings_from_console_input->setOptions($this);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption('no-cache', null, InputOption::VALUE_NONE, 'disable the binary analysis cache');
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $target_regex = $input->getOption('target-regex');
         if ($target_regex !== null) {
             return $this->executeDaemonMode($input, $output);

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -66,11 +66,22 @@ final class PhpSpyDaemonCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'output file path (default: stdout)'
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $no_cache = (bool)$input->getOption('no-cache');
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);

--- a/src/Command/PhpSpy/PhpSpyDaemonCommand.php
+++ b/src/Command/PhpSpy/PhpSpyDaemonCommand.php
@@ -66,22 +66,13 @@ final class PhpSpyDaemonCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'output file path (default: stdout)'
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $no_cache = (bool)$input->getOption('no-cache');
         $daemon_settings = $this->daemon_settings_from_console_input->createSettings($input);
         $get_trace_settings = $this->get_trace_settings_from_console_input->createSettings($input);

--- a/src/Command/PhpSpy/PhpSpyInstallCommand.php
+++ b/src/Command/PhpSpy/PhpSpyInstallCommand.php
@@ -59,22 +59,13 @@ final class PhpSpyInstallCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'path to an existing phpspy binary to check'
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $check_only = (bool)$input->getOption('check');
         /** @var string|null $phpspy_path_option */
         $phpspy_path_option = $input->getOption('phpspy-path');

--- a/src/Command/PhpSpy/PhpSpyInstallCommand.php
+++ b/src/Command/PhpSpy/PhpSpyInstallCommand.php
@@ -59,11 +59,22 @@ final class PhpSpyInstallCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'path to an existing phpspy binary to check'
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $check_only = (bool)$input->getOption('check');
         /** @var string|null $phpspy_path_option */
         $phpspy_path_option = $input->getOption('phpspy-path');

--- a/src/Command/PhpSpy/PhpSpyTraceCommand.php
+++ b/src/Command/PhpSpy/PhpSpyTraceCommand.php
@@ -77,6 +77,12 @@ final class PhpSpyTraceCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'output file path (default: stdout)'
         );
+        $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+        );
     }
 
     /**
@@ -89,6 +95,11 @@ final class PhpSpyTraceCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/PhpSpy/PhpSpyTraceCommand.php
+++ b/src/Command/PhpSpy/PhpSpyTraceCommand.php
@@ -77,12 +77,7 @@ final class PhpSpyTraceCommand extends ReliCommand
             InputOption::VALUE_REQUIRED,
             'output file path (default: stdout)'
         );
-        $this->addOption(
-            'memory-limit',
-            null,
-            InputOption::VALUE_REQUIRED,
-            'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-        );
+        $this->addMemoryLimitOption();
     }
 
     /**
@@ -95,11 +90,7 @@ final class PhpSpyTraceCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ($input->getOption('no-cache')) {
             $this->binary_analysis_cache->disable();
         }

--- a/src/Command/Rbt/AnalyzeCommand.php
+++ b/src/Command/Rbt/AnalyzeCommand.php
@@ -141,12 +141,23 @@ final class AnalyzeCommand extends ReliCommand
                 . ' Example: "self+total,tail"',
                 SectionLayout::DEFAULT_SPEC,
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         $top = max(0, (int) $input->getOption('top'));
         /** @var string|null $callers_pattern */
         $callers_pattern = $input->getOption('callers');

--- a/src/Command/Rbt/AnalyzeCommand.php
+++ b/src/Command/Rbt/AnalyzeCommand.php
@@ -141,23 +141,14 @@ final class AnalyzeCommand extends ReliCommand
                 . ' Example: "self+total,tail"',
                 SectionLayout::DEFAULT_SPEC,
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         $top = max(0, (int) $input->getOption('top'));
         /** @var string|null $callers_pattern */
         $callers_pattern = $input->getOption('callers');

--- a/src/Command/Rbt/ExploreCommand.php
+++ b/src/Command/Rbt/ExploreCommand.php
@@ -77,12 +77,23 @@ final class ExploreCommand extends ReliCommand
                 . ' or --path-map /var/www/html=. for project-relative paths).'
                 . ' May be specified multiple times; longest prefix wins',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         if ((bool) $input->getOption('diagnose')) {
             return $this->runDiagnose($output);
         }

--- a/src/Command/Rbt/ExploreCommand.php
+++ b/src/Command/Rbt/ExploreCommand.php
@@ -77,23 +77,14 @@ final class ExploreCommand extends ReliCommand
                 . ' or --path-map /var/www/html=. for project-relative paths).'
                 . ' May be specified multiple times; longest prefix wins',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         if ((bool) $input->getOption('diagnose')) {
             return $this->runDiagnose($output);
         }

--- a/src/Command/Rbt/RecoverCommand.php
+++ b/src/Command/Rbt/RecoverCommand.php
@@ -42,23 +42,14 @@ final class RecoverCommand extends ReliCommand
                 'Output format: rbt (re-encoded binary trace) or phpspy (text)',
                 'rbt',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         /** @var string $format */
         $format = $input->getOption('format');
         $reader = new BinaryTraceReader();

--- a/src/Command/Rbt/RecoverCommand.php
+++ b/src/Command/Rbt/RecoverCommand.php
@@ -42,12 +42,23 @@ final class RecoverCommand extends ReliCommand
                 'Output format: rbt (re-encoded binary trace) or phpspy (text)',
                 'rbt',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         /** @var string $format */
         $format = $input->getOption('format');
         $reader = new BinaryTraceReader();

--- a/src/Command/ReliCommand.php
+++ b/src/Command/ReliCommand.php
@@ -14,8 +14,60 @@ declare(strict_types=1);
 namespace Reli\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class ReliCommand extends Command
 {
+    /**
+     * Env var that {@see worker-entry.php} reads to raise the
+     * `memory_limit` of every amphp-spawned worker (e.g. the readers
+     * fanned out by `inspector:daemon` / `inspector:top`). `ini_set` in
+     * the parent process does not propagate; this env-var bridge does.
+     */
+    public const string MEMORY_LIMIT_ENV = 'RELI_MEMORY_LIMIT';
+
     abstract public static function getDockerProfile(): DockerProfile;
+
+    /**
+     * Returns `static` so the helper composes inside Command::configure()
+     * chains (`$this->setName(...)->setDescription(...)->addMemoryLimitOption()`).
+     */
+    protected function addMemoryLimitOption(): static
+    {
+        return $this->addOption(
+            'memory-limit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'set PHP memory_limit for this reli process (e.g. 2G, 512M).'
+            . ' Daemon-style commands (inspector:daemon, inspector:top)'
+            . ' propagate the value to their spawned worker processes via'
+            . ' the ' . self::MEMORY_LIMIT_ENV . ' env var.',
+        );
+    }
+
+    protected function applyMemoryLimit(InputInterface $input, OutputInterface $output): void
+    {
+        /** @var mixed $raw */
+        $raw = $input->getOption('memory-limit');
+        if (!is_string($raw) || $raw === '') {
+            return;
+        }
+        if (ini_set('memory_limit', $raw) === false) {
+            $err = $output instanceof ConsoleOutputInterface
+                ? $output->getErrorOutput()
+                : $output;
+            $err->writeln(
+                "<comment>warning: ini_set('memory_limit', '{$raw}') failed;"
+                . ' value may be malformed (expected e.g. 2G, 512M, -1).</comment>',
+            );
+            return;
+        }
+        // Propagate to amphp workers spawned via Lib\Amphp\ContextCreator.
+        // putenv() updates the current process env, which child processes
+        // started via proc_open / Amp\Process inherit by default.
+        putenv(self::MEMORY_LIMIT_ENV . '=' . $raw);
+    }
 }

--- a/src/Command/Rmem/RmemMcpCommand.php
+++ b/src/Command/Rmem/RmemMcpCommand.php
@@ -81,12 +81,23 @@ final class RmemMcpCommand extends ReliCommand
                 InputOption::VALUE_REQUIRED,
                 'base URL of an rmem:live / explore --http-bridge server; enables rmem_navigate to broadcast focus events to browsers',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         /** @var string|null $rmemPath */
         $rmemPath = $input->getOption('rmem');
         /** @var string|null $socketPath */

--- a/src/Command/Rmem/RmemMcpCommand.php
+++ b/src/Command/Rmem/RmemMcpCommand.php
@@ -81,23 +81,14 @@ final class RmemMcpCommand extends ReliCommand
                 InputOption::VALUE_REQUIRED,
                 'base URL of an rmem:live / explore --http-bridge server; enables rmem_navigate to broadcast focus events to browsers',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         /** @var string|null $rmemPath */
         $rmemPath = $input->getOption('rmem');
         /** @var string|null $socketPath */

--- a/src/Command/Rmem/RmemQueryCommand.php
+++ b/src/Command/Rmem/RmemQueryCommand.php
@@ -82,12 +82,7 @@ final class RmemQueryCommand extends ReliCommand
                 InputOption::VALUE_NONE,
                 'validate string_dict and other sections for truncation or corruption',
             )
-            ->addOption(
-                'memory-limit',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
-            )
+            ->addMemoryLimitOption()
         ;
     }
 
@@ -97,11 +92,7 @@ final class RmemQueryCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var string|null $memory_limit */
-        $memory_limit = $input->getOption('memory-limit');
-        if (is_string($memory_limit) && $memory_limit !== '') {
-            ini_set('memory_limit', $memory_limit);
-        }
+        $this->applyMemoryLimit($input, $output);
         /** @var string|null $serverPath */
         $serverPath = $input->getOption('server');
         if ($serverPath !== null) {

--- a/src/Command/Rmem/RmemQueryCommand.php
+++ b/src/Command/Rmem/RmemQueryCommand.php
@@ -82,6 +82,12 @@ final class RmemQueryCommand extends ReliCommand
                 InputOption::VALUE_NONE,
                 'validate string_dict and other sections for truncation or corruption',
             )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'set PHP memory_limit for analysis (e.g. 2G, 512M)',
+            )
         ;
     }
 
@@ -91,6 +97,11 @@ final class RmemQueryCommand extends ReliCommand
     #[\Override]
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $memory_limit */
+        $memory_limit = $input->getOption('memory-limit');
+        if (is_string($memory_limit) && $memory_limit !== '') {
+            ini_set('memory_limit', $memory_limit);
+        }
         /** @var string|null $serverPath */
         $serverPath = $input->getOption('server');
         if ($serverPath !== null) {

--- a/src/Lib/Amphp/worker-entry.php
+++ b/src/Lib/Amphp/worker-entry.php
@@ -20,6 +20,17 @@ use Reli\Lib\Log\StateCollector\StateCollector;
 use Psr\Log\LoggerInterface;
 
 return function (Channel $channel) use ($argv): void {
+    // Inherit the reli parent's --memory-limit. ini_set() in the parent
+    // does not cross the proc_open boundary, so ReliCommand pushes the
+    // value through env (RELI_MEMORY_LIMIT) and we reapply it here at
+    // worker startup. Without this, daemon-style readers keep the
+    // bootstrap default and OOM independently of what the user passed
+    // on the command line.
+    $worker_memory_limit = getenv('RELI_MEMORY_LIMIT');
+    if (is_string($worker_memory_limit) && $worker_memory_limit !== '') {
+        ini_set('memory_limit', $worker_memory_limit);
+    }
+
     // Worker is spawned by reli's parent with exactly 4 argv entries; a
     // mismatch means either the launcher contract changed or the worker
     // was invoked manually. Without this guard, the destructuring below


### PR DESCRIPTION
## Summary
This change adds a `--memory-limit` command-line option to all Reli commands, allowing users to configure PHP's memory limit for analysis operations without modifying php.ini or environment variables.

## Key Changes
- Added `--memory-limit` option to 26 commands across multiple command categories:
  - Cache commands: `ClearCommand`
  - Converter commands: `CallgrindCommand`, `FlameGraphCommand`, `FoldedCommand`, `PhpspyCommand`, `PprofCommand`, `SpeedscopeCommand`, `RbtCommand`
  - Inspector commands: `MemoryDumpInspectCommand`, `MemoryDumpNormalizeCommand`, `DaemonCommand`, `GetEgAddressCommand`, `GetTraceCommand`, `PeekVarCommand`, `TopLikeCommand`
  - Docker commands: `PrintWrapperCommand`
  - PhpSpy commands: `PhpSpyDaemonCommand`, `PhpSpyInstallCommand`, `PhpSpyTraceCommand`
  - Rbt commands: `AnalyzeCommand`, `ExploreCommand`, `RecoverCommand`
  - Rmem commands: `RmemMcpCommand`, `RmemQueryCommand`

- Each command now:
  - Imports `InputOption` from Symfony Console
  - Defines the `--memory-limit` option accepting values like "2G" or "512M"
  - Calls `ini_set('memory_limit', $memory_limit)` at the start of execution when the option is provided

## Implementation Details
- The option is defined as `VALUE_REQUIRED` to accept memory size values
- Validation checks that the value is a non-empty string before applying it via `ini_set()`
- Type hint comments (`/** @var string|null $memory_limit */`) ensure proper static analysis
- The memory limit is set early in command execution, before any analysis operations begin

https://claude.ai/code/session_01BpSeSbgC1EQZTNk7oyUovp