### PR TITLE
docs(0.12.0): pre-release sweep — six small fixes

### DIFF
--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -57,6 +57,7 @@ the top of the emitted wrapper. At the time of writing:
 
 - `cache:clear`
 - `converter:*` (callgrind, flamegraph, folded, phpspy, pprof, rbt, speedscope)
+- `docker:print-wrapper`
 - `inspector:memory:analyze`, `inspector:memory:compare`,
   `inspector:memory:dump:inspect`, `inspector:memory:normalize-dump`,
   `inspector:memory:report`, `inspector:optimize-memory-db`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,9 @@ echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
 
 The wrapper's baked-in image tag matches the version of reli the
 `docker run` invocation pulled, so there's no `:latest` drift —
-re-run the first command above to upgrade.
+to upgrade, re-run whichever install command you used (the `eval`
+form for the current shell only, or the `docker run ... > ...wrapper.sh`
+form to refresh the saved file that future shells will source).
 
 The wrapper runs each `reli` invocation as a container with
 `--cap-add=SYS_PTRACE --pid=host --network=host`, which gives reli

--- a/docs/inspection/peek-var-command.md
+++ b/docs/inspection/peek-var-command.md
@@ -131,6 +131,15 @@ Variables not found in the target process show `<not found>`.
 {"global::$counter":{"type":"long","value":42,"array_count":null},"global::$name":{"type":"string","value":"hello_world","array_count":null},"global::$items":{"type":"array","value":null,"array_count":10}}
 ```
 
+Variables that aren't found in the target are emitted as plain
+`null` (not an object with `type`/`value`/`array_count`), so when
+scripting around the JSON output use a presence check rather than
+indexing into `.type` directly:
+
+```json
+{"global::$missing":null,"memory::memory_get_usage":{"type":"long","value":398968,"array_count":null}}
+```
+
 ## Repeat Mode
 
 With `--repeat=<ms>`, the command polls the target process at the given

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -137,8 +137,10 @@ reli inspector:daemon \
 For attaching to a single worker (`inspector:trace`), pass the PHP
 worker **TID** rather than the FrankenPHP parent PID. The pattern
 below intentionally excludes `php-main` — that's the bootstrap
-thread, not a worker, and attaching to it produces empty traces /
-"failed to find ZendMM main chunk" on memory commands. See
+thread, not a worker, and attaching to it fails (the exact message
+varies by FrankenPHP / PHP build; current builds typically print
+`_tsrm_ls_cache slot is uninitialized`, older ones
+`failed to find ZendMM main chunk`). See
 [tracing/frankenphp.md](tracing/frankenphp.md) for the full story.
 
 ```bash

--- a/docs/tracing/advanced-capture.md
+++ b/docs/tracing/advanced-capture.md
@@ -11,6 +11,14 @@ can attach three extra layers of detail to each sample:
 All three work with every output format (`.rbt`, `template:phpspy*`,
 `json_lines`) and on top of `inspector:daemon` the same way.
 
+> **`template:json_lines` opcode field is a placeholder today.**
+> Each frame carries an `opline` object whose `opcode` sub-field is
+> currently always emitted as `{}` — opcode-name resolution into the
+> JSON template is not wired up yet. For opcode-aware analysis prefer
+> `.rbt` (`rbt:analyze --with-opcode` / `c` in `rbt:explore`) or
+> `template:phpspy_with_opcode`, both of which surface the opcode
+> name (`ZEND_DO_FCALL`, `ZEND_ASSIGN`, …) directly.
+
 ## Executing opcode
 
 Useful when you want to know not only which line is slow but which

--- a/src/Command/Inspector/CoreDumpCommand.php
+++ b/src/Command/Inspector/CoreDumpCommand.php
@@ -58,7 +58,7 @@ final class CoreDumpCommand extends ReliCommand
         $this->setName('inspector:coredump')
             ->setDescription('get memory usage from a core dump file')
         ;
-        $this->memory_profiler_settings_from_console_input->setOptions($this);
+        $this->memory_profiler_settings_from_console_input->setOptions($this, include_stop_process: false);
         $this->target_php_settings_from_console_input->setOptions($this);
         $this->addOption(
             'pid',

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -47,7 +47,7 @@ final class MemoryAnalyzeCommand extends ReliCommand
         $this->setName('inspector:memory:analyze')
             ->setDescription('analyze a memory dump file created by inspector:memory:dump')
         ;
-        $this->memory_profiler_settings_from_console_input->setOptions($this);
+        $this->memory_profiler_settings_from_console_input->setOptions($this, include_stop_process: false);
         $this->addArgument(
             'dump-file',
             InputArgument::REQUIRED,

--- a/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
+++ b/src/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInput.php
@@ -22,15 +22,17 @@ use Symfony\Component\Console\Input\InputOption;
 final class MemoryProfilerSettingsFromConsoleInput
 {
     /** @codeCoverageIgnore */
-    public function setOptions(Command $command): void
+    public function setOptions(Command $command, bool $include_stop_process = true): void
     {
-        $command->addOption(
-            'stop-process',
-            null,
-            InputOption::VALUE_NEGATABLE,
-            'stop the process while inspecting (default: on)',
-            true,
-        );
+        if ($include_stop_process) {
+            $command->addOption(
+                'stop-process',
+                null,
+                InputOption::VALUE_NEGATABLE,
+                'stop the process while inspecting (default: on)',
+                true,
+            );
+        }
         $command->addOption(
             'pretty-print',
             null,
@@ -106,7 +108,9 @@ final class MemoryProfilerSettingsFromConsoleInput
 
     public function createSettings(InputInterface $input): MemoryProfilerSettings
     {
-        $stop_process = Cast::toBool($input->getOption('stop-process'));
+        $stop_process = $input->hasOption('stop-process')
+            ? Cast::toBool($input->getOption('stop-process'))
+            : true;
         $pretty_print = Cast::toBool($input->getOption('pretty-print'));
         $memory_exhaustion_error_details = null;
         if (

--- a/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
+++ b/tests/Inspector/Settings/MemoryProfilerSettings/MemoryProfilerSettingsFromConsoleInputTest.php
@@ -38,6 +38,7 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
     public function testFromConsoleInput(): void
     {
         $input = $this->createBaseMock();
+        $input->expects()->hasOption('stop-process')->andReturns(true)->atLeast()->once();
         $input->expects()->getOption('stop-process')->andReturns(true)->atLeast()->once();
         $input->expects()->getOption('pretty-print')->andReturns(false)->atLeast()->once();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -60,6 +61,7 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
     public function testFromConsoleInputDepthNotInteger(): void
     {
         $input = $this->createBaseMock();
+        $input->expects()->hasOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -77,6 +79,7 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
     public function testFromConsoleInputDepthNotPositive(): void
     {
         $input = $this->createBaseMock();
+        $input->expects()->hasOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();
@@ -113,6 +116,7 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
     public function testFormatDetection(?string $format, ?string $path, string $expected): void
     {
         $input = $this->createBaseMock();
+        $input->expects()->hasOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns(null)->atLeast()->once();
@@ -130,6 +134,7 @@ class MemoryProfilerSettingsFromConsoleInputTest extends BaseTestCase
     public function testFromConsoleInputLineNotInteger(): void
     {
         $input = $this->createBaseMock();
+        $input->expects()->hasOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('stop-process')->andReturns(true)->zeroOrMoreTimes();
         $input->expects()->getOption('pretty-print')->andReturns(false)->zeroOrMoreTimes();
         $input->expects()->getOption('memory-limit-error-file')->andReturns('abc.php')->atLeast()->once();


### PR DESCRIPTION
## Summary

Pre-release walk through the README → `docs/*` for 0.12.0, exercising
the user-facing flows on a real target. Six small drift items came up
that are not covered by the docs PRs already in flight (#751, #753) or
the recently merged set (#742-#752): five docs fixes and one stale CLI
flag the docs walk surfaced. All in one commit because each is tiny and
they share the same release-readiness motivation.

## What was checked

Walked the README showcase commands end-to-end against a live PHP
target on the host:

- `inspector:trace -p <pid> -o trace.rbt` + `rbt:analyze` (the README
  hot-frames example, including `--last --last-depth=10 --top=10
  --sections="tail,self+total" --crop-anchor=right --path=short
  --crop=auto`)
- `rbt:explore --help`
- `inspector:memory:dump` → `inspector:memory:analyze -f rmem`
  → `rmem:viz` (HTML emitted) → `inspector:memory:report`
  → `inspector:memory:compare`
- `inspector:trace -- php -r '...'` smoke test from getting-started.md
- `inspector:top -p <pid>` (PR #751's claim that `-p` works)
- `inspector:peek-var` (text + JSON, including a missing variable)
- `inspector:watch -p <pid> --memory-usage --action=log --oneshot=1`
- `inspector:sidecar` with `--socket=` to a 0700 dir (banner format)
- `inspector:memory:dump:inspect`
- `inspector:trace -f template:phpspy_with_opcode` /
  `template:json_lines`
- `q`-quit via pty (both stdout-template mode and `-o trace.rbt`):
  rbt is finalised cleanly, exit 0, no zombie

Plus link-existence sweep across the 30 cross-references in
`README.md` and `docs/README.md`, and CLI `--help` vs. doc table
diffing on the high-traffic commands.

## Out of scope (already handled by other PRs)

Skipped anything covered by:

- **#751 (open)** — `pgrep -nfx`, "binary"→"rmem" wording in the three
  memory docs, `inspector:memory:dump` options table, `dump:inspect`
  reposition, FrankenPHP `--php-regex` rationale, troubleshooting
  regex defaults, `rbt:explore` terminal error message, `inspector:top
  -p` note
- **#753 (open)** — `inspector:coredump` readlink fail-soft for NTS
  post-mortem
- Merged: **#752** (`coredump -f rmem`), **#750** (frankenphp.md
  `php-main` failure modes), **#749** (README `-f binary`→`-f rmem`),
  **#748** (static property defaults), **#747** (XDG dirs in wrapper),
  **#746** (binary→rmem rename + autodetect), **#745** (recipes drop
  `sudo`), **#744** (Docker memory_limit), **#743** (docker-wrapper
  Security paragraph), **#742** (`/opt/reli/php-ptrace/php`)

## The six fixes

### 1. `docs/recipes.md` — FrankenPHP `php-main` blurb stale

The FrankenPHP recipe still warned about "empty traces / 'failed to
find ZendMM main chunk' on memory commands". PR #750 already updated
`docs/tracing/frankenphp.md` to acknowledge that the exact error
varies by build (current `dunglas/frankenphp:latest` /
`dunglas/frankenphp:php8.3` print
`_tsrm_ls_cache slot is uninitialized`; older builds got past TSRM by
accident and failed at ZendMM-main-chunk lookup). Recipes was the
only doc still asserting the old wording — a user copying the recipe
on a current image and grep'ing for "ZendMM main chunk" wouldn't find
anything. Synced the wording with frankenphp.md.

### 2. `docs/getting-started.md` — "re-run the first command above to upgrade"

The Install section recommends saving the wrapper to a file and
sourcing it from `~/.bashrc`/`~/.zshrc` for persistence (L86-89), but
the upgrade hint that follows ("re-run the first command above to
upgrade") points at the `eval "$(docker run ...)"` line two blocks
above. For users on the persistent path, the eval only updates the
function in the current shell — future shells keep loading the old
saved file until that file is regenerated. Spell out both paths so
users on either install route have an actionable instruction.

`docs/docker-wrapper.md` had the same wording but its blocks are
adjacent so the same phrase is unambiguous there; not touched.

### 3. `inspector:coredump` / `inspector:memory:analyze` — stale `--stop-process` flag

`--help` on both commands listed `--stop-process | --no-stop-process`
"stop the process while inspecting (default: on)", but both operate
on a static file (a `.rdump` or an ELF core) — there is no live
target to stop. The flag was inherited from
`MemoryProfilerSettingsFromConsoleInput::setOptions`, which is also
called from the live `inspector:memory`.

Added an `include_stop_process` parameter (default `true`) to
`setOptions()`; the two offline commands pass `false`. `createSettings`
falls back to `true` via `hasOption()` when the option isn't
registered, so live behaviour is byte-for-byte identical.

This is the only code change in the PR; surfaced from the docs walk
because `docs/memory/coredump.md` Options table didn't list
`stop-process` and the help-vs-doc diff exposed it.

### 4. `docs/tracing/advanced-capture.md` — `template:json_lines` opcode field is a placeholder

Each frame in `template:json_lines` carries an `opline` object whose
`opcode` sub-field always renders as `{}`:

```json
"opline":{"op1":0,"op2":0,"result":0,"extended_value":0,"lineno":1,"opcode":{},"op1_type":0,...}
```

Opcode-name resolution into the JSON template isn't wired up. Until
it is, document the limitation and point opcode-aware users at `.rbt`
(`rbt:analyze --with-opcode` / `c` in `rbt:explore`) or
`template:phpspy_with_opcode` — both surface the opcode name
(`ZEND_DO_FCALL`, `ZEND_ASSIGN`, …) directly. Filed as a doc note,
not a code fix, because the JSON template hasn't designed an
opcode-name resolver yet (the `phpspy_with_opcode` template gets it
from a different code path).

### 5. `docs/docker-wrapper.md` — Minimal allowlist missing `docker:print-wrapper`

`docker:print-wrapper --profile=minimal` prints a header listing the
Minimal-safe commands; it includes `docker:print-wrapper` itself. The
docs allowlist (L58-64) didn't. Added it. (The doc says "At the time
of writing" so the drift was acknowledged in spirit, but the
omission would surprise a user trying to refresh their wrapper from
a Minimal-only install.)

### 6. `docs/inspection/peek-var-command.md` — JSON missing-variable shape

The text format documents `<not found>` for missing variables (L126),
but the JSON example only covers the success path. In practice
missing variables come back as plain `null`:

```json
{"global::$missing":null,"memory::memory_get_usage":{"type":"long","value":398968,"array_count":null}}
```

i.e. not an object with `type`/`value`/`array_count`. A consumer
indexing into `.type` blindly will trip up. Added the missing
example + a one-line note about presence-checking before deref.

## Verification

**Docs walk** (manual, against a live PHP 8.4 NTS target on the host):

- README showcase commands 1-4 all produce the documented output
  shapes
- getting-started smoke test (`reli inspector:trace -- php -r '...'`)
  scrolls samples; `q` exits cleanly
- `q`-quit via pty: with `-o trace.rbt` the file finalises (rbt
  magic + valid varints, `rbt:analyze` reads back 287 samples, exit
  0, no zombie)
- 30-ish cross-reference link targets all exist
- CLI `--help` vs. doc table diffing on `inspector:memory*`,
  `inspector:coredump`, `inspector:trace`, `inspector:top`,
  `inspector:watch`, `inspector:sidecar`, `inspector:peek-var`,
  `rmem:explore`, `docker:print-wrapper`

**Code**:

- `phpcs --standard=PSR12` on the touched src files: clean
- `psalm --no-progress --show-info=false`: no errors
- `phpunit --filter MemoryProfilerSettingsFromConsoleInputTest`:
  14/14 green (added matching `hasOption('stop-process')` mock
  expectations alongside the existing `getOption` ones)
- After the change:
  - `php ./reli inspector:coredump --help | grep stop-process` →
    nothing
  - `php ./reli inspector:memory:analyze --help | grep stop-process` →
    nothing
  - `php ./reli inspector:memory --help | grep stop-process` →
    `--stop-process | --no-stop-process` (unchanged)

The 3 pre-existing FrankenPHP / mod_php integration test failures in
this sandbox are environmental (no docker targets) and reproduce on
unmodified `0.12.x` — unrelated to this PR.

## Test plan

- [x] phpcs / psalm clean on touched files
- [x] Targeted phpunit (`MemoryProfilerSettingsFromConsoleInputTest`)
      green
- [x] `inspector:coredump --help` and `inspector:memory:analyze
      --help` no longer expose `--stop-process`
- [x] `inspector:memory --help` still does
- [ ] CI: full unit suite + `target-version` group on the merge
- [ ] Reviewer eyeballs each doc paragraph against the live CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)