### PR TITLE
Fix phantom WeakMap cycle findings by handling inline HashTable headers

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitWeakMapJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitWeakMapJob.php
@@ -18,6 +18,11 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendWeakMap;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableOverheadMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ArrayElementsContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ArrayPossibleOverheadContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\InlineArrayHeaderContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\WeakMapContext;
 
 /**
@@ -49,12 +54,59 @@ final class EmitWeakMapJob implements CollectorJob
         $parent = $node_id >= 0 ? $node_id : null;
 
         try {
-            $queue->push(new EmitArrayDirectJob(
-                $this->zend_weak_map->ht,
-                $parent,
-                'entries',
-            ));
+            $array = $this->zend_weak_map->ht;
         } catch (\Throwable) {
+            return;
+        }
+
+        // The inner HashTable header is INLINE in zend_weakmap
+        // (`{ HashTable ht; zend_object std; }` with `ht` at offset 0), so its
+        // bytes already belong to the parent ZendObjectMemoryLocation
+        // (sizeof(zend_weakmap) ≈ 96 B includes the 56 B ht). Use
+        // InlineArrayHeaderContext — same structural shape as
+        // ArrayHeaderContext but without a ZendArrayMemoryLocation — so the
+        // header doesn't (a) double-count those 56 B nor (b) collide with the
+        // WeakMap object on `(address)` keying inside
+        // `PdoMemoryOutput::computeCanonicalNodeIds` / the binary canonical
+        // map, which used to close (object → weak_map → entries) into a
+        // phantom 1x WeakMap cycle_cluster.
+        //
+        // The buckets table (`arData`) is a separate heap allocation and is
+        // tracked normally.
+        $entries_context = new InlineArrayHeaderContext();
+        $array_elements_context = null;
+        if (!is_null($array->arData) && !$array->isUninitialized()) {
+            $array_table_location = ZendArrayTableMemoryLocation::fromZendArray($array);
+            $array_table_overhead_location =
+                ZendArrayTableOverheadMemoryLocation::fromZendArrayAndUsedLocation(
+                    $array,
+                    $array_table_location,
+                );
+            $ctx->memory_locations->add($array_table_location);
+            $ctx->memory_locations->add($array_table_overhead_location);
+
+            $array_elements_context = new ArrayElementsContext($array_table_location);
+            $array_elements_context->setCount($array->nNumOfElements);
+            $overhead_context = new ArrayPossibleOverheadContext($array_table_overhead_location);
+
+            $entries_context->add('array_elements', $array_elements_context);
+            $entries_context->add('possible_unused_area', $overhead_context);
+        }
+
+        $entries_node_id = $ctx->emitNode($entries_context, $parent, 'entries');
+
+        if ($array_elements_context !== null) {
+            $raw_elements = $array_elements_context->getMemoNodeId();
+            $elements_node_id = $raw_elements !== null
+                ? ($raw_elements < 0 ? -$raw_elements - 1 : $raw_elements)
+                : ($entries_node_id >= 0 ? $entries_node_id : null);
+            try {
+                $queue->push(new ArrayElementsIteratorJob(
+                    $array,
+                    $elements_node_id,
+                ));
+            } catch (\Throwable) {
+            }
         }
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/InlineArrayHeaderContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/InlineArrayHeaderContext.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+/**
+ * Structural marker for a HashTable header that is INLINE inside an enclosing
+ * struct (e.g. `zend_weakmap = { HashTable ht; zend_object std; }`).
+ *
+ * Unlike {@see ArrayHeaderContext}, this does not own a
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayMemoryLocation}
+ * — the inline header's bytes are already accounted for by the enclosing
+ * struct's location, so emitting one here would double-count them and (more
+ * subtly) collide with the parent on `(address)` keying inside
+ * `PdoMemoryOutput::computeCanonicalNodeIds` / the binary canonical map. That
+ * collision used to close the (object → weak_map → entries-ht) chain into a
+ * phantom `cycle_cluster: 1x WeakMap` finding on every WeakMap, including
+ * empty ones.
+ *
+ * Children — `array_elements` (the heap-allocated buckets table) and
+ * `possible_unused_area` (its over-allocated tail) — are attached the same
+ * way as on {@see ArrayHeaderContext} so report passes and viz code can keep
+ * navigating by link name.
+ */
+final class InlineArrayHeaderContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+
+    public function getElements(): ?ArrayElementsContext
+    {
+        /** @var ArrayElementsContext|null */
+        return $this->referencing_contexts['array_elements'] ?? null;
+    }
+}

--- a/src/Rmem/Live/VizHtmlBuilder.php
+++ b/src/Rmem/Live/VizHtmlBuilder.php
@@ -295,6 +295,7 @@ final class VizHtmlBuilder
      */
     private const STRUCTURAL_NODE_TYPES = [
         'ArrayHeaderContext',
+        'InlineArrayHeaderContext',
         'ArrayPossibleOverheadContext',
     ];
 

--- a/tests/Command/Inspector/MemoryReportCommandIntegrationTest.php
+++ b/tests/Command/Inspector/MemoryReportCommandIntegrationTest.php
@@ -137,6 +137,184 @@ class MemoryReportCommandIntegrationTest extends BaseTestCase
         yield from TargetPhpVmProvider::from(ZendTypeReader::V72);
     }
 
+    public static function provideFromV80(): \Generator
+    {
+        yield from TargetPhpVmProvider::from(ZendTypeReader::V80);
+    }
+
+    /**
+     * @return array{resource, int, array<int, resource>}
+     */
+    private function startWeakMapTargetProcess(string $docker_image_name): array
+    {
+        // Just `new WeakMap()` — no entries. This used to surface as a
+        // phantom `cycle_cluster: 1x WeakMap` finding because the inline
+        // HashTable header (offset 0 of zend_weakmap) shared its base
+        // address with the WeakMap object node, and
+        // `PdoMemoryOutput::computeCanonicalNodeIds` (and the binary
+        // canonical map) merged them on `(address)` keying.
+        $target_script = <<<'PHP'
+        <?php
+        $wm = new WeakMap();
+        fputs(STDOUT, "ready\n");
+        fgets(STDIN);
+        PHP;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $ready = fgets($pipes[1]);
+        $this->assertSame("ready\n", $ready);
+
+        return [$this->child, $pid, $pipes];
+    }
+
+    /**
+     * Empty WeakMap must not produce a phantom cycle finding.
+     *
+     * Regression test: see EmitWeakMapJob — the inner ht is INLINE in
+     * `zend_weakmap = { HashTable ht; zend_object std; }` (`ht` at offset 0),
+     * so the WeakMap object node and the inline ht header would otherwise
+     * share their base address and get unified by the canonical-node-id
+     * pipeline, closing the (object → weak_map → entries) chain into a
+     * phantom 1x WeakMap cycle_cluster.
+     */
+    #[DataProvider('provideFromV80')]
+    public function testEmptyWeakMapProducesNoCycleFinding(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no target version');
+        }
+
+        $dump_path = $this->createTmpFile();
+        $db_path = $this->createTmpFile('.db');
+        $report_path = $this->createTmpFile('.json');
+        $container = $this->createContainer();
+        [, $pid, ] = $this->startWeakMapTargetProcess($docker_image_name);
+
+        /** @var MemoryDumpCommand $dump_command */
+        $dump_command = $container->make(MemoryDumpCommand::class);
+        $dump_input = new ArrayInput([
+            '--pid' => (string)$pid,
+            '--output' => $dump_path,
+            '--include-binary' => true,
+        ]);
+        $dump_input->setInteractive(false);
+        $this->assertSame(0, $dump_command->run($dump_input, new BufferedOutput()));
+
+        /** @var MemoryAnalyzeCommand $analyze_command */
+        $analyze_command = $container->make(MemoryAnalyzeCommand::class);
+        $analyze_input = new ArrayInput([
+            'dump-file' => $dump_path,
+            '--output-format' => 'sqlite3',
+            '--output' => $db_path,
+        ]);
+        $analyze_input->setInteractive(false);
+        ob_start();
+        try {
+            $this->assertSame(0, $analyze_command->run($analyze_input, new BufferedOutput()));
+        } finally {
+            ob_end_clean();
+        }
+
+        /** @var MemoryReportCommand $report_command */
+        $report_command = $container->make(MemoryReportCommand::class);
+        $report_input = new ArrayInput([
+            'db-file' => $db_path,
+            '--output-format' => 'report-json',
+            '--output' => $report_path,
+        ]);
+        $report_input->setInteractive(false);
+        $this->assertSame(0, $report_command->run($report_input, new BufferedOutput()));
+
+        $json = file_get_contents($report_path);
+        $this->assertNotFalse($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+        /** @var array{findings?: list<array{kind: string, facts?: array{composition?: string}}>} $decoded */
+
+        $weakmap_cycles = array_filter(
+            $decoded['findings'] ?? [],
+            static fn(array $f): bool =>
+                in_array($f['kind'], ['cycle_cluster', 'micro_cycle', 'di_container_cycle'], true)
+                && isset($f['facts']['composition'])
+                && str_contains((string)$f['facts']['composition'], 'WeakMap'),
+        );
+
+        $this->assertEmpty(
+            $weakmap_cycles,
+            'Empty WeakMap must not surface as a cycle finding;'
+            . ' got: '
+            . json_encode(array_values($weakmap_cycles)),
+        );
+    }
+
+    /**
+     * Same regression test, but on the rmem (binary) report path. The
+     * canonical map there is computed by BinaryContextTreeSink, so this
+     * exercises a separate code path from the SQLite test above.
+     */
+    #[DataProvider('provideFromV80')]
+    public function testEmptyWeakMapProducesNoCycleFindingOnRmemPath(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('no target version');
+        }
+
+        $rmem_path = $this->createTmpFile('.rmem');
+        $report_path = $this->createTmpFile('.json');
+        $container = $this->createContainer();
+        [, $pid, ] = $this->startWeakMapTargetProcess($docker_image_name);
+
+        /** @var MemoryCommand $memory_command */
+        $memory_command = $container->make(MemoryCommand::class);
+        $memory_input = new ArrayInput([
+            '--pid' => (string)$pid,
+            '--output' => $rmem_path,
+            '--output-format' => 'rmem',
+        ]);
+        $memory_input->setInteractive(false);
+        $this->assertSame(0, $memory_command->run($memory_input, new BufferedOutput()));
+
+        /** @var MemoryReportCommand $report_command */
+        $report_command = $container->make(MemoryReportCommand::class);
+        $report_input = new ArrayInput([
+            'db-file' => $rmem_path,
+            '--output-format' => 'report-json',
+            '--output' => $report_path,
+        ]);
+        $report_input->setInteractive(false);
+        $this->assertSame(0, $report_command->run($report_input, new BufferedOutput()));
+
+        $json = file_get_contents($report_path);
+        $this->assertNotFalse($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+        /** @var array{findings?: list<array{kind: string, facts?: array{composition?: string}}>} $decoded */
+
+        $weakmap_cycles = array_filter(
+            $decoded['findings'] ?? [],
+            static fn(array $f): bool =>
+                in_array($f['kind'], ['cycle_cluster', 'micro_cycle', 'di_container_cycle'], true)
+                && isset($f['facts']['composition'])
+                && str_contains((string)$f['facts']['composition'], 'WeakMap'),
+        );
+
+        $this->assertEmpty(
+            $weakmap_cycles,
+            'Empty WeakMap must not surface as a cycle finding (rmem path);'
+            . ' got: '
+            . json_encode(array_values($weakmap_cycles)),
+        );
+    }
+
     #[DataProvider('provideFromV72')]
     public function testReportContainsRankingSections(
         string $php_version,


### PR DESCRIPTION
## Summary
Fixes a regression where empty WeakMap objects were incorrectly surfacing as phantom cycle cluster findings in memory reports. The issue stemmed from the inline HashTable header within `zend_weakmap` colliding with the parent object node during canonical node ID computation.

## Key Changes

- **Added `InlineArrayHeaderContext`**: A new reference context type that represents a HashTable header that is INLINE within an enclosing struct (like `zend_weakmap`). Unlike `ArrayHeaderContext`, it does not emit its own `ZendArrayMemoryLocation`, preventing double-counting of bytes and address collisions.

- **Refactored `EmitWeakMapJob`**: Updated to properly handle the inline HashTable structure by:
  - Using `InlineArrayHeaderContext` instead of `EmitArrayDirectJob` for the entries header
  - Manually tracking the heap-allocated buckets table (`arData`) via `ZendArrayTableMemoryLocation` and `ZendArrayTableOverheadMemoryLocation`
  - Emitting array elements through `ArrayElementsIteratorJob` when entries exist
  - Preventing the (object → weak_map → entries-ht) chain from closing into a phantom cycle

- **Updated `VizHtmlBuilder`**: Added `InlineArrayHeaderContext` to the list of structural node types for proper visualization handling.

- **Added regression tests**: Two comprehensive integration tests (`testEmptyWeakMapProducesNoCycleFinding` and `testEmptyWeakMapProducesNoCycleFindingOnRmemPath`) that verify empty WeakMap objects no longer produce phantom cycle findings on both SQLite and binary (rmem) report paths.

## Implementation Details

The core issue was that `zend_weakmap` has the structure `{ HashTable ht; zend_object std; }` with the `ht` at offset 0. The inline header's bytes are already accounted for by the parent `ZendObjectMemoryLocation`, so emitting a separate location would cause:
1. Double-counting of the 56-byte header
2. Address collision in `PdoMemoryOutput::computeCanonicalNodeIds` and the binary canonical map, which unify nodes by address

The fix ensures the inline header is tracked structurally without its own memory location, while the separate heap-allocated buckets table is tracked normally.

https://claude.ai/code/session_013ktpuSRKo5vQkF8UtADThW