### PR TITLE
Add --pull=always to docker run commands in documentation

### DIFF
--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -17,12 +17,15 @@ eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper --
 
 `--pull=always` forces Docker to refresh `reliforp/reli-prof:latest`
 before invoking `docker:print-wrapper`. Without it, a previously
-cached `:latest` from an older release can be missing this command
-(or other newer features) and the bootstrap fails with
-`There are no commands defined in the "docker" namespace.` It only
-matters at install time — once the wrapper is installed, the
-per-invocation `reli` calls use the specific tag baked into the
-wrapper rather than `:latest`.
+cached `:latest` falls into one of two failure modes: a pre-0.12
+cache lacks `docker:print-wrapper` entirely and the bootstrap fails
+with `There are no commands defined in the "docker" namespace.`,
+while a more recent but stale cache silently emits a wrapper baked
+with the older image's tag — pinning you to a previous reli release
+without any error. Once the wrapper is installed, per-invocation
+`reli` calls use the specific tag baked into the wrapper rather
+than `:latest`, so the flag only matters at install / upgrade time
+— but it matters at *every* install or upgrade.
 
 For persistence across shells, save the emitted wrapper to a file once
 and `source` it from your rc — pasting the `eval "$(docker run ...)"`

--- a/docs/docker-wrapper.md
+++ b/docs/docker-wrapper.md
@@ -9,11 +9,20 @@ routed through `docker run` transparently.
 
 ```bash
 # Full profile (default) — attaches to live processes.
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper)"
 
 # Minimal profile — viewers / converters only, lower privilege.
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper --profile=minimal)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper --profile=minimal)"
 ```
+
+`--pull=always` forces Docker to refresh `reliforp/reli-prof:latest`
+before invoking `docker:print-wrapper`. Without it, a previously
+cached `:latest` from an older release can be missing this command
+(or other newer features) and the bootstrap fails with
+`There are no commands defined in the "docker" namespace.` It only
+matters at install time — once the wrapper is installed, the
+per-invocation `reli` calls use the specific tag baked into the
+wrapper rather than `:latest`.
 
 For persistence across shells, save the emitted wrapper to a file once
 and `source` it from your rc — pasting the `eval "$(docker run ...)"`
@@ -23,13 +32,15 @@ down:
 
 ```bash
 mkdir -p ~/.local/share/reli
-docker run --rm reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
+docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
 echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
 ```
 
 The image tag is baked into the emitted wrapper (matching the image
 the `docker run` pulled), so you don't get accidental `:latest` drift —
-re-run the snippet above to upgrade.
+re-run the snippet above to upgrade. `--pull=always` makes that re-run
+actually fetch the newest `:latest` rather than reusing the cached
+image from the previous install.
 
 ## Profiles
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ installs a shell function `reli` so the rest of this doc works
 exactly as written, with no docker flag incantations to remember:
 
 ```bash
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper)"
 ```
 
 Then, still in the same shell:
@@ -75,6 +75,15 @@ Then, still in the same shell:
 ```bash
 reli --version
 ```
+
+`--pull=always` forces Docker to refresh `reliforp/reli-prof:latest`
+before running `docker:print-wrapper`. Without it, a previously
+cached `:latest` from an older release can be missing this command
+(or other newer features) and the bootstrap fails with
+`There are no commands defined in the "docker" namespace.` Once
+the wrapper is installed, the per-invocation `reli` calls use the
+specific tag baked into the wrapper instead of `:latest`, so this
+flag matters only at install time.
 
 To keep it across shells, **don't** paste the `eval "$(docker run ...)"`
 line into your `~/.bashrc` / `~/.zshrc` directly — that re-runs
@@ -84,7 +93,7 @@ source that instead:
 
 ```bash
 mkdir -p ~/.local/share/reli
-docker run --rm reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
+docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper > ~/.local/share/reli/wrapper.sh
 echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
 ```
 
@@ -93,6 +102,9 @@ The wrapper's baked-in image tag matches the version of reli the
 to upgrade, re-run whichever install command you used (the `eval`
 form for the current shell only, or the `docker run ... > ...wrapper.sh`
 form to refresh the saved file that future shells will source).
+`--pull=always` makes that re-run actually fetch the newest
+`:latest` rather than reusing the cached image from the previous
+install.
 
 The wrapper runs each `reli` invocation as a container with
 `--cap-add=SYS_PTRACE --pid=host --network=host`, which gives reli
@@ -102,7 +114,7 @@ and for the lower-privilege `reli-view` variant (viewer-only, safe
 on shared hosts):
 
 ```bash
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper --profile=minimal)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper --profile=minimal)"
 ```
 
 The minimal profile installs the shell function as `reli-view` (not

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,12 +78,18 @@ reli --version
 
 `--pull=always` forces Docker to refresh `reliforp/reli-prof:latest`
 before running `docker:print-wrapper`. Without it, a previously
-cached `:latest` from an older release can be missing this command
-(or other newer features) and the bootstrap fails with
-`There are no commands defined in the "docker" namespace.` Once
-the wrapper is installed, the per-invocation `reli` calls use the
-specific tag baked into the wrapper instead of `:latest`, so this
-flag matters only at install time.
+cached `:latest` falls into one of two failure modes depending on
+its age. A pre-0.12 cache lacks `docker:print-wrapper` entirely and
+the bootstrap fails outright with
+`There are no commands defined in the "docker" namespace.` A more
+recent but still stale cache (e.g. you pulled `:latest` while 0.12.0
+was current and 0.13.0 has since shipped) "succeeds" silently but
+emits a wrapper baked with the older image's tag — leaving you
+pinned to a previous reli release without any error to flag the
+drift. Once the wrapper is installed, the per-invocation `reli`
+calls use the specific tag baked into the wrapper instead of
+`:latest`, so this flag matters only at install / upgrade time —
+but it matters at *every* install or upgrade, not just the first.
 
 To keep it across shells, **don't** paste the `eval "$(docker run ...)"`
 line into your `~/.bashrc` / `~/.zshrc` directly — that re-runs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,26 +76,18 @@ Then, still in the same shell:
 reli --version
 ```
 
-`--pull=always` forces Docker to refresh `reliforp/reli-prof:latest`
-before running `docker:print-wrapper`. Without it, a previously
-cached `:latest` falls into one of two failure modes depending on
-its age. A pre-0.12 cache lacks `docker:print-wrapper` entirely and
-the bootstrap fails outright with
-`There are no commands defined in the "docker" namespace.` A more
-recent but still stale cache (e.g. you pulled `:latest` while 0.12.0
-was current and 0.13.0 has since shipped) "succeeds" silently but
-emits a wrapper baked with the older image's tag — leaving you
-pinned to a previous reli release without any error to flag the
-drift. Once the wrapper is installed, the per-invocation `reli`
-calls use the specific tag baked into the wrapper instead of
-`:latest`, so this flag matters only at install / upgrade time —
-but it matters at *every* install or upgrade, not just the first.
+`--pull=always` is required, not optional polish: a stale local
+`:latest` either lacks `docker:print-wrapper` outright (pre-0.12) or
+silently emits a wrapper pinned to an older reli release. See
+[docker-wrapper.md § Install](docker-wrapper.md#install) for the full
+breakdown — the short version is "always pass the flag at first
+install and at every upgrade".
 
-To keep it across shells, **don't** paste the `eval "$(docker run ...)"`
-line into your `~/.bashrc` / `~/.zshrc` directly — that re-runs
-`docker run` on every shell start (slow, and breaks shell startup
-if the Docker daemon is down). Save the wrapper to a file once and
-source that instead:
+To keep the wrapper across shells, save the emitted snippet to a file
+once and `source` that file from your rc — **don't** paste the
+`eval "$(docker run ...)"` line into `~/.bashrc` / `~/.zshrc`
+directly, that re-runs `docker run` on every shell start (slow, and
+breaks shell startup if the Docker daemon is down):
 
 ```bash
 mkdir -p ~/.local/share/reli
@@ -103,14 +95,9 @@ docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper > ~/.local
 echo 'source ~/.local/share/reli/wrapper.sh' >> ~/.bashrc   # or ~/.zshrc
 ```
 
-The wrapper's baked-in image tag matches the version of reli the
-`docker run` invocation pulled, so there's no `:latest` drift —
-to upgrade, re-run whichever install command you used (the `eval`
-form for the current shell only, or the `docker run ... > ...wrapper.sh`
-form to refresh the saved file that future shells will source).
-`--pull=always` makes that re-run actually fetch the newest
-`:latest` rather than reusing the cached image from the previous
-install.
+To upgrade, re-run the same command — the wrapper bakes a concrete
+image tag at install time, so re-running with `--pull=always` is the
+canonical upgrade path.
 
 The wrapper runs each `reli` invocation as a container with
 `--cap-add=SYS_PTRACE --pid=host --network=host`, which gives reli

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -28,18 +28,38 @@ eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper)"
 ```
 
 This defines `reli` as a shell function in the current session. To persist,
-users append the command to their `~/.bashrc` / `~/.zshrc`.
+users save the emitted snippet to a file (e.g.
+`~/.local/share/reli/wrapper.sh`) once and source that file from
+`~/.bashrc` / `~/.zshrc`. **Don't** paste the `eval "$(docker run ...)"`
+line directly into rc files — combined with `--pull=always` (below) it
+would Docker-pull on every shell startup, which is slow and breaks shell
+startup outright if the Docker daemon is down. The save-and-source form
+is the recommended persistence shape across all the user-facing docs
+(getting-started.md, docker-wrapper.md).
 
 `--pull=always` is a deliberate part of the bootstrap recipe rather than
-optional polish: a previously cached `reliforp/reli-prof:latest` from an
-older release lacks `docker:print-wrapper` itself (the command only exists
-in 0.12.0+), and `docker run` with the default `--pull=missing` happily
-reuses that stale image. The bootstrap then fails with
-`There are no commands defined in the "docker" namespace.`, which reads
-like a reli bug rather than a Docker cache miss. Forcing a pull at install
-time sidesteps the trap. The flag only matters at install time — the
-emitted wrapper bakes a concrete image tag and never re-pulls per
-invocation.
+optional polish. A previously cached `reliforp/reli-prof:latest` produces
+two distinct failure modes depending on its age:
+
+1. **Pre-0.12 cache** — the image lacks `docker:print-wrapper` itself
+   (the command was added in 0.12.0). `docker run` with the default
+   `--pull=missing` reuses the stale image and the bootstrap fails with
+   `There are no commands defined in the "docker" namespace.`, which
+   reads like a reli bug rather than a Docker cache miss. This is the
+   failure mode that motivated adding the flag in the first place.
+2. **Stale-but-recent cache** — the image has `docker:print-wrapper`
+   but predates the most recent release (e.g. you pulled `:latest`
+   while 0.12.0 was current and 0.13.0 has since shipped). The
+   bootstrap "succeeds" silently, but `defaultImage()` bakes the older
+   image's tag into the emitted wrapper, leaving the user pinned to a
+   previous reli release with no error to flag the drift. This is the
+   quieter failure mode; the user only notices when a feature they
+   expect from the new release is missing or behaves unexpectedly.
+
+Forcing a pull at install time sidesteps both. The flag matters only
+at install / upgrade time — the emitted wrapper bakes a concrete image
+tag and never re-pulls per invocation — but it matters at *every*
+install or upgrade, not just the first.
 
 ### Why a CLI subcommand (not a standalone script / README snippet)
 

--- a/docs/internals/design-docker-wrapper.md
+++ b/docs/internals/design-docker-wrapper.md
@@ -24,11 +24,22 @@ The wrapper is a **shell function**, emitted by a new reli CLI subcommand
 that prints a shell snippet to stdout. Install with one command:
 
 ```bash
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper)"
 ```
 
 This defines `reli` as a shell function in the current session. To persist,
 users append the command to their `~/.bashrc` / `~/.zshrc`.
+
+`--pull=always` is a deliberate part of the bootstrap recipe rather than
+optional polish: a previously cached `reliforp/reli-prof:latest` from an
+older release lacks `docker:print-wrapper` itself (the command only exists
+in 0.12.0+), and `docker run` with the default `--pull=missing` happily
+reuses that stale image. The bootstrap then fails with
+`There are no commands defined in the "docker" namespace.`, which reads
+like a reli bug rather than a Docker cache miss. Forcing a pull at install
+time sidesteps the trap. The flag only matters at install time — the
+emitted wrapper bakes a concrete image tag and never re-pulls per
+invocation.
 
 ### Why a CLI subcommand (not a standalone script / README snippet)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,7 @@ First, try `cat /proc/<pid>/maps` to check the memory map of the target PHP proc
 Re-install with the full profile and retry:
 
 ```bash
-eval "$(docker run --rm reliforp/reli-prof docker:print-wrapper)"
+eval "$(docker run --rm --pull=always reliforp/reli-prof docker:print-wrapper)"
 ```
 
 The two profiles can coexist — see [docker-wrapper.md](docker-wrapper.md) for the side-by-side install pattern (`--name=reli` / `--name=reliv`).


### PR DESCRIPTION
## Summary
Updated all documentation examples to include the `--pull=always` flag when running the `docker:print-wrapper` command. This ensures users always get the latest image version during installation, preventing bootstrap failures from stale cached images.

## Changes
- Added `--pull=always` flag to all `docker run` commands in installation examples across four documentation files
- Added explanatory sections in `docker-wrapper.md`, `getting-started.md`, and `internals/design-docker-wrapper.md` describing why this flag is necessary
- Clarified that the flag only matters at install time, as the emitted wrapper bakes in a specific image tag for subsequent invocations

## Details
The `--pull=always` flag forces Docker to refresh the `reliforp/reli-prof:latest` image before running the bootstrap command. Without it, users with a previously cached `:latest` image from an older release may encounter the error:
```
There are no commands defined in the "docker" namespace.
```

This occurs because the `docker:print-wrapper` subcommand only exists in version 0.12.0+, and Docker's default `--pull=missing` behavior reuses stale cached images. By forcing a pull at install time, we prevent this confusing failure mode while maintaining efficiency (the flag only affects the initial bootstrap; subsequent `reli` invocations use the version-pinned tag baked into the wrapper).

https://claude.ai/code/session_01MeV6JZNJXY2DrjhNpbpF4S