### PR TITLE
Add PHP 7.0 support for TMP/VAR variable inspection

### DIFF
--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -753,7 +753,6 @@ The `objects_store` is an important table that holds references to all objects i
 The references in the objects_store don't add refcount to the objects.
 
 # Currently not yet supported
-- TMP/VARs in PHP 7.0 target
 - internal classes other than `\Closure`, `\Fiber`, `\Generator`, `\WeakReference`, `\WeakMap`, `\PDO`, `\PDOStatement`, `SimpleXMLElement`, `SimpleXMLIterator`, and `FFI\CData`
 - The contents of resources
 - Data that can only be reached from circular references that don't contain any objects

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -758,6 +758,15 @@ The references in the objects_store don't add refcount to the objects.
 - Data that can only be reached from circular references that don't contain any objects
 - Support for the opcache SHM
 
+## PHP 7.0 caveat: best-effort TMP/VAR inspection
+
+PHP 7.0 has no `zend_op_array.live_range` table (introduced in 7.1), so reli
+cannot determine which TMP/VAR slots are live at the current opcode. On 7.0
+targets reli scans every TMP/VAR slot and skips those whose zval is `IS_UNDEF`,
+which means a stale value left in a TMP slot by a previous opcode may surface
+as `$_T[N]` in the dump even though it is no longer logically live. On
+PHP 7.1+ liveness filtering remains exact.
+
 # Troubleshooting
 ## jq says "parse error: Exceeds depth limit for parsing at line 1"
 It's not a bug of Reli, but a limitation of `jq`. Currently, `jq` doesn't have a way to increase the limit without recompiling it. You can also try some other tools like `gojq` or `jj` instead.

--- a/docs/memory/memory-profiler.md
+++ b/docs/memory/memory-profiler.md
@@ -762,8 +762,12 @@ The references in the objects_store don't add refcount to the objects.
 
 PHP 7.0 has no `zend_op_array.live_range` table (introduced in 7.1), so reli
 cannot determine which TMP/VAR slots are live at the current opcode. On 7.0
-targets reli scans every TMP/VAR slot and skips those whose zval is `IS_UNDEF`,
-which means a stale value left in a TMP slot by a previous opcode may surface
+targets reli scans every TMP/VAR slot and skips those whose zval tag is
+`IS_UNDEF` or an internal/garbage tag (`IS_PTR`, `IS_CONSTANT_AST`, or any
+unknown byte value); only user-visible value tags
+(`IS_NULL`/`IS_FALSE`/`IS_TRUE`/`IS_LONG`/`IS_DOUBLE`/`IS_STRING`/`IS_ARRAY`/
+`IS_OBJECT`/`IS_RESOURCE`/`IS_REFERENCE`/`IS_INDIRECT`) pass the filter. As a
+result a stale value left in a TMP slot by a previous opcode may still surface
 as `$_T[N]` in the dump even though it is no longer logically live. On
 PHP 7.1+ liveness filtering remains exact.
 

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -424,9 +424,11 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         assert(!is_null($this->opline));
         $current_op_num = $func->op_array->getOpNumFromOpline($this->opline);
         $live_tmp_vars = $func->op_array->findLiveTmpVars($current_op_num, $dereferencer);
-        $live_tmp_vars_map = array_flip(array_map($this->liveTmpVarToNum(...), $live_tmp_vars));
+        $live_tmp_vars_map = $live_tmp_vars === null
+            ? null
+            : array_flip(array_map($this->liveTmpVarToNum(...), $live_tmp_vars));
         for ($i = $compiled_variables_num; $i < $compiled_variables_num + $tmp_num; $i++) {
-            if (!isset($live_tmp_vars_map[$i])) {
+            if ($live_tmp_vars_map !== null and !isset($live_tmp_vars_map[$i])) {
                 continue;
             }
             $name = '$_T[' . ($i - $compiled_variables_num) . ']';

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -28,6 +28,27 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
 {
     use InlineCDataCreatorTrait;
 
+    /**
+     * Zval type tags that may legitimately appear in a TMP/VAR slot on
+     * PHP 7.0 when scanned without live_range guidance. Anything outside
+     * this set (IS_UNDEF, internal compiler tags like IS_PTR /
+     * IS_CONSTANT_AST, or "UNKNOWN" garbage bytes) is treated as stale.
+     * Stored as a flipped map so `isset()` lookup is O(1).
+     */
+    private const TMP_TYPE_WHITELIST_PHP70 = [
+        'IS_NULL' => true,
+        'IS_FALSE' => true,
+        'IS_TRUE' => true,
+        'IS_LONG' => true,
+        'IS_DOUBLE' => true,
+        'IS_STRING' => true,
+        'IS_ARRAY' => true,
+        'IS_OBJECT' => true,
+        'IS_RESOURCE' => true,
+        'IS_REFERENCE' => true,
+        'IS_INDIRECT' => true,
+    ];
+
     /** @var Pointer<ZendFunction>|null */
     public ?Pointer $func;
 
@@ -434,6 +455,18 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
             $name = '$_T[' . ($i - $compiled_variables_num) . ']';
             $zval = $variable_table->offsetGet($i);
             if ($zval->isUndef()) {
+                continue;
+            }
+            // No liveness info (PHP 7.0): a stale slot can hold a non-UNDEF
+            // zval whose type byte is junk, or an internal compiler tag
+            // (IS_PTR, IS_CONSTANT_AST, etc.) that has no user-visible
+            // representation. Drop those before they reach the resolver,
+            // where a bogus value pointer would otherwise turn into a
+            // phantom node or an extra cross-edge via address dedup.
+            if (
+                $live_tmp_vars_map === null
+                and !isset(self::TMP_TYPE_WHITELIST_PHP70[$zval->getType()])
+            ) {
                 continue;
             }
             yield $name => $zval;

--- a/src/Lib/PhpInternals/Types/Zend/ZendOpArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOpArray.php
@@ -246,10 +246,28 @@ final class ZendOpArray
         return Cast::toInt(($opline->address - $this->opcodes->address) / $opline->size);
     }
 
+    public function hasLiveRangeSupport(): bool
+    {
+        return in_array(
+            'live_range',
+            \FFI::typeof($this->cdata->casted)->getStructFieldNames(),
+            true,
+        );
+    }
+
+    /**
+     * @return list<int>|null Byte-offset list of live TMP/VAR slots at $op_num,
+     *                       or null when the target PHP has no live_range table
+     *                       (PHP 7.0). A null return means liveness is unknown,
+     *                       and callers should fall back to iterating all TMPs.
+     */
     public function findLiveTmpVars(
         int $op_num,
         Dereferencer $dereferencer,
-    ): array {
+    ): ?array {
+        if (!$this->hasLiveRangeSupport()) {
+            return null;
+        }
         if ($this->live_range === null) {
             return [];
         }

--- a/src/Lib/PhpInternals/Types/Zend/ZendOpArray.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendOpArray.php
@@ -248,11 +248,9 @@ final class ZendOpArray
 
     public function hasLiveRangeSupport(): bool
     {
-        return in_array(
-            'live_range',
-            \FFI::typeof($this->cdata->casted)->getStructFieldNames(),
-            true,
-        );
+        $fields = \FFI::typeof($this->cdata->casted)->getStructFieldNames();
+        return in_array('live_range', $fields, true)
+            and in_array('last_live_range', $fields, true);
     }
 
     /**

--- a/tests/Lib/PhpInternals/Types/Zend/ZendOpArrayTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendOpArrayTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use Reli\BaseTestCase;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\Dereferencer;
+
+class ZendOpArrayTest extends BaseTestCase
+{
+    /** @var array<string, FFI> */
+    private array $ffi_holder = [];
+
+    private function buildOpArrayFromHeader(string $version): ZendOpArray
+    {
+        $ffi = FFI::load(
+            __DIR__ . '/../../../../../src/Lib/PhpInternals/Headers/' . $version . '.h'
+        );
+        $this->assertNotNull($ffi);
+        $this->ffi_holder[$version] = $ffi;
+        $cdata = $ffi->new('zend_op_array');
+        $this->assertNotNull($cdata);
+        return new ZendOpArray(new CastedCData($cdata, $cdata));
+    }
+
+    public function testHasLiveRangeSupportIsFalseOnV70(): void
+    {
+        $op_array = $this->buildOpArrayFromHeader('v70');
+        $this->assertFalse($op_array->hasLiveRangeSupport());
+    }
+
+    public function testHasLiveRangeSupportIsTrueOnV71(): void
+    {
+        $op_array = $this->buildOpArrayFromHeader('v71');
+        $this->assertTrue($op_array->hasLiveRangeSupport());
+    }
+
+    public function testFindLiveTmpVarsReturnsNullOnV70(): void
+    {
+        $op_array = $this->buildOpArrayFromHeader('v70');
+        $dereferencer = $this->createMock(Dereferencer::class);
+        $dereferencer->expects($this->never())->method('deref');
+
+        $this->assertNull($op_array->findLiveTmpVars(0, $dereferencer));
+    }
+
+    public function testFindLiveTmpVarsReturnsEmptyArrayOnV71WhenLiveRangeIsNull(): void
+    {
+        $op_array = $this->buildOpArrayFromHeader('v71');
+        $dereferencer = $this->createMock(Dereferencer::class);
+        $dereferencer->expects($this->never())->method('deref');
+
+        $this->assertSame([], $op_array->findLiveTmpVars(0, $dereferencer));
+    }
+}


### PR DESCRIPTION
## Summary

Adds best-effort TMP/VAR inspection on PHP 7.0 targets in the memory profiler. PHP 7.0 has no `zend_op_array.live_range` table (it was introduced in 7.1), so reli previously returned `[]` from `findLiveTmpVars()` and the TMP/VAR loop in `ZendExecuteData::getVariables()` skipped every slot.

Closes #312.

## Approach

When the C struct lacks `live_range` (i.e. 7.0), `findLiveTmpVars()` now returns `null`, signalling "liveness unknown". `getVariables()` distinguishes this from a 7.1+ run with no live ranges (`[]`):

| target | `findLiveTmpVars()` | TMP loop |
|---|---|---|
| PHP 7.1+ | `int[]` (live offsets) | filter by live offsets |
| PHP 7.1+ with no live ranges | `[]` | nothing yielded |
| PHP 7.0 | `null` | scan all slots, drop `IS_UNDEF` and non-whitelisted tags |

Without a liveness analyser this is necessarily best-effort: a stale value left in a TMP slot by a previous opcode may surface as `$_T[N]`. To keep that noise contained, the 7.0 path also drops slots whose tag is not a user-visible value type (`IS_NULL` / `IS_FALSE` / `IS_TRUE` / `IS_LONG` / `IS_DOUBLE` / `IS_STRING` / `IS_ARRAY` / `IS_OBJECT` / `IS_RESOURCE` / `IS_REFERENCE` / `IS_INDIRECT`). Internal compiler tags (`IS_PTR`, `IS_CONSTANT_AST`, `IS_ALIAS_PTR`) and out-of-range type bytes (`UNKNOWN`) are filtered out before the resolver sees them — otherwise a bogus value pointer would either be silently caught at the job-level `\Throwable` handler in `MemoryLocationsCollector` or, worse, alias an already-walked address via `address_map` dedup and emit a phantom cross-edge in the dump.

PHP 7.1+ behaviour is unchanged: the existing `live_range` filter still runs first, and the no-liveness branch is never reached.

## Key Changes

- **`ZendOpArray::hasLiveRangeSupport()`** — new predicate, true when the FFI struct exposes both `live_range` and `last_live_range`.
- **`ZendOpArray::findLiveTmpVars()`** — return type tightened to `?array`; returns `null` when `hasLiveRangeSupport()` is false, `[]` when supported but no ranges cover the current op.
- **`ZendExecuteData::getVariables()`** — handles the `null` return by skipping the live-set filter; additionally consults a new `TMP_TYPE_WHITELIST_PHP70` constant before yielding stale-suspicious slots.
- **Docs** — removed "TMP/VARs in PHP 7.0 target" from the "Currently not yet supported" list and added a "PHP 7.0 caveat: best-effort TMP/VAR inspection" subsection spelling out the limitation and the type-tag filter.
- **Tests** — added `tests/Lib/PhpInternals/Types/Zend/ZendOpArrayTest.php` covering the v70-vs-v71 split for both `hasLiveRangeSupport()` and `findLiveTmpVars()`. The fixture pins the loaded FFI instance on the test object because dropping it frees the `CType` info while the `CData` survives, which would trigger the same lifetime trap documented in `docs/internals/ffi-cdata-lifetime.md`.

## Test Plan

- [x] `php vendor/bin/psalm.phar` — no errors
- [x] `php vendor/bin/phpcs --standard=PSR12 src/Lib/PhpInternals/Types/Zend/ZendOpArray.php src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php tests/Lib/PhpInternals/Types/Zend/ZendOpArrayTest.php` — clean
- [x] `php vendor/bin/phpunit --exclude-group target-version` — all related suites pass; the four new `ZendOpArrayTest` cases included
- [ ] Sanity-checked on a real PHP 7.0 target via `inspector:memory:dump`

https://claude.ai/code/session_018TVTaM6N89zPBAmJ1XVYf6