### PR TITLE
Add support for tracking PHP resource registry (EG(regular_list))

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecutorGlobals.php
@@ -56,6 +56,9 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
     /** @psalm-suppress PropertyNotSetInConstructor */
     public ZendArray $included_files;
 
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public ZendArray $regular_list;
+
     /** @var Pointer<ZendArray>|null */
     public ?Pointer $ini_directives;
 
@@ -93,6 +96,7 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
         unset($this->objects_store);
         unset($this->exception);
         unset($this->included_files);
+        unset($this->regular_list);
     }
 
     #[\Override]
@@ -234,6 +238,10 @@ final class ZendExecutorGlobals implements LazyDereferencable, PointedTypeResolv
             ),
             'included_files' => $this->included_files = $this->createInlineDereferencable(
                 'included_files',
+                ZendArray::class,
+            ),
+            'regular_list' => $this->regular_list = $this->createInlineDereferencable(
+                'regular_list',
                 ZendArray::class,
             ),
             'exception' => $this->exception = $this->readExceptionEager(),

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitRegularListJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitRegularListJob.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
+
+use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\RegularListContext;
+
+/**
+ * Emit the EG(regular_list) root branch and push a bucket iterator.
+ *
+ * Mirrors EmitObjectsStoreJob in spirit: regular_list is the global registry
+ * of active resources, but the references it holds should not pin a resource
+ * as "live" on its own — otherwise every registered resource looks reachable.
+ * All edges out of this root are emitted with EdgeStrength::Weak so that
+ * resources reachable only via regular_list show up as leak candidates,
+ * the same way unrooted objects do under objects_store.
+ *
+ * Each entry's zval is IS_RESOURCE; we dispatch directly to EmitResourceJob
+ * (which carries the existing PHP_STREAM heuristic) rather than going
+ * through ResolveZvalJob, because we want to override the edge strength
+ * and avoid surprises if a non-resource ever sneaks into regular_list.
+ */
+final class EmitRegularListJob implements CollectorJob
+{
+    public function __construct(
+        private ZendArray $regular_list,
+    ) {
+    }
+
+    #[\Override]
+    public function execute(CollectorContext $ctx, JobQueue $queue): void
+    {
+        if ($this->regular_list->isUninitialized() || is_null($this->regular_list->arData)) {
+            return;
+        }
+
+        $array_table_location = ZendArrayTableMemoryLocation::fromZendArray($this->regular_list);
+        $ctx->memory_locations->add($array_table_location);
+
+        $regular_list_context = new RegularListContext($array_table_location);
+        $root_node_id = $ctx->emitNode(
+            $regular_list_context,
+            null,
+            'regular_list',
+            EdgeStrength::Weak,
+        );
+        $parent = $root_node_id >= 0 ? $root_node_id : null;
+
+        $queue->push(new RegularListBucketIteratorJob(
+            $this->regular_list,
+            $parent,
+        ));
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/RegularListBucketIteratorJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/RegularListBucketIteratorJob.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
+
+use Reli\Lib\PhpInternals\Types\Zend\ZendArray;
+use Reli\Lib\PhpInternals\Types\Zend\Zval;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
+use Reli\Lib\Process\Pointer\Pointer;
+
+/**
+ * Iterator job that processes one regular_list bucket per tick (DFS).
+ *
+ * regular_list is a HashTable<int, zval>, where each zval is IS_RESOURCE
+ * pointing at a zend_resource. We push EmitResourceJob directly with
+ * EdgeStrength::Weak rather than going through ResolveZvalJob, both to
+ * keep edges weak and to skip the cost of zval-type dispatch for entries
+ * that are by construction always resources.
+ */
+final class RegularListBucketIteratorJob implements CollectorJob
+{
+    private bool $started = false;
+    private ?\Iterator $iterator = null;
+
+    public function __construct(
+        private ZendArray $regular_list,
+        private ?int $parent_node_id,
+    ) {
+    }
+
+    #[\Override]
+    public function execute(CollectorContext $ctx, JobQueue $queue): void
+    {
+        if (!$this->started) {
+            $this->started = true;
+            $gen = $this->regular_list->getItemIteratorWithZendStringKeyIfAssoc($ctx->dereferencer);
+            if ($gen instanceof \Iterator) {
+                $this->iterator = $gen;
+            } else {
+                $this->iterator = (function () use ($gen): \Generator {
+                    yield from $gen;
+                })();
+            }
+            $this->iterator->rewind();
+        }
+
+        $iterator = $this->iterator;
+        if ($iterator === null || !$iterator->valid()) {
+            return;
+        }
+
+        try {
+            /** @var int|Pointer $key */
+            $key = $iterator->key();
+            /** @var Zval $zval */
+            $zval = $iterator->current();
+            $iterator->next();
+
+            $key_string = $key instanceof Pointer ? '' : (string)$key;
+
+            if ($zval->isResource() && !is_null($zval->value->res)) {
+                if ($iterator->valid()) {
+                    $queue->push($this);
+                }
+                $queue->push(new EmitResourceJob(
+                    $zval->value->res,
+                    $this->parent_node_id,
+                    $key_string,
+                    EdgeStrength::Weak,
+                ));
+                return;
+            }
+
+            // Non-resource entry (shouldn't happen in regular_list, but be
+            // defensive — skip and advance to the next bucket).
+            if ($iterator->valid()) {
+                $queue->push($this);
+            }
+        } catch (\Throwable) {
+            if ($iterator->valid()) {
+                $queue->push($this);
+            }
+        }
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -312,6 +312,7 @@ final class MemoryLocationsCollector
         // Process "definition" branches before "usage" branches so the
         // canonical tree lives under the named globals/tables, not
         // buried inside a call frame.
+        $queue->push(new Collector\Job\EmitRegularListJob($eg->regular_list));
         $queue->push(new Collector\Job\EmitObjectsStoreJob($eg->objects_store));
         $queue->push(new Collector\Job\EmitCallFramesJob($eg));
         $queue->push(new Collector\Job\EmitModulesJob($bg_address));

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/RegularListContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/RegularListContext.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableMemoryLocation;
+
+/**
+ * Root context for EG(regular_list) — the active resource list.
+ *
+ * Like ObjectsStoreContext, edges from this root to individual resources
+ * are weak so that resources whose only reachability is via regular_list
+ * surface as leak candidates rather than appearing live.
+ */
+final class RegularListContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+
+    public function __construct(
+        public ZendArrayTableMemoryLocation $memory_location,
+    ) {
+    }
+
+    #[\Override]
+    public function getLocations(): iterable
+    {
+        return [$this->memory_location];
+    }
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        return [
+            '#count' => count($this->referencing_contexts),
+        ];
+    }
+
+    #[\Override]
+    public function getLinkStrength(string $link_name): EdgeStrength
+    {
+        return EdgeStrength::Weak;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/TopReferenceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/TopReferenceContext.php
@@ -26,6 +26,7 @@ final class TopReferenceContext implements ReferenceContext
         public IncludedFilesContext $included_files,
         public ArrayHeaderContext $interned_strings,
         public ObjectsStoreContext $objects_store,
+        public RegularListContext $regular_list,
         public GlobalCallbacksContext $global_callbacks,
         public ModulesContext $modules,
     ) {
@@ -45,6 +46,7 @@ final class TopReferenceContext implements ReferenceContext
             'global_callbacks' => $this->global_callbacks,
             'modules' => $this->modules,
             'objects_store' => $this->objects_store,
+            'regular_list' => $this->regular_list,
         ];
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2825,6 +2825,209 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     }
 
     /**
+     * EG(regular_list) must show up as a root branch and its outgoing
+     * edges to resources must be weak — same reasoning as objects_store:
+     * a resource only reachable via the registry should not look pinned
+     * alive, otherwise stream/resource leaks are invisible.
+     */
+    #[DataProvider('provideFromV80')]
+    public function testRegularListRootBranchTracksResourcesWithWeakEdges(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            $memory_stream = fopen('php://memory', 'r+');
+            fwrite($memory_stream, str_repeat('M', 256));
+            $temp_stream = fopen('php://temp', 'r+');
+            $file_stream = fopen('php://stdout', 'w');
+            fputs($file_stream, "a\n");
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("a\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $sink = new ArrayContextTreeSink();
+        $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+
+        $contexts_analyzed = $sink->getResult();
+
+        $this->assertArrayHasKey(
+            'regular_list',
+            $contexts_analyzed,
+            'regular_list must appear as a root branch alongside objects_store'
+        );
+        $regular_list = $contexts_analyzed['regular_list'];
+        $this->assertSame('RegularListContext', $regular_list['#type'] ?? null);
+        $this->assertSame(
+            'weak',
+            $regular_list['#edge_strength'] ?? null,
+            'The regular_list root edge itself must be weak'
+        );
+
+        // Walk children: each entry is either a ResourceContext node (first
+        // time seen) or a #reference_node_id pointing at the canonical
+        // ResourceContext emitted under a stronger root (e.g.
+        // global_variables). Either way the edge from regular_list must be
+        // weak so leak analysis can see "only registry-reachable" resources.
+        $resource_edge_count = 0;
+        $weak_edge_count = 0;
+        $resolved_resource_count = 0;
+        foreach ($regular_list as $key => $value) {
+            if (!is_array($value) || str_starts_with((string)$key, '#')) {
+                continue;
+            }
+            $resource_edge_count++;
+            if (($value['#edge_strength'] ?? null) === 'weak') {
+                $weak_edge_count++;
+            }
+            if (isset($value['#reference_node_id'])) {
+                continue;
+            }
+            if (($value['#type'] ?? null) === 'ResourceContext') {
+                $resolved_resource_count++;
+            }
+        }
+
+        $this->assertGreaterThan(
+            0,
+            $resource_edge_count,
+            'regular_list should have at least one resource edge — '
+            . 'the script opened three streams'
+        );
+        $this->assertSame(
+            $resource_edge_count,
+            $weak_edge_count,
+            'Every edge from regular_list must be weak'
+        );
+        // Sanity: at least one of the registered resources should resolve
+        // to a ResourceContext somewhere in the graph (either inline under
+        // regular_list or via a #reference_node_id whose target lives under
+        // global_variables).
+        $found_resource_anywhere = false;
+        $find = static function (array $tree) use (&$find, &$found_resource_anywhere): void {
+            foreach ($tree as $key => $value) {
+                if (!is_array($value) || $key === '#locations') {
+                    continue;
+                }
+                if (($value['#type'] ?? null) === 'ResourceContext') {
+                    $found_resource_anywhere = true;
+                    return;
+                }
+                $find($value);
+            }
+        };
+        $find($contexts_analyzed);
+        $this->assertTrue(
+            $found_resource_anywhere,
+            'At least one ResourceContext should be reachable in the analyzed graph'
+        );
+        $this->assertGreaterThanOrEqual(
+            0,
+            $resolved_resource_count,
+            'sanity: resolved-inline counter is non-negative'
+        );
+    }
+
+    /**
      * Bug 2 regression test: In streaming mode, ObjectContext nodes must have
      * a tree edge to their ObjectPropertiesContext even when all properties
      * are object references (deferred during objects_store collection).

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/RegularListContextTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/RegularListContextTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArrayTableMemoryLocation;
+
+class RegularListContextTest extends BaseTestCase
+{
+    private function makeMemoryLocation(): ZendArrayTableMemoryLocation
+    {
+        return new ZendArrayTableMemoryLocation(0x1000, 256, false);
+    }
+
+    public function testGetName(): void
+    {
+        $context = new RegularListContext($this->makeMemoryLocation());
+        $this->assertSame('RegularListContext', $context->getName());
+    }
+
+    public function testGetLocationsReturnsTheBackingTable(): void
+    {
+        $location = $this->makeMemoryLocation();
+        $context = new RegularListContext($location);
+        $this->assertSame([$location], iterator_to_array($context->getLocations()));
+    }
+
+    public function testGetContextsReturnsCount(): void
+    {
+        $context = new RegularListContext($this->makeMemoryLocation());
+        $context->add('1', new SentinelContext(10));
+        $context->add('2', new SentinelContext(20));
+        $contexts = iterator_to_array($context->getContexts());
+        $this->assertSame(2, $contexts['#count']);
+    }
+
+    /**
+     * Edges out of regular_list must be Weak so resources reachable only
+     * through this registry surface as leak candidates instead of looking
+     * pinned alive — same reasoning as ObjectsStoreContext.
+     */
+    public function testGetLinkStrengthIsWeak(): void
+    {
+        $context = new RegularListContext($this->makeMemoryLocation());
+        $this->assertSame(EdgeStrength::Weak, $context->getLinkStrength('1'));
+        $this->assertSame(EdgeStrength::Weak, $context->getLinkStrength('any'));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds memory profiling support for PHP's global resource registry (`EG(regular_list)`), enabling the profiler to track active resources and identify resource leaks. Resources reachable only through the registry are now correctly surfaced as leak candidates rather than appearing as live objects.

## Key Changes

- **New Job Classes**: Added `EmitRegularListJob` and `RegularListBucketIteratorJob` to handle the collection and iteration of the resource registry with depth-first search processing
- **New Context Class**: Introduced `RegularListContext` to represent the resource registry as a root reference context with weak edge strength (similar to `ObjectsStoreContext`)
- **ZendExecutorGlobals Extension**: Added `regular_list` field to expose the `EG(regular_list)` HashTable for memory analysis
- **TopReferenceContext Integration**: Updated to include `RegularListContext` in the top-level reference context hierarchy
- **MemoryLocationsCollector Integration**: Wired `EmitRegularListJob` into the collection pipeline to process the resource registry during memory profiling

## Implementation Details

- Resources in `regular_list` are emitted with `EdgeStrength::Weak` to prevent them from appearing artificially "live" — only resources reachable through other strong references are considered truly live
- The iterator processes one bucket per execution tick to maintain responsive profiling
- Direct dispatch to `EmitResourceJob` bypasses `ResolveZvalJob` to avoid type dispatch overhead and ensure consistent weak edge strength for all registry entries
- Defensive error handling ensures iteration continues even if individual resource entries are malformed

https://claude.ai/code/session_01V3EEhEhG4jJ3pFBdPqsv3p