### PR TITLE
Extract stream metadata and child decoders in resource collection

### DIFF
--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1190,6 +1190,9 @@ typedef struct _php_stream_ops {
 	uintptr_t set_option;
 } php_stream_ops;
 
+// PHP 7.0 layout (no bitfield packing yet — fgetss_state, is_persistent,
+// in_free, fclose_stdiocast and __exposed are full ints; flags / eof live
+// after orig_path, not before res). Bitfield packing was introduced in 7.2.
 struct _php_stream {
 	const php_stream_ops *ops;
 	uintptr_t abstract;
@@ -1202,14 +1205,18 @@ struct _php_stream {
 	uintptr_t wrapper;
 	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint8_t flags_bitfield;
-	uint8_t fgetss_state;
+	int32_t fgetss_state;
+	int32_t is_persistent;
 	char mode[16];
-	uint32_t flags;
 	zend_resource *res;
+	int32_t in_free;
+	int32_t fclose_stdiocast;
 	uintptr_t stdiocast;
+	int32_t exposed;
 	char *orig_path;
 	zend_resource *ctx;
+	int32_t flags;
+	int32_t eof;
 	zend_off_t position;
 	unsigned char *readbuf;
 	size_t readbuflen;

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1258,6 +1258,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1236,6 +1236,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v70.h
+++ b/src/Lib/PhpInternals/Headers/v70.h
@@ -1251,6 +1251,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1285,6 +1285,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1278,6 +1278,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1217,6 +1217,9 @@ typedef struct _php_stream_ops {
 	uintptr_t set_option;
 } php_stream_ops;
 
+// PHP 7.1 shares the pre-bitfield layout with 7.0: int fgetss_state /
+// is_persistent / in_free / fclose_stdiocast / __exposed; flags and eof
+// sit after orig_path. Bitfield packing was introduced in 7.2.
 struct _php_stream {
 	const php_stream_ops *ops;
 	uintptr_t abstract;
@@ -1229,14 +1232,18 @@ struct _php_stream {
 	uintptr_t wrapper;
 	uintptr_t wrapperthis;
 	zval wrapperdata;
-	uint8_t flags_bitfield;
-	uint8_t fgetss_state;
+	int32_t fgetss_state;
+	int32_t is_persistent;
 	char mode[16];
-	uint32_t flags;
 	zend_resource *res;
+	int32_t in_free;
+	int32_t fclose_stdiocast;
 	uintptr_t stdiocast;
+	int32_t exposed;
 	char *orig_path;
 	zend_resource *ctx;
+	int32_t flags;
+	int32_t eof;
 	zend_off_t position;
 	unsigned char *readbuf;
 	size_t readbuflen;

--- a/src/Lib/PhpInternals/Headers/v71.h
+++ b/src/Lib/PhpInternals/Headers/v71.h
@@ -1263,6 +1263,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1279,6 +1279,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1257,6 +1257,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v72.h
+++ b/src/Lib/PhpInternals/Headers/v72.h
@@ -1272,6 +1272,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1250,6 +1250,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1272,6 +1272,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v73.h
+++ b/src/Lib/PhpInternals/Headers/v73.h
@@ -1265,6 +1265,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1288,6 +1288,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1303,6 +1303,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v74.h
+++ b/src/Lib/PhpInternals/Headers/v74.h
@@ -1310,6 +1310,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1315,6 +1315,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1330,6 +1330,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v80.h
+++ b/src/Lib/PhpInternals/Headers/v80.h
@@ -1337,6 +1337,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1496,6 +1496,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1474,6 +1474,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v81.h
+++ b/src/Lib/PhpInternals/Headers/v81.h
@@ -1489,6 +1489,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1518,6 +1518,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1533,6 +1533,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v82.h
+++ b/src/Lib/PhpInternals/Headers/v82.h
@@ -1540,6 +1540,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1575,6 +1575,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1560,6 +1560,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v83.h
+++ b/src/Lib/PhpInternals/Headers/v83.h
@@ -1582,6 +1582,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1663,6 +1663,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1648,6 +1648,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v84.h
+++ b/src/Lib/PhpInternals/Headers/v84.h
@@ -1670,6 +1670,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1667,6 +1667,21 @@ typedef struct {
 	char *tmpdir;
 } php_stream_temp_data;
 
+// main/streams/plain_wrapper.c
+typedef struct {
+	uintptr_t file;
+	int fd;
+	uint32_t flags_bitfield;
+	int lock_flag;
+	zend_string *temp_name;
+} php_stdio_stream_data;
+
+// main/streams/userspace.c
+typedef struct {
+	uintptr_t wrapper;
+	zval object;
+} php_userstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1689,6 +1689,23 @@ typedef struct {
 	int socket;
 } php_netstream_data_t;
 
+// ext/standard/glob_wrapper.c — partial view of php_glob_stream_data starting
+// at offset 88 from the head of the real struct. The real struct begins with
+// glob_t (whose internals differ between glibc and musl) followed by
+//   size_t index;        // +72
+//   int    flags;        // +80 (+4 padding)
+// then the four fields below at +88. We rely on sizeof(glob_t) == 72 being
+// stable across glibc 2.10+ and musl 0.5+ on x86_64/aarch64; the reader
+// validates each (path, path_len) and (pattern, pattern_len) pair by
+// comparing strlen(*ptr) against the declared length and silently degrades
+// to label-only on any mismatch (other libc, future ABI break).
+typedef struct {
+	char *path;
+	size_t path_len;
+	char *pattern;
+	size_t pattern_len;
+} php_glob_stream_data_tail;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Headers/v85.h
+++ b/src/Lib/PhpInternals/Headers/v85.h
@@ -1682,6 +1682,13 @@ typedef struct {
 	zval object;
 } php_userstream_data_t;
 
+// main/network.h (php_netstream_data_t — only the leading php_socket_t fd is
+// declared here; subsequent fields (sockaddr_storage, struct timeval, enum
+// ownership, …) vary by libc / PHP version and are intentionally omitted.)
+typedef struct {
+	int socket;
+} php_netstream_data_t;
+
 // ext/pdo/php_pdo_driver.h
 typedef char pdo_error_type[6];
 

--- a/src/Lib/PhpInternals/Types/Php/PhpGlobStreamDataTail.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpGlobStreamDataTail.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\php_glob_stream_data_tail;
+use Reli\Lib\FFI\FFIHelper;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+
+final class PhpGlobStreamDataTail implements CDataDereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $path;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $path_len;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $pattern;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $pattern_len;
+
+    /**
+     * @param CastedCData<php_glob_stream_data_tail> $casted_cdata
+     * @param Pointer<PhpGlobStreamDataTail> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->path);
+        unset($this->path_len);
+        unset($this->pattern);
+        unset($this->pattern_len);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'path' => $this->path = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->path
+            ),
+            'path_len' => $this->path_len = $this->casted_cdata->casted->path_len,
+            'pattern' => $this->pattern = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->pattern
+            ),
+            'pattern_len' => $this->pattern_len = $this->casted_cdata->casted->pattern_len,
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'php_glob_stream_data_tail';
+    }
+
+    #[\Override]
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /**
+         * @var CastedCData<php_glob_stream_data_tail> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpInternals/Types/Php/PhpNetstreamData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpNetstreamData.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\php_netstream_data_t;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+
+final class PhpNetstreamData implements CDataDereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $socket;
+
+    /**
+     * @param CastedCData<php_netstream_data_t> $casted_cdata
+     * @param Pointer<PhpNetstreamData> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->socket);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'socket' => $this->socket = $this->casted_cdata->casted->socket,
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'php_netstream_data_t';
+    }
+
+    #[\Override]
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /**
+         * @var CastedCData<php_netstream_data_t> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpInternals/Types/Php/PhpStdioStreamData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStdioStreamData.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\php_stdio_stream_data;
+use Reli\Lib\FFI\FFIHelper;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\Process\Pointer\CDataDereferencable;
+use Reli\Lib\Process\Pointer\Pointer;
+
+final class PhpStdioStreamData implements CDataDereferencable
+{
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $fd;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $temp_name;
+
+    /**
+     * @param CastedCData<php_stdio_stream_data> $casted_cdata
+     * @param Pointer<PhpStdioStreamData> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->fd);
+        unset($this->temp_name);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'fd' => $this->fd = $this->casted_cdata->casted->fd,
+            'temp_name' => $this->temp_name = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->temp_name
+            ),
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'php_stdio_stream_data';
+    }
+
+    #[\Override]
+    public static function fromCastedCData(CastedCData $casted_cdata, Pointer $pointer): static
+    {
+        /**
+         * @var CastedCData<php_stdio_stream_data> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        return new self($casted_cdata, $pointer);
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpInternals/Types/Php/PhpStream.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpStream.php
@@ -28,6 +28,8 @@ final class PhpStream implements CDataDereferencable
     public int $abstract;
     /** @psalm-suppress PropertyNotSetInConstructor */
     public int $res;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public int $orig_path;
 
     /**
      * @param CastedCData<php_stream> $casted_cdata
@@ -40,6 +42,7 @@ final class PhpStream implements CDataDereferencable
         unset($this->ops);
         unset($this->abstract);
         unset($this->res);
+        unset($this->orig_path);
     }
 
     public function __get(string $field_name): mixed
@@ -51,6 +54,9 @@ final class PhpStream implements CDataDereferencable
             'abstract' => $this->abstract = $this->casted_cdata->casted->abstract,
             'res' => $this->res = FFIHelper::castPointerToInt(
                 $this->casted_cdata->casted->res
+            ),
+            'orig_path' => $this->orig_path = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->orig_path
             ),
         };
     }

--- a/src/Lib/PhpInternals/Types/Php/PhpUserstreamData.php
+++ b/src/Lib/PhpInternals/Types/Php/PhpUserstreamData.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Php;
+
+use FFI\PhpInternals\php_userstream_data_t;
+use Reli\Lib\PhpInternals\CastedCData;
+use Reli\Lib\PhpInternals\Types\Zend\InlineCDataCreatorTrait;
+use Reli\Lib\PhpInternals\Types\Zend\Zval;
+use Reli\Lib\Process\Pointer\PointedTypeResolver;
+use Reli\Lib\Process\Pointer\PointedTypeResolverAware;
+use Reli\Lib\Process\Pointer\Pointer;
+
+/**
+ * @psalm-consistent-constructor
+ * @psalm-suppress ClassMustBeFinal
+ */
+class PhpUserstreamData implements PointedTypeResolverAware
+{
+    use InlineCDataCreatorTrait;
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    public Zval $object;
+
+    /**
+     * @param CastedCData<php_userstream_data_t> $casted_cdata
+     * @param Pointer<PhpUserstreamData> $pointer
+     */
+    public function __construct(
+        private CastedCData $casted_cdata,
+        private Pointer $pointer,
+    ) {
+        unset($this->object);
+    }
+
+    public function __get(string $field_name): mixed
+    {
+        return match ($field_name) {
+            'object' => $this->object = $this->createInlineDereferencable('object', Zval::class),
+        };
+    }
+
+    #[\Override]
+    public static function getCTypeName(): string
+    {
+        return 'php_userstream_data_t';
+    }
+
+    #[\Override]
+    public static function fromCastedCDataWithResolver(
+        CastedCData $casted_cdata,
+        Pointer $pointer,
+        PointedTypeResolver $pointed_type_resolver,
+    ): static {
+        /**
+         * @var CastedCData<php_userstream_data_t> $casted_cdata
+         * @var Pointer<self> $pointer
+         */
+        $self = new static($casted_cdata, $pointer);
+        $self->pointed_type_resolver = $pointed_type_resolver;
+        return $self;
+    }
+
+    #[\Override]
+    public function getPointer(): Pointer
+    {
+        return $this->pointer;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
 
 use Reli\Lib\PhpInternals\Types\C\RawString;
+use Reli\Lib\PhpInternals\Types\Php\PhpStdioStreamData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStream;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamMemoryData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamOps;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamTempData;
+use Reli\Lib\PhpInternals\Types\Php\PhpUserstreamData;
 use Reli\Lib\PhpInternals\Types\Zend\ZendResource;
 use Reli\Lib\PhpInternals\Types\Zend\ZendString;
+use Reli\Lib\PhpInternals\Types\Zend\Zval;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
@@ -80,8 +83,10 @@ final class EmitResourceJob implements CollectorJob
             ->resource_context_pool
             ->getContextForLocation($memory_location);
 
-        // Try to collect stream data (best effort)
-        $this->tryCollectStreamData($resource, $ctx, $resource_context);
+        // Try to collect stream data (best effort).
+        // For userspace streams the embedded zval is returned and dispatched
+        // after emitNode so the resulting node_id can parent the zval graph.
+        $deferred_userspace_zval = $this->tryCollectStreamData($resource, $ctx, $resource_context);
 
         $node_id = $ctx->emitNode(
             $resource_context,
@@ -92,16 +97,24 @@ final class EmitResourceJob implements CollectorJob
         if ($node_id >= 0) {
             $ctx->address_map[$address] = $node_id;
         }
+
+        if ($deferred_userspace_zval !== null) {
+            $queue->push(new ResolveZvalJob(
+                $deferred_userspace_zval,
+                $node_id >= 0 ? $node_id : null,
+                'stream_userspace_object',
+            ));
+        }
     }
 
     private function tryCollectStreamData(
         ZendResource $resource,
         CollectorContext $ctx,
         ResourceContext $resource_context,
-    ): void {
+    ): ?Zval {
         $ptr_address = $resource->ptr;
         if ($ptr_address === 0) {
-            return;
+            return null;
         }
 
         try {
@@ -113,12 +126,12 @@ final class EmitResourceJob implements CollectorJob
             $php_stream = $ctx->dereferencer->deref($php_stream_pointer);
 
             if ($php_stream->res !== $this->pointer->address) {
-                return;
+                return null;
             }
 
             $ops_address = $php_stream->ops;
             if ($ops_address === 0) {
-                return;
+                return null;
             }
             $ops = $ctx->dereferencer->deref(new Pointer(
                 PhpStreamOps::class,
@@ -128,7 +141,7 @@ final class EmitResourceJob implements CollectorJob
 
             $label_address = $ops->label;
             if ($label_address === 0) {
-                return;
+                return null;
             }
             $label = (string)$ctx->dereferencer->deref(new Pointer(RawString::class, $label_address, 32));
             $resource_context->stream_type_label = $label;
@@ -137,10 +150,15 @@ final class EmitResourceJob implements CollectorJob
                 $this->collectMemoryStreamData($php_stream, $ctx, $resource_context);
             } elseif ($label === 'TEMP') {
                 $this->collectTempStreamData($php_stream, $ctx, $resource_context);
+            } elseif ($label === 'STDIO') {
+                $this->collectStdioStreamData($php_stream, $ctx, $resource_context);
+            } elseif ($label === 'user-space') {
+                return $this->extractUserspaceObjectZval($php_stream, $ctx);
             }
         } catch (\Throwable) {
-            return;
+            return null;
         }
+        return null;
     }
 
     private function collectMemoryStreamData(
@@ -231,5 +249,66 @@ final class EmitResourceJob implements CollectorJob
         if ($inner_label === 'MEMORY') {
             $this->collectMemoryStreamData($inner_stream, $ctx, $resource_context);
         }
+    }
+
+    private function collectStdioStreamData(
+        PhpStream $php_stream,
+        CollectorContext $ctx,
+        ResourceContext $resource_context,
+    ): void {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return;
+        }
+
+        $stdio_data = $ctx->dereferencer->deref(new Pointer(
+            PhpStdioStreamData::class,
+            $abstract_address,
+            $ctx->zend_type_reader->sizeOf('php_stdio_stream_data'),
+        ));
+
+        $resource_context->stream_fd = $stdio_data->fd;
+
+        $temp_name_address = $stdio_data->temp_name;
+        if ($temp_name_address === 0) {
+            return;
+        }
+
+        $string_pointer = new Pointer(
+            ZendString::class,
+            $temp_name_address,
+            $ctx->zend_type_reader->sizeOf('zend_string'),
+        );
+
+        if (!$ctx->memory_locations->has($temp_name_address)) {
+            $str = $ctx->dereferencer->deref($string_pointer);
+            $memory_location = ZendStringMemoryLocation::fromZendString($str, $ctx->dereferencer);
+            $ctx->memory_locations->add($memory_location);
+            $string_context = $ctx->context_pools->string_context_pool->getContextForLocation($memory_location);
+            $resource_context->add('stream_temp_name', $string_context);
+        } else {
+            $cached = $ctx->context_pools->string_context_pool->getContextByAddress($temp_name_address);
+            if ($cached !== null) {
+                $resource_context->add('stream_temp_name', $cached);
+            }
+        }
+    }
+
+    private function extractUserspaceObjectZval(
+        PhpStream $php_stream,
+        CollectorContext $ctx,
+    ): ?Zval {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return null;
+        }
+
+        $userstream_data = $ctx->dereferencer->deref(new Pointer(
+            PhpUserstreamData::class,
+            $abstract_address,
+            $ctx->zend_type_reader->sizeOf('php_userstream_data_t'),
+        ));
+
+        return $userstream_data->object;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -151,7 +151,7 @@ final class EmitResourceJob implements CollectorJob
             $orig_path_address = $php_stream->orig_path;
             if ($orig_path_address !== 0) {
                 $resource_context->stream_orig_path = (string)$ctx->dereferencer->deref(
-                    new Pointer(RawString::class, $orig_path_address, 256),
+                    new Pointer(RawString::class, $orig_path_address, 4096),
                 );
             }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
 
 use Reli\Lib\PhpInternals\Types\C\RawString;
+use Reli\Lib\PhpInternals\Types\Php\PhpGlobStreamDataTail;
 use Reli\Lib\PhpInternals\Types\Php\PhpNetstreamData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStdioStreamData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStream;
@@ -169,6 +170,8 @@ final class EmitResourceJob implements CollectorJob
                 || $label === 'udg_socket'
             ) {
                 $this->collectSocketStreamData($php_stream, $ctx, $resource_context);
+            } elseif ($label === 'glob') {
+                $this->collectGlobStreamData($php_stream, $ctx, $resource_context);
             }
         } catch (\Throwable) {
             return null;
@@ -326,6 +329,75 @@ final class EmitResourceJob implements CollectorJob
         ));
 
         $resource_context->stream_fd = $netstream_data->socket;
+    }
+
+    /**
+     * Decode the (path, pattern) pair stored at the tail of
+     * php_glob_stream_data.
+     *
+     * The struct begins with `glob_t` (libc-internal, layout differs between
+     * glibc and musl) followed by `size_t index; int flags;`. On 64-bit Linux
+     * this puts (path, path_len, pattern, pattern_len) at offset 88, because
+     * sizeof(glob_t) == 72 has been stable since glibc 2.10 (2009) and musl
+     * 0.5 (2011). _php_stream_opendir does not populate stream->orig_path for
+     * the glob wrapper, so this is the only place the pattern is recoverable.
+     *
+     * Each (ptr, len) pair is validated by checking strlen-vs-len consistency
+     * against the bytes actually mapped at the pointer; on any mismatch
+     * (other libc, future ABI break) the resource silently degrades to
+     * label-only.
+     */
+    private function collectGlobStreamData(
+        PhpStream $php_stream,
+        CollectorContext $ctx,
+        ResourceContext $resource_context,
+    ): void {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return;
+        }
+
+        $tail_size = $ctx->zend_type_reader->sizeOf('php_glob_stream_data_tail');
+        $tail = $ctx->dereferencer->deref(new Pointer(
+            PhpGlobStreamDataTail::class,
+            $abstract_address + 88,
+            $tail_size,
+        ));
+
+        $path = $this->validatedGlobString($ctx, $tail->path, $tail->path_len);
+        $pattern = $this->validatedGlobString($ctx, $tail->pattern, $tail->pattern_len);
+        if ($path === null || $pattern === null) {
+            return;
+        }
+
+        $resource_context->stream_orig_path = 'glob://' . $path . '/' . $pattern;
+    }
+
+    /**
+     * Read $len bytes at $address and return the string only when its
+     * length matches $len exactly (i.e. the bytes are NUL-free up to
+     * $len, with the byte at $len being NUL or end-of-buffer). Returns
+     * null on any inconsistency.
+     */
+    private function validatedGlobString(
+        CollectorContext $ctx,
+        int $address,
+        int $len,
+    ): ?string {
+        if ($address === 0 || $len <= 0 || $len > 4096) {
+            return null;
+        }
+        try {
+            $raw = (string)$ctx->dereferencer->deref(
+                new Pointer(RawString::class, $address, $len + 1),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+        if (strlen($raw) !== $len) {
+            return null;
+        }
+        return $raw;
     }
 
     private function extractUserspaceObjectZval(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -332,20 +332,32 @@ final class EmitResourceJob implements CollectorJob
     }
 
     /**
-     * Decode the (path, pattern) pair stored at the tail of
-     * php_glob_stream_data.
+     * Decode the (path, pattern) pair stored at the tail of the glob
+     * stream's abstract data.
      *
-     * The struct begins with `glob_t` (libc-internal, layout differs between
-     * glibc and musl) followed by `size_t index; int flags;`. On 64-bit Linux
-     * this puts (path, path_len, pattern, pattern_len) at offset 88, because
-     * sizeof(glob_t) == 72 has been stable since glibc 2.10 (2009) and musl
-     * 0.5 (2011). _php_stream_opendir does not populate stream->orig_path for
-     * the glob wrapper, so this is the only place the pattern is recoverable.
+     * The struct begins with a glob_t-shaped header followed by
+     * `size_t index; int flags;` (+4 padding) and then the four
+     * (path, path_len, pattern, pattern_len) fields we care about. The
+     * header size depends on which glob implementation PHP was built
+     * against, and we probe both known offsets:
      *
-     * Each (ptr, len) pair is validated by checking strlen-vs-len consistency
-     * against the bytes actually mapped at the pointer; on any mismatch
-     * (other libc, future ABI break) the resource silently degrades to
-     * label-only.
+     *   - offset 88: PHP 7.0 .. 8.4 (and PHP 8.5 built with
+     *     --with-system-glob), where the header is libc's `glob_t` and
+     *     `sizeof(glob_t) == 72` on 64-bit Linux for both glibc 2.10+
+     *     and musl 0.5+.
+     *   - offset 112: PHP 8.5 default build, where the header is the
+     *     bundled `php_glob_t` struct from main/php_glob.h
+     *     (`sizeof(php_glob_t) == 96`, with extra `gl_matchc` and
+     *     `gl_statv` fields plus an `gl_errfunc` pointer not present
+     *     in libc's glob_t).
+     *
+     * _php_stream_opendir does not populate stream->orig_path for the
+     * glob wrapper, so this is the only place the pattern is recoverable.
+     *
+     * Each (ptr, len) pair is validated by checking strlen-vs-len
+     * consistency against the bytes actually mapped at the pointer; on
+     * any mismatch the resource silently degrades to label-only — same
+     * best-effort posture as the rest of tryCollectStreamData.
      */
     private function collectGlobStreamData(
         PhpStream $php_stream,
@@ -357,20 +369,34 @@ final class EmitResourceJob implements CollectorJob
             return;
         }
 
-        $tail_size = $ctx->zend_type_reader->sizeOf('php_glob_stream_data_tail');
-        $tail = $ctx->dereferencer->deref(new Pointer(
-            PhpGlobStreamDataTail::class,
-            $abstract_address + 88,
-            $tail_size,
-        ));
+        foreach ([88, 112] as $tail_offset) {
+            $synthetic_uri = $this->tryDecodeGlobTail($ctx, $abstract_address + $tail_offset);
+            if ($synthetic_uri !== null) {
+                $resource_context->stream_orig_path = $synthetic_uri;
+                return;
+            }
+        }
+    }
+
+    private function tryDecodeGlobTail(CollectorContext $ctx, int $tail_address): ?string
+    {
+        try {
+            $tail = $ctx->dereferencer->deref(new Pointer(
+                PhpGlobStreamDataTail::class,
+                $tail_address,
+                $ctx->zend_type_reader->sizeOf('php_glob_stream_data_tail'),
+            ));
+        } catch (\Throwable) {
+            return null;
+        }
 
         $path = $this->validatedGlobString($ctx, $tail->path, $tail->path_len);
         $pattern = $this->validatedGlobString($ctx, $tail->pattern, $tail->pattern_len);
         if ($path === null || $pattern === null) {
-            return;
+            return null;
         }
 
-        $resource_context->stream_orig_path = 'glob://' . $path . '/' . $pattern;
+        return 'glob://' . $path . '/' . $pattern;
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
 
 use Reli\Lib\PhpInternals\Types\C\RawString;
+use Reli\Lib\PhpInternals\Types\Php\PhpNetstreamData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStdioStreamData;
 use Reli\Lib\PhpInternals\Types\Php\PhpStream;
 use Reli\Lib\PhpInternals\Types\Php\PhpStreamMemoryData;
@@ -146,6 +147,13 @@ final class EmitResourceJob implements CollectorJob
             $label = (string)$ctx->dereferencer->deref(new Pointer(RawString::class, $label_address, 32));
             $resource_context->stream_type_label = $label;
 
+            $orig_path_address = $php_stream->orig_path;
+            if ($orig_path_address !== 0) {
+                $resource_context->stream_orig_path = (string)$ctx->dereferencer->deref(
+                    new Pointer(RawString::class, $orig_path_address, 256),
+                );
+            }
+
             if ($label === 'MEMORY') {
                 $this->collectMemoryStreamData($php_stream, $ctx, $resource_context);
             } elseif ($label === 'TEMP') {
@@ -154,6 +162,13 @@ final class EmitResourceJob implements CollectorJob
                 $this->collectStdioStreamData($php_stream, $ctx, $resource_context);
             } elseif ($label === 'user-space') {
                 return $this->extractUserspaceObjectZval($php_stream, $ctx);
+            } elseif (
+                $label === 'tcp_socket'
+                || $label === 'udp_socket'
+                || $label === 'unix_socket'
+                || $label === 'udg_socket'
+            ) {
+                $this->collectSocketStreamData($php_stream, $ctx, $resource_context);
             }
         } catch (\Throwable) {
             return null;
@@ -292,6 +307,25 @@ final class EmitResourceJob implements CollectorJob
                 $resource_context->add('stream_temp_name', $cached);
             }
         }
+    }
+
+    private function collectSocketStreamData(
+        PhpStream $php_stream,
+        CollectorContext $ctx,
+        ResourceContext $resource_context,
+    ): void {
+        $abstract_address = $php_stream->abstract;
+        if ($abstract_address === 0) {
+            return;
+        }
+
+        $netstream_data = $ctx->dereferencer->deref(new Pointer(
+            PhpNetstreamData::class,
+            $abstract_address,
+            $ctx->zend_type_reader->sizeOf('php_netstream_data_t'),
+        ));
+
+        $resource_context->stream_fd = $netstream_data->socket;
     }
 
     private function extractUserspaceObjectZval(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
@@ -20,6 +20,7 @@ final class ResourceContext implements ReferenceContext
     use ReferenceContextDefault;
 
     public ?string $stream_type_label = null;
+    public ?int $stream_fd = null;
 
     public function __construct(
         public ZendResourceMemoryLocation $memory_location,
@@ -38,6 +39,9 @@ final class ResourceContext implements ReferenceContext
         $contexts = [];
         if ($this->stream_type_label !== null) {
             $contexts['stream_type_label'] = $this->stream_type_label;
+        }
+        if ($this->stream_fd !== null) {
+            $contexts['stream_fd'] = $this->stream_fd;
         }
         return $contexts;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/ResourceContext.php
@@ -21,6 +21,7 @@ final class ResourceContext implements ReferenceContext
 
     public ?string $stream_type_label = null;
     public ?int $stream_fd = null;
+    public ?string $stream_orig_path = null;
 
     public function __construct(
         public ZendResourceMemoryLocation $memory_location,
@@ -42,6 +43,9 @@ final class ResourceContext implements ReferenceContext
         }
         if ($this->stream_fd !== null) {
             $contexts['stream_fd'] = $this->stream_fd;
+        }
+        if ($this->stream_orig_path !== null) {
+            $contexts['stream_orig_path'] = $this->stream_orig_path;
         }
         return $contexts;
     }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -88,6 +88,11 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         yield from TargetPhpVmProvider::from(ZendTypeReader::V80);
     }
 
+    public static function provideFromV70()
+    {
+        yield from TargetPhpVmProvider::from(ZendTypeReader::V70);
+    }
+
     #[DataProvider('provideFromV80')]
     public function testCollectAllFromV80(string $php_version, string $docker_image_name): void
     {
@@ -2827,9 +2832,12 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     /**
      * Per-label child decoders attached to the resource (STDIO temp_name,
      * userspace object zval, socket fd, glob orig_path) should surface on
-     * the ResourceContext as either child links or scalar metadata.
+     * the ResourceContext as either child links or scalar metadata. Target
+     * script is kept PHP 7.0+ compatible so it can run against every
+     * supported PHP version (no typed properties, no first-class callable
+     * syntax).
      */
-    #[DataProvider('provideFromV80')]
+    #[DataProvider('provideFromV70')]
     public function testStreamChildDecodersExposeFdOrigPathAndUserspaceObject(
         string $php_version,
         string $docker_image_name,
@@ -2857,8 +2865,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
 
             class ReliTestStream {
                 public $context;
-                public string $marker = 'RELI_USERSPACE_MARKER';
-                private bool $eof = false;
+                public $marker = 'RELI_USERSPACE_MARKER';
+                private $eof = false;
                 public function stream_open($path, $mode, $options, &$opened_path) { return true; }
                 public function stream_eof() { return $this->eof; }
                 public function stream_read($count) { $this->eof = true; return ''; }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2825,6 +2825,237 @@ class MemoryLocationsCollectorTest extends BaseTestCase
     }
 
     /**
+     * Per-label child decoders attached to the resource (STDIO temp_name,
+     * userspace object zval, socket fd, glob orig_path) should surface on
+     * the ResourceContext as either child links or scalar metadata.
+     */
+    #[DataProvider('provideFromV80')]
+    public function testStreamChildDecodersExposeFdOrigPathAndUserspaceObject(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            $stdio_path = tempnam(sys_get_temp_dir(), 'reli-stdio-');
+            $stdio_stream = fopen($stdio_path, 'r+');
+            $tmp_stream = tmpfile();
+
+            $sock_path = sys_get_temp_dir() . '/reli-sock-' . uniqid();
+            $server = stream_socket_server('unix://' . $sock_path);
+
+            $glob_dir = sys_get_temp_dir() . '/reli-glob-' . uniqid();
+            mkdir($glob_dir);
+            touch($glob_dir . '/a.txt');
+            $glob_stream = opendir('glob://' . $glob_dir . '/*.txt');
+
+            class ReliTestStream {
+                public $context;
+                public string $marker = 'RELI_USERSPACE_MARKER';
+                private bool $eof = false;
+                public function stream_open($path, $mode, $options, &$opened_path) { return true; }
+                public function stream_eof() { return $this->eof; }
+                public function stream_read($count) { $this->eof = true; return ''; }
+            }
+            stream_wrapper_register('relitest', ReliTestStream::class);
+            $userspace_stream = fopen('relitest://hello', 'r');
+
+            echo "ready\n";
+            fgets(STDIN);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(
+                php_version: $php_version,
+            )
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            )
+        );
+        $sink = new ArrayContextTreeSink();
+        $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+
+        $contexts_analyzed = $sink->getResult();
+
+        $found_stdio_with_orig_path = false;
+        $found_stdio_with_temp_name = false;
+        $found_unix_socket_with_fd = false;
+        $found_glob_with_pattern = false;
+        $found_userspace_with_object = false;
+
+        $walk = function (array $tree) use (
+            &$walk,
+            &$found_stdio_with_orig_path,
+            &$found_stdio_with_temp_name,
+            &$found_unix_socket_with_fd,
+            &$found_glob_with_pattern,
+            &$found_userspace_with_object,
+        ): void {
+            foreach ($tree as $key => $value) {
+                if (!is_array($value) || $key === '#locations') {
+                    continue;
+                }
+                $type = $value['#type'] ?? null;
+                $label = $value['stream_type_label'] ?? null;
+                if ($type === 'ResourceContext' && $label !== null) {
+                    $orig_path = $value['stream_orig_path'] ?? null;
+                    $fd = $value['stream_fd'] ?? null;
+                    if ($label === 'STDIO') {
+                        if (is_string($orig_path) && str_contains($orig_path, 'reli-stdio-')) {
+                            if (is_int($fd) && $fd > 2) {
+                                $found_stdio_with_orig_path = true;
+                            }
+                        }
+                        if (isset($value['stream_temp_name'])) {
+                            $found_stdio_with_temp_name = true;
+                        }
+                    }
+                    // unix_socket: PHP < 8.4 does not always populate
+                    // stream->orig_path for streams created via
+                    // stream_socket_server, so we only require the fd here.
+                    if ($label === 'unix_socket') {
+                        if (is_int($fd) && $fd > 2) {
+                            $found_unix_socket_with_fd = true;
+                        }
+                    }
+                    // glob:// streams: PHP's _php_stream_opendir does not
+                    // populate php_stream->orig_path, and the pattern lives
+                    // inside php_glob_stream_data after a libc-dependent
+                    // glob_t (size differs between glibc and musl). We
+                    // intentionally do not decode that struct, so the only
+                    // signal exposed for glob is the label itself.
+                    if ($label === 'glob') {
+                        $found_glob_with_pattern = true;
+                    }
+                    if ($label === 'user-space') {
+                        if (isset($value['stream_userspace_object'])) {
+                            $found_userspace_with_object = true;
+                        }
+                    }
+                }
+                $walk($value);
+            }
+        };
+        $walk($contexts_analyzed);
+
+        $this->assertTrue(
+            $found_stdio_with_orig_path,
+            'STDIO stream should expose orig_path (file path) and stream_fd > 2'
+        );
+        $this->assertTrue(
+            $found_stdio_with_temp_name,
+            'tmpfile()-backed STDIO stream should expose a stream_temp_name child string'
+        );
+        $this->assertTrue(
+            $found_unix_socket_with_fd,
+            'unix_socket stream should expose stream_fd and orig_path with the socket file path'
+        );
+        $this->assertTrue(
+            $found_glob_with_pattern,
+            'glob:// stream should at least be tagged with stream_type_label=glob'
+        );
+        $this->assertTrue(
+            $found_userspace_with_object,
+            'user-space stream should expose a stream_userspace_object child for the wrapper instance'
+        );
+    }
+
+    /**
      * EG(regular_list) must show up as a root branch and its outgoing
      * edges to resources must be weak — same reasoning as objects_store:
      * a resource only reachable via the registry should not look pinned

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -3013,14 +3013,20 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                             $found_unix_socket_with_fd = true;
                         }
                     }
-                    // glob:// streams: PHP's _php_stream_opendir does not
-                    // populate php_stream->orig_path, and the pattern lives
-                    // inside php_glob_stream_data after a libc-dependent
-                    // glob_t (size differs between glibc and musl). We
-                    // intentionally do not decode that struct, so the only
-                    // signal exposed for glob is the label itself.
+                    // glob:// streams: _php_stream_opendir does not populate
+                    // php_stream->orig_path, but reli reconstructs a synthetic
+                    // 'glob://<path>/<pattern>' from the (path, pattern) pair
+                    // that lives at the tail of php_glob_stream_data (after
+                    // the libc-internal glob_t header).
                     if ($label === 'glob') {
-                        $found_glob_with_pattern = true;
+                        if (
+                            is_string($orig_path)
+                            && str_starts_with($orig_path, 'glob://')
+                            && str_contains($orig_path, 'reli-glob-')
+                            && str_contains($orig_path, '*.txt')
+                        ) {
+                            $found_glob_with_pattern = true;
+                        }
                     }
                     if ($label === 'user-space') {
                         if (isset($value['stream_userspace_object'])) {
@@ -3047,7 +3053,7 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         );
         $this->assertTrue(
             $found_glob_with_pattern,
-            'glob:// stream should at least be tagged with stream_type_label=glob'
+            'glob:// stream should expose synthetic stream_orig_path with the pattern'
         );
         $this->assertTrue(
             $found_userspace_with_object,

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -396,6 +396,14 @@ class php_netstream_data_t extends CData
     public int $socket;
 }
 
+class php_glob_stream_data_tail extends CData
+{
+    public ?CPointer $path;
+    public int $path_len;
+    public ?CPointer $pattern;
+    public int $pattern_len;
+}
+
 class pdo_dbh_object_t extends CData
 {
     public ?CPointer $inner;

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -362,6 +362,7 @@ class php_stream extends CData
     public ?CPointer $ops;
     public int $abstract;
     public ?CPointer $res;
+    public ?CPointer $orig_path;
 }
 
 class php_stream_memory_data extends CData
@@ -388,6 +389,11 @@ class php_userstream_data_t extends CData
 {
     public int $wrapper;
     public zval $object;
+}
+
+class php_netstream_data_t extends CData
+{
+    public int $socket;
 }
 
 class pdo_dbh_object_t extends CData

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -376,6 +376,20 @@ class php_stream_temp_data extends CData
     public int $smax;
 }
 
+class php_stdio_stream_data extends CData
+{
+    public int $file;
+    public int $fd;
+    public int $lock_flag;
+    public ?CPointer $temp_name;
+}
+
+class php_userstream_data_t extends CData
+{
+    public int $wrapper;
+    public zval $object;
+}
+
 class pdo_dbh_object_t extends CData
 {
     public ?CPointer $inner;


### PR DESCRIPTION
## Summary
This change enhances resource context collection to expose stream-specific metadata and child decoders (file descriptors, paths, temporary names, and userspace objects) that were previously unavailable during memory analysis.

## Key Changes

- **Stream metadata extraction**: Added collection of `stream_orig_path` (file path) and `stream_fd` (file descriptor) from PHP stream structures for all stream types
- **STDIO stream support**: Implemented `collectStdioStreamData()` to extract file descriptor and temporary file names (via `stream_temp_name` child link)
- **Socket stream support**: Implemented `collectSocketStreamData()` to extract socket file descriptors from TCP, UDP, Unix, and UDG sockets
- **Glob stream support**: Implemented `collectGlobStreamData()` to reconstruct synthetic `glob://<path>/<pattern>` paths from the `php_glob_stream_data_tail` structure, validating against libc ABI stability assumptions
- **Userspace stream support**: Implemented `extractUserspaceObjectZval()` to defer and expose the embedded userspace object zval as a child context (`stream_userspace_object`)
- **Type definitions**: Added C struct definitions for `php_stdio_stream_data`, `php_userstream_data_t`, `php_netstream_data_t`, and `php_glob_stream_data_tail` across all PHP version headers (7.0–8.5)
- **Deferred zval processing**: Modified `EmitResourceJob` to return deferred userspace zvals and dispatch them via `ResolveZvalJob` after the resource node is emitted, ensuring proper parent-child relationships
- **ResourceContext extensions**: Added `stream_fd` and `stream_orig_path` fields to `ResourceContext` for scalar metadata storage

## Implementation Details

- Glob stream path reconstruction validates `(path, path_len)` and `(pattern, pattern_len)` pairs by comparing `strlen()` against declared lengths, gracefully degrading to label-only on ABI mismatches
- Socket stream collection handles multiple socket types (TCP, UDP, Unix domain, Unix datagram) with a single code path
- Userspace stream zval extraction is deferred to allow the resource node ID to be available as a parent reference
- All stream data collection is wrapped in try-catch to ensure best-effort behavior without disrupting overall collection

## Testing
Added comprehensive test `testStreamChildDecodersExposeFdOrigPathAndUserspaceObject` covering STDIO, tmpfile, Unix socket, glob, and userspace stream types with validation of exposed metadata and child contexts.

https://claude.ai/code/session_01JHvTqhs7UirDahtVNn9TH8