### PR TITLE
Implement orphan allocation analysis for unaccounted ZendMM memory

### DIFF
--- a/docs/internals/design-orphan-allocation-analysis.md
+++ b/docs/internals/design-orphan-allocation-analysis.md
@@ -1,0 +1,489 @@
+# Orphan Allocation Analysis — Design Note
+
+## Motivation
+
+Reli's current memory analysis can pinpoint leaks whose roots live inside
+the PHP object graph (objects_store, function_table, class_table, symbol
+tables, etc.). It struggles when the leak is **C-extension-side emalloc'd
+memory that is not reachable from any of those roots**, because such
+allocations show up as "unanalyzed" bytes with no node, no type, and no
+shape — only an `Analyzed: X%` figure that goes down.
+
+This was demonstrated end-to-end while investigating amphp/file issue #88
+(uv driver leak). The actual workflow that landed on the culprit looked
+like this:
+
+1. `inspector:memory:report` on T1 / T2 → notice `Analyzed 62.1% → 45.8%`
+2. Diff `Type Breakdown` between T1/T2 by hand → confirm typed delta = 0
+3. Run `inspector:memory:dump:inspect` twice → text-diff region maps
+   (shifted indexes had to be stripped, then `comm -23` on sorted
+   addresses) → find `+728 KB at 0x7f9b92200000`
+4. Read `/proc/<pid>/mem` directly with `dd | od` to see the leaked
+   bytes; identify a `~480 byte` then later a `~192 byte` repeating
+   structure
+5. Manually decode the bytes against `struct stat` / `uv_stat_t` /
+   `Bucket` / `zval` layouts; resolve `.text` pointers to PHP binary
+   symbols by hand
+6. After several wrong hypotheses, identify the leak as **per-instance
+   property name `Bucket` entries** in object property tables
+
+Most of those steps are mechanical and could be done by the tool. This
+document proposes the smallest set of features that would have collapsed
+the workflow above into running `inspector:memory:compare` once and
+reading the output.
+
+## Non-goals
+
+- Building a full `valgrind`-style memcheck. The aim is to surface
+  unaccounted allocations and label them with confidence-scored
+  shape detectors, not to track allocation lifetimes.
+- Decoding C-extension-specific structs in core. Extension-specific
+  detectors (`uv_fs_t`, `curl_easy`, libxml node, …) belong in a
+  contrib registry; only POSIX / glibc / PHP-core types ship in core.
+- Replacing the existing root-traversal analysis. The new path is
+  complementary: bin walker enumerates allocations from the allocator
+  side; root traversal continues to claim what it can.
+
+## Architecture
+
+```
+                        ┌────────────────────────┐
+   live target /        │   ZendMM bin walker    │
+   rdump file    ────►  │   (chunk page_map +    │
+                        │    free_slot freelist) │
+                        └──────────┬─────────────┘
+                                   │ slot list
+                                   │ (addr, size, bin_id)
+                                   ▼
+                        ┌────────────────────────┐
+                        │   detector pipeline    │
+                        │   (PHP / POSIX / glibc)│ ◄── symbol map
+                        │   + negative-evidence  │     (existing)
+                        └──────────┬─────────────┘
+                                   │ labeled allocations
+                                   ▼
+                        ┌────────────────────────┐
+                        │   rmem sidecar tables  │
+                        │   ・bin_slots          │
+                        │   ・region_map         │
+                        │   ・detected_shapes    │
+                        └──────────┬─────────────┘
+                                   │
+                ┌──────────────────┼──────────────────┐
+                ▼                  ▼                  ▼
+          memory:report     memory:compare     rmem:query --bin
+          (new sections)    (new deltas)       (drill-down)
+```
+
+Key design constraint: rmem stays the single sink. analyze produces it
+once; report / compare / query consume it. No new file formats; new
+data lives as rmem sidecar tables (same pattern as `.rmem.derived`).
+
+## A. ZendMM bin walker
+
+### Goal
+
+Enumerate every live allocation in ZendMM, grouped by bin size, with
+addresses preserved for drill-down.
+
+### Inputs
+
+- `zend_mm_heap*` — already located by reli at cold-attach time
+  (`PhpGlobalsFinder` / `findZendMmMainChunk`)
+- `zend_mm_chunk*` linked list — followed from `heap->main_chunk`
+
+### Walk
+
+```
+for each chunk in heap:
+    free_set = collect_freelist(heap->free_slot[*], chunk)
+    for each page in chunk->map[ZEND_MM_PAGES]:
+        kind = chunk->map[page]
+        if kind == 0: skip (free page)
+        elif kind & ZEND_MM_IS_LRUN:
+            n = ZEND_MM_LRUN_PAGES(kind)
+            emit Slot(addr=chunk + page*4096, size=n*4096, bin=LARGE)
+            advance n pages
+        elif kind & ZEND_MM_IS_SRUN:
+            bin_num = ZEND_MM_SRUN_BIN_NUM(kind)
+            slot_size = bin_data_size[bin_num]
+            for slot in run:
+                if slot.addr ∉ free_set:
+                    emit Slot(addr, slot_size, bin_num)
+```
+
+Subtleties:
+
+- `free_slot[bin]` is a singly-linked list whose link pointer lives at
+  the start of each free slot. The walker has to traverse the list
+  for every bin first, build `free_set`, then sweep the run.
+- `cached_chunks` are free.
+- ZendMM chunk size is fixed (2 MiB, 512 pages of 4 KiB). Bin sizes
+  follow the standard PHP table (8, 16, 24, 32, 40, 48, 56, 64, 80,
+  96, 112, 128, 160, 192, 256, 320, 384, 448, 512, 640, 768, 896,
+  1024, 1280, 1536, 1792, 2048, 2560, 3072 — 30 bins).
+
+### Existing reuse
+
+The `zendmm_heap_fragmentation_high` finding already walks `chunk->map`
+to compute free-page space. The new walker is the same traversal with
+slot-level emission added; both should share the underlying iterator.
+
+### Outputs (rmem sidecar)
+
+- `bin_histogram`: `{ bin_id → { count, total_bytes } }`
+- `bin_slots`: `{ bin_id → address[] }` (drill-down)
+
+### Sizing
+
+Worst case for a daemon with hundreds of MiB ZendMM: ~10M slots,
+80 MiB raw uint64 list. Mitigations:
+
+- **Default**: histogram only; `bin_slots` populated only for bins
+  with `count ≥ threshold` or `size ≤ N` (cheap-to-store sizes)
+- **Opt-in**: `--include-orphans` for full slot lists
+- **Storage**: vbyte / delta-encode addresses inside a chunk
+  (consecutive slots in a small run differ by a constant) —
+  3-5× compression in practice
+- **Sidecar file**: write to `.rmem.bins` (same pattern as
+  `.rmem.derived`) so the base rmem stays unchanged
+
+## B. compare deltas
+
+### B.1 Type Breakdown delta
+
+The information already exists in analyze output but is not surfaced
+by compare. Join the two `Type Breakdown` maps, compute deltas, sort
+by absolute delta, print top N.
+
+When the join produces all-zero deltas, **emit the row anyway** with
+an explicit note `(no typed allocation grew)` — that is the signal
+that the leak is not in PHP-managed objects.
+
+### B.2 Region map delta
+
+Currently lost: rdump → rmem drops the region map. Two options:
+
+- (a) Preserve region map as rmem sidecar at analyze time
+- (b) Require both rdumps when comparing
+
+(a) is preferred — keeps the rmem-only workflow. Region maps are small
+(few hundred entries × 32 bytes), negligible cost.
+
+Compare output groups regions into:
+
+- **Added**: present in target, absent in baseline
+- **Grown**: same address, larger size
+- **Shrunk**: same address, smaller size
+- **Removed**: present in baseline, absent in target
+
+### B.3 Bin histogram delta
+
+Falls out of A. Top N bins by `|count_delta|`, with size annotation:
+
+```
+bin    size  baseline  target  delta
+─────────────────────────────────────
+bin_3  32 B   ...        ...    +16,041
+bin_8  192 B  567        567        0
+```
+
+### B.4 Unaccounted delta finding
+
+Synthetic finding triggered when:
+
+```
+heap_usage_delta > threshold AND sum(type_breakdown_delta) ≈ 0
+```
+
+(threshold ≈ 100 KiB or 1% of heap, whichever is smaller). Output:
+
+```
+[HIGH] Heap +Δ but typed delta = 0
+       Likely orphan / C-extension emalloc.
+       See: bin histogram delta, region map delta.
+```
+
+This is the signpost that takes the user to B.3 / B.2.
+
+## C. Detector pipeline
+
+### Interface
+
+```php
+interface AllocationDetector
+{
+    public function name(): string;
+
+    public function apply(Slot $slot, DetectorContext $ctx): ?Detection;
+}
+
+final class Detection
+{
+    public function __construct(
+        public readonly string $label,
+        public readonly Confidence $confidence, // LOW / MED / HIGH
+        public readonly array $fields,           // structured decoded fields
+        public readonly ?string $hexdumpExcerpt, // first ~64 bytes
+    ) {}
+}
+
+final class DetectorContext
+{
+    public function __construct(
+        public readonly SymbolMap $symbols,         // existing reli symbol map
+        public readonly MemoryReader $reader,       // can reach outside the slot
+        public readonly ReachableAddressSet $reachable,
+    ) {}
+}
+
+final class Slot
+{
+    public function __construct(
+        public readonly int $address,
+        public readonly int $size,
+        public readonly int $binId,
+        public readonly string $first64Bytes,
+    ) {}
+}
+```
+
+### Negative-evidence rule
+
+```php
+final class ReachabilityFilter
+{
+    /**
+     * Drop detections whose slot is reachable through the standard PHP
+     * roots (objects_store, function_table, class_table, symbol_table,
+     * interned_strings). Such allocations are not "orphan"; they are
+     * normal data that detector heuristics matched by accident.
+     */
+    public function isLikelyOrphan(Slot $slot): bool { ... }
+}
+```
+
+Run as the last step of the pipeline, before persisting Detection
+records. This single rule eliminates the largest class of false
+positives (function-pointer-bearing structs that look like leaked
+op_arrays but are actually live compiled bytecode).
+
+### Built-in detectors
+
+| Detector | Primary signal | Confidence |
+|---|---|---|
+| `FunctionPointerDetector` | 8-byte values that fall inside any loaded module's `.text`; resolved to symbol via `SymbolMap` | HIGH (when symbol resolves) |
+| `ZendStringDetector` | `gc + hash + len` at +0/+8/+16, NUL terminator at `+24+len` | HIGH |
+| `BucketDetector` | 32 B; +0..+15 looks like a `zval` (valid `type` byte 0..21); +16 looks like a hash; +24 → readable `zend_string` | HIGH |
+| `ZendOpDetector` | 32 B; first 8 B is an opcode-handler symbol (cluster of related `.text` addresses) | MED |
+| `StatDetector` | 144 B; `S_IFMT` set in mode; uid/gid reasonable; nlink ≥ 1; timestamps within ±50 years | HIGH |
+| `TimespecDetector` | `(sec, nsec<1e9)` pairs in sequence | LOW (use as evidence for higher detectors) |
+| `SockaddrDetector` | `sa_family` is an `AF_*` enum | HIGH |
+| `IovecDetector` | `(ptr, len)` pairs with valid pointers and reasonable lengths | MED |
+| `GlibcMallocChunkHeader` | `size_with_flags` low-3-bit pattern + `prev_size` consistency | MED |
+
+PHP / POSIX / glibc only in core. Extension-specific detectors
+(`uv_fs_t`, `curl_easy`, `xmlNode`, `pdo_stmt_dbh`, `event_t`, …) live
+in `src/Detector/Contrib/` and are auto-registered. Out-of-tree
+contributions can register their own via Composer autoloading.
+
+### Pipeline
+
+```
+slots from bin walker
+    ↓
+group by fingerprint (first 24 bytes)  ← run detectors once per group
+    ↓
+each detector applied → candidate Detections
+    ↓
+ReachabilityFilter drops reachable matches
+    ↓
+pick best per slot:
+    1. confidence: HIGH > MED > LOW
+    2. specificity: more specific type wins on tie
+    3. keep up to 3 candidates if all HIGH (multi-label)
+    ↓
+persist to rmem.detected_shapes
+```
+
+False-positive control is grounded in three principles:
+
+1. **Confidence visibility**: every Detection is rendered with its
+   confidence. No silent inference.
+2. **Hex always available**: the slot's first 64 bytes are kept in the
+   Detection so the user can sanity-check.
+3. **Reachability gate**: the negative-evidence filter is mandatory,
+   not optional.
+
+## D. Periodicity detection
+
+Implemented as a post-processing step on bin walker output, not a
+separate signal-processing pass:
+
+```
+for each bin:
+    for each chunk:
+        slots = ordered_by_addr(slots_in_bin_in_chunk)
+        groups = group_by(slots, key=fingerprint(slot.first_24_bytes))
+        for group:
+            stride = mode of consecutive slot.addr deltas
+            count  = len(group)
+            if count ≥ THRESHOLD:
+                emit PeriodicGroup(bin, fingerprint, count, stride)
+```
+
+The "stride 192, count 565" / "stride 32, count 16,000" patterns from
+the issue #88 investigation surface directly here. No FFT / autocorr
+needed; the bin walker already gives us enough structure.
+
+Surfaced in `memory:report` as a `Periodic groups` section.
+
+## E. Drill-down commands
+
+### `rmem:query --bin=N`
+
+Existing query gains:
+
+```
+rmem:query <file> --bin=N [--sample=K]
+```
+
+Lists all addresses in bin N. With `--sample=K`, prints the first K
+with hexdump.
+
+### `inspector:memory:peek` (new)
+
+Raw byte read from a live target or rdump:
+
+```
+inspector:memory:peek -p PID --address=0x... --length=256
+inspector:memory:peek --rdump=t2.rdump --address=0x... --length=256
+```
+
+Prints hexdump + ASCII. This is the bottom of the drill-down funnel
+when detectors don't quite reach a confident label.
+
+## Output integration
+
+### `inspector:memory:report` — new sections
+
+```
+=== Bin Histogram ===
+  bin   size    count   total
+  ─────────────────────────────
+  bin_3  32 B  23,041  720.0 KB
+  bin_8  192 B    567  106.3 KB
+  …
+
+=== Unclassified slots by inferred shape ===
+  size  count   fingerprint   inferred shape                   confidence
+  ──────────────────────────────────────────────────────────────────────
+  32 B  16,042  ab12cd…       Bucket(zval IS_STRING,           HIGH
+                              key→zend_string @0x…
+                              "…UvFile…poll")
+  192 B    234  00…0e24…      struct stat (mode 0644,          HIGH
+                              size 0, blksize 4096)
+  64 B    331   07310b…       orphan? (.text ptr but           MED
+                              not reachable)
+
+=== Periodic groups ===
+  bin     stride  count    fingerprint    sample addr
+  ──────────────────────────────────────────────────────
+  32 B       32  16,000   ab12cd…         0x7f…1145000
+  192 B     192     567   00…0e24…        0x7f…1578000
+```
+
+### `inspector:memory:compare` — additional deltas
+
+```
+=== Type Breakdown Delta ===
+  (no typed allocation grew)
+
+=== Region Map Delta ===
+  Added:
+    +728.0 KiB at 0x7f9b92200000
+
+=== Bin Histogram Delta ===
+  bin   size  baseline  target   delta
+  ────────────────────────────────────────
+  bin_3  32 B    7,000  23,041  +16,041
+  bin_8  192 B     567     567        0
+
+=== Findings ===
+  [HIGH] Heap +Δ but typed delta = 0 — likely orphan / C-extension
+         emalloc. See bin histogram delta and region map delta.
+```
+
+## Open questions
+
+1. **Bin walker cost on large heaps.** A multi-hundred-MiB ZendMM may
+   contain ~10M slots. Defaulting to histogram-only (no slot list)
+   avoids the worst case; `--include-orphans` flips the switch.
+2. **rmem size.** Address lists balloon `.rmem`. Recommendation:
+   write to `.rmem.bins` sidecar (same idiom as `.rmem.derived`) so
+   the base rmem is untouched and the sidecar can be regenerated.
+3. **Best-detection selection rule.** Confidence-first or
+   specificity-first? Tentative: confidence-first — bias toward fewer
+   wrong labels at the cost of occasional generic ones.
+4. **PHP version coverage.** ZendMM layout is stable across 7.x / 8.x
+   in shape but the chunk-map encoding macros differ. Branch via
+   `PhpVersionDetector` (already used elsewhere). FrankenPHP-style
+   embedded SAPIs are also in scope (see CLAUDE.md notes on libphp
+   preemption).
+5. **Detector plugin packaging.** Composer package or in-tree
+   `src/Detector/Contrib/`? Tentative: in-tree to start; Composer
+   discovery later if external authors need it.
+
+## Phasing
+
+### Phase 1 — collapse 80% of the manual workflow
+
+- A.1 ZendMM bin walker (histogram + slot list, opt-in)
+- B.1 Type Breakdown delta in compare
+- B.2 Region map delta in compare (with rmem sidecar)
+- D Periodicity detection on bin walker output
+
+After Phase 1: today's manual workflow ("two `dump:inspect` runs +
+sort + comm + od") collapses to a single `compare` invocation that
+prints the right-shaped output, but the user still has to interpret
+the bytes.
+
+### Phase 2 — automate culprit identification
+
+- A.2 Promote unclassified slots to `UnclassifiedAllocation` virtual
+  nodes in rmem (lets the existing compare node-diff path see them)
+- B.3 Bin histogram delta in compare
+- B.4 "Heap +Δ, typed delta=0" finding
+- C.1 `FunctionPointerDetector` + `ReachabilityFilter`
+- C.2 `ZendStringDetector` / `BucketDetector` / `ZendOpDetector`
+- E.2 `inspector:memory:peek`
+
+After Phase 2: the issue #88 investigation outputs
+`bin[32B] +16,000 BucketDetector → key="…UvFile…poll"` directly,
+which is the actual conclusion of the manual session.
+
+### Phase 3 — generality
+
+- C.3 POSIX / glibc detectors (`StatDetector`, `SockaddrDetector`,
+  `IovecDetector`, `TimespecDetector`, `GlibcMallocChunkHeader`)
+- E.1 `rmem:query --bin`
+- Detector plugin registry (in-tree contrib + autoloading)
+- Extension-specific detectors as contrib (`uv_fs_t`, `curl_easy`,
+  libxml node, …)
+
+## Validation
+
+amphp/file issue #88 becomes the regression test for Phases 1-2:
+
+- Add `tests/Regression/AmphpFileIssue88Test.php` (group:
+  `target-version`, requires ext-uv).
+- Test fixture: scripted daemon, baseline + post-load dumps captured
+  with `inspector:memory:dump`.
+- Assertions:
+  - Phase 1: compare output contains a non-zero `bin[32 B]` delta
+    and the "heap grew but typed delta = 0" finding.
+  - Phase 2: compare output contains
+    `BucketDetector ... key contains "UvFile"` for the leaked bin.
+
+If a future change to detectors / walker / compare breaks the issue
+#88 chain, this test fails loudly with a recognizable diff.

--- a/docs/internals/design-orphan-allocation-analysis.md
+++ b/docs/internals/design-orphan-allocation-analysis.md
@@ -424,6 +424,27 @@ when detectors don't quite reach a confident label.
 1. **Bin walker cost on large heaps.** ~10M slots for hundreds of MiB
    of ZendMM is acceptable; the walker always runs and always emits
    the full slot list. Compression is a future knob, not a v1 concern.
+
+   **Empirical overhead** (PHP 8.4, sandbox, 5-run mean of
+   `inspector:memory:analyze` on synthetic targets):
+
+   | target | walker OFF | walker ON | Δ wall | Δ rmem |
+   |---|---|---|---|---|
+   | 23 MB heap, 90K alloc | 10.00 s | 11.68 s | **+16.8 %** | +0.7 % |
+   | 232 MB heap, 900K alloc | 99.22 s | 116.39 s | **+17.3 %** | +0.07 % |
+
+   Linear scaling, ~17 % wall-time across both target sizes. rmem
+   size delta is essentially noise (per-(bin, label) sample address
+   list capped at 256, so total bounded by shape cardinality, not by
+   slot count).
+
+   **Default-on with `--no-bin-walk` opt-out.** The orphan-allocation
+   features are the whole point of the pipeline; default-off would
+   just hide them. The 17 % surcharge is acceptable for a
+   once-per-investigation analyze; users with very large dumps who
+   don't need the orphan path can pass `--no-bin-walk` to
+   `inspector:memory:analyze` to skip it.
+
 2. **rmem size.** Slot lists land directly in rmem alongside
    `bin_histogram`. No sidecar file; rmem already sits in the same
    order of magnitude for non-trivial captures.

--- a/docs/internals/design-orphan-allocation-analysis.md
+++ b/docs/internals/design-orphan-allocation-analysis.md
@@ -129,24 +129,28 @@ The `zendmm_heap_fragmentation_high` finding already walks `chunk->map`
 to compute free-page space. The new walker is the same traversal with
 slot-level emission added; both should share the underlying iterator.
 
-### Outputs (rmem sidecar)
+### Outputs (rmem)
+
+Both stored directly in rmem, always populated (no opt-in):
 
 - `bin_histogram`: `{ bin_id → { count, total_bytes } }`
 - `bin_slots`: `{ bin_id → address[] }` (drill-down)
 
 ### Sizing
 
-Worst case for a daemon with hundreds of MiB ZendMM: ~10M slots,
-80 MiB raw uint64 list. Mitigations:
+Worst case for a daemon with hundreds of MiB ZendMM is on the order
+of 10M slots × 8 B = ~80 MiB raw uint64 list. Acceptable to land in
+rmem as-is; rmem is already in this size range for non-trivial
+captures.
 
-- **Default**: histogram only; `bin_slots` populated only for bins
-  with `count ≥ threshold` or `size ≤ N` (cheap-to-store sizes)
-- **Opt-in**: `--include-orphans` for full slot lists
-- **Storage**: vbyte / delta-encode addresses inside a chunk
-  (consecutive slots in a small run differ by a constant) —
-  3-5× compression in practice
-- **Sidecar file**: write to `.rmem.bins` (same pattern as
-  `.rmem.derived`) so the base rmem stays unchanged
+Compression knobs available if needed later:
+
+- vbyte / delta-encode addresses inside a chunk (consecutive slots in
+  a small run differ by a constant) — 3-5× in practice
+- Skip per-bin slot lists for bins below a threshold count, keeping
+  histogram only
+
+Default is no compression; revisit if profiling shows a real problem.
 
 ## B. compare deltas
 
@@ -282,10 +286,11 @@ op_arrays but are actually live compiled bytecode).
 | `IovecDetector` | `(ptr, len)` pairs with valid pointers and reasonable lengths | MED |
 | `GlibcMallocChunkHeader` | `size_with_flags` low-3-bit pattern + `prev_size` consistency | MED |
 
-PHP / POSIX / glibc only in core. Extension-specific detectors
-(`uv_fs_t`, `curl_easy`, `xmlNode`, `pdo_stmt_dbh`, `event_t`, …) live
-in `src/Detector/Contrib/` and are auto-registered. Out-of-tree
-contributions can register their own via Composer autoloading.
+PHP / POSIX / glibc only in core, registered statically. Extension-
+specific detectors (`uv_fs_t`, `curl_easy`, `xmlNode`, `pdo_stmt_dbh`,
+`event_t`, …) are out of scope for the initial implementation; the
+packaging story (in-tree contrib vs. Composer-discovered plugin) is
+deferred until external authors need it.
 
 ### Pipeline
 
@@ -414,25 +419,28 @@ when detectors don't quite reach a confident label.
          emalloc. See bin histogram delta and region map delta.
 ```
 
-## Open questions
+## Decisions
 
-1. **Bin walker cost on large heaps.** A multi-hundred-MiB ZendMM may
-   contain ~10M slots. Defaulting to histogram-only (no slot list)
-   avoids the worst case; `--include-orphans` flips the switch.
-2. **rmem size.** Address lists balloon `.rmem`. Recommendation:
-   write to `.rmem.bins` sidecar (same idiom as `.rmem.derived`) so
-   the base rmem is untouched and the sidecar can be regenerated.
-3. **Best-detection selection rule.** Confidence-first or
-   specificity-first? Tentative: confidence-first — bias toward fewer
-   wrong labels at the cost of occasional generic ones.
+1. **Bin walker cost on large heaps.** ~10M slots for hundreds of MiB
+   of ZendMM is acceptable; the walker always runs and always emits
+   the full slot list. Compression is a future knob, not a v1 concern.
+2. **rmem size.** Slot lists land directly in rmem alongside
+   `bin_histogram`. No sidecar file; rmem already sits in the same
+   order of magnitude for non-trivial captures.
+3. **Best-detection selection rule.** Confidence-first, then
+   specificity on tie. Bias toward fewer wrong labels at the cost of
+   occasional generic ones.
 4. **PHP version coverage.** ZendMM layout is stable across 7.x / 8.x
    in shape but the chunk-map encoding macros differ. Branch via
    `PhpVersionDetector` (already used elsewhere). FrankenPHP-style
-   embedded SAPIs are also in scope (see CLAUDE.md notes on libphp
+   embedded SAPIs are in scope (see CLAUDE.md notes on libphp
    preemption).
-5. **Detector plugin packaging.** Composer package or in-tree
-   `src/Detector/Contrib/`? Tentative: in-tree to start; Composer
-   discovery later if external authors need it.
+
+## Deferred
+
+- **Detector plugin packaging.** In-tree contrib vs. Composer
+  discovery is left open; revisit when external authors actually
+  ask for it. For now built-in detectors are registered statically.
 
 ## Phasing
 
@@ -467,9 +475,9 @@ which is the actual conclusion of the manual session.
 - C.3 POSIX / glibc detectors (`StatDetector`, `SockaddrDetector`,
   `IovecDetector`, `TimespecDetector`, `GlibcMallocChunkHeader`)
 - E.1 `rmem:query --bin`
-- Detector plugin registry (in-tree contrib + autoloading)
-- Extension-specific detectors as contrib (`uv_fs_t`, `curl_easy`,
-  libxml node, …)
+
+Extension-specific detectors and the plugin packaging question are
+deferred until there is real demand.
 
 ## Validation
 

--- a/src/Command/Inspector/MemoryAnalyzeCommand.php
+++ b/src/Command/Inspector/MemoryAnalyzeCommand.php
@@ -74,6 +74,15 @@ final class MemoryAnalyzeCommand extends ReliCommand
             InputOption::VALUE_NONE,
             'disable the offset-table fast path (use FFI path for all reads)',
         );
+        $this->addOption(
+            'no-bin-walk',
+            null,
+            InputOption::VALUE_NONE,
+            'skip the ZendMM bin walker (orphan-allocation analysis:'
+                . ' per-bin histogram, periodic groups, shape detectors,'
+                . ' region map). Reclaims ~17% wall-time on heaps where'
+                . ' the orphan-allocation features aren\'t needed.',
+        );
     }
 
     #[\Override]
@@ -100,11 +109,13 @@ final class MemoryAnalyzeCommand extends ReliCommand
 
         $read_buffer_size = self::parseByteSize((string) $input->getOption('read-buffer'));
         $no_fast_path = (bool) $input->getOption('no-fast-path');
+        $no_bin_walk = (bool) $input->getOption('no-bin-walk');
         $dump_reader = $this->memory_dump_reader_factory->createFromPath(
             $dump_file,
             $path_mapping,
             $read_buffer_size,
             $no_fast_path,
+            $no_bin_walk,
         );
         $dump_reader->read($memory_profiler_settings);
 

--- a/src/Command/Inspector/MemoryBinQueryCommand.php
+++ b/src/Command/Inspector/MemoryBinQueryCommand.php
@@ -1,0 +1,325 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
+use Reli\Inspector\Output\MemoryOutput\Comparison\BinShapeCountsSnapshot;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Drill-down query for the bin walker output persisted in an rmem file.
+ *
+ * `inspector:memory:bin-query <rmem> --bin=N [--shape=...] [--sample=K]`
+ *
+ * Lists sample addresses the bin walker captured for the given bin
+ * (and optionally a single shape label). Pipes naturally into
+ * `inspector:memory:peek --rdump=...` for byte-level inspection — this
+ * is the design's E.1 deliverable + the validator-flagged drill-down
+ * gap that left them hand-poking `/proc/<pid>/mem` to look at more
+ * than one slot.
+ *
+ * Sample addresses are capped per (bin, shape) at analyze time
+ * (see {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker::PER_SHAPE_SAMPLE_CAP}),
+ * so this command never returns more than that cap regardless of how
+ * many slots the bin actually held.
+ */
+final class MemoryBinQueryCommand extends ReliCommand
+{
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('inspector:memory:bin-query')
+            ->setDescription(
+                'list sample slot addresses captured by the bin walker'
+                . ' for a given ZendMM bin'
+            )
+        ;
+        $this->addArgument(
+            'rmem-file',
+            InputArgument::REQUIRED,
+            'path to an rmem file produced by inspector:memory:analyze',
+        );
+        $this->addOption(
+            'bin',
+            'b',
+            InputOption::VALUE_REQUIRED,
+            'bin number (0..29). Pass --list-bins to see what is available.',
+        );
+        $this->addOption(
+            'shape',
+            's',
+            InputOption::VALUE_REQUIRED,
+            'restrict to a single inferred shape label'
+                . ' (e.g. "Bucket(zval IS_STRING)")',
+        );
+        $this->addOption(
+            'sample',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'maximum number of sample addresses to print (default 16)',
+            '16',
+        );
+        $this->addOption(
+            'list-bins',
+            null,
+            InputOption::VALUE_NONE,
+            'list every bin that has captured samples and exit',
+        );
+        $this->addMemoryLimitOption();
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->applyMemoryLimit($input, $output);
+
+        /** @var string $rmem_file */
+        $rmem_file = $input->getArgument('rmem-file');
+
+        $snapshot = $this->loadShapeCounts($rmem_file);
+        if ($snapshot === null || $snapshot === []) {
+            $output->writeln(
+                '<error>no bin_shape_counts entry found in this rmem file</error>',
+            );
+            $output->writeln(
+                '  (was it produced before the per-slot scan landed?'
+                . ' re-run inspector:memory:analyze on a fresh rdump.)',
+            );
+            return 1;
+        }
+
+        if ((bool)$input->getOption('list-bins')) {
+            $this->listBins($output, $snapshot);
+            return 0;
+        }
+
+        $bin_opt = $input->getOption('bin');
+        if ($bin_opt === null || $bin_opt === '') {
+            $output->writeln(
+                '<error>--bin is required (or pass --list-bins)</error>',
+            );
+            return 1;
+        }
+        $bin = (int)$bin_opt;
+        if (!isset($snapshot[$bin])) {
+            $output->writeln(sprintf(
+                '<error>no captures for bin %d in this rmem file</error>',
+                $bin,
+            ));
+            return 1;
+        }
+
+        $shape_filter = $input->getOption('shape');
+        $shape_filter = is_string($shape_filter) && $shape_filter !== ''
+            ? $shape_filter
+            : null;
+
+        $sample_opt = $input->getOption('sample');
+        $sample_cap = is_string($sample_opt) || is_int($sample_opt)
+            ? max(1, (int)$sample_opt)
+            : 16;
+
+        $this->dumpBin(
+            $output,
+            $bin,
+            $snapshot[$bin],
+            $shape_filter,
+            $sample_cap,
+        );
+        return 0;
+    }
+
+    /**
+     * @return array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string,
+     *     sample_addrs: list<int>
+     * }>>|null
+     */
+    private function loadShapeCounts(string $rmem_file): ?array
+    {
+        if (!is_readable($rmem_file)) {
+            throw new \RuntimeException("rmem file not readable: {$rmem_file}");
+        }
+        $reader = BinaryReader::open($rmem_file);
+        if (!$reader->hasSection(Format::SECTION_SUMMARY)) {
+            return null;
+        }
+        $data = $reader->getSectionData(Format::SECTION_SUMMARY);
+        $dict = $reader->getStringDict();
+
+        $offset = 0;
+        /** @var array{1: int} $cnt */
+        $cnt = unpack('V', $data, $offset);
+        $entry_count = $cnt[1];
+        $offset += 4;
+
+        for ($i = 0; $i < $entry_count; $i++) {
+            /** @var array{1: int} $kid */
+            $kid = unpack('V', $data, $offset);
+            $offset += 4;
+            /** @var array{1: int} $vid */
+            $vid = unpack('V', $data, $offset);
+            $offset += 4;
+
+            $key = $dict->lookup($kid[1]);
+            if ($key !== 'bin_shape_counts') {
+                continue;
+            }
+            $value = $dict->lookup($vid[1]);
+            if (!is_string($value) || $value === '') {
+                return null;
+            }
+            return BinShapeCountsSnapshot::decode($value);
+        }
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string,
+     *     sample_addrs: list<int>
+     * }>> $snapshot
+     */
+    private function listBins(OutputInterface $output, array $snapshot): void
+    {
+        $output->writeln('<info>Bins with captured samples:</info>');
+        $output->writeln('');
+        $output->writeln(sprintf(
+            '  %3s  %8s  %s',
+            'Bin',
+            'Size',
+            'Shapes (count)',
+        ));
+        $output->writeln('  ' . str_repeat('-', 70));
+        $bins = array_keys($snapshot);
+        sort($bins);
+        foreach ($bins as $bin) {
+            $shapes = $snapshot[$bin];
+            $size = ZendMmBinsInfo::getSize($bin);
+            $shape_summary = [];
+            foreach ($shapes as $label => $row) {
+                $shape_summary[] = sprintf('%s(%d)', $label, $row['count']);
+            }
+            // Cap rendered shape list to keep the line readable.
+            $shown = array_slice($shape_summary, 0, 3);
+            $extra = count($shape_summary) - count($shown);
+            $line = implode(', ', $shown);
+            if ($extra > 0) {
+                $line .= sprintf(', … %d more', $extra);
+            }
+            $output->writeln(sprintf(
+                '  %3d  %5d B  %s',
+                $bin,
+                $size,
+                $line,
+            ));
+        }
+    }
+
+    /**
+     * @param array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string,
+     *     sample_addrs: list<int>
+     * }> $bin_data
+     */
+    private function dumpBin(
+        OutputInterface $output,
+        int $bin,
+        array $bin_data,
+        ?string $shape_filter,
+        int $sample_cap,
+    ): void {
+        $size = ZendMmBinsInfo::getSize($bin);
+        $output->writeln(sprintf(
+            '<info>bin[%d] %d B  (%d shapes captured)</info>',
+            $bin,
+            $size,
+            count($bin_data),
+        ));
+        $output->writeln('');
+
+        $shown_any = false;
+        foreach ($bin_data as $label => $row) {
+            if ($shape_filter !== null && $label !== $shape_filter) {
+                continue;
+            }
+            $shown_any = true;
+            $orphan = $row['count'] - $row['reachable_count'];
+            $output->writeln(sprintf(
+                '  %s  [%s]  count=%d  orphan=%d  reachable=%d',
+                $label,
+                strtoupper($row['confidence']),
+                $row['count'],
+                $orphan,
+                $row['reachable_count'],
+            ));
+            $samples = $row['sample_addrs'];
+            if ($samples === []) {
+                $output->writeln(
+                    '    (no sample addresses persisted for this shape)',
+                );
+                continue;
+            }
+            $cap = min($sample_cap, count($samples));
+            for ($i = 0; $i < $cap; $i++) {
+                $output->writeln(sprintf('    0x%016x', $samples[$i]));
+            }
+            $remaining = count($samples) - $cap;
+            if ($remaining > 0) {
+                $output->writeln(sprintf(
+                    '    … %d more sample address%s available'
+                        . ' (raise --sample to see them)',
+                    $remaining,
+                    $remaining === 1 ? '' : 'es',
+                ));
+            }
+            $output->writeln('');
+        }
+
+        if (!$shown_any) {
+            $output->writeln(sprintf(
+                '<error>no shape "%s" in bin[%d]</error>',
+                $shape_filter ?? '(none)',
+                $bin,
+            ));
+        }
+    }
+}

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -264,6 +264,8 @@ final class MemoryCommand extends ReliCommand
                     'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
                     'bin_walk_periodic_groups'
                         => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                    'bin_shape_counts'
+                        => $collected_memories->bin_walk_result->toSummaryShapeCountsArray(),
                 ]
                 : []
             )

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -259,6 +259,14 @@ final class MemoryCommand extends ReliCommand
                 'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
                 'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
             ]
+            + ($collected_memories->bin_walk_result !== null
+                ? [
+                    'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
+                    'bin_walk_periodic_groups'
+                        => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                ]
+                : []
+            )
             + [
                 'heap_memory_analyzed_percentage' =>
                     (float)$summary_base['zend_mm_heap_usage']

--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -267,6 +267,7 @@ final class MemoryCommand extends ReliCommand
                 ]
                 : []
             )
+            + ['region_map' => $collected_memories->getRegionMap()->toSummaryArray()]
             + [
                 'heap_memory_analyzed_percentage' =>
                     (float)$summary_base['zend_mm_heap_usage']

--- a/src/Command/Inspector/MemoryPeekCommand.php
+++ b/src/Command/Inspector/MemoryPeekCommand.php
@@ -1,0 +1,379 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use FFI;
+use Reli\Command\DockerProfile;
+use Reli\Command\ReliCommand;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Raw byte read from a live target or rdump file.
+ *
+ * The bottom of the orphan-allocation drill-down funnel (design doc
+ * section E.2): when {@see BinHistogramPass} surfaces "+16,041 bin[32 B]"
+ * but the detector pipeline can't earn a HIGH-confidence label, the user
+ * peeks the sample address and decodes the bytes by hand. Replaces the
+ * `dd if=/proc/<pid>/mem | od -A x -t x1z` recipe with a self-contained
+ * command that also works against rdump files for offline analysis.
+ */
+final class MemoryPeekCommand extends ReliCommand
+{
+    /** Hard cap on read length to prevent runaway dumps. */
+    private const MAX_LENGTH = 64 * 1024;
+
+    private const RDUMP_MAGIC = "RDUMP\0\0\0";
+
+    #[\Override]
+    public static function getDockerProfile(): DockerProfile
+    {
+        return DockerProfile::Minimal;
+    }
+
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    public function configure(): void
+    {
+        $this->setName('inspector:memory:peek')
+            ->setDescription(
+                'read raw bytes from a live target process or rdump file'
+                . ' and print as hexdump'
+            )
+        ;
+        $this->addOption(
+            'pid',
+            'p',
+            InputOption::VALUE_REQUIRED,
+            'PID of the live target process',
+        );
+        $this->addOption(
+            'rdump',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'path to an rdump file to read from instead of a live target',
+        );
+        $this->addOption(
+            'address',
+            'a',
+            InputOption::VALUE_REQUIRED,
+            'remote address to read from (hex 0x... or decimal)',
+        );
+        $this->addOption(
+            'length',
+            'l',
+            InputOption::VALUE_REQUIRED,
+            sprintf(
+                'number of bytes to read (default 256, max %d)',
+                self::MAX_LENGTH,
+            ),
+            '256',
+        );
+        $this->addMemoryLimitOption();
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    #[\Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->applyMemoryLimit($input, $output);
+
+        $pid_opt = $input->getOption('pid');
+        $rdump_opt = $input->getOption('rdump');
+        if (
+            ($pid_opt === null && $rdump_opt === null)
+            || ($pid_opt !== null && $rdump_opt !== null)
+        ) {
+            $output->writeln(
+                '<error>exactly one of --pid or --rdump must be supplied</error>',
+            );
+            return 1;
+        }
+
+        $address_opt = $input->getOption('address');
+        if (!is_string($address_opt) || $address_opt === '') {
+            $output->writeln('<error>--address is required</error>');
+            return 1;
+        }
+        $address = $this->parseAddress($address_opt);
+        if ($address === null) {
+            $output->writeln(
+                "<error>could not parse address: {$address_opt}</error>",
+            );
+            return 1;
+        }
+
+        $length_opt = $input->getOption('length');
+        $length = is_string($length_opt) || is_int($length_opt)
+            ? (int)$length_opt
+            : 256;
+        if ($length <= 0) {
+            $output->writeln('<error>--length must be positive</error>');
+            return 1;
+        }
+        if ($length > self::MAX_LENGTH) {
+            $output->writeln(sprintf(
+                '<error>--length capped at %d bytes</error>',
+                self::MAX_LENGTH,
+            ));
+            return 1;
+        }
+
+        try {
+            $bytes = $pid_opt !== null
+                ? $this->readFromLive((int)$pid_opt, $address, $length)
+                : $this->readFromRdump((string)$rdump_opt, $address, $length);
+        } catch (\Throwable $e) {
+            $output->writeln(
+                "<error>read failed: {$e->getMessage()}</error>",
+            );
+            return 1;
+        }
+
+        $output->writeln(sprintf(
+            '<info>%d bytes from 0x%x</info>',
+            strlen($bytes),
+            $address,
+        ));
+        $output->writeln('');
+        $output->write($this->hexdump($bytes, $address));
+        return 0;
+    }
+
+    private function parseAddress(string $raw): ?int
+    {
+        $raw = trim($raw);
+        if (str_starts_with($raw, '0x') || str_starts_with($raw, '0X')) {
+            $hex = substr($raw, 2);
+            if ($hex === '' || !ctype_xdigit($hex)) {
+                return null;
+            }
+            return (int)hexdec($hex);
+        }
+        if (!ctype_digit($raw)) {
+            return null;
+        }
+        return (int)$raw;
+    }
+
+    private function readFromLive(int $pid, int $address, int $length): string
+    {
+        $cdata = $this->memory_reader->read($pid, $address, $length);
+        return FFI::string($cdata, $length);
+    }
+
+    private function readFromRdump(string $path, int $address, int $length): string
+    {
+        $fp = @fopen($path, 'rb');
+        if ($fp === false) {
+            throw new \RuntimeException("failed to open rdump file: {$path}");
+        }
+        try {
+            return $this->readSliceFromRdump($fp, $address, $length);
+        } finally {
+            fclose($fp);
+        }
+    }
+
+    /**
+     * Walk the rdump's regions (no data load) and read the slice
+     * intersecting the requested range. Supports cross-region reads by
+     * concatenating slices in order. Reads stop at the first gap; the
+     * caller sees whatever was reachable.
+     *
+     * @param resource $fp
+     */
+    private function readSliceFromRdump($fp, int $address, int $length): string
+    {
+        $magic = fread($fp, 8);
+        if ($magic !== self::RDUMP_MAGIC) {
+            throw new \RuntimeException('not an rdump file');
+        }
+        $version = $this->readUint32($fp);
+        if ($version !== 1 && $version !== 2) {
+            throw new \RuntimeException(
+                "unsupported rdump format version: {$version}",
+            );
+        }
+        // Header tail: php_version, pid, eg_address, cg_address,
+        // (rss_bytes if v2), memory_map_count, region_count.
+        $this->readString($fp);
+        fseek($fp, 8 * 3, SEEK_CUR);
+        if ($version >= 2) {
+            fseek($fp, 8, SEEK_CUR);
+        }
+        $memory_map_count = $this->readUint32($fp);
+        $region_count = $this->readUint32($fp);
+
+        // Skip the memory-map section — we only need the regions.
+        for ($i = 0; $i < $memory_map_count; $i++) {
+            $this->readString($fp); // begin
+            $this->readString($fp); // end
+            $this->readString($fp); // file_offset
+            fseek($fp, 4, SEEK_CUR); // attribute bytes
+            $this->readString($fp); // device_id
+            fseek($fp, 8, SEEK_CUR); // inode
+            $this->readString($fp); // name
+        }
+
+        // Region table walk: for each region, decide what slice (if any)
+        // intersects [address, address+length). Read just that slice.
+        $end = $address + $length;
+        /** @var list<array{addr: int, slice: string}> $hits */
+        $hits = [];
+        for ($i = 0; $i < $region_count; $i++) {
+            $region_addr = $this->readInt64($fp);
+            $region_size = $this->readInt64($fp);
+            $region_end = $region_addr + $region_size;
+            $data_offset = ftell($fp);
+            if ($data_offset === false) {
+                throw new \RuntimeException('ftell failed');
+            }
+
+            $overlap_start = max($region_addr, $address);
+            $overlap_end = min($region_end, $end);
+            if ($overlap_start < $overlap_end) {
+                $slice_offset = $overlap_start - $region_addr;
+                $slice_len = $overlap_end - $overlap_start;
+                if (fseek($fp, $data_offset + $slice_offset, SEEK_SET) !== 0) {
+                    throw new \RuntimeException('seek into region data failed');
+                }
+                $slice = fread($fp, $slice_len);
+                if ($slice === false || strlen($slice) !== $slice_len) {
+                    throw new \RuntimeException(
+                        "failed to read {$slice_len} bytes at region offset {$slice_offset}",
+                    );
+                }
+                $hits[] = ['addr' => $overlap_start, 'slice' => $slice];
+            }
+
+            // Advance past the region's data block so the next iteration
+            // is positioned at the next region header.
+            if (fseek($fp, $data_offset + $region_size, SEEK_SET) !== 0) {
+                throw new \RuntimeException('seek past region data failed');
+            }
+        }
+
+        if ($hits === []) {
+            throw new \RuntimeException(sprintf(
+                'address 0x%x is not covered by any region in this rdump',
+                $address,
+            ));
+        }
+
+        usort(
+            $hits,
+            static fn(array $a, array $b): int => $a['addr'] <=> $b['addr'],
+        );
+
+        // Stitch slices in address order; bail at the first gap so we
+        // don't quietly fabricate non-contiguous bytes.
+        $expected = $hits[0]['addr'];
+        $out = '';
+        foreach ($hits as $hit) {
+            if ($hit['addr'] !== $expected) {
+                break;
+            }
+            $out .= $hit['slice'];
+            $expected = $hit['addr'] + strlen($hit['slice']);
+        }
+        return $out;
+    }
+
+    /**
+     * Render bytes as a 16-byte-per-line hexdump with address column +
+     * ASCII gutter. Mirrors `od -A x -t x1z` shape so users coming from
+     * the manual workflow read the output without relearning anything.
+     */
+    private function hexdump(string $bytes, int $base_addr): string
+    {
+        $out = '';
+        $len = strlen($bytes);
+        for ($i = 0; $i < $len; $i += 16) {
+            $row = substr($bytes, $i, 16);
+            $hex_parts = [];
+            $ascii = '';
+            $row_len = strlen($row);
+            for ($j = 0; $j < 16; $j++) {
+                if ($j < $row_len) {
+                    $byte = ord($row[$j]);
+                    $hex_parts[] = sprintf('%02x', $byte);
+                    $ascii .= ($byte >= 0x20 && $byte < 0x7f)
+                        ? chr($byte)
+                        : '.';
+                } else {
+                    $hex_parts[] = '  ';
+                    $ascii .= ' ';
+                }
+                if ($j === 7) {
+                    $hex_parts[] = '';
+                }
+            }
+            $out .= sprintf(
+                "%016x  %s  |%s|\n",
+                $base_addr + $i,
+                implode(' ', $hex_parts),
+                $ascii,
+            );
+        }
+        return $out;
+    }
+
+    /** @param resource $fp */
+    private function readUint32($fp): int
+    {
+        $data = fread($fp, 4);
+        if ($data === false || strlen($data) !== 4) {
+            throw new \RuntimeException('failed to read uint32');
+        }
+        /** @var array{val: int} $result */
+        $result = unpack('Vval', $data);
+        return $result['val'];
+    }
+
+    /** @param resource $fp */
+    private function readInt64($fp): int
+    {
+        $data = fread($fp, 8);
+        if ($data === false || strlen($data) !== 8) {
+            throw new \RuntimeException('failed to read int64');
+        }
+        /** @var array{val: int} $result */
+        $result = unpack('Pval', $data);
+        return $result['val'];
+    }
+
+    /** @param resource $fp */
+    private function readString($fp): string
+    {
+        $len = $this->readUint32($fp);
+        if ($len === 0) {
+            return '';
+        }
+        $data = fread($fp, $len);
+        if ($data === false || strlen($data) !== $len) {
+            throw new \RuntimeException("failed to read string of length {$len}");
+        }
+        return $data;
+    }
+}

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -274,6 +274,8 @@ final class CoreDumpReader
                     'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
                     'bin_walk_periodic_groups'
                         => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                    'bin_shape_counts'
+                        => $collected_memories->bin_walk_result->toSummaryShapeCountsArray(),
                 ]
                 : []
             )

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -277,6 +277,7 @@ final class CoreDumpReader
                 ]
                 : []
             )
+            + ['region_map' => $collected_memories->getRegionMap()->toSummaryArray()]
             + [
                 'heap_memory_analyzed_percentage' =>
                     (float)$summary_base['zend_mm_heap_usage']

--- a/src/Inspector/CoreDumpReader/CoreDumpReader.php
+++ b/src/Inspector/CoreDumpReader/CoreDumpReader.php
@@ -269,6 +269,14 @@ final class CoreDumpReader
                 'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
                 'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
             ]
+            + ($collected_memories->bin_walk_result !== null
+                ? [
+                    'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
+                    'bin_walk_periodic_groups'
+                        => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                ]
+                : []
+            )
             + [
                 'heap_memory_analyzed_percentage' =>
                     (float)$summary_base['zend_mm_heap_usage']

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -241,6 +241,7 @@ final class MemoryDumpReader
                 ]
                 : []
             )
+            + ['region_map' => $collected_memories->getRegionMap()->toSummaryArray()]
             + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
             + [
                 'heap_memory_analyzed_percentage' =>

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -39,6 +39,7 @@ final class MemoryDumpReader
         private ?int $bg_address = null,
         private ?int $rss_bytes = null,
         private ?FastPathReader $fast_path = null,
+        private bool $disable_bin_walk = false,
     ) {
     }
 
@@ -77,6 +78,7 @@ final class MemoryDumpReader
                 $this->bg_address,
                 $sink,
                 $this->fast_path,
+                $this->disable_bin_walk,
             );
 
             $region_boundaries = new RegionBoundaries(
@@ -166,6 +168,7 @@ final class MemoryDumpReader
             $this->bg_address,
             $sink,
             $this->fast_path,
+            $this->disable_bin_walk,
         );
 
         // RegionBoundaries is already set on the sink by collectAll()

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -238,6 +238,8 @@ final class MemoryDumpReader
                     'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
                     'bin_walk_periodic_groups'
                         => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                    'bin_shape_counts'
+                        => $collected_memories->bin_walk_result->toSummaryShapeCountsArray(),
                 ]
                 : []
             )

--- a/src/Inspector/MemoryDump/MemoryDumpReader.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReader.php
@@ -231,6 +231,16 @@ final class MemoryDumpReader
                 'chunks_total_free_bytes' => $collected_memories->chunks_total_free_bytes,
                 'chunks_mostly_empty_count' => $collected_memories->chunks_mostly_empty_count,
             ]
+            + ($collected_memories->bin_walk_result !== null
+                ? [
+                    // Non-scalar values are JSON-encoded by the summary
+                    // writer (PDO + binary paths both call json_encode).
+                    'bin_walk' => $collected_memories->bin_walk_result->toSummaryHistogramArray(),
+                    'bin_walk_periodic_groups'
+                        => $collected_memories->bin_walk_result->toSummaryPeriodicGroupsArray(),
+                ]
+                : []
+            )
             + ($rss_bytes !== null ? ['rss' => $rss_bytes] : [])
             + [
                 'heap_memory_analyzed_percentage' =>

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -47,6 +47,7 @@ final class MemoryDumpReaderFactory
         array $path_mapping,
         int $read_buffer_size = 256 * 1024,
         bool $disable_fast_path = false,
+        bool $disable_bin_walk = false,
     ): MemoryDumpReader {
         $fp = fopen($file_path, 'rb');
         if ($fp === false) {
@@ -118,6 +119,7 @@ final class MemoryDumpReaderFactory
             $parsed['cg_address'],
             rss_bytes: $parsed['rss_bytes'],
             fast_path: $fast_path,
+            disable_bin_walk: $disable_bin_walk,
         );
     }
 

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinDelta.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinDelta.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * Per-bin live-allocation delta between two snapshots.
+ *
+ * Materialised by {@see ComparisonGenerator::compareBinHistogram} from the
+ * `bin_walk` summary entry the analyze path writes (see
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker}).
+ *
+ * The big payoff for the user is "16,041 new 32-byte slots between
+ * baseline and target" landing as a single row instead of having to diff
+ * two `memory:dump:inspect` runs by hand.
+ */
+final class BinDelta
+{
+    public function __construct(
+        public readonly int $bin_num,
+        public readonly int $bin_size,
+        public readonly int $baseline_count,
+        public readonly int $target_count,
+        public readonly int $baseline_bytes,
+        public readonly int $target_bytes,
+        public readonly int $count_delta,
+        public readonly int $bytes_delta,
+    ) {
+    }
+
+    /** @return array<string, int> */
+    public function toArray(): array
+    {
+        return [
+            'bin_num' => $this->bin_num,
+            'bin_size' => $this->bin_size,
+            'baseline_count' => $this->baseline_count,
+            'target_count' => $this->target_count,
+            'baseline_bytes' => $this->baseline_bytes,
+            'target_bytes' => $this->target_bytes,
+            'count_delta' => $this->count_delta,
+            'bytes_delta' => $this->bytes_delta,
+        ];
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinHistogramSnapshot.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinHistogramSnapshot.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * Decode the JSON-serialised `bin_walk` summary entry written by
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult::toSummaryHistogramArray}.
+ *
+ * Lives here (and not in the BinWalk namespace) because it is purely a
+ * comparison-layer concern — analyze writes the raw payload, and only
+ * the comparison data providers need to round-trip it back into a typed
+ * structure.
+ */
+final class BinHistogramSnapshot
+{
+    /**
+     * @return array{
+     *     histogram: array<int, array{count: int, total_bytes: int}>,
+     *     large_run_count?: int,
+     *     large_run_bytes?: int,
+     *     live_small_slot_count?: int,
+     *     live_small_slot_bytes?: int,
+     *     walked_chunk_count?: int,
+     *     partial?: bool
+     * }|null
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess
+     */
+    public static function decode(string $json): ?array
+    {
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !isset($decoded['histogram']) || !is_array($decoded['histogram'])) {
+            return null;
+        }
+
+        /** @var array<int, array{count: int, total_bytes: int}> $histogram */
+        $histogram = [];
+        foreach ($decoded['histogram'] as $bin_num => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $histogram[(int)$bin_num] = [
+                'count' => (int)($row['count'] ?? 0),
+                'total_bytes' => (int)($row['total_bytes'] ?? 0),
+            ];
+        }
+        ksort($histogram);
+
+        $out = ['histogram' => $histogram];
+        foreach (
+            [
+                'large_run_count',
+                'large_run_bytes',
+                'live_small_slot_count',
+                'live_small_slot_bytes',
+                'walked_chunk_count',
+            ] as $key
+        ) {
+            if (isset($decoded[$key]) && is_scalar($decoded[$key])) {
+                $out[$key] = (int)$decoded[$key];
+            }
+        }
+        if (isset($decoded['partial'])) {
+            $out['partial'] = (bool)$decoded['partial'];
+        }
+        /**
+         * @var array{
+         *     histogram: array<int, array{count: int, total_bytes: int}>,
+         *     large_run_count?: int,
+         *     large_run_bytes?: int,
+         *     live_small_slot_count?: int,
+         *     live_small_slot_bytes?: int,
+         *     walked_chunk_count?: int,
+         *     partial?: bool
+         * } $out
+         */
+        return $out;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinShapeCountsSnapshot.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinShapeCountsSnapshot.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * Decode the JSON-serialised `bin_shape_counts` summary entry written by
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult::toSummaryShapeCountsArray}.
+ *
+ * Returns a flat map keyed by `bin_num => label => row` so the comparison
+ * generator can do a straight outer-join on (bin, shape) without having
+ * to walk a list-of-lists shape twice.
+ */
+final class BinShapeCountsSnapshot
+{
+    /**
+     * @return array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string
+     * }>>|null
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess
+     */
+    public static function decode(string $json): ?array
+    {
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !isset($decoded['bin']) || !is_array($decoded['bin'])) {
+            return null;
+        }
+        $out = [];
+        foreach ($decoded['bin'] as $bin_row) {
+            if (!is_array($bin_row) || !isset($bin_row['bin_num'], $bin_row['shapes'])) {
+                continue;
+            }
+            $bin_num = (int)$bin_row['bin_num'];
+            $shapes = is_array($bin_row['shapes']) ? $bin_row['shapes'] : [];
+            $by_label = [];
+            foreach ($shapes as $shape) {
+                if (!is_array($shape) || !isset($shape['label'])) {
+                    continue;
+                }
+                $label = (string)$shape['label'];
+                $by_label[$label] = [
+                    'count' => (int)($shape['count'] ?? 0),
+                    'reachable_count' => (int)($shape['reachable_count'] ?? 0),
+                    'confidence' => (string)($shape['confidence'] ?? 'medium'),
+                ];
+            }
+            $out[$bin_num] = $by_label;
+        }
+        return $out;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinShapeCountsSnapshot.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinShapeCountsSnapshot.php
@@ -27,7 +27,8 @@ final class BinShapeCountsSnapshot
      * @return array<int, array<string, array{
      *     count: int,
      *     reachable_count: int,
-     *     confidence: string
+     *     confidence: string,
+     *     sample_addrs: list<int>
      * }>>|null
      * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess
      */
@@ -50,10 +51,19 @@ final class BinShapeCountsSnapshot
                     continue;
                 }
                 $label = (string)$shape['label'];
+                $sample_addrs = [];
+                if (isset($shape['sample_addrs']) && is_array($shape['sample_addrs'])) {
+                    foreach ($shape['sample_addrs'] as $addr) {
+                        if (is_int($addr) || is_string($addr)) {
+                            $sample_addrs[] = (int)$addr;
+                        }
+                    }
+                }
                 $by_label[$label] = [
                     'count' => (int)($shape['count'] ?? 0),
                     'reachable_count' => (int)($shape['reachable_count'] ?? 0),
                     'confidence' => (string)($shape['confidence'] ?? 'medium'),
+                    'sample_addrs' => $sample_addrs,
                 ];
             }
             $out[$bin_num] = $by_label;

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinShapeDelta.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinShapeDelta.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * One row of the per-(bin, shape) count delta — pairs with
+ * {@see \Reli\Inspector\Output\MemoryOutput\Report\Pass\BinShapePass}'s
+ * per-slot tally.
+ *
+ * The leak signal that came out of the issue #88 validation was
+ * "+2,000 Bucket(IS_STRING) in bin[3]" — content-varying shapes that
+ * the periodic-group path skipped because every Bucket carried distinct
+ * hash + key bytes. This delta surfaces them directly. Reachability
+ * deltas are tracked separately (`reachable_count_delta`) because the
+ * orphan-count delta is the actionable bit ("orphans grew") while
+ * reachable-count growth is usually normal.
+ */
+final class BinShapeDelta
+{
+    public function __construct(
+        public readonly int $bin_num,
+        public readonly int $bin_size,
+        public readonly string $shape,
+        public readonly int $baseline_count,
+        public readonly int $target_count,
+        public readonly int $count_delta,
+        public readonly int $baseline_reachable,
+        public readonly int $target_reachable,
+        public readonly int $reachable_count_delta,
+        public readonly int $orphan_count_delta,
+        public readonly string $confidence,
+    ) {
+    }
+
+    /** @return array<string, int|string> */
+    public function toArray(): array
+    {
+        return [
+            'bin_num' => $this->bin_num,
+            'bin_size' => $this->bin_size,
+            'shape' => $this->shape,
+            'baseline_count' => $this->baseline_count,
+            'target_count' => $this->target_count,
+            'count_delta' => $this->count_delta,
+            'baseline_reachable' => $this->baseline_reachable,
+            'target_reachable' => $this->target_reachable,
+            'reachable_count_delta' => $this->reachable_count_delta,
+            'orphan_count_delta' => $this->orphan_count_delta,
+            'confidence' => $this->confidence,
+        ];
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
@@ -97,6 +97,41 @@ final class BinaryComparisonDataProvider implements ComparisonDataProvider
         return $this->class_map_cache ?? [];
     }
 
+    /**
+     * @psalm-suppress MixedAssignment, PossiblyInvalidArrayAccess
+     */
+    #[\Override]
+    public function loadBinHistogramSnapshot(): ?array
+    {
+        if (!$this->reader->hasSection(Format::SECTION_SUMMARY)) {
+            return null;
+        }
+        $data = $this->reader->getSectionData(Format::SECTION_SUMMARY);
+        $dict = $this->reader->getStringDict();
+
+        $offset = 0;
+        $entry_count = unpack('V', $data, $offset)[1];
+        $offset += 4;
+
+        for ($i = 0; $i < $entry_count; $i++) {
+            $key_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+            $value_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+
+            $key = $dict->lookup($key_id);
+            if ($key !== 'bin_walk') {
+                continue;
+            }
+            $value = $dict->lookup($value_id);
+            if (!is_string($value) || $value === '') {
+                return null;
+            }
+            return BinHistogramSnapshot::decode($value);
+        }
+        return null;
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
@@ -167,6 +167,41 @@ final class BinaryComparisonDataProvider implements ComparisonDataProvider
         return null;
     }
 
+    /**
+     * @psalm-suppress MixedAssignment, PossiblyInvalidArrayAccess
+     */
+    #[\Override]
+    public function loadBinShapeCounts(): ?array
+    {
+        if (!$this->reader->hasSection(Format::SECTION_SUMMARY)) {
+            return null;
+        }
+        $data = $this->reader->getSectionData(Format::SECTION_SUMMARY);
+        $dict = $this->reader->getStringDict();
+
+        $offset = 0;
+        $entry_count = unpack('V', $data, $offset)[1];
+        $offset += 4;
+
+        for ($i = 0; $i < $entry_count; $i++) {
+            $key_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+            $value_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+
+            $key = $dict->lookup($key_id);
+            if ($key !== 'bin_shape_counts') {
+                continue;
+            }
+            $value = $dict->lookup($value_id);
+            if (!is_string($value) || $value === '') {
+                return null;
+            }
+            return BinShapeCountsSnapshot::decode($value);
+        }
+        return null;
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
@@ -132,6 +132,41 @@ final class BinaryComparisonDataProvider implements ComparisonDataProvider
         return null;
     }
 
+    /**
+     * @psalm-suppress MixedAssignment, PossiblyInvalidArrayAccess
+     */
+    #[\Override]
+    public function loadRegionMap(): ?array
+    {
+        if (!$this->reader->hasSection(Format::SECTION_SUMMARY)) {
+            return null;
+        }
+        $data = $this->reader->getSectionData(Format::SECTION_SUMMARY);
+        $dict = $this->reader->getStringDict();
+
+        $offset = 0;
+        $entry_count = unpack('V', $data, $offset)[1];
+        $offset += 4;
+
+        for ($i = 0; $i < $entry_count; $i++) {
+            $key_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+            $value_id = unpack('V', $data, $offset)[1];
+            $offset += 4;
+
+            $key = $dict->lookup($key_id);
+            if ($key !== 'region_map') {
+                continue;
+            }
+            $value = $dict->lookup($value_id);
+            if (!is_string($value) || $value === '') {
+                return null;
+            }
+            return RegionMapSnapshot::decode($value);
+        }
+        return null;
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
@@ -69,7 +69,8 @@ interface ComparisonDataProvider
      * @return array<int, array<string, array{
      *     count: int,
      *     reachable_count: int,
-     *     confidence: string
+     *     confidence: string,
+     *     sample_addrs: list<int>
      * }>>|null
      */
     public function loadBinShapeCounts(): ?array;

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
@@ -63,5 +63,16 @@ interface ComparisonDataProvider
      */
     public function loadRegionMap(): ?array;
 
+    /**
+     * Per-(bin, shape) tally from the per-slot detector scan.
+     *
+     * @return array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string
+     * }>>|null
+     */
+    public function loadBinShapeCounts(): ?array;
+
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult;
 }

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
@@ -55,5 +55,13 @@ interface ComparisonDataProvider
      */
     public function loadBinHistogramSnapshot(): ?array;
 
+    /**
+     * The address-range snapshot the analyze pipeline persisted via
+     * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionMap}.
+     *
+     * @return list<array{kind: string, address: int, size: int}>|null
+     */
+    public function loadRegionMap(): ?array;
+
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult;
 }

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonDataProvider.php
@@ -39,5 +39,21 @@ interface ComparisonDataProvider
      */
     public function loadClassMap(): array;
 
+    /**
+     * Decoded bin walker output from the summary section, or null when the
+     * snapshot pre-dates the bin walker / the ZendMM walk failed.
+     *
+     * @return array{
+     *     histogram: array<int, array{count: int, total_bytes: int}>,
+     *     large_run_count?: int,
+     *     large_run_bytes?: int,
+     *     live_small_slot_count?: int,
+     *     live_small_slot_bytes?: int,
+     *     walked_chunk_count?: int,
+     *     partial?: bool
+     * }|null
+     */
+    public function loadBinHistogramSnapshot(): ?array;
+
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult;
 }

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -13,8 +13,13 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput\Comparison;
 
+use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportResult;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
 
 final class ComparisonGenerator
 {
@@ -80,6 +85,16 @@ final class ComparisonGenerator
             $target_report,
         );
 
+        $bin_deltas = $this->compareBinHistogram(
+            $baseline->loadBinHistogramSnapshot(),
+            $target->loadBinHistogramSnapshot(),
+        );
+
+        $unaccounted = $this->detectUnaccountedDelta(
+            $summary_deltas,
+            $type_deltas,
+        );
+
         return new ComparisonResult(
             baseline_meta: $baseline_report->meta,
             target_meta: $target_report->meta,
@@ -89,6 +104,148 @@ final class ComparisonGenerator
             class_added: $class_added,
             class_removed: $class_removed,
             findings_diff: $findings_diff,
+            bin_deltas: $bin_deltas,
+            unaccounted_finding: $unaccounted,
+        );
+    }
+
+    /**
+     * @param array{
+     *     histogram: array<int, array{count: int, total_bytes: int}>,
+     *     large_run_count?: int,
+     *     large_run_bytes?: int,
+     *     live_small_slot_count?: int,
+     *     live_small_slot_bytes?: int,
+     *     walked_chunk_count?: int,
+     *     partial?: bool
+     * }|null $baseline
+     * @param array{
+     *     histogram: array<int, array{count: int, total_bytes: int}>,
+     *     large_run_count?: int,
+     *     large_run_bytes?: int,
+     *     live_small_slot_count?: int,
+     *     live_small_slot_bytes?: int,
+     *     walked_chunk_count?: int,
+     *     partial?: bool
+     * }|null $target
+     * @return list<BinDelta>
+     */
+    private function compareBinHistogram(?array $baseline, ?array $target): array
+    {
+        if ($baseline === null && $target === null) {
+            return [];
+        }
+        $b_hist = $baseline['histogram'] ?? [];
+        $t_hist = $target['histogram'] ?? [];
+
+        $bins = array_unique(array_merge(array_keys($b_hist), array_keys($t_hist)));
+        $deltas = [];
+        foreach ($bins as $bin_num) {
+            $b = $b_hist[$bin_num] ?? ['count' => 0, 'total_bytes' => 0];
+            $t = $t_hist[$bin_num] ?? ['count' => 0, 'total_bytes' => 0];
+            $count_delta = $t['count'] - $b['count'];
+            $bytes_delta = $t['total_bytes'] - $b['total_bytes'];
+            if ($count_delta === 0 && $bytes_delta === 0) {
+                continue;
+            }
+            $deltas[] = new BinDelta(
+                bin_num: $bin_num,
+                bin_size: ZendMmBinsInfo::getSize($bin_num),
+                baseline_count: $b['count'],
+                target_count: $t['count'],
+                baseline_bytes: $b['total_bytes'],
+                target_bytes: $t['total_bytes'],
+                count_delta: $count_delta,
+                bytes_delta: $bytes_delta,
+            );
+        }
+
+        // Sort by absolute byte delta — biggest movers first.
+        usort(
+            $deltas,
+            static fn(BinDelta $a, BinDelta $b) => abs($b->bytes_delta) <=> abs($a->bytes_delta),
+        );
+
+        return $deltas;
+    }
+
+    /**
+     * Synthetic "heap grew but the typed allocations didn't" finding (B.4
+     * in the orphan-allocation design). The signal is the design's North
+     * Star: when this fires, the user knows the leak is C-extension-side
+     * emalloc territory and should consult the bin histogram delta.
+     *
+     * Threshold: heap_usage delta clears the smaller of 100 KiB or 1% of
+     * baseline. Lower bar than fragmentation findings on purpose — even a
+     * small heap growth with a flat type breakdown is worth surfacing.
+     *
+     * @param list<SummaryDelta> $summary_deltas
+     * @param list<TypeDelta> $type_deltas
+     */
+    private function detectUnaccountedDelta(
+        array $summary_deltas,
+        array $type_deltas,
+    ): ?Finding {
+        $heap_delta = null;
+        $heap_baseline = null;
+        foreach ($summary_deltas as $sd) {
+            if ($sd->metric === 'zend_mm_heap_usage') {
+                $heap_delta = (int)$sd->delta;
+                $heap_baseline = (int)$sd->baseline;
+                break;
+            }
+        }
+        if ($heap_delta === null || $heap_delta <= 0) {
+            return null;
+        }
+
+        $abs_threshold = 100 * 1024;
+        $rel_threshold = $heap_baseline !== null && $heap_baseline > 0
+            ? (int)floor(Cast::toFloat($heap_baseline) * 0.01)
+            : $abs_threshold;
+        $threshold = min($abs_threshold, $rel_threshold);
+        if ($heap_delta < $threshold) {
+            return null;
+        }
+
+        $type_delta_sum = 0;
+        $type_delta_abs_sum = 0;
+        foreach ($type_deltas as $td) {
+            $type_delta_sum += $td->memory_delta;
+            $type_delta_abs_sum += abs($td->memory_delta);
+        }
+
+        // "Approximately zero" relative to the heap movement: typed deltas
+        // explain less than 10% of what the heap absorbed.
+        if ($type_delta_abs_sum >= (int)floor(Cast::toFloat($heap_delta) * 0.1)) {
+            return null;
+        }
+
+        return new Finding(
+            kind: 'unaccounted_heap_delta',
+            severity: FindingSeverity::High,
+            confidence: FindingConfidence::High,
+            summary: sprintf(
+                'Heap grew by %s but typed allocations only moved by %s'
+                . ' — likely orphan / C-extension emalloc',
+                SizeFormatter::format($heap_delta),
+                SizeFormatter::format($type_delta_sum),
+            ),
+            facts: [
+                'heap_usage_delta' => $heap_delta,
+                'type_delta_sum' => $type_delta_sum,
+                'type_delta_abs_sum' => $type_delta_abs_sum,
+            ],
+            hypothesis: 'The heap absorbed bytes that no PHP-rooted node claimed.'
+                . ' Standard culprits: extension-side emalloc (curl_easy, uv_*, libxml,'
+                . ' pdo_stmt) leaking structs that ZendMM tracks but the root walker'
+                . ' never reaches.',
+            next_checks: [
+                'Inspect the bin histogram delta below for the largest +Δ bin',
+                'Run inspector:memory:report --no-derived-cache on the target dump'
+                    . ' to see the periodic-groups table, which surfaces the leaked shape',
+            ],
+            impact_bytes: $heap_delta,
         );
     }
 

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -92,6 +92,11 @@ final class ComparisonGenerator
             $target->loadBinHistogramSnapshot(),
         );
 
+        $region_deltas = $this->compareRegionMap(
+            $baseline->loadRegionMap(),
+            $target->loadRegionMap(),
+        );
+
         $unaccounted = $this->detectUnaccountedDelta(
             $summary_deltas,
             $type_deltas,
@@ -108,7 +113,106 @@ final class ComparisonGenerator
             findings_diff: $findings_diff,
             bin_deltas: $bin_deltas,
             unaccounted_finding: $unaccounted,
+            region_deltas: $region_deltas,
         );
+    }
+
+    /**
+     * Diff two region-map snapshots into Added / Grown / Shrunk / Removed
+     * rows. The snapshot is persisted by analyze (see
+     * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionMap}) so this
+     * works on the rmem-only workflow without holding both rdumps.
+     *
+     * Identity key is `(kind, address)` rather than address alone — a
+     * vm_stack and a chunk that happen to start at the same address are
+     * still semantically distinct, and the chunk pool re-mmaps freed
+     * chunks at fresh addresses anyway, so we don't need to track size
+     * mutations across kinds.
+     *
+     * @param list<array{kind: string, address: int, size: int}>|null $baseline
+     * @param list<array{kind: string, address: int, size: int}>|null $target
+     * @return list<RegionDelta>
+     */
+    private function compareRegionMap(?array $baseline, ?array $target): array
+    {
+        if ($baseline === null && $target === null) {
+            return [];
+        }
+        $baseline ??= [];
+        $target ??= [];
+
+        /** @var array<string, array{kind: string, address: int, size: int}> $b_index */
+        $b_index = [];
+        foreach ($baseline as $row) {
+            $b_index[$row['kind'] . ':' . $row['address']] = $row;
+        }
+        /** @var array<string, array{kind: string, address: int, size: int}> $t_index */
+        $t_index = [];
+        foreach ($target as $row) {
+            $t_index[$row['kind'] . ':' . $row['address']] = $row;
+        }
+
+        $deltas = [];
+        foreach ($t_index as $k => $t_row) {
+            $b_row = $b_index[$k] ?? null;
+            if ($b_row === null) {
+                $deltas[] = new RegionDelta(
+                    kind: $t_row['kind'],
+                    address: $t_row['address'],
+                    baseline_size: 0,
+                    target_size: $t_row['size'],
+                    size_delta: $t_row['size'],
+                    change: RegionDelta::CHANGE_ADDED,
+                );
+                continue;
+            }
+            $size_delta = $t_row['size'] - $b_row['size'];
+            if ($size_delta > 0) {
+                $deltas[] = new RegionDelta(
+                    kind: $t_row['kind'],
+                    address: $t_row['address'],
+                    baseline_size: $b_row['size'],
+                    target_size: $t_row['size'],
+                    size_delta: $size_delta,
+                    change: RegionDelta::CHANGE_GROWN,
+                );
+            } elseif ($size_delta < 0) {
+                $deltas[] = new RegionDelta(
+                    kind: $t_row['kind'],
+                    address: $t_row['address'],
+                    baseline_size: $b_row['size'],
+                    target_size: $t_row['size'],
+                    size_delta: $size_delta,
+                    change: RegionDelta::CHANGE_SHRUNK,
+                );
+            }
+            // size_delta === 0 → no row emitted (region unchanged).
+        }
+        foreach ($b_index as $k => $b_row) {
+            if (isset($t_index[$k])) {
+                continue;
+            }
+            $deltas[] = new RegionDelta(
+                kind: $b_row['kind'],
+                address: $b_row['address'],
+                baseline_size: $b_row['size'],
+                target_size: 0,
+                size_delta: -$b_row['size'],
+                change: RegionDelta::CHANGE_REMOVED,
+            );
+        }
+
+        // Sort by absolute size delta — biggest movers first; stable
+        // tie-break on address keeps output deterministic.
+        usort(
+            $deltas,
+            static function (RegionDelta $a, RegionDelta $b): int {
+                $cmp = abs($b->size_delta) <=> abs($a->size_delta);
+                return $cmp !== 0 ? $cmp : ($a->address <=> $b->address);
+            },
+        );
+
+        return $deltas;
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -52,6 +52,8 @@ final class ComparisonGenerator
         'bin_periodic_group',
         'bin_periodic_orphan',
         'bin_periodic_reachable',
+        'bin_shape_count',
+        'bin_shape_unclassified',
     ];
 
     public function compare(
@@ -97,6 +99,11 @@ final class ComparisonGenerator
             $target->loadRegionMap(),
         );
 
+        $bin_shape_deltas = $this->compareBinShapeCounts(
+            $baseline->loadBinShapeCounts(),
+            $target->loadBinShapeCounts(),
+        );
+
         $unaccounted = $this->detectUnaccountedDelta(
             $summary_deltas,
             $type_deltas,
@@ -114,7 +121,82 @@ final class ComparisonGenerator
             bin_deltas: $bin_deltas,
             unaccounted_finding: $unaccounted,
             region_deltas: $region_deltas,
+            bin_shape_deltas: $bin_shape_deltas,
         );
+    }
+
+    /**
+     * Outer-join two per-(bin, shape) snapshots and emit BinShapeDelta
+     * rows for every shape whose count moved. Sorted by |orphan_delta|
+     * descending — the leak signal is "orphans grew", regardless of
+     * whether reachable copies of the shape also grew on the side.
+     *
+     * @param array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string
+     * }>>|null $baseline
+     * @param array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string
+     * }>>|null $target
+     * @return list<BinShapeDelta>
+     */
+    private function compareBinShapeCounts(?array $baseline, ?array $target): array
+    {
+        if ($baseline === null && $target === null) {
+            return [];
+        }
+        $baseline ??= [];
+        $target ??= [];
+
+        $bin_nums = array_unique(array_merge(array_keys($baseline), array_keys($target)));
+
+        $out = [];
+        foreach ($bin_nums as $bin_num) {
+            $b_bin = $baseline[$bin_num] ?? [];
+            $t_bin = $target[$bin_num] ?? [];
+            $labels = array_unique(array_merge(array_keys($b_bin), array_keys($t_bin)));
+            foreach ($labels as $label) {
+                $b = $b_bin[$label] ?? [
+                    'count' => 0,
+                    'reachable_count' => 0,
+                    'confidence' => 'medium',
+                ];
+                $t = $t_bin[$label] ?? [
+                    'count' => 0,
+                    'reachable_count' => 0,
+                    'confidence' => 'medium',
+                ];
+                $count_delta = $t['count'] - $b['count'];
+                if ($count_delta === 0) {
+                    continue;
+                }
+                $reachable_delta = $t['reachable_count'] - $b['reachable_count'];
+                $orphan_delta = $count_delta - $reachable_delta;
+                $out[] = new BinShapeDelta(
+                    bin_num: $bin_num,
+                    bin_size: \Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo::getSize($bin_num),
+                    shape: $label,
+                    baseline_count: $b['count'],
+                    target_count: $t['count'],
+                    count_delta: $count_delta,
+                    baseline_reachable: $b['reachable_count'],
+                    target_reachable: $t['reachable_count'],
+                    reachable_count_delta: $reachable_delta,
+                    orphan_count_delta: $orphan_delta,
+                    confidence: $t['confidence'] !== '' ? $t['confidence'] : $b['confidence'],
+                );
+            }
+        }
+
+        usort(
+            $out,
+            static fn(BinShapeDelta $a, BinShapeDelta $b)
+                => abs($b->orphan_count_delta) <=> abs($a->orphan_count_delta),
+        );
+        return $out;
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -42,6 +42,9 @@ final class ComparisonGenerator
         'class_ranking',
         'retained_exact',
         'retained_approximate',
+        'bin_histogram_overview',
+        'bin_histogram_entry',
+        'bin_periodic_group',
     ];
 
     public function compare(

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -50,6 +50,8 @@ final class ComparisonGenerator
         'bin_histogram_overview',
         'bin_histogram_entry',
         'bin_periodic_group',
+        'bin_periodic_orphan',
+        'bin_periodic_reachable',
     ];
 
     public function compare(

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonGenerator.php
@@ -134,12 +134,14 @@ final class ComparisonGenerator
      * @param array<int, array<string, array{
      *     count: int,
      *     reachable_count: int,
-     *     confidence: string
+     *     confidence: string,
+     *     sample_addrs: list<int>
      * }>>|null $baseline
      * @param array<int, array<string, array{
      *     count: int,
      *     reachable_count: int,
-     *     confidence: string
+     *     confidence: string,
+     *     sample_addrs: list<int>
      * }>>|null $target
      * @return list<BinShapeDelta>
      */
@@ -163,11 +165,13 @@ final class ComparisonGenerator
                     'count' => 0,
                     'reachable_count' => 0,
                     'confidence' => 'medium',
+                    'sample_addrs' => [],
                 ];
                 $t = $t_bin[$label] ?? [
                     'count' => 0,
                     'reachable_count' => 0,
                     'confidence' => 'medium',
+                    'sample_addrs' => [],
                 ];
                 $count_delta = $t['count'] - $b['count'];
                 if ($count_delta === 0) {

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput\Comparison;
 
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+
 final class ComparisonResult
 {
     /**
@@ -23,6 +25,7 @@ final class ComparisonResult
      * @param list<ClassDelta> $class_changes
      * @param list<ClassDelta> $class_added
      * @param list<ClassDelta> $class_removed
+     * @param list<BinDelta> $bin_deltas
      */
     public function __construct(
         public readonly array $baseline_meta,
@@ -33,13 +36,15 @@ final class ComparisonResult
         public readonly array $class_added,
         public readonly array $class_removed,
         public readonly FindingsDiff $findings_diff,
+        public readonly array $bin_deltas = [],
+        public readonly ?Finding $unaccounted_finding = null,
     ) {
     }
 
     /** @return array<string, mixed> */
     public function toArray(): array
     {
-        return [
+        $out = [
             'baseline' => $this->baseline_meta,
             'target' => $this->target_meta,
             'summary_deltas' => array_map(
@@ -57,5 +62,15 @@ final class ComparisonResult
             ],
             'findings_diff' => $this->findings_diff->toArray(),
         ];
+        if ($this->bin_deltas !== []) {
+            $out['bin_deltas'] = array_map(
+                fn(BinDelta $d) => $d->toArray(),
+                $this->bin_deltas,
+            );
+        }
+        if ($this->unaccounted_finding !== null) {
+            $out['unaccounted_finding'] = $this->unaccounted_finding->toArray();
+        }
+        return $out;
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
@@ -27,6 +27,7 @@ final class ComparisonResult
      * @param list<ClassDelta> $class_removed
      * @param list<BinDelta> $bin_deltas
      * @param list<RegionDelta> $region_deltas
+     * @param list<BinShapeDelta> $bin_shape_deltas
      */
     public function __construct(
         public readonly array $baseline_meta,
@@ -40,6 +41,7 @@ final class ComparisonResult
         public readonly array $bin_deltas = [],
         public readonly ?Finding $unaccounted_finding = null,
         public readonly array $region_deltas = [],
+        public readonly array $bin_shape_deltas = [],
     ) {
     }
 
@@ -74,6 +76,12 @@ final class ComparisonResult
             $out['region_deltas'] = array_map(
                 fn(RegionDelta $d) => $d->toArray(),
                 $this->region_deltas,
+            );
+        }
+        if ($this->bin_shape_deltas !== []) {
+            $out['bin_shape_deltas'] = array_map(
+                fn(BinShapeDelta $d) => $d->toArray(),
+                $this->bin_shape_deltas,
             );
         }
         if ($this->unaccounted_finding !== null) {

--- a/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/ComparisonResult.php
@@ -26,6 +26,7 @@ final class ComparisonResult
      * @param list<ClassDelta> $class_added
      * @param list<ClassDelta> $class_removed
      * @param list<BinDelta> $bin_deltas
+     * @param list<RegionDelta> $region_deltas
      */
     public function __construct(
         public readonly array $baseline_meta,
@@ -38,6 +39,7 @@ final class ComparisonResult
         public readonly FindingsDiff $findings_diff,
         public readonly array $bin_deltas = [],
         public readonly ?Finding $unaccounted_finding = null,
+        public readonly array $region_deltas = [],
     ) {
     }
 
@@ -66,6 +68,12 @@ final class ComparisonResult
             $out['bin_deltas'] = array_map(
                 fn(BinDelta $d) => $d->toArray(),
                 $this->bin_deltas,
+            );
+        }
+        if ($this->region_deltas !== []) {
+            $out['region_deltas'] = array_map(
+                fn(RegionDelta $d) => $d->toArray(),
+                $this->region_deltas,
             );
         }
         if ($this->unaccounted_finding !== null) {

--- a/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Comparison\Formatter;
 use Reli\Inspector\Output\MemoryOutput\Comparison\BinDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ClassDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ComparisonResult;
+use Reli\Inspector\Output\MemoryOutput\Comparison\RegionDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\SummaryDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\TypeDelta;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
@@ -46,6 +47,12 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
 
         // Class deltas
         $this->formatClassDeltas($lines, $result);
+
+        // Region map delta (B.2) — Added / Grown / Shrunk / Removed
+        // groups of address ranges. Sits above the bin delta because
+        // a "+728 KiB at 0x..." callout points the user at the rough
+        // location before the bin histogram tells them what's inside.
+        $this->formatRegionDeltas($lines, $result->region_deltas);
 
         // ZendMM bin histogram delta — sourced from the bin walker
         // (analyze-time) and decoded from the rmem summary section.
@@ -289,6 +296,81 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
             }
             $lines[] = '';
         }
+    }
+
+    /**
+     * @param list<string> $lines
+     * @param list<RegionDelta> $deltas
+     */
+    private function formatRegionDeltas(array &$lines, array $deltas): void
+    {
+        if ($deltas === []) {
+            return;
+        }
+
+        $lines[] = '=== Region Map Delta ===';
+        $lines[] = '';
+
+        $by_change = [
+            RegionDelta::CHANGE_ADDED => [],
+            RegionDelta::CHANGE_GROWN => [],
+            RegionDelta::CHANGE_SHRUNK => [],
+            RegionDelta::CHANGE_REMOVED => [],
+        ];
+        foreach ($deltas as $rd) {
+            $by_change[$rd->change][] = $rd;
+        }
+
+        foreach (
+            [
+                RegionDelta::CHANGE_ADDED => 'Added',
+                RegionDelta::CHANGE_GROWN => 'Grown',
+                RegionDelta::CHANGE_SHRUNK => 'Shrunk',
+                RegionDelta::CHANGE_REMOVED => 'Removed',
+            ] as $change => $label
+        ) {
+            $rows = array_slice($by_change[$change], 0, 20);
+            if ($rows === []) {
+                continue;
+            }
+            $lines[] = "  {$label}:";
+            foreach ($rows as $rd) {
+                if ($change === RegionDelta::CHANGE_ADDED) {
+                    $lines[] = sprintf(
+                        '    + %s [%s] at 0x%012x',
+                        SizeFormatter::format($rd->target_size),
+                        $rd->kind,
+                        $rd->address,
+                    );
+                } elseif ($change === RegionDelta::CHANGE_REMOVED) {
+                    $lines[] = sprintf(
+                        '    - %s [%s] at 0x%012x',
+                        SizeFormatter::format($rd->baseline_size),
+                        $rd->kind,
+                        $rd->address,
+                    );
+                } else {
+                    $sign = $rd->size_delta >= 0 ? '+' : '-';
+                    $lines[] = sprintf(
+                        '    %s %s [%s] at 0x%012x  (%s → %s)',
+                        $sign,
+                        SizeFormatter::format(abs($rd->size_delta)),
+                        $rd->kind,
+                        $rd->address,
+                        SizeFormatter::format($rd->baseline_size),
+                        SizeFormatter::format($rd->target_size),
+                    );
+                }
+            }
+            if (count($by_change[$change]) > 20) {
+                $lines[] = sprintf(
+                    '    … %d more %s',
+                    count($by_change[$change]) - 20,
+                    $label,
+                );
+            }
+        }
+        $lines[] = '';
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput\Comparison\Formatter;
 
+use Reli\Inspector\Output\MemoryOutput\Comparison\BinDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ClassDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ComparisonResult;
 use Reli\Inspector\Output\MemoryOutput\Comparison\SummaryDelta;
@@ -45,6 +46,20 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
 
         // Class deltas
         $this->formatClassDeltas($lines, $result);
+
+        // ZendMM bin histogram delta — sourced from the bin walker
+        // (analyze-time) and decoded from the rmem summary section.
+        // Lands above the findings diff so the user can correlate
+        // "+16,041 bin[32 B]" with the unaccounted-delta finding when
+        // both fire on the same comparison.
+        $this->formatBinDeltas($lines, $result->bin_deltas);
+
+        // Synthetic "heap grew but typed delta ≈ 0" finding (B.4).
+        // High-severity callout above the regular findings diff so the
+        // signal can't get buried under per-class noise.
+        if ($result->unaccounted_finding !== null) {
+            $this->formatUnaccountedFinding($lines, $result->unaccounted_finding);
+        }
 
         // Findings diff
         $this->formatFindingsDiff($lines, $result);
@@ -274,6 +289,69 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
             }
             $lines[] = '';
         }
+    }
+
+    /**
+     * @param list<string> $lines
+     * @param list<BinDelta> $deltas
+     */
+    private function formatBinDeltas(array &$lines, array $deltas): void
+    {
+        if ($deltas === []) {
+            return;
+        }
+
+        $lines[] = '=== ZendMM Bin Histogram Delta ===';
+        $lines[] = '';
+        $lines[] = sprintf(
+            '  %3s  %8s %12s %12s %14s %14s',
+            'Bin',
+            'Size',
+            'Baseline',
+            'Target',
+            "Count \xce\x94",
+            "Memory \xce\x94",
+        );
+        $lines[] = '  ' . str_repeat('-', 73);
+
+        foreach (array_slice($deltas, 0, 30) as $bd) {
+            $count_str = sprintf('%+d', $bd->count_delta);
+            $bytes_sign = $bd->bytes_delta >= 0 ? '+' : '-';
+            $bytes_str = $bytes_sign . SizeFormatter::format(abs($bd->bytes_delta));
+            $lines[] = sprintf(
+                '  %3d  %8s %12s %12s %14s %14s',
+                $bd->bin_num,
+                SizeFormatter::format($bd->bin_size),
+                number_format($bd->baseline_count),
+                number_format($bd->target_count),
+                $count_str,
+                $bytes_str,
+            );
+        }
+        $lines[] = '';
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function formatUnaccountedFinding(array &$lines, Finding $f): void
+    {
+        $lines[] = '=== Unaccounted Heap Delta ===';
+        $lines[] = '';
+        $tag = strtoupper($f->severity->value);
+        $impact = $f->impact_bytes > 0
+            ? SizeFormatter::format($f->impact_bytes)
+            : '—';
+        $lines[] = "  [{$tag}] {$impact}: {$f->summary}";
+        if ($f->hypothesis !== '') {
+            foreach (explode("\n", $f->hypothesis) as $h) {
+                $lines[] = "    {$h}";
+            }
+        }
+        if ($f->next_checks !== []) {
+            $lines[] = '    Next: ' . implode('; ', $f->next_checks);
+        }
+        $lines[] = '';
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/Formatter/TextComparisonFormatter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\Comparison\Formatter;
 
 use Reli\Inspector\Output\MemoryOutput\Comparison\BinDelta;
+use Reli\Inspector\Output\MemoryOutput\Comparison\BinShapeDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ClassDelta;
 use Reli\Inspector\Output\MemoryOutput\Comparison\ComparisonResult;
 use Reli\Inspector\Output\MemoryOutput\Comparison\RegionDelta;
@@ -60,6 +61,12 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
         // "+16,041 bin[32 B]" with the unaccounted-delta finding when
         // both fire on the same comparison.
         $this->formatBinDeltas($lines, $result->bin_deltas);
+
+        // Per-(bin, shape) deltas — the per-slot scan output. Surfaces
+        // "+2,000 Bucket(IS_STRING) in bin[3]" leaks that the periodic-
+        // group path (above) misses because content-varying shapes
+        // never form a fingerprint cluster.
+        $this->formatBinShapeDeltas($lines, $result->bin_shape_deltas);
 
         // Synthetic "heap grew but typed delta ≈ 0" finding (B.4).
         // High-severity callout above the regular findings diff so the
@@ -408,6 +415,40 @@ final class TextComparisonFormatter implements ComparisonFormatterInterface
                 number_format($bd->target_count),
                 $count_str,
                 $bytes_str,
+            );
+        }
+        $lines[] = '';
+    }
+
+    /**
+     * @param list<string> $lines
+     * @param list<BinShapeDelta> $deltas
+     */
+    private function formatBinShapeDeltas(array &$lines, array $deltas): void
+    {
+        if ($deltas === []) {
+            return;
+        }
+        $lines[] = '=== Per-bin Shape Detection Delta ===';
+        $lines[] = '';
+        $lines[] = sprintf(
+            '  %3s  %-32s %14s %14s %14s',
+            'Bin',
+            'Shape',
+            "Count \xce\x94",
+            "Orphan \xce\x94",
+            "Reachable \xce\x94",
+        );
+        $lines[] = '  ' . str_repeat('-', 84);
+        foreach (array_slice($deltas, 0, 30) as $sd) {
+            $shape_cell = sprintf('%s [%s]', $sd->shape, strtoupper($sd->confidence));
+            $lines[] = sprintf(
+                '  %3d  %-32s %14s %14s %14s',
+                $sd->bin_num,
+                strlen($shape_cell) > 32 ? substr($shape_cell, 0, 31) . '…' : $shape_cell,
+                sprintf('%+d', $sd->count_delta),
+                sprintf('%+d', $sd->orphan_count_delta),
+                sprintf('%+d', $sd->reachable_count_delta),
             );
         }
         $lines[] = '';

--- a/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
@@ -87,6 +87,23 @@ final class PdoComparisonDataProvider implements ComparisonDataProvider
         return $result;
     }
 
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    #[\Override]
+    public function loadBinHistogramSnapshot(): ?array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT value FROM summary WHERE run_id = :run_id AND key = 'bin_walk'"
+        );
+        $stmt->execute([':run_id' => $this->run_id]);
+        $value = $stmt->fetchColumn();
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+        return BinHistogramSnapshot::decode($value);
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
@@ -121,6 +121,23 @@ final class PdoComparisonDataProvider implements ComparisonDataProvider
         return RegionMapSnapshot::decode($value);
     }
 
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    #[\Override]
+    public function loadBinShapeCounts(): ?array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT value FROM summary WHERE run_id = :run_id AND key = 'bin_shape_counts'"
+        );
+        $stmt->execute([':run_id' => $this->run_id]);
+        $value = $stmt->fetchColumn();
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+        return BinShapeCountsSnapshot::decode($value);
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/PdoComparisonDataProvider.php
@@ -104,6 +104,23 @@ final class PdoComparisonDataProvider implements ComparisonDataProvider
         return BinHistogramSnapshot::decode($value);
     }
 
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    #[\Override]
+    public function loadRegionMap(): ?array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT value FROM summary WHERE run_id = :run_id AND key = 'region_map'"
+        );
+        $stmt->execute([':run_id' => $this->run_id]);
+        $value = $stmt->fetchColumn();
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+        return RegionMapSnapshot::decode($value);
+    }
+
     #[\Override]
     public function generateReport(bool $full_analysis, ?bool $ffi_csr): ReportResult
     {

--- a/src/Inspector/Output/MemoryOutput/Comparison/RegionDelta.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/RegionDelta.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * One row of the region-map delta — the design's B.2 deliverable.
+ *
+ * `change` is one of {@see self::CHANGE_*}. For ADDED / REMOVED rows the
+ * "other side" size is 0 (the region only exists on one side); for GROWN /
+ * SHRUNK rows both sizes are non-zero and the delta is `target - baseline`.
+ *
+ * Region maps come from {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionMap}
+ * and are persisted to rmem at analyze time so this delta works on the
+ * rmem-only workflow without needing both rdumps in hand.
+ */
+final class RegionDelta
+{
+    public const CHANGE_ADDED = 'added';
+    public const CHANGE_GROWN = 'grown';
+    public const CHANGE_SHRUNK = 'shrunk';
+    public const CHANGE_REMOVED = 'removed';
+
+    public function __construct(
+        public readonly string $kind,
+        public readonly int $address,
+        public readonly int $baseline_size,
+        public readonly int $target_size,
+        public readonly int $size_delta,
+        public readonly string $change,
+    ) {
+    }
+
+    /** @return array<string, int|string> */
+    public function toArray(): array
+    {
+        return [
+            'kind' => $this->kind,
+            'address' => $this->address,
+            'baseline_size' => $this->baseline_size,
+            'target_size' => $this->target_size,
+            'size_delta' => $this->size_delta,
+            'change' => $this->change,
+        ];
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Comparison/RegionMapSnapshot.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/RegionMapSnapshot.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+/**
+ * Decode the JSON-serialised `region_map` summary entry written by
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionMap::toSummaryArray}.
+ *
+ * Companion to {@see BinHistogramSnapshot} — the comparison data
+ * providers JSON-encode non-scalar summary values, so a typed
+ * round-trip helper keeps the consumer side honest.
+ */
+final class RegionMapSnapshot
+{
+    /**
+     * @return list<array{kind: string, address: int, size: int}>|null
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess
+     */
+    public static function decode(string $json): ?array
+    {
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+        $out = [];
+        foreach ($decoded as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            if (
+                !isset($row['kind'], $row['address'], $row['size'])
+                || !is_string($row['kind'])
+            ) {
+                continue;
+            }
+            $out[] = [
+                'kind' => $row['kind'],
+                'address' => (int)$row['address'],
+                'size' => (int)$row['size'],
+            ];
+        }
+        return $out;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -43,6 +43,9 @@ final class TextReportFormatter implements ReportFormatterInterface
         $class_rankings = [];
         $top_arrays = [];
         $top_strings = [];
+        $bin_histogram_overview = null;
+        $bin_histogram_entries = [];
+        $bin_periodic_groups = [];
 
         foreach ($result->findings as $finding) {
             if (in_array($finding->kind, ['overview', 'coverage_gap', 'call_stack'], true)) {
@@ -55,6 +58,21 @@ final class TextReportFormatter implements ReportFormatterInterface
                 $top_arrays[] = $finding;
             } elseif ($finding->kind === 'large_string') {
                 $top_strings[] = $finding;
+            } elseif ($finding->kind === 'bin_histogram_overview') {
+                $bin_histogram_overview = $finding;
+            } elseif ($finding->kind === 'bin_histogram_entry') {
+                $bin_histogram_entries[] = $finding;
+            } elseif (
+                $finding->kind === 'bin_periodic_group'
+                || $finding->kind === 'bin_periodic_hotspot'
+            ) {
+                // Hotspots also fall into the actionable section so the
+                // user gets the leak signal up top; the bin-level table
+                // below repeats them with stride/fingerprint detail.
+                $bin_periodic_groups[] = $finding;
+                if ($finding->kind === 'bin_periodic_hotspot') {
+                    $actionable[] = $finding;
+                }
             } elseif (
                 in_array($finding->kind, ['root_blame', 'retained_exact', 'retained_approximate'], true)
             ) {
@@ -243,6 +261,109 @@ final class TextReportFormatter implements ReportFormatterInterface
                     $pct,
                 );
             }
+            $lines[] = '';
+        }
+
+        // ZendMM bin histogram — per-bin live-allocation distribution
+        // recovered by the bin walker. Surfaces "where on the heap is
+        // mass concentrated" with bin granularity (the type breakdown
+        // above only sees what reli's root-traversal could claim).
+        if ($bin_histogram_entries !== []) {
+            $lines[] = '=== ZendMM Bin Histogram ===';
+            $lines[] = '';
+            if ($bin_histogram_overview !== null) {
+                $lines[] = '  ' . $bin_histogram_overview->summary;
+                $lines[] = '';
+            }
+            $lines[] = sprintf('  %3s  %8s %12s %14s', 'Bin', 'Size', 'Count', 'Memory');
+            $lines[] = '  ' . str_repeat('-', 41);
+
+            // Sort by total_bytes desc — biggest bins first.
+            usort(
+                $bin_histogram_entries,
+                static function (Finding $a, Finding $b): int {
+                    /** @var int $am */
+                    $am = $a->facts['total_bytes'] ?? 0;
+                    /** @var int $bm */
+                    $bm = $b->facts['total_bytes'] ?? 0;
+                    return $bm <=> $am;
+                },
+            );
+
+            foreach ($bin_histogram_entries as $finding) {
+                $facts = $finding->facts;
+                /** @var int $bin_num */
+                $bin_num = $facts['bin_num'] ?? 0;
+                /** @var int $bin_size */
+                $bin_size = $facts['bin_size'] ?? 0;
+                /** @var int $count */
+                $count = $facts['count'] ?? 0;
+                /** @var int $memory */
+                $memory = $facts['total_bytes'] ?? 0;
+                $lines[] = sprintf(
+                    '  %3d  %8s %12s %14s',
+                    $bin_num,
+                    SizeFormatter::format($bin_size),
+                    number_format($count),
+                    SizeFormatter::format($memory),
+                );
+            }
+            $lines[] = '';
+        }
+
+        // Periodic groups — runs of like-shaped slots that are the
+        // signature of "extension X is leaking copies of struct Y".
+        if ($bin_periodic_groups !== []) {
+            $lines[] = '=== ZendMM Periodic Groups ===';
+            $lines[] = '';
+            $lines[] = sprintf(
+                '  %8s %10s %8s  %-14s  %s',
+                'BinSize',
+                'Count',
+                'Stride',
+                'Sample addr',
+                'Fingerprint (hex, first 16 B)',
+            );
+            $lines[] = '  ' . str_repeat('-', 80);
+
+            // Already sorted by count desc inside the bin walker but
+            // re-sort here to be defensive (findings may have been
+            // reshuffled by parallel passes).
+            usort(
+                $bin_periodic_groups,
+                static function (Finding $a, Finding $b): int {
+                    /** @var int $ac */
+                    $ac = $a->facts['count'] ?? 0;
+                    /** @var int $bc */
+                    $bc = $b->facts['count'] ?? 0;
+                    return $bc <=> $ac;
+                },
+            );
+
+            foreach ($bin_periodic_groups as $finding) {
+                $facts = $finding->facts;
+                /** @var int $bin_size */
+                $bin_size = $facts['bin_size'] ?? 0;
+                /** @var int $count */
+                $count = $facts['count'] ?? 0;
+                /** @var int $stride */
+                $stride = $facts['stride'] ?? 0;
+                /** @var int $sample */
+                $sample = $facts['sample_addr'] ?? 0;
+                /** @var string $fp */
+                $fp = $facts['fingerprint'] ?? '';
+                $tag = $finding->kind === 'bin_periodic_hotspot' ? '*' : ' ';
+                $lines[] = sprintf(
+                    ' %s%8s %10s %8d  0x%012x  %s',
+                    $tag,
+                    SizeFormatter::format($bin_size),
+                    number_format($count),
+                    $stride,
+                    $sample,
+                    substr($fp, 0, 32),
+                );
+            }
+            $lines[] = '  (* = hotspot: dominates its bin)';
             $lines[] = '';
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -317,14 +317,15 @@ final class TextReportFormatter implements ReportFormatterInterface
             $lines[] = '=== ZendMM Periodic Groups ===';
             $lines[] = '';
             $lines[] = sprintf(
-                '  %8s %10s %8s  %-14s  %s',
+                '  %8s %10s %8s  %-14s  %-32s %s',
                 'BinSize',
                 'Count',
                 'Stride',
                 'Sample addr',
-                'Fingerprint (hex, first 16 B)',
+                'Inferred shape',
+                'Fingerprint',
             );
-            $lines[] = '  ' . str_repeat('-', 80);
+            $lines[] = '  ' . str_repeat('-', 96);
 
             // Already sorted by count desc inside the bin walker but
             // re-sort here to be defensive (findings may have been
@@ -352,15 +353,23 @@ final class TextReportFormatter implements ReportFormatterInterface
                 $sample = $facts['sample_addr'] ?? 0;
                 /** @var string $fp */
                 $fp = $facts['fingerprint'] ?? '';
+                /** @var string $shape */
+                $shape = $facts['inferred_shape'] ?? '';
+                /** @var string $confidence */
+                $confidence = $facts['inferred_confidence'] ?? '';
+                $shape_cell = $shape !== ''
+                    ? sprintf('%s [%s]', $shape, strtoupper($confidence))
+                    : '—';
                 $tag = $finding->kind === 'bin_periodic_hotspot' ? '*' : ' ';
                 $lines[] = sprintf(
-                    ' %s%8s %10s %8d  0x%012x  %s',
+                    ' %s%8s %10s %8d  0x%012x  %-32s %s',
                     $tag,
                     SizeFormatter::format($bin_size),
                     number_format($count),
                     $stride,
                     $sample,
-                    substr($fp, 0, 32),
+                    strlen($shape_cell) > 32 ? substr($shape_cell, 0, 31) . '…' : $shape_cell,
+                    substr($fp, 0, 16),
                 );
             }
             $lines[] = '  (* = hotspot: dominates its bin)';

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -65,10 +65,15 @@ final class TextReportFormatter implements ReportFormatterInterface
             } elseif (
                 $finding->kind === 'bin_periodic_group'
                 || $finding->kind === 'bin_periodic_hotspot'
+                || $finding->kind === 'bin_periodic_orphan'
+                || $finding->kind === 'bin_periodic_reachable'
             ) {
                 // Hotspots also fall into the actionable section so the
                 // user gets the leak signal up top; the bin-level table
                 // below repeats them with stride/fingerprint detail.
+                // Reachable groups stay in the table for transparency
+                // (so the user sees what reli's root walker already
+                // claimed) but never go into the actionable section.
                 $bin_periodic_groups[] = $finding;
                 if ($finding->kind === 'bin_periodic_hotspot') {
                     $actionable[] = $finding;
@@ -317,22 +322,30 @@ final class TextReportFormatter implements ReportFormatterInterface
             $lines[] = '=== ZendMM Periodic Groups ===';
             $lines[] = '';
             $lines[] = sprintf(
-                '  %8s %10s %8s  %-14s  %-32s %s',
+                '   %8s %10s %8s  %-14s  %-9s %-32s %s',
                 'BinSize',
                 'Count',
                 'Stride',
                 'Sample addr',
+                'Reach',
                 'Inferred shape',
                 'Fingerprint',
             );
-            $lines[] = '  ' . str_repeat('-', 96);
+            $lines[] = '  ' . str_repeat('-', 105);
 
             // Already sorted by count desc inside the bin walker but
             // re-sort here to be defensive (findings may have been
-            // reshuffled by parallel passes).
+            // reshuffled by parallel passes). Hotspot rows float above
+            // non-hotspot rows of the same count so the leak signal
+            // lands first.
             usort(
                 $bin_periodic_groups,
                 static function (Finding $a, Finding $b): int {
+                    $a_rank = self::periodicGroupKindRank($a->kind);
+                    $b_rank = self::periodicGroupKindRank($b->kind);
+                    if ($a_rank !== $b_rank) {
+                        return $a_rank <=> $b_rank;
+                    }
                     /** @var int $ac */
                     $ac = $a->facts['count'] ?? 0;
                     /** @var int $bc */
@@ -356,23 +369,36 @@ final class TextReportFormatter implements ReportFormatterInterface
                 /** @var string $shape */
                 $shape = $facts['inferred_shape'] ?? '';
                 /** @var string $confidence */
-                $confidence = $facts['inferred_confidence'] ?? '';
+                $confidence = $facts['effective_confidence']
+                    ?? $facts['inferred_confidence']
+                    ?? '';
+                /** @var string $reach */
+                $reach = $facts['reachability'] ?? '';
                 $shape_cell = $shape !== ''
                     ? sprintf('%s [%s]', $shape, strtoupper($confidence))
                     : '—';
-                $tag = $finding->kind === 'bin_periodic_hotspot' ? '*' : ' ';
+                $reach_cell = $reach !== '' ? $reach : '—';
+                $tag = match ($finding->kind) {
+                    'bin_periodic_hotspot'
+                        => $finding->severity === FindingSeverity::High ? '**' : '* ',
+                    'bin_periodic_orphan' => 'o ',
+                    'bin_periodic_reachable' => '= ',
+                    default => '  ',
+                };
                 $lines[] = sprintf(
-                    ' %s%8s %10s %8d  0x%012x  %-32s %s',
+                    ' %s%8s %10s %8d  0x%012x  %-9s %-32s %s',
                     $tag,
                     SizeFormatter::format($bin_size),
                     number_format($count),
                     $stride,
                     $sample,
+                    $reach_cell,
                     strlen($shape_cell) > 32 ? substr($shape_cell, 0, 31) . '…' : $shape_cell,
                     substr($fp, 0, 16),
                 );
             }
-            $lines[] = '  (* = hotspot: dominates its bin)';
+            $lines[] = '  (** = orphan hotspot, * = hotspot, o = orphan group,'
+                . ' = = reachable / claimed by PHP roots)';
             $lines[] = '';
         }
 
@@ -616,6 +642,22 @@ final class TextReportFormatter implements ReportFormatterInterface
             FindingSeverity::Medium => 2,
             FindingSeverity::Low => 3,
             FindingSeverity::Info => 4,
+        };
+    }
+
+    /**
+     * Sort key for the ZendMM Periodic Groups table: hotspots first
+     * (orphan-promoted ahead of plain), then orphan-only groups, then
+     * unclassified, then reachable-only at the bottom (lowest signal).
+     */
+    private static function periodicGroupKindRank(string $kind): int
+    {
+        return match ($kind) {
+            'bin_periodic_hotspot' => 0,
+            'bin_periodic_orphan' => 1,
+            'bin_periodic_group' => 2,
+            'bin_periodic_reachable' => 3,
+            default => 4,
         };
     }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -46,6 +46,7 @@ final class TextReportFormatter implements ReportFormatterInterface
         $bin_histogram_overview = null;
         $bin_histogram_entries = [];
         $bin_periodic_groups = [];
+        $bin_shape_counts = [];
 
         foreach ($result->findings as $finding) {
             if (in_array($finding->kind, ['overview', 'coverage_gap', 'call_stack'], true)) {
@@ -62,6 +63,11 @@ final class TextReportFormatter implements ReportFormatterInterface
                 $bin_histogram_overview = $finding;
             } elseif ($finding->kind === 'bin_histogram_entry') {
                 $bin_histogram_entries[] = $finding;
+            } elseif (
+                $finding->kind === 'bin_shape_count'
+                || $finding->kind === 'bin_shape_unclassified'
+            ) {
+                $bin_shape_counts[] = $finding;
             } elseif (
                 $finding->kind === 'bin_periodic_group'
                 || $finding->kind === 'bin_periodic_hotspot'
@@ -399,6 +405,81 @@ final class TextReportFormatter implements ReportFormatterInterface
             }
             $lines[] = '  (** = orphan hotspot, * = hotspot, o = orphan group,'
                 . ' = = reachable / claimed by PHP roots)';
+            $lines[] = '';
+        }
+
+        // Per-bin shape detection — built from per-slot detector hits,
+        // independent of fingerprint clustering. Surfaces "76% of bin[3]
+        // is Bucket(IS_STRING)" for content-varying shapes that the
+        // periodic-group path skips because their bytes don't match
+        // slot-to-slot. Grouped by bin so the user reads "what's in
+        // this bin?" in one block.
+        if ($bin_shape_counts !== []) {
+            /** @var array<int, list<Finding>> $by_bin */
+            $by_bin = [];
+            foreach ($bin_shape_counts as $f) {
+                /** @var int $bin_num */
+                $bin_num = $f->facts['bin_num'] ?? -1;
+                $by_bin[$bin_num][] = $f;
+            }
+            ksort($by_bin);
+
+            $lines[] = '=== Per-bin Shape Detection ===';
+            $lines[] = '';
+            $lines[] = sprintf(
+                '  %3s  %-32s %10s %8s  %s',
+                'Bin',
+                'Shape',
+                'Count',
+                '%',
+                'Reach (orphan/reachable)',
+            );
+            $lines[] = '  ' . str_repeat('-', 86);
+            foreach ($by_bin as $bin_num => $rows) {
+                // Sort within a bin: real shapes first (by count desc),
+                // unclassified last.
+                usort($rows, static function (Finding $a, Finding $b): int {
+                    $a_uc = $a->kind === 'bin_shape_unclassified' ? 1 : 0;
+                    $b_uc = $b->kind === 'bin_shape_unclassified' ? 1 : 0;
+                    if ($a_uc !== $b_uc) {
+                        return $a_uc <=> $b_uc;
+                    }
+                    /** @var int $ac */
+                    $ac = $a->facts['count'] ?? 0;
+                    /** @var int $bc */
+                    $bc = $b->facts['count'] ?? 0;
+                    return $bc <=> $ac;
+                });
+                foreach ($rows as $f) {
+                    /** @var int $count */
+                    $count = $f->facts['count'] ?? 0;
+                    /** @var float $pct */
+                    $pct = $f->facts['percentage'] ?? 0.0;
+                    if ($f->kind === 'bin_shape_unclassified') {
+                        $shape_cell = 'unclassified';
+                        $reach_cell = '—';
+                    } else {
+                        /** @var string $shape */
+                        $shape = $f->facts['shape'] ?? '?';
+                        /** @var string $confidence */
+                        $confidence = $f->facts['confidence'] ?? '';
+                        $shape_cell = sprintf('%s [%s]', $shape, strtoupper($confidence));
+                        /** @var int $orphan */
+                        $orphan = $f->facts['orphan_count'] ?? 0;
+                        /** @var int $reachable */
+                        $reachable = $f->facts['reachable_count'] ?? 0;
+                        $reach_cell = sprintf('%d / %d', $orphan, $reachable);
+                    }
+                    $lines[] = sprintf(
+                        '  %3d  %-32s %10s %7.1f%%  %s',
+                        $bin_num,
+                        strlen($shape_cell) > 32 ? substr($shape_cell, 0, 31) . '…' : $shape_cell,
+                        number_format($count),
+                        $pct,
+                        $reach_cell,
+                    );
+                }
+            }
             $lines[] = '';
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinHistogramPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinHistogramPass.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
+
+/**
+ * Surface the per-bin live-allocation histogram produced by the bin walker.
+ *
+ * Emits one informational `bin_histogram_entry` finding per non-empty small
+ * bin plus a single `bin_histogram_overview` line. These findings carry the
+ * raw shape of "where is the heap right now": whether the leak is in 32 B
+ * Buckets, 192 B stat structs, large pages, etc. The text formatter renders
+ * them as a table; the comparison path can diff them across runs.
+ *
+ * See docs/internals/design-orphan-allocation-analysis.md (sections A and
+ * "Output integration").
+ */
+final class BinHistogramPass implements PassInterface
+{
+    /** @param array<int, array<string, mixed>> $summary */
+    public function __construct(
+        private array $summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess, MixedOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $flat = [];
+        foreach ($this->summary as $entry) {
+            foreach ($entry as $k => $v) {
+                $flat[$k] = $v;
+            }
+        }
+
+        $bin_walk = $this->decode($flat['bin_walk'] ?? null);
+        if ($bin_walk === null) {
+            return [];
+        }
+
+        $histogram = $bin_walk['histogram'] ?? [];
+        if (!is_array($histogram) || $histogram === []) {
+            return [];
+        }
+
+        /** @var array<int, array{count: int, total_bytes: int}> $histogram_typed */
+        $histogram_typed = [];
+        foreach ($histogram as $bin_num => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $histogram_typed[(int)$bin_num] = [
+                'count' => (int)($row['count'] ?? 0),
+                'total_bytes' => (int)($row['total_bytes'] ?? 0),
+            ];
+        }
+        ksort($histogram_typed);
+
+        $live_count = (int)($bin_walk['live_small_slot_count'] ?? 0);
+        $live_bytes = (int)($bin_walk['live_small_slot_bytes'] ?? 0);
+        $large_count = (int)($bin_walk['large_run_count'] ?? 0);
+        $large_bytes = (int)($bin_walk['large_run_bytes'] ?? 0);
+        $walked_chunks = (int)($bin_walk['walked_chunk_count'] ?? 0);
+        $partial = (bool)($bin_walk['partial'] ?? false);
+
+        $findings = [];
+
+        $findings[] = new Finding(
+            kind: 'bin_histogram_overview',
+            severity: FindingSeverity::Info,
+            confidence: FindingConfidence::High,
+            summary: sprintf(
+                'ZendMM live: %s in %s small slots across %d bin classes'
+                . ' + %s in %d large runs (%d chunk%s walked%s)',
+                SizeFormatter::format($live_bytes),
+                number_format($live_count),
+                count($histogram_typed),
+                SizeFormatter::format($large_bytes),
+                $large_count,
+                $walked_chunks,
+                $walked_chunks === 1 ? '' : 's',
+                $partial ? ', partial walk' : '',
+            ),
+            facts: [
+                'live_small_slot_count' => $live_count,
+                'live_small_slot_bytes' => $live_bytes,
+                'large_run_count' => $large_count,
+                'large_run_bytes' => $large_bytes,
+                'walked_chunk_count' => $walked_chunks,
+                'partial' => $partial,
+            ],
+        );
+
+        foreach ($histogram_typed as $bin_num => $row) {
+            $bin_size = ZendMmBinsInfo::getSize($bin_num);
+            $findings[] = new Finding(
+                kind: 'bin_histogram_entry',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: sprintf(
+                    'bin[%d B]: %s live (%s)',
+                    $bin_size,
+                    number_format($row['count']),
+                    SizeFormatter::format($row['total_bytes']),
+                ),
+                facts: [
+                    'bin_num' => $bin_num,
+                    'bin_size' => $bin_size,
+                    'count' => $row['count'],
+                    'total_bytes' => $row['total_bytes'],
+                ],
+                impact_bytes: $row['total_bytes'],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Tolerate either a JSON string (from rmem / sqlite summary) or a
+     * decoded array (in-process tests).
+     *
+     * @return array<string, mixed>|null
+     * @psalm-suppress MixedAssignment
+     */
+    private function decode(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            /** @var array<string, mixed> $value */
+            return $value;
+        }
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                /** @var array<string, mixed> $decoded */
+                return $decoded;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use PhpCast\Cast;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+/**
+ * Surface periodic same-shape allocation runs detected by the bin walker.
+ *
+ * "Periodic" here is the design's "stride 32, count 16,000" pattern — the
+ * fingerprint of an extension leaking N copies of a single struct. The bin
+ * walker has already done the grouping; this pass only renders the result
+ * as findings with the right severity (Medium when a single group dominates
+ * a bin; Info otherwise).
+ */
+final class BinPeriodicityPass implements PassInterface
+{
+    /**
+     * Above this fraction of a bin's live slots, a single periodic group is
+     * treated as a likely orphan-allocation hotspot.
+     */
+    private const HOTSPOT_FRACTION = 0.5;
+
+    /** @param array<int, array<string, mixed>> $summary */
+    public function __construct(
+        private array $summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess, MixedOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $flat = [];
+        foreach ($this->summary as $entry) {
+            foreach ($entry as $k => $v) {
+                $flat[$k] = $v;
+            }
+        }
+
+        $groups = $this->decode($flat['bin_walk_periodic_groups'] ?? null);
+        if ($groups === null || $groups === []) {
+            return [];
+        }
+
+        // Total live count per bin lets us compute hotspot ratios.
+        /** @var array<int, int> $bin_counts */
+        $bin_counts = [];
+        $bin_walk = $this->decode($flat['bin_walk'] ?? null);
+        if (is_array($bin_walk) && isset($bin_walk['histogram']) && is_array($bin_walk['histogram'])) {
+            foreach ($bin_walk['histogram'] as $bin_num => $row) {
+                if (is_array($row)) {
+                    $bin_counts[(int)$bin_num] = (int)($row['count'] ?? 0);
+                }
+            }
+        }
+
+        $findings = [];
+        foreach ($groups as $g) {
+            if (!is_array($g)) {
+                continue;
+            }
+            $bin_num = (int)($g['bin_num'] ?? 0);
+            $bin_size = (int)($g['bin_size'] ?? 0);
+            $count = (int)($g['count'] ?? 0);
+            $stride = (int)($g['stride'] ?? 0);
+            $fp = (string)($g['fingerprint'] ?? '');
+            $sample_addr = (int)($g['sample_addr'] ?? 0);
+            if ($count <= 0 || $bin_size <= 0) {
+                continue;
+            }
+
+            $bin_total = $bin_counts[$bin_num] ?? 0;
+            $is_hotspot = $bin_total > 0
+                && Cast::toFloat($count) / Cast::toFloat($bin_total) >= self::HOTSPOT_FRACTION;
+
+            $findings[] = new Finding(
+                kind: $is_hotspot ? 'bin_periodic_hotspot' : 'bin_periodic_group',
+                severity: $is_hotspot ? FindingSeverity::Medium : FindingSeverity::Info,
+                confidence: FindingConfidence::Medium,
+                summary: sprintf(
+                    'bin[%d B]: %s same-shape live slots, stride %d B%s'
+                    . ' (sample 0x%x, fp %s%s)',
+                    $bin_size,
+                    number_format($count),
+                    $stride,
+                    $bin_total > 0
+                        ? sprintf(
+                            ' — %.0f%% of bin',
+                            Cast::toFloat($count) / Cast::toFloat($bin_total) * 100.0,
+                        )
+                        : '',
+                    $sample_addr,
+                    substr($fp, 0, 16),
+                    strlen($fp) > 16 ? '…' : '',
+                ),
+                facts: [
+                    'bin_num' => $bin_num,
+                    'bin_size' => $bin_size,
+                    'count' => $count,
+                    'stride' => $stride,
+                    'fingerprint' => $fp,
+                    'sample_addr' => $sample_addr,
+                    'bin_total' => $bin_total,
+                ],
+                hypothesis: $is_hotspot
+                    ? 'Likely orphan / C-extension emalloc — many same-shape allocations'
+                        . ' dominate this bin without a typed PHP root.'
+                    : '',
+                impact_bytes: $count * $bin_size,
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return list<array<string, mixed>>|array<string, mixed>|null
+     * @psalm-suppress MixedAssignment
+     */
+    private function decode(mixed $value): array|null
+    {
+        if (is_array($value)) {
+            /** @var list<array<string, mixed>>|array<string, mixed> $value */
+            return $value;
+        }
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                /** @var list<array<string, mixed>>|array<string, mixed> $decoded */
+                return $decoded;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
@@ -83,6 +83,10 @@ final class BinPeriodicityPass implements PassInterface
             $stride = (int)($g['stride'] ?? 0);
             $fp = (string)($g['fingerprint'] ?? '');
             $sample_addr = (int)($g['sample_addr'] ?? 0);
+            $inferred_shape = isset($g['inferred_shape']) ? (string)$g['inferred_shape'] : '';
+            $inferred_confidence = isset($g['inferred_confidence'])
+                ? (string)$g['inferred_confidence']
+                : '';
             if ($count <= 0 || $bin_size <= 0) {
                 continue;
             }
@@ -91,13 +95,35 @@ final class BinPeriodicityPass implements PassInterface
             $is_hotspot = $bin_total > 0
                 && Cast::toFloat($count) / Cast::toFloat($bin_total) >= self::HOTSPOT_FRACTION;
 
+            // Inferred shape, when present, leads the summary text — it's
+            // the bit a human reader actually wants ("16,000 Buckets")
+            // rather than the raw fingerprint.
+            $shape_prefix = $inferred_shape !== ''
+                ? sprintf('%s × ', $inferred_shape)
+                : '';
+
+            $facts = [
+                'bin_num' => $bin_num,
+                'bin_size' => $bin_size,
+                'count' => $count,
+                'stride' => $stride,
+                'fingerprint' => $fp,
+                'sample_addr' => $sample_addr,
+                'bin_total' => $bin_total,
+            ];
+            if ($inferred_shape !== '') {
+                $facts['inferred_shape'] = $inferred_shape;
+                $facts['inferred_confidence'] = $inferred_confidence;
+            }
+
             $findings[] = new Finding(
                 kind: $is_hotspot ? 'bin_periodic_hotspot' : 'bin_periodic_group',
                 severity: $is_hotspot ? FindingSeverity::Medium : FindingSeverity::Info,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
-                    'bin[%d B]: %s same-shape live slots, stride %d B%s'
+                    '%sbin[%d B]: %s same-shape live slots, stride %d B%s'
                     . ' (sample 0x%x, fp %s%s)',
+                    $shape_prefix,
                     $bin_size,
                     number_format($count),
                     $stride,
@@ -111,15 +137,7 @@ final class BinPeriodicityPass implements PassInterface
                     substr($fp, 0, 16),
                     strlen($fp) > 16 ? '…' : '',
                 ),
-                facts: [
-                    'bin_num' => $bin_num,
-                    'bin_size' => $bin_size,
-                    'count' => $count,
-                    'stride' => $stride,
-                    'fingerprint' => $fp,
-                    'sample_addr' => $sample_addr,
-                    'bin_total' => $bin_total,
-                ],
+                facts: $facts,
                 hypothesis: $is_hotspot
                     ? 'Likely orphan / C-extension emalloc — many same-shape allocations'
                         . ' dominate this bin without a typed PHP root.'

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPass.php
@@ -17,6 +17,7 @@ use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\PeriodicGroup;
 
 /**
  * Surface periodic same-shape allocation runs detected by the bin walker.
@@ -87,6 +88,12 @@ final class BinPeriodicityPass implements PassInterface
             $inferred_confidence = isset($g['inferred_confidence'])
                 ? (string)$g['inferred_confidence']
                 : '';
+            $effective_confidence = isset($g['effective_confidence'])
+                ? (string)$g['effective_confidence']
+                : $inferred_confidence;
+            $reachability = isset($g['reachability']) ? (string)$g['reachability'] : '';
+            $reachable_samples = (int)($g['reachable_samples'] ?? 0);
+            $sampled_count = (int)($g['sampled_count'] ?? 0);
             if ($count <= 0 || $bin_size <= 0) {
                 continue;
             }
@@ -94,6 +101,17 @@ final class BinPeriodicityPass implements PassInterface
             $bin_total = $bin_counts[$bin_num] ?? 0;
             $is_hotspot = $bin_total > 0
                 && Cast::toFloat($count) / Cast::toFloat($bin_total) >= self::HOTSPOT_FRACTION;
+
+            // Apply the design's negative-evidence rule: a group whose
+            // sampled addresses are all reachable from PHP roots was
+            // matched by accident, not because it's a leak. Demote it
+            // out of the hotspot bucket so the user's eye lands on the
+            // real signals.
+            $is_orphan = $reachability === PeriodicGroup::REACHABILITY_ORPHAN;
+            $is_reachable = $reachability === PeriodicGroup::REACHABILITY_REACHABLE;
+            if ($is_reachable) {
+                $is_hotspot = false;
+            }
 
             // Inferred shape, when present, leads the summary text — it's
             // the bit a human reader actually wants ("16,000 Buckets")
@@ -114,15 +132,62 @@ final class BinPeriodicityPass implements PassInterface
             if ($inferred_shape !== '') {
                 $facts['inferred_shape'] = $inferred_shape;
                 $facts['inferred_confidence'] = $inferred_confidence;
+                $facts['effective_confidence'] = $effective_confidence;
+            }
+            if ($reachability !== '') {
+                $facts['reachability'] = $reachability;
+                $facts['reachable_samples'] = $reachable_samples;
+                $facts['sampled_count'] = $sampled_count;
             }
 
+            // Kind selection encodes both the hotspot heuristic and the
+            // reachability verdict. `bin_periodic_reachable` is the only
+            // ranking-style kind among them — it has no leak signal so
+            // the comparison filter (RANKING_KINDS in ComparisonGenerator)
+            // already treats it as info.
+            if ($is_reachable) {
+                $kind = 'bin_periodic_reachable';
+                $severity = FindingSeverity::Info;
+            } elseif ($is_hotspot && $is_orphan) {
+                $kind = 'bin_periodic_hotspot';
+                // Orphan + hotspot = the strongest leak signal we have.
+                $severity = FindingSeverity::High;
+            } elseif ($is_hotspot) {
+                $kind = 'bin_periodic_hotspot';
+                $severity = FindingSeverity::Medium;
+            } elseif ($is_orphan) {
+                $kind = 'bin_periodic_orphan';
+                $severity = FindingSeverity::Info;
+            } else {
+                $kind = 'bin_periodic_group';
+                $severity = FindingSeverity::Info;
+            }
+
+            // Confidence on the Finding itself reflects the detector's
+            // post-reachability promotion: orphan + detector match → HIGH.
+            $finding_confidence = match ($effective_confidence) {
+                'high' => FindingConfidence::High,
+                'low' => FindingConfidence::Low,
+                default => FindingConfidence::Medium,
+            };
+
+            $reachability_suffix = match ($reachability) {
+                PeriodicGroup::REACHABILITY_ORPHAN
+                    => sprintf(' [orphan: 0/%d samples reachable]', $sampled_count),
+                PeriodicGroup::REACHABILITY_REACHABLE
+                    => sprintf(' [reachable: %d/%d samples reachable]', $reachable_samples, $sampled_count),
+                PeriodicGroup::REACHABILITY_MIXED
+                    => sprintf(' [mixed: %d/%d samples reachable]', $reachable_samples, $sampled_count),
+                default => '',
+            };
+
             $findings[] = new Finding(
-                kind: $is_hotspot ? 'bin_periodic_hotspot' : 'bin_periodic_group',
-                severity: $is_hotspot ? FindingSeverity::Medium : FindingSeverity::Info,
-                confidence: FindingConfidence::Medium,
+                kind: $kind,
+                severity: $severity,
+                confidence: $finding_confidence,
                 summary: sprintf(
                     '%sbin[%d B]: %s same-shape live slots, stride %d B%s'
-                    . ' (sample 0x%x, fp %s%s)',
+                    . ' (sample 0x%x, fp %s%s)%s',
                     $shape_prefix,
                     $bin_size,
                     number_format($count),
@@ -136,9 +201,10 @@ final class BinPeriodicityPass implements PassInterface
                     $sample_addr,
                     substr($fp, 0, 16),
                     strlen($fp) > 16 ? '…' : '',
+                    $reachability_suffix,
                 ),
                 facts: $facts,
-                hypothesis: $is_hotspot
+                hypothesis: $kind === 'bin_periodic_hotspot'
                     ? 'Likely orphan / C-extension emalloc — many same-shape allocations'
                         . ' dominate this bin without a typed PHP root.'
                     : '',

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinShapePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinShapePass.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+/**
+ * Surface the per-bin shape tally produced by the bin walker's per-slot
+ * detector scan.
+ *
+ * The periodic-group path (BinPeriodicityPass) only fires when many
+ * slots share the same fingerprint — which excludes content-varying
+ * shapes like Bucket entries, where every slot carries a distinct hash
+ * and key pointer. This pass walks the bin walker's per-slot scan
+ * results and emits one info-level row per (bin, shape) so users see
+ * "76% of bin[3] is Bucket(IS_STRING)" even though no two of those
+ * Buckets had the same bytes.
+ *
+ * The pass is intentionally noisy at Info severity — false positives
+ * are real in header-only detection, so the user reads it as evidence,
+ * not a verdict. The actionable signal sits in BinPeriodicityPass +
+ * the per-bin compare delta.
+ */
+final class BinShapePass implements PassInterface
+{
+    /** @param array<int, array<string, mixed>> $summary */
+    public function __construct(
+        private array $summary,
+    ) {
+    }
+
+    /**
+     * @return list<Finding>
+     * @psalm-suppress MixedAssignment, MixedArgument, MixedArrayAccess, MixedOperand
+     */
+    #[\Override]
+    public function analyze(): array
+    {
+        $flat = [];
+        foreach ($this->summary as $entry) {
+            foreach ($entry as $k => $v) {
+                $flat[$k] = $v;
+            }
+        }
+
+        $payload = $this->decode($flat['bin_shape_counts'] ?? null);
+        if ($payload === null || !isset($payload['bin']) || !is_array($payload['bin'])) {
+            return [];
+        }
+
+        $findings = [];
+        foreach ($payload['bin'] as $bin_row) {
+            if (!is_array($bin_row)) {
+                continue;
+            }
+            $bin_num = (int)($bin_row['bin_num'] ?? -1);
+            $unclassified = (int)($bin_row['unclassified'] ?? 0);
+            $shapes = is_array($bin_row['shapes'] ?? null) ? $bin_row['shapes'] : [];
+
+            if ($bin_num < 0) {
+                continue;
+            }
+
+            $total = $unclassified;
+            foreach ($shapes as $row) {
+                if (is_array($row) && isset($row['count'])) {
+                    $total += (int)$row['count'];
+                }
+            }
+            if ($total <= 0) {
+                continue;
+            }
+
+            foreach ($shapes as $row) {
+                if (!is_array($row)) {
+                    continue;
+                }
+                $label = (string)($row['label'] ?? '');
+                $count = (int)($row['count'] ?? 0);
+                $reachable = (int)($row['reachable_count'] ?? 0);
+                $confidence = (string)($row['confidence'] ?? 'medium');
+                if ($label === '' || $count === 0) {
+                    continue;
+                }
+                $orphan = $count - $reachable;
+                $pct = (float)$count / (float)$total * 100.0;
+
+                $findings[] = new Finding(
+                    kind: 'bin_shape_count',
+                    severity: FindingSeverity::Info,
+                    confidence: $this->mapConfidence($confidence),
+                    summary: sprintf(
+                        'bin[%d]: %s × %s (%.1f%%, %d orphan / %d reachable)',
+                        $bin_num,
+                        $label,
+                        number_format($count),
+                        $pct,
+                        $orphan,
+                        $reachable,
+                    ),
+                    facts: [
+                        'bin_num' => $bin_num,
+                        'shape' => $label,
+                        'count' => $count,
+                        'reachable_count' => $reachable,
+                        'orphan_count' => $orphan,
+                        'percentage' => round($pct, 1),
+                        'confidence' => $confidence,
+                    ],
+                );
+            }
+
+            if ($unclassified > 0) {
+                $pct = (float)$unclassified / (float)$total * 100.0;
+                $findings[] = new Finding(
+                    kind: 'bin_shape_unclassified',
+                    severity: FindingSeverity::Info,
+                    confidence: FindingConfidence::Low,
+                    summary: sprintf(
+                        'bin[%d]: unclassified × %s (%.1f%%)',
+                        $bin_num,
+                        number_format($unclassified),
+                        $pct,
+                    ),
+                    facts: [
+                        'bin_num' => $bin_num,
+                        'count' => $unclassified,
+                        'percentage' => round($pct, 1),
+                    ],
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    private function mapConfidence(string $raw): FindingConfidence
+    {
+        return match ($raw) {
+            'high' => FindingConfidence::High,
+            'low' => FindingConfidence::Low,
+            default => FindingConfidence::Medium,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     * @psalm-suppress MixedAssignment
+     */
+    private function decode(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            /** @var array<string, mixed> $value */
+            return $value;
+        }
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                /** @var array<string, mixed> $decoded */
+                return $decoded;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BinShapePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BinShapePass.php
@@ -67,14 +67,13 @@ final class BinShapePass implements PassInterface
                 continue;
             }
             $bin_num = (int)($bin_row['bin_num'] ?? -1);
-            $unclassified = (int)($bin_row['unclassified'] ?? 0);
             $shapes = is_array($bin_row['shapes'] ?? null) ? $bin_row['shapes'] : [];
 
             if ($bin_num < 0) {
                 continue;
             }
 
-            $total = $unclassified;
+            $total = 0;
             foreach ($shapes as $row) {
                 if (is_array($row) && isset($row['count'])) {
                     $total += (int)$row['count'];
@@ -97,20 +96,30 @@ final class BinShapePass implements PassInterface
                 }
                 $orphan = $count - $reachable;
                 $pct = (float)$count / (float)$total * 100.0;
+                $is_unclassified = $label === 'unclassified';
 
                 $findings[] = new Finding(
-                    kind: 'bin_shape_count',
+                    kind: $is_unclassified ? 'bin_shape_unclassified' : 'bin_shape_count',
                     severity: FindingSeverity::Info,
-                    confidence: $this->mapConfidence($confidence),
-                    summary: sprintf(
-                        'bin[%d]: %s × %s (%.1f%%, %d orphan / %d reachable)',
-                        $bin_num,
-                        $label,
-                        number_format($count),
-                        $pct,
-                        $orphan,
-                        $reachable,
-                    ),
+                    confidence: $is_unclassified
+                        ? FindingConfidence::Low
+                        : $this->mapConfidence($confidence),
+                    summary: $is_unclassified
+                        ? sprintf(
+                            'bin[%d]: unclassified × %s (%.1f%%)',
+                            $bin_num,
+                            number_format($count),
+                            $pct,
+                        )
+                        : sprintf(
+                            'bin[%d]: %s × %s (%.1f%%, %d orphan / %d reachable)',
+                            $bin_num,
+                            $label,
+                            number_format($count),
+                            $pct,
+                            $orphan,
+                            $reachable,
+                        ),
                     facts: [
                         'bin_num' => $bin_num,
                         'shape' => $label,
@@ -119,26 +128,6 @@ final class BinShapePass implements PassInterface
                         'orphan_count' => $orphan,
                         'percentage' => round($pct, 1),
                         'confidence' => $confidence,
-                    ],
-                );
-            }
-
-            if ($unclassified > 0) {
-                $pct = (float)$unclassified / (float)$total * 100.0;
-                $findings[] = new Finding(
-                    kind: 'bin_shape_unclassified',
-                    severity: FindingSeverity::Info,
-                    confidence: FindingConfidence::Low,
-                    summary: sprintf(
-                        'bin[%d]: unclassified × %s (%.1f%%)',
-                        $bin_num,
-                        number_format($unclassified),
-                        $pct,
-                    ),
-                    facts: [
-                        'bin_num' => $bin_num,
-                        'count' => $unclassified,
-                        'percentage' => round($pct, 1),
                     ],
                 );
             }

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\Report;
 
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\PassInterface;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\BinHistogramPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\BinPeriodicityPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BlameAllocationPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CallStackPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChokePointPass;
@@ -111,6 +113,8 @@ final class ReportGenerator
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
         $findings = array_merge($findings, (new ChunkCacheHeuristicPass($summary))->analyze());
         $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinHistogramPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinPeriodicityPass($summary))->analyze());
 
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
         $run_phase3 = $full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000);
@@ -342,6 +346,8 @@ final class ReportGenerator
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
         $findings = array_merge($findings, (new ChunkCacheHeuristicPass($summary))->analyze());
         $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinHistogramPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinPeriodicityPass($summary))->analyze());
 
         // Phase 3: Substrate passes — binary goes straight here.
         //

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -16,6 +16,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\PassInterface;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BinHistogramPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BinPeriodicityPass;
+use Reli\Inspector\Output\MemoryOutput\Report\Pass\BinShapePass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\BlameAllocationPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\CallStackPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\ChokePointPass;
@@ -115,6 +116,7 @@ final class ReportGenerator
         $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
         $findings = array_merge($findings, (new BinHistogramPass($summary))->analyze());
         $findings = array_merge($findings, (new BinPeriodicityPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinShapePass($summary))->analyze());
 
         // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
         $run_phase3 = $full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000);
@@ -348,6 +350,7 @@ final class ReportGenerator
         $findings = array_merge($findings, (new ChunkFragmentationPass($summary))->analyze());
         $findings = array_merge($findings, (new BinHistogramPass($summary))->analyze());
         $findings = array_merge($findings, (new BinPeriodicityPass($summary))->analyze());
+        $findings = array_merge($findings, (new BinShapePass($summary))->analyze());
 
         // Phase 3: Substrate passes — binary goes straight here.
         //

--- a/src/Lib/Dwarf/NativeSymbolResolver.php
+++ b/src/Lib/Dwarf/NativeSymbolResolver.php
@@ -104,14 +104,33 @@ final class NativeSymbolResolver
             }
         }
 
-        // Try loading from the binary itself
-        $resolver = $this->tryLoadFromFile($modulePath);
+        // Strict 3-step probe so distro-stripped binaries with a
+        // separate `-dbgsym` companion surface their full symbol set
+        // (the validator's PHP 8.3 + php8.3-cli-dbgsym setup).
+        //
+        // Old behaviour deferred everything to the all-in-one
+        // {@see Elf64ReverseSymbolResolver::loadFromBinary}, which
+        // returns success on the first non-null hit — `.dynsym`
+        // counted, so the debug-file branch was never reached and
+        // we ended up only ever resolving exported symbols.
+        //
+        //  1. main binary `.symtab`  — the typical "binary not stripped"
+        //     case (custom builds with debug); cheap, the binary is
+        //     already in the page cache after exec.
+        //  2. separate debug file `.symtab` — distro convention; brings
+        //     in vtables (`std_object_handlers` etc.) that
+        //     FunctionPointerDetector wants to label.
+        //  3. main binary `.dynsym` — last resort. Exports only;
+        //     `execute_ex+0x...` lands here, vtables don't.
+        $resolver = $this->tryLoadSymtabFromFile($modulePath);
         if ($resolver === null) {
-            // Fallback: try separate debug file for .symtab
             $debugFile = $this->debugFileLocator->locate($modulePath);
             if ($debugFile !== null) {
-                $resolver = $this->tryLoadFromFile($debugFile);
+                $resolver = $this->tryLoadSymtabFromFile($debugFile);
             }
+        }
+        if ($resolver === null) {
+            $resolver = $this->tryLoadDynsymFromFile($modulePath);
         }
 
         if ($resolver !== null && $fingerprint !== null) {
@@ -174,20 +193,39 @@ final class NativeSymbolResolver
         return $this->isFileCache[$path];
     }
 
-    private function tryLoadFromFile(string $filePath): ?Elf64ReverseSymbolResolver
+    private function tryLoadSymtabFromFile(string $filePath): ?Elf64ReverseSymbolResolver
+    {
+        $reader = $this->readBinary($filePath);
+        if ($reader === null) {
+            return null;
+        }
+        return Elf64ReverseSymbolResolver::loadSymtabFromBinary(
+            $this->elfParser,
+            $reader,
+        );
+    }
+
+    private function tryLoadDynsymFromFile(string $filePath): ?Elf64ReverseSymbolResolver
+    {
+        $reader = $this->readBinary($filePath);
+        if ($reader === null) {
+            return null;
+        }
+        return Elf64ReverseSymbolResolver::loadDynsymFromBinary(
+            $this->elfParser,
+            $reader,
+        );
+    }
+
+    private function readBinary(string $filePath): ?StringByteReader
     {
         $resolved = $this->resolvePath($filePath);
-
         try {
             $binary = $this->fileReader->readAll($resolved);
         } catch (\Throwable) {
             return null;
         }
-
-        return Elf64ReverseSymbolResolver::loadFromBinary(
-            $this->elfParser,
-            new StringByteReader($binary),
-        );
+        return new StringByteReader($binary);
     }
 
     /**

--- a/src/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolver.php
+++ b/src/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolver.php
@@ -63,31 +63,68 @@ final class Elf64ReverseSymbolResolver
         return $resolver;
     }
 
-    public static function loadFromBinary(Elf64Parser $parser, ByteReaderInterface $data): ?self
-    {
+    /**
+     * Try to build a resolver from the binary's `.symtab` section
+     * (full symbol table, includes static / non-exported entries —
+     * notably C++ vtables and the `B`/`D`-typed `std_object_handlers`
+     * style globals reli's FunctionPointerDetector wants to label).
+     *
+     * Returns null when the binary is stripped (no `.symtab`). The
+     * caller should then try the separate debug file before falling
+     * back to {@see loadDynsymFromBinary}, which only sees exported
+     * symbols.
+     */
+    public static function loadSymtabFromBinary(
+        Elf64Parser $parser,
+        ByteReaderInterface $data,
+    ): ?self {
         try {
             $elf_header = $parser->parseElfHeader($data);
             if ($elf_header->e_shnum === 0 || $elf_header->e_shoff->toInt() === 0) {
-                return self::loadDynamicOnly($parser, $data);
+                return null;
             }
-
             $section_headers = $parser->parseSectionHeader($data, $elf_header);
-
-            // Try .symtab first (has more symbols)
             $symtab_entry = $section_headers->findSymbolTableEntry();
             $strtab_entry = $section_headers->findStringTableEntry();
-
-            if ($symtab_entry !== null && $strtab_entry !== null) {
-                $symbol_table = $parser->parseSymbolTableFromSectionHeader($data, $symtab_entry);
-                $string_table = $parser->parseStringTableFromSectionHeader($data, $strtab_entry);
-                return self::fromSymbolTableAndStringTable($symbol_table, $string_table);
+            if ($symtab_entry === null || $strtab_entry === null) {
+                return null;
             }
-
-            // Fallback to .dynsym
-            return self::loadDynamicOnly($parser, $data);
+            $symbol_table = $parser->parseSymbolTableFromSectionHeader($data, $symtab_entry);
+            $string_table = $parser->parseStringTableFromSectionHeader($data, $strtab_entry);
+            return self::fromSymbolTableAndStringTable($symbol_table, $string_table);
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    /**
+     * Last-resort path: build a resolver from the dynamic symbol table
+     * (`.dynsym`) only. Catches exported symbols (the equivalent of
+     * `nm -D`) but misses static-storage globals like vtables.
+     */
+    public static function loadDynsymFromBinary(
+        Elf64Parser $parser,
+        ByteReaderInterface $data,
+    ): ?self {
+        return self::loadDynamicOnly($parser, $data);
+    }
+
+    /**
+     * Compatibility entry point: tries `.symtab` first, then falls
+     * back to `.dynsym` from the same binary. Callers that have access
+     * to a separate debug file should prefer the explicit
+     * {@see loadSymtabFromBinary} / {@see loadDynsymFromBinary} pair
+     * so they can interleave the debug-file lookup between the two
+     * steps — stripped distro binaries with a `-dbgsym` companion
+     * never surface their full symbol set otherwise.
+     */
+    public static function loadFromBinary(Elf64Parser $parser, ByteReaderInterface $data): ?self
+    {
+        $resolver = self::loadSymtabFromBinary($parser, $data);
+        if ($resolver !== null) {
+            return $resolver;
+        }
+        return self::loadDynsymFromBinary($parser, $data);
     }
 
     private static function loadDynamicOnly(Elf64Parser $parser, ByteReaderInterface $data): ?self

--- a/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendMmHeap.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
+use Reli\Lib\FFI\FFIHelper;
 use Reli\Lib\PhpInternals\CastedCData;
 use Reli\Lib\Process\Pointer\CDataDereferencable;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -226,6 +227,36 @@ final class ZendMmHeap implements LazyDereferencable, CDataDereferencable
     public function getPointer(): Pointer
     {
         return $this->pointer;
+    }
+
+    /**
+     * Read the heads of `free_slot[ZEND_MM_BINS]` as raw addresses.
+     *
+     * Only meaningful when this heap was loaded eagerly (the chunk-walker
+     * path always loads the main chunk eagerly so that path is fine).
+     * Returns an empty array if no eager CData is attached.
+     *
+     * The FFI Psalm stub for `zend_mm_heap` does not declare `free_slot`
+     * (the project's stubs cover only the reli-touched fields), so the
+     * field-fetch + array-access here are necessarily mixed; suppress
+     * narrowly rather than fattening the stub for one read site.
+     *
+     * @return list<int>
+     * @psalm-suppress UndefinedPropertyFetch, MixedArrayAccess, MixedArgument
+     */
+    public function getFreeSlotHeads(): array
+    {
+        if ($this->casted_cdata === null) {
+            return [];
+        }
+        $heads = [];
+        // ZEND_MM_BINS is 30 across all supported PHP versions.
+        for ($i = 0; $i < 30; $i++) {
+            $heads[] = FFIHelper::castPointerToInt(
+                $this->casted_cdata->casted->free_slot[$i],
+            );
+        }
+        return $heads;
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -38,16 +38,18 @@ final class BinWalkResult
      *     reachable_count: int,
      *     confidence: string
      * }>> $bin_shape_counts
-     *     Per-(bin, shape) tally from the per-slot detector scan. Lets the
-     *     report surface "76% of bin[3] is Bucket(IS_STRING)" for shapes
-     *     the periodic-group path skips because the bytes vary per slot.
-     * @param array<int, int> $bin_unclassified_counts Per-bin slots no
-     *     detector matched.
+     *     Per-(bin, label) tally from the per-slot detector scan. Lets
+     *     the report surface "76% of bin[3] is Bucket(IS_STRING)" for
+     *     shapes the periodic-group path skips because the bytes vary
+     *     per slot. Slots that no detector matched live under the
+     *     special label `unclassified` inside this same map so they
+     *     can be drilled into via bin-query.
      * @param array<int, array<string, list<int>>> $bin_shape_addrs
      *     Per-(bin, label) sample addresses (capped at
      *     {@see ZendMmBinWalker::PER_SHAPE_SAMPLE_CAP}). Persisted in the
      *     rmem summary so `inspector:memory:bin-query` can return real
      *     pointer-into-the-leak addresses for `memory:peek` follow-up.
+     *     Includes the `unclassified` label.
      */
     public function __construct(
         public readonly array $small_bin_histogram,
@@ -59,7 +61,6 @@ final class BinWalkResult
         public readonly int $walked_chunk_count,
         public readonly bool $partial,
         public readonly array $bin_shape_counts = [],
-        public readonly array $bin_unclassified_counts = [],
         public readonly array $bin_shape_addrs = [],
     ) {
     }
@@ -121,17 +122,15 @@ final class BinWalkResult
      *         "bin_num": int,
      *         "shapes": [
      *           {label, count, reachable_count, confidence, sample_addrs}, …
-     *         ],
-     *         "unclassified": int
+     *         ]
      *       }, …
      *     ]
      *   }
      *
-     * Stored as a single JSON entry keyed `bin_shape_counts` so the
-     * comparison provider can decode it without the rmem reader caring
-     * about the inner shape. The sample_addrs list (capped per
-     * {@see ZendMmBinWalker::PER_SHAPE_SAMPLE_CAP}) is what backs the
-     * `inspector:memory:bin-query` drill-down.
+     * The `unclassified` slots live inside `shapes` under the literal
+     * label `"unclassified"` — the validator's drill-down ask
+     * (`bin-query --shape=unclassified`) is satisfied by the same code
+     * path as classified shapes; no separate field needed.
      *
      * @return array{
      *     bin: list<array{
@@ -142,22 +141,18 @@ final class BinWalkResult
      *             reachable_count: int,
      *             confidence: string,
      *             sample_addrs: list<int>
-     *         }>,
-     *         unclassified: int
+     *         }>
      *     }>
      * }
      */
     public function toSummaryShapeCountsArray(): array
     {
         $bin_rows = [];
-        $bin_nums = array_unique(array_merge(
-            array_keys($this->bin_shape_counts),
-            array_keys($this->bin_unclassified_counts),
-        ));
+        $bin_nums = array_keys($this->bin_shape_counts);
         sort($bin_nums);
         foreach ($bin_nums as $bin_num) {
             $shapes = [];
-            foreach ($this->bin_shape_counts[$bin_num] ?? [] as $label => $row) {
+            foreach ($this->bin_shape_counts[$bin_num] as $label => $row) {
                 $shapes[] = [
                     'label' => $label,
                     'count' => $row['count'],
@@ -173,7 +168,6 @@ final class BinWalkResult
             $bin_rows[] = [
                 'bin_num' => $bin_num,
                 'shapes' => $shapes,
-                'unclassified' => $this->bin_unclassified_counts[$bin_num] ?? 0,
             ];
         }
         return ['bin' => $bin_rows];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -84,14 +84,16 @@ final class BinWalkResult
      *     count: int,
      *     stride: int,
      *     fingerprint: string,
-     *     sample_addr: int
+     *     sample_addr: int,
+     *     inferred_shape?: string,
+     *     inferred_confidence?: string
      * }>
      */
     public function toSummaryPeriodicGroupsArray(): array
     {
         $out = [];
         foreach ($this->periodic_groups as $g) {
-            $out[] = [
+            $row = [
                 'bin_num' => $g->bin_num,
                 'bin_size' => $g->bin_size,
                 'count' => $g->count,
@@ -99,6 +101,11 @@ final class BinWalkResult
                 'fingerprint' => $g->fingerprint_hex,
                 'sample_addr' => $g->sample_addr,
             ];
+            if ($g->detection !== null) {
+                $row['inferred_shape'] = $g->detection->label;
+                $row['inferred_confidence'] = $g->detection->confidence;
+            }
+            $out[] = $row;
         }
         return $out;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -86,7 +86,11 @@ final class BinWalkResult
      *     fingerprint: string,
      *     sample_addr: int,
      *     inferred_shape?: string,
-     *     inferred_confidence?: string
+     *     inferred_confidence?: string,
+     *     effective_confidence?: string,
+     *     reachability?: string,
+     *     reachable_samples?: int,
+     *     sampled_count?: int
      * }>
      */
     public function toSummaryPeriodicGroupsArray(): array
@@ -104,6 +108,15 @@ final class BinWalkResult
             if ($g->detection !== null) {
                 $row['inferred_shape'] = $g->detection->label;
                 $row['inferred_confidence'] = $g->detection->confidence;
+                $effective = $g->effectiveConfidence();
+                if ($effective !== null) {
+                    $row['effective_confidence'] = $effective;
+                }
+            }
+            if ($g->reachability !== null) {
+                $row['reachability'] = $g->reachability;
+                $row['reachable_samples'] = $g->reachable_samples;
+                $row['sampled_count'] = $g->sampled_count;
             }
             $out[] = $row;
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -33,6 +33,16 @@ final class BinWalkResult
      * @param array<int, array{count: int, total_bytes: int}> $small_bin_histogram
      *     Keyed by bin id (0..29). Only bins with at least one live slot are present.
      * @param list<PeriodicGroup> $periodic_groups
+     * @param array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string
+     * }>> $bin_shape_counts
+     *     Per-(bin, shape) tally from the per-slot detector scan. Lets the
+     *     report surface "76% of bin[3] is Bucket(IS_STRING)" for shapes
+     *     the periodic-group path skips because the bytes vary per slot.
+     * @param array<int, int> $bin_unclassified_counts Per-bin slots no
+     *     detector matched.
      */
     public function __construct(
         public readonly array $small_bin_histogram,
@@ -43,6 +53,8 @@ final class BinWalkResult
         public readonly array $periodic_groups,
         public readonly int $walked_chunk_count,
         public readonly bool $partial,
+        public readonly array $bin_shape_counts = [],
+        public readonly array $bin_unclassified_counts = [],
     ) {
     }
 
@@ -93,6 +105,70 @@ final class BinWalkResult
      *     sampled_count?: int
      * }>
      */
+    /**
+     * Per-bin shape tally for the rmem summary section.
+     *
+     * Schema:
+     *   {
+     *     "bin": [
+     *       {
+     *         "bin_num": int,
+     *         "shapes": [
+     *           {label, count, reachable_count, confidence}, …
+     *         ],
+     *         "unclassified": int
+     *       }, …
+     *     ]
+     *   }
+     *
+     * Stored as a single JSON entry keyed `bin_shape_counts` so the
+     * comparison provider can decode it without the rmem reader caring
+     * about the inner shape.
+     *
+     * @return array{
+     *     bin: list<array{
+     *         bin_num: int,
+     *         shapes: list<array{
+     *             label: string,
+     *             count: int,
+     *             reachable_count: int,
+     *             confidence: string
+     *         }>,
+     *         unclassified: int
+     *     }>
+     * }
+     */
+    public function toSummaryShapeCountsArray(): array
+    {
+        $bin_rows = [];
+        $bin_nums = array_unique(array_merge(
+            array_keys($this->bin_shape_counts),
+            array_keys($this->bin_unclassified_counts),
+        ));
+        sort($bin_nums);
+        foreach ($bin_nums as $bin_num) {
+            $shapes = [];
+            foreach ($this->bin_shape_counts[$bin_num] ?? [] as $label => $row) {
+                $shapes[] = [
+                    'label' => $label,
+                    'count' => $row['count'],
+                    'reachable_count' => $row['reachable_count'],
+                    'confidence' => $row['confidence'],
+                ];
+            }
+            usort(
+                $shapes,
+                static fn(array $a, array $b): int => $b['count'] <=> $a['count'],
+            );
+            $bin_rows[] = [
+                'bin_num' => $bin_num,
+                'shapes' => $shapes,
+                'unclassified' => $this->bin_unclassified_counts[$bin_num] ?? 0,
+            ];
+        }
+        return ['bin' => $bin_rows];
+    }
+
     public function toSummaryPeriodicGroupsArray(): array
     {
         $out = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+/**
+ * Output of {@see ZendMmBinWalker::walk()}.
+ *
+ * Captures the per-bin live-allocation distribution recovered by walking
+ * `chunk->map` and subtracting `heap->free_slot[]` freelists. The histogram
+ * always covers all 30 small-bin classes (8 B → 3072 B); large/huge runs are
+ * summarised separately.
+ *
+ * Periodic groups are runs of like-fingerprinted live slots in a single bin
+ * within a single chunk that the walker observed back-to-back at a constant
+ * stride. They are the headline signal for "C-extension is leaking N copies
+ * of the same struct" — see docs/internals/design-orphan-allocation-analysis.md
+ * section D.
+ */
+final class BinWalkResult
+{
+    /**
+     * @param array<int, array{count: int, total_bytes: int}> $small_bin_histogram
+     *     Keyed by bin id (0..29). Only bins with at least one live slot are present.
+     * @param list<PeriodicGroup> $periodic_groups
+     */
+    public function __construct(
+        public readonly array $small_bin_histogram,
+        public readonly int $large_run_count,
+        public readonly int $large_run_bytes,
+        public readonly int $live_small_slot_count,
+        public readonly int $live_small_slot_bytes,
+        public readonly array $periodic_groups,
+        public readonly int $walked_chunk_count,
+        public readonly bool $partial,
+    ) {
+    }
+
+    /**
+     * Compact dict for embedding inside the rmem summary section.
+     *
+     * Stored as a single JSON-encoded summary value (see how
+     * {@see \Reli\Inspector\Output\MemoryOutput\BinaryMemoryOutput::serializeSummary}
+     * handles non-scalar values). Schema is intentionally flat so a future
+     * reader can decode without classloading this DTO.
+     *
+     * @return array{
+     *     histogram: array<int, array{count: int, total_bytes: int}>,
+     *     large_run_count: int,
+     *     large_run_bytes: int,
+     *     live_small_slot_count: int,
+     *     live_small_slot_bytes: int,
+     *     walked_chunk_count: int,
+     *     partial: bool
+     * }
+     */
+    public function toSummaryHistogramArray(): array
+    {
+        return [
+            'histogram' => $this->small_bin_histogram,
+            'large_run_count' => $this->large_run_count,
+            'large_run_bytes' => $this->large_run_bytes,
+            'live_small_slot_count' => $this->live_small_slot_count,
+            'live_small_slot_bytes' => $this->live_small_slot_bytes,
+            'walked_chunk_count' => $this->walked_chunk_count,
+            'partial' => $this->partial,
+        ];
+    }
+
+    /**
+     * @return list<array{
+     *     bin_num: int,
+     *     bin_size: int,
+     *     count: int,
+     *     stride: int,
+     *     fingerprint: string,
+     *     sample_addr: int
+     * }>
+     */
+    public function toSummaryPeriodicGroupsArray(): array
+    {
+        $out = [];
+        foreach ($this->periodic_groups as $g) {
+            $out[] = [
+                'bin_num' => $g->bin_num,
+                'bin_size' => $g->bin_size,
+                'count' => $g->count,
+                'stride' => $g->stride,
+                'fingerprint' => $g->fingerprint_hex,
+                'sample_addr' => $g->sample_addr,
+            ];
+        }
+        return $out;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/BinWalkResult.php
@@ -43,6 +43,11 @@ final class BinWalkResult
      *     the periodic-group path skips because the bytes vary per slot.
      * @param array<int, int> $bin_unclassified_counts Per-bin slots no
      *     detector matched.
+     * @param array<int, array<string, list<int>>> $bin_shape_addrs
+     *     Per-(bin, label) sample addresses (capped at
+     *     {@see ZendMmBinWalker::PER_SHAPE_SAMPLE_CAP}). Persisted in the
+     *     rmem summary so `inspector:memory:bin-query` can return real
+     *     pointer-into-the-leak addresses for `memory:peek` follow-up.
      */
     public function __construct(
         public readonly array $small_bin_histogram,
@@ -55,6 +60,7 @@ final class BinWalkResult
         public readonly bool $partial,
         public readonly array $bin_shape_counts = [],
         public readonly array $bin_unclassified_counts = [],
+        public readonly array $bin_shape_addrs = [],
     ) {
     }
 
@@ -114,7 +120,7 @@ final class BinWalkResult
      *       {
      *         "bin_num": int,
      *         "shapes": [
-     *           {label, count, reachable_count, confidence}, …
+     *           {label, count, reachable_count, confidence, sample_addrs}, …
      *         ],
      *         "unclassified": int
      *       }, …
@@ -123,7 +129,9 @@ final class BinWalkResult
      *
      * Stored as a single JSON entry keyed `bin_shape_counts` so the
      * comparison provider can decode it without the rmem reader caring
-     * about the inner shape.
+     * about the inner shape. The sample_addrs list (capped per
+     * {@see ZendMmBinWalker::PER_SHAPE_SAMPLE_CAP}) is what backs the
+     * `inspector:memory:bin-query` drill-down.
      *
      * @return array{
      *     bin: list<array{
@@ -132,7 +140,8 @@ final class BinWalkResult
      *             label: string,
      *             count: int,
      *             reachable_count: int,
-     *             confidence: string
+     *             confidence: string,
+     *             sample_addrs: list<int>
      *         }>,
      *         unclassified: int
      *     }>
@@ -154,6 +163,7 @@ final class BinWalkResult
                     'count' => $row['count'],
                     'reachable_count' => $row['reachable_count'],
                     'confidence' => $row['confidence'],
+                    'sample_addrs' => $this->bin_shape_addrs[$bin_num][$label] ?? [],
                 ];
             }
             usort(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
@@ -66,8 +66,11 @@ final class BucketDetector implements ShapeDetector
     }
 
     #[\Override]
-    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-    {
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection {
         if ($bin_size !== 32 || strlen($fingerprint) < 24) {
             return null;
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
@@ -16,35 +16,48 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
 /**
  * Detect HashTable Bucket headers (32 B slots).
  *
- * A `Bucket` is laid out as:
+ * Layout:
  *
- *   +0..+15  zval val            (zval = u64 value + u32 type/flags + u32 type_info)
+ *   +0..+7   zval value          (u8)
+ *   +8       zval u1.v.type      (zend_uchar)
+ *   +9..+15  zval u1.v.{flags,u} + u2
  *   +16..+23 zend_ulong h        (hash)
  *   +24..+31 zend_string *key    (NULL for indexed entries)
  *
- * Within the zval, byte +8 holds the type tag (zend_uchar `u1.v.type`) —
- * IS_UNDEF (0) … IS_PTR (13) on PHP 7+ runs, with IS_INDIRECT etc. up to
- * 17. Anything outside [0, 21] is a strong signal that this is not a zval
- * at all, so the detector rejects.
+ * Tightening over the original header-only check, in response to the
+ * issue #88 validator data ("13 zval_type variants × 15 hits each from
+ * uninit'd HashTable expansion slots, all with all-zero value/h/key"):
  *
- * On the 24 B fingerprint we only see (val + h) and not the trailing
- * key pointer, so the strongest verdict header-only inspection can earn
- * is MED. The design's HIGH-confidence Bucket detector does follow-up
- * reads to walk into the key zend_string; that is intentionally deferred
- * to Phase 2.5.
+ *  - Pointer-bearing zvals (IS_STRING, IS_ARRAY, IS_OBJECT, IS_RESOURCE,
+ *    IS_REFERENCE, IS_CONSTANT_AST, IS_INDIRECT, IS_PTR, IS_ALIAS_PTR)
+ *    require a plausible non-zero pointer at +0..+7. Bytes near zero or
+ *    obvious garbage get rejected.
+ *  - All-zero (value=0, h=0, key=0) buckets — regardless of zval type
+ *    byte — collapse to a single `Bucket(uninit?)` label so the report
+ *    stops listing "+15 each" garbage variants.
+ *  - Symbol map covers IS_CONSTANT_AST (11), IS_INDIRECT (13), IS_PTR
+ *    (14), IS_ALIAS_PTR (15); deeper-internal types ≥ 16 are rejected.
+ *
+ * Confidence stays MEDIUM on a 24 B fingerprint because the trailing
+ * key-zend_string isn't followed; the design's HIGH-confidence Bucket
+ * detector that walks into the key remains future work.
  */
 final class BucketDetector implements ShapeDetector
 {
+    /** Pointer sanity ceiling — anything beyond this is not a userspace address. */
+    private const POINTER_MAX = 0x800000000000;
+
     /**
-     * Whitelist of plausible zval u1.v.type values across PHP 7.x / 8.x.
-     * IS_UNDEF=0 and IS_NULL=1 are common in newly-allocated buckets;
-     * IS_FALSE/IS_TRUE/IS_LONG/IS_DOUBLE/IS_STRING/IS_ARRAY/IS_OBJECT
-     * /IS_RESOURCE/IS_REFERENCE land in 2..10; the rest are internal
-     * (IS_INDIRECT, IS_PTR, IS_ALIAS_PTR, etc.).
+     * Pointer floor — addresses below 0x1000 are either NULL or kernel-
+     * /reserved-page territory; never a real PHP allocation.
      */
-    private const VALID_ZVAL_TYPES = [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-    ];
+    private const POINTER_MIN = 0x1000;
+
+    /**
+     * zval type bytes that store a pointer at +0..+7. For these, an
+     * all-zero or otherwise-bogus value is a strong rejection signal.
+     */
+    private const POINTER_ZVAL_TYPES = [6, 7, 8, 9, 10, 11, 13, 14, 15];
 
     #[\Override]
     public function name(): string
@@ -60,7 +73,52 @@ final class BucketDetector implements ShapeDetector
         }
 
         $type_byte = ord($fingerprint[8]);
-        if (!in_array($type_byte, self::VALID_ZVAL_TYPES, true)) {
+        if ($type_byte > 15) {
+            // Deep-internal types only show up in unsafe contexts; in
+            // a HashTable bucket they're almost always garbage from an
+            // uninit'd slot or a non-bucket allocation.
+            return null;
+        }
+
+        /** @var array{1: int} $val */
+        $val = unpack('P', substr($fingerprint, 0, 8));
+        $value = $val[1];
+
+        /** @var array{1: int} $hu */
+        $hu = unpack('P', substr($fingerprint, 16, 8));
+        $hash = $hu[1];
+
+        // Key is at +24..+31; only available on full-slot fingerprints
+        // (32 B bin, fingerprint ≥ 32 B which is guaranteed for bin
+        // size 32). Non-NULL keys point at zend_string.
+        $key = 0;
+        if (strlen($fingerprint) >= 32) {
+            /** @var array{1: int} $kv */
+            $kv = unpack('P', substr($fingerprint, 24, 8));
+            $key = $kv[1];
+        }
+
+        // Collapse "all-zero" / freshly-allocated bucket slots to a
+        // single label so the per-bin shape table doesn't fan out
+        // into 13 × `+15` zval-type variants.
+        if ($value === 0 && $hash === 0 && $key === 0) {
+            return new ShapeDetection(
+                label: 'Bucket(uninit?)',
+                confidence: ShapeDetection::CONFIDENCE_LOW,
+            );
+        }
+
+        // Pointer-bearing zvals: value must look like a userspace
+        // pointer. Reject obviously garbage values.
+        if (in_array($type_byte, self::POINTER_ZVAL_TYPES, true)) {
+            if (!$this->looksLikePointer($value)) {
+                return null;
+            }
+        }
+
+        // Non-NULL key must look like a pointer too. NULL is fine
+        // (indexed bucket entry).
+        if ($key !== 0 && !$this->looksLikePointer($key)) {
             return null;
         }
 
@@ -76,7 +134,10 @@ final class BucketDetector implements ShapeDetector
             8 => 'IS_OBJECT',
             9 => 'IS_RESOURCE',
             10 => 'IS_REFERENCE',
+            11 => 'IS_CONSTANT_AST',
             13 => 'IS_INDIRECT',
+            14 => 'IS_PTR',
+            15 => 'IS_ALIAS_PTR',
             default => sprintf('zval_type=%d', $type_byte),
         };
 
@@ -84,5 +145,18 @@ final class BucketDetector implements ShapeDetector
             label: sprintf('Bucket(zval %s)', $type_label),
             confidence: ShapeDetection::CONFIDENCE_MEDIUM,
         );
+    }
+
+    private function looksLikePointer(int $value): bool
+    {
+        // Reject negative-looking (high bit set) and below the userspace
+        // floor; require 8-byte alignment that PHP allocations honour.
+        if ($value <= 0 || $value >= self::POINTER_MAX) {
+            return false;
+        }
+        if ($value < self::POINTER_MIN) {
+            return false;
+        }
+        return ($value & 0x7) === 0;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Detect HashTable Bucket headers (32 B slots).
+ *
+ * A `Bucket` is laid out as:
+ *
+ *   +0..+15  zval val            (zval = u64 value + u32 type/flags + u32 type_info)
+ *   +16..+23 zend_ulong h        (hash)
+ *   +24..+31 zend_string *key    (NULL for indexed entries)
+ *
+ * Within the zval, byte +8 holds the type tag (zend_uchar `u1.v.type`) —
+ * IS_UNDEF (0) … IS_PTR (13) on PHP 7+ runs, with IS_INDIRECT etc. up to
+ * 17. Anything outside [0, 21] is a strong signal that this is not a zval
+ * at all, so the detector rejects.
+ *
+ * On the 24 B fingerprint we only see (val + h) and not the trailing
+ * key pointer, so the strongest verdict header-only inspection can earn
+ * is MED. The design's HIGH-confidence Bucket detector does follow-up
+ * reads to walk into the key zend_string; that is intentionally deferred
+ * to Phase 2.5.
+ */
+final class BucketDetector implements ShapeDetector
+{
+    /**
+     * Whitelist of plausible zval u1.v.type values across PHP 7.x / 8.x.
+     * IS_UNDEF=0 and IS_NULL=1 are common in newly-allocated buckets;
+     * IS_FALSE/IS_TRUE/IS_LONG/IS_DOUBLE/IS_STRING/IS_ARRAY/IS_OBJECT
+     * /IS_RESOURCE/IS_REFERENCE land in 2..10; the rest are internal
+     * (IS_INDIRECT, IS_PTR, IS_ALIAS_PTR, etc.).
+     */
+    private const VALID_ZVAL_TYPES = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    ];
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'BucketDetector';
+    }
+
+    #[\Override]
+    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+    {
+        if ($bin_size !== 32 || strlen($fingerprint) < 24) {
+            return null;
+        }
+
+        $type_byte = ord($fingerprint[8]);
+        if (!in_array($type_byte, self::VALID_ZVAL_TYPES, true)) {
+            return null;
+        }
+
+        $type_label = match ($type_byte) {
+            0 => 'IS_UNDEF',
+            1 => 'IS_NULL',
+            2 => 'IS_FALSE',
+            3 => 'IS_TRUE',
+            4 => 'IS_LONG',
+            5 => 'IS_DOUBLE',
+            6 => 'IS_STRING',
+            7 => 'IS_ARRAY',
+            8 => 'IS_OBJECT',
+            9 => 'IS_RESOURCE',
+            10 => 'IS_REFERENCE',
+            13 => 'IS_INDIRECT',
+            default => sprintf('zval_type=%d', $type_byte),
+        };
+
+        return new ShapeDetection(
+            label: sprintf('Bucket(zval %s)', $type_label),
+            confidence: ShapeDetection::CONFIDENCE_MEDIUM,
+        );
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetector.php
@@ -56,8 +56,16 @@ final class BucketDetector implements ShapeDetector
     /**
      * zval type bytes that store a pointer at +0..+7. For these, an
      * all-zero or otherwise-bogus value is a strong rejection signal.
+     *
+     * Bytes 6..10 are stable across all supported PHP versions
+     * (IS_STRING / IS_ARRAY / IS_OBJECT / IS_RESOURCE / IS_REFERENCE).
+     * We additionally include 11..15 because every internal type that
+     * lands in this range across PHP 7.3 → 8.x is also pointer-typed
+     * (IS_CONSTANT_AST / IS_INDIRECT / IS_PTR / IS_ALIAS_PTR) — the
+     * specific name varies but "value field is a pointer" doesn't, so
+     * the zero-value rejection is correct on every version.
      */
-    private const POINTER_ZVAL_TYPES = [6, 7, 8, 9, 10, 11, 13, 14, 15];
+    private const POINTER_ZVAL_TYPES = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
 
     #[\Override]
     public function name(): string
@@ -125,6 +133,15 @@ final class BucketDetector implements ShapeDetector
             return null;
         }
 
+        // Type bytes 0..10 are stable across every supported PHP
+        // (V70 → V85). Bytes ≥ 11 differ per PHP version (e.g. PHP 8.x
+        // has IS_INDIRECT=12 / IS_PTR=13 / IS_ALIAS_PTR=14, while
+        // V73/V74 have IS_INDIRECT=13 / IS_PTR=14 / IS_ALIAS_PTR=15)
+        // — see {@see \Reli\Lib\PhpInternals\Types\Zend\V73\ZvalU1}
+        // and friends. Without a PHP-version-aware DetectorContext we
+        // can't pick the right label, so labels for 11+ stay as the
+        // raw `zval_type=N` digit. Misnaming an internal type is worse
+        // than admitting "bytes don't fit a stable label".
         $type_label = match ($type_byte) {
             0 => 'IS_UNDEF',
             1 => 'IS_NULL',
@@ -137,10 +154,6 @@ final class BucketDetector implements ShapeDetector
             8 => 'IS_OBJECT',
             9 => 'IS_RESOURCE',
             10 => 'IS_REFERENCE',
-            11 => 'IS_CONSTANT_AST',
-            13 => 'IS_INDIRECT',
-            14 => 'IS_PTR',
-            15 => 'IS_ALIAS_PTR',
             default => sprintf('zval_type=%d', $type_byte),
         };
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorContext.php
@@ -28,6 +28,7 @@ final class DetectorContext
 {
     public function __construct(
         public readonly ?ModuleResolverInterface $module_resolver = null,
+        public readonly ?SymbolResolverInterface $symbol_resolver = null,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorContext.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Side-channel data the bin walker shares with detectors that need
+ * more than the slot's bytes.
+ *
+ * Built once per analyze run by {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker}
+ * from the target's process memory map (live target or embedded in the
+ * rdump). Detectors that don't need it (Bucket, ZendString, Stat) ignore
+ * the parameter; {@see FunctionPointerDetector} requires it.
+ *
+ * Fields are read-only and may all be null — detectors must handle that.
+ */
+final class DetectorContext
+{
+    public function __construct(
+        public readonly ?ModuleResolverInterface $module_resolver = null,
+    ) {
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Default detector lineup + the confidence-rank / best-pick helpers that
+ * both the bin walker (per-slot scan) and the periodicity detector
+ * (per-group label) consume.
+ *
+ * Lives here rather than inside PeriodicityDetector because the per-slot
+ * shape scan that surfaces "76% of bin[3] is Bucket(IS_STRING)" — added to
+ * cover content-varying shapes that don't form periodic groups — needs the
+ * same pipeline without dragging in the stride-detection plumbing.
+ */
+final class DetectorRegistry
+{
+    /** @return list<ShapeDetector> */
+    public static function defaults(): array
+    {
+        return [
+            new BucketDetector(),
+            new ZendStringDetector(),
+        ];
+    }
+
+    /**
+     * Pick the highest-confidence detection from the registered detectors.
+     * Confidence-first per the design's selection rule
+     * (HIGH > MEDIUM > LOW), then first-registered wins on tie. Detectors
+     * that return null are skipped.
+     *
+     * @param list<ShapeDetector> $detectors
+     */
+    public static function pickBest(
+        array $detectors,
+        string $bytes,
+        int $bin_size,
+    ): ?ShapeDetection {
+        $best = null;
+        foreach ($detectors as $d) {
+            $hit = $d->detect($bytes, $bin_size);
+            if ($hit === null) {
+                continue;
+            }
+            if (
+                $best === null
+                || self::confidenceRank($hit->confidence) > self::confidenceRank($best->confidence)
+            ) {
+                $best = $hit;
+            }
+        }
+        return $best;
+    }
+
+    public static function confidenceRank(string $c): int
+    {
+        return match ($c) {
+            ShapeDetection::CONFIDENCE_HIGH => 3,
+            ShapeDetection::CONFIDENCE_MEDIUM => 2,
+            ShapeDetection::CONFIDENCE_LOW => 1,
+            default => 0,
+        };
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
@@ -29,6 +29,11 @@ final class DetectorRegistry
     public static function defaults(): array
     {
         return [
+            // FunctionPointerDetector first so module-resolved labels
+            // ("func_ptr (libuv.so.1)") win tie-breaks over the
+            // pattern-only OpArrayDetector ("func_ptr_array(N × 32 B)")
+            // when both would match.
+            new FunctionPointerDetector(),
             new BucketDetector(),
             new ZendStringDetector(),
             new StatDetector(),
@@ -42,16 +47,20 @@ final class DetectorRegistry
      * (HIGH > MEDIUM > LOW), then first-registered wins on tie. Detectors
      * that return null are skipped.
      *
+     * `$context` is forwarded to every detector — those that don't need
+     * it ignore the parameter via their default-null arg.
+     *
      * @param list<ShapeDetector> $detectors
      */
     public static function pickBest(
         array $detectors,
         string $bytes,
         int $bin_size,
+        ?DetectorContext $context = null,
     ): ?ShapeDetection {
         $best = null;
         foreach ($detectors as $d) {
-            $hit = $d->detect($bytes, $bin_size);
+            $hit = $d->detect($bytes, $bin_size, $context);
             if ($hit === null) {
                 continue;
             }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
@@ -31,6 +31,7 @@ final class DetectorRegistry
         return [
             new BucketDetector(),
             new ZendStringDetector(),
+            new StatDetector(),
         ];
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/DetectorRegistry.php
@@ -32,6 +32,7 @@ final class DetectorRegistry
             new BucketDetector(),
             new ZendStringDetector(),
             new StatDetector(),
+            new OpArrayDetector(),
         ];
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetector.php
@@ -95,8 +95,24 @@ final class FunctionPointerDetector implements ShapeDetector
             );
         }
 
+        // Symbol-level promotion: when a symbol resolver is in context
+        // and lands the pointer inside a named function, render the
+        // full "module:symbol+offset" so the validator can read
+        // "is this an opcode handler in libphp.so or a libuv callback?"
+        // off a single line in the compare output.
+        $symbol_label = '';
+        if ($context->symbol_resolver !== null) {
+            $hit = $context->symbol_resolver->resolve($ptr);
+            if ($hit !== null) {
+                [$sym_name, $offset] = $hit;
+                $symbol_label = $offset > 0
+                    ? sprintf(':%s+0x%x', $sym_name, $offset)
+                    : sprintf(':%s', $sym_name);
+            }
+        }
+
         return new ShapeDetection(
-            label: sprintf('func_ptr (%s)', $module),
+            label: sprintf('func_ptr (%s%s)', $module, $symbol_label),
             confidence: ShapeDetection::CONFIDENCE_HIGH,
         );
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetector.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * The design's HIGH-confidence function-pointer detector (section C).
+ *
+ * Reads the leading 8-byte qword as a candidate function pointer and
+ * uses the {@see ModuleResolverInterface} from {@see DetectorContext}
+ * to confirm the address sits inside an executable region. When it does,
+ * label the slot with the loaded module's basename — the validator's
+ * issue #88 retest needs to know whether the leaked handler addresses
+ * point into `libphp.so` (zend_op handlers) or `libuv.so.1` (libuv
+ * callback table) to disambiguate the leak source.
+ *
+ * Confidence is HIGH when both axes match (executable region + named
+ * module), MEDIUM for executable but unnamed mappings (anonymous JIT
+ * pages), null otherwise. Without a module resolver in context the
+ * detector can't do its job and bows out — same behaviour as a
+ * detector that doesn't apply to this slot.
+ *
+ * Symbol-level resolution (`execute_ex+0xN` style) is the next step
+ * past this commit; it needs an ELF symbol table walker plumbed
+ * through, which is heavier than the module-level cut shipping here.
+ *
+ * Runs ahead of {@see OpArrayDetector} in the registry order so a
+ * single-pointer "this looks like a vtable / handler" verdict can
+ * dominate slots where the OpArrayDetector would also have matched —
+ * a labelled module name is more useful to the user than a stride
+ * count when both apply.
+ */
+final class FunctionPointerDetector implements ShapeDetector
+{
+    /**
+     * Userspace pointer floor — 0x100000 covers ELF text segments on
+     * Linux x86_64 (the typical PIE base, plus standard non-PIE
+     * 0x400000). Below this is either NULL or kernel-page territory.
+     */
+    private const TEXT_MIN = 0x100000;
+
+    /** Userspace ceiling — same as the rest of the detectors. */
+    private const TEXT_MAX = 0x800000000000;
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'FunctionPointerDetector';
+    }
+
+    #[\Override]
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection {
+        if ($context === null || $context->module_resolver === null) {
+            return null;
+        }
+        if (strlen($fingerprint) < 8) {
+            return null;
+        }
+
+        /** @var array{1: int} $u */
+        $u = unpack('P', substr($fingerprint, 0, 8));
+        $ptr = $u[1];
+
+        if ($ptr < self::TEXT_MIN || $ptr >= self::TEXT_MAX) {
+            return null;
+        }
+
+        $resolver = $context->module_resolver;
+        if (!$resolver->isExecutable($ptr)) {
+            // Pointer-shaped but not pointing into anything executable.
+            // Could be a heap pointer that happens to look high; the
+            // other detectors handle pointer-bearing zvals.
+            return null;
+        }
+
+        $module = $resolver->moduleBasenameFor($ptr);
+        if ($module === null) {
+            return new ShapeDetection(
+                label: sprintf('func_ptr (anon-exec @0x%x)', $ptr),
+                confidence: ShapeDetection::CONFIDENCE_MEDIUM,
+            );
+        }
+
+        return new ShapeDetection(
+            label: sprintf('func_ptr (%s)', $module),
+            confidence: ShapeDetection::CONFIDENCE_HIGH,
+        );
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ModuleResolverInterface.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ModuleResolverInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Resolve a remote-process address to the loaded-module name + executable
+ * region status the address falls in.
+ *
+ * Kept narrow on purpose so detectors don't depend on the full
+ * {@see \Reli\Lib\Process\MemoryMap\ProcessMemoryMap} API and tests can
+ * stand up trivial fakes. The default implementation
+ * {@see ProcessMemoryMapModuleResolver} adapts a real `ProcessMemoryMap`.
+ */
+interface ModuleResolverInterface
+{
+    /**
+     * Basename of the loaded module the address falls in (e.g. `libphp.so`,
+     * `libuv.so.1`). Returns null when the address isn't in any named
+     * module — anonymous mappings, JIT pages, or unknown ranges.
+     */
+    public function moduleBasenameFor(int $address): ?string;
+
+    /**
+     * True when the address sits inside any executable region of the
+     * target's memory map. The basis for the design's
+     * FunctionPointerDetector — a value that points into `.text` is
+     * almost certainly a function pointer, not random data.
+     */
+    public function isExecutable(int $address): bool;
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/NativeSymbolResolverAdapter.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/NativeSymbolResolverAdapter.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\Lib\Dwarf\NativeSymbolResolver;
+
+/**
+ * {@see SymbolResolverInterface} backed by reli's call-trace
+ * {@see NativeSymbolResolver}. Reuses the same ELF symbol-table
+ * parser, per-binary cache, and base-address calculation that the
+ * native trace path already paid the engineering cost for.
+ *
+ * Defensive: NativeSymbolResolver can throw on malformed binaries
+ * or unreadable files; the adapter swallows those into null so a
+ * single bad module doesn't abort the per-slot scan.
+ */
+final class NativeSymbolResolverAdapter implements SymbolResolverInterface
+{
+    public function __construct(
+        private NativeSymbolResolver $resolver,
+    ) {
+    }
+
+    #[\Override]
+    public function resolve(int $address): ?array
+    {
+        try {
+            return $this->resolver->resolve($address);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
@@ -32,14 +32,19 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
  *
  * Validation:
  *   - At least 3 consecutive 32-byte sub-blocks each start with a
- *     plausible `.text` pointer (in [0x100000, POINTER_MAX), 4-byte
- *     aligned to match common ELF text alignment).
+ *     plausible `.text` pointer (in [0x100000, POINTER_MAX)).
  *   - The total length stays within the slot.
  *
  * Confidence:
  *   - 3-4 sub-blocks → MEDIUM (could still be coincidence).
  *   - 5+ sub-blocks  → HIGH (the chance of a 5-pointer .text run by
  *     accident is negligible).
+ *
+ * Alignment is not checked: PHP's opcode handlers (`execute_ex`'s
+ * computed-goto labels) and JIT trampolines land at byte-granular
+ * offsets inside `.text`, so requiring 4/16-byte alignment turns out
+ * to miss the validator's exact leak shape (handler addresses ending
+ * in 0x5a / 0xee / 0xb5 / 0xe0 / 0x01 — clearly 1-byte aligned).
  *
  * Symbol resolution (resolving the leading `.text` ptr to e.g.
  * `execute_ex+0x...` or `php_uv_*`) is the design's negative-evidence
@@ -115,9 +120,10 @@ final class OpArrayDetector implements ShapeDetector
         if ($ptr < self::TEXT_MIN) {
             return false;
         }
-        // ELF function entries are typically 16-byte aligned but we
-        // accept 4-byte alignment to tolerate older toolchains and
-        // odd JIT-emitted code.
-        return ($ptr & 0x3) === 0;
+        // No alignment check: PHP opcode handlers are computed-goto
+        // labels at byte-granular offsets inside execute_ex, and JIT
+        // trampolines land wherever the page allocator gave them.
+        // Range membership is the only safe filter.
+        return true;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Detect 32-byte-stride structures whose every element starts with a
+ * pointer that looks like a code-segment (`.text`) address.
+ *
+ * The validator's issue #88 retest had ~2,000 unclassified 224 B slots
+ * laid out as
+ *
+ *     [.text ptr][24 B small ints + flags] × 7  → 7 × 32 B = 224
+ *
+ * That's the shape of a 7-instruction `zend_op` array, but it might
+ * also be any other PHP-internal (or libuv-internal) function-pointer
+ * table laid out the same way. Without dragging in a full symbol
+ * resolver — the design's HIGH-confidence FunctionPointerDetector,
+ * deferred to Phase 2.5 — we can still surface "this looks like a
+ * function-pointer-bearing struct of N elements" so the slots stop
+ * showing up as `unclassified`.
+ *
+ * Validation:
+ *   - At least 3 consecutive 32-byte sub-blocks each start with a
+ *     plausible `.text` pointer (in [0x100000, POINTER_MAX), 4-byte
+ *     aligned to match common ELF text alignment).
+ *   - The total length stays within the slot.
+ *
+ * Confidence:
+ *   - 3-4 sub-blocks → MEDIUM (could still be coincidence).
+ *   - 5+ sub-blocks  → HIGH (the chance of a 5-pointer .text run by
+ *     accident is negligible).
+ *
+ * Symbol resolution (resolving the leading `.text` ptr to e.g.
+ * `execute_ex+0x...` or `php_uv_*`) is the design's negative-evidence
+ * promotion path and remains future work.
+ */
+final class OpArrayDetector implements ShapeDetector
+{
+    private const STRIDE = 32;
+    private const MIN_HITS = 3;
+    private const HIGH_CONFIDENCE_HITS = 5;
+
+    /**
+     * Lower bound for `.text` pointer sanity. ELF executables on Linux
+     * x86_64 typically map `.text` at 0x400000+; PIE and dynamic
+     * libraries can be anywhere from 0x100000 upward.
+     */
+    private const TEXT_MIN = 0x100000;
+
+    /** Userspace ceiling — same as other detectors. */
+    private const TEXT_MAX = 0x800000000000;
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'OpArrayDetector';
+    }
+
+    #[\Override]
+    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+    {
+        if ($bin_size < self::STRIDE * self::MIN_HITS) {
+            return null;
+        }
+        $fp_len = strlen($fingerprint);
+        $max_in_slot = intdiv($bin_size, self::STRIDE);
+        $max_in_fp = intdiv($fp_len, self::STRIDE);
+        $max_ops = min($max_in_slot, $max_in_fp);
+        if ($max_ops < self::MIN_HITS) {
+            return null;
+        }
+
+        $hits = 0;
+        for ($i = 0; $i < $max_ops; $i++) {
+            $offset = $i * self::STRIDE;
+            /** @var array{1: int} $u */
+            $u = unpack('P', substr($fingerprint, $offset, 8));
+            $ptr = $u[1];
+            if (!$this->looksLikeTextPointer($ptr)) {
+                break; // Run broken — count consecutive only.
+            }
+            $hits++;
+        }
+
+        if ($hits < self::MIN_HITS) {
+            return null;
+        }
+
+        $confidence = $hits >= self::HIGH_CONFIDENCE_HITS
+            ? ShapeDetection::CONFIDENCE_HIGH
+            : ShapeDetection::CONFIDENCE_MEDIUM;
+
+        return new ShapeDetection(
+            label: sprintf('func_ptr_array(%d × 32 B)', $hits),
+            confidence: $confidence,
+        );
+    }
+
+    private function looksLikeTextPointer(int $ptr): bool
+    {
+        if ($ptr <= 0 || $ptr >= self::TEXT_MAX) {
+            return false;
+        }
+        if ($ptr < self::TEXT_MIN) {
+            return false;
+        }
+        // ELF function entries are typically 16-byte aligned but we
+        // accept 4-byte alignment to tolerate older toolchains and
+        // odd JIT-emitted code.
+        return ($ptr & 0x3) === 0;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetector.php
@@ -73,8 +73,11 @@ final class OpArrayDetector implements ShapeDetector
     }
 
     #[\Override]
-    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-    {
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection {
         if ($bin_size < self::STRIDE * self::MIN_HITS) {
             return null;
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ProcessMemoryMapModuleResolver.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ProcessMemoryMapModuleResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
+
+/**
+ * {@see ModuleResolverInterface} backed by a {@see ProcessMemoryMap} —
+ * the live-target case populates this from `/proc/<pid>/maps`, the
+ * rdump case from the map embedded in the dump file. Either way the
+ * detector layer stays oblivious to the source.
+ */
+final class ProcessMemoryMapModuleResolver implements ModuleResolverInterface
+{
+    public function __construct(
+        private ProcessMemoryMap $memory_map,
+    ) {
+    }
+
+    #[\Override]
+    public function moduleBasenameFor(int $address): ?string
+    {
+        foreach ($this->memory_map->findByAddress($address) as $area) {
+            $name = $area->name;
+            if ($name === '' || $name[0] === '[') {
+                // Anonymous mappings ([heap], [stack], [vdso], …)
+                // aren't a meaningful module label.
+                continue;
+            }
+            return basename($name);
+        }
+        return null;
+    }
+
+    #[\Override]
+    public function isExecutable(int $address): bool
+    {
+        foreach ($this->memory_map->findByAddress($address) as $area) {
+            if ($area->attribute->execute) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetection.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetection.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * A detector's verdict on a slot's byte shape.
+ *
+ * Confidence levels track the design doc: HIGH means the byte pattern is
+ * specific enough that a false positive is unlikely (e.g. zend_string
+ * header with valid gc + plausible len + NUL terminator at the right
+ * offset); MED means the pattern is suggestive but not unique; LOW means
+ * "could be" — only useful as supporting evidence.
+ *
+ * A detector that needs more bytes than the 24 B fingerprint to commit
+ * to HIGH should return MED here; the design's full pipeline (Phase 2.5
+ * and beyond) is expected to read the rest of the slot before promoting.
+ */
+final class ShapeDetection
+{
+    public const CONFIDENCE_HIGH = 'high';
+    public const CONFIDENCE_MEDIUM = 'medium';
+    public const CONFIDENCE_LOW = 'low';
+
+    public function __construct(
+        public readonly string $label,
+        public readonly string $confidence,
+    ) {
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetector.php
@@ -36,9 +36,19 @@ interface ShapeDetector
     public function name(): string;
 
     /**
-     * Inspect the slot's first-24-byte fingerprint and bin size; return
+     * Inspect the slot's first-N-byte fingerprint and bin size; return
      * a labelled detection or null when the bytes don't match the
      * detector's expected shape.
+     *
+     * `$context` carries side-channel data (e.g. a module resolver) for
+     * detectors that need more than the slot bytes — most detectors
+     * ignore it. Keep accepting `null` so plain-bytes-only call sites
+     * (tests, the periodicity grouping path) don't have to construct
+     * a context.
      */
-    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection;
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection;
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ShapeDetector.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Best-effort decoder for the byte shape of a single bin slot.
+ *
+ * The bin walker collects the first ~24 bytes of every live small slot
+ * as a fingerprint; detectors get those bytes plus the slot size and may
+ * return a {@see ShapeDetection} when the bytes match a known structural
+ * pattern (Bucket header, zend_string header, …).
+ *
+ * Detectors are intentionally header-only — they can match on the first
+ * 24 B fingerprint alone, no follow-up reads of the heap. That keeps the
+ * detector pipeline a pure function over already-collected data and lets
+ * us run it in PeriodicityDetector without touching the live target.
+ *
+ * Reachability filtering (the design's "negative-evidence rule") is
+ * applied separately by the caller; detectors should report any structural
+ * match they see and let downstream code suppress it when the slot is
+ * already claimed by the root walker.
+ */
+interface ShapeDetector
+{
+    public function name(): string;
+
+    /**
+     * Inspect the slot's first-24-byte fingerprint and bin size; return
+     * a labelled detection or null when the bytes don't match the
+     * detector's expected shape.
+     */
+    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection;
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
@@ -81,11 +81,29 @@ final class StatDetector implements ShapeDetector
     ];
 
     /**
-     * Candidate offsets to scan. Includes natural boundaries (0, multiples
-     * of 8) plus the ones the validator's traffic actually exhibited
-     * (48 for 192 B uv_fs_t, 80 for 224 B uv_fs_t variants).
+     * Candidate offsets to scan. Includes the natural 8-byte boundaries
+     * the validator actually exhibits (48 for 192 B uv_fs_t, 80 for
+     * 224 B variants) plus 4-byte intermediates so we tolerate stat
+     * embedded after fields with non-8-byte natural alignment.
      */
-    private const OFFSETS = [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80];
+    private const OFFSETS = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80];
+
+    /**
+     * Minimum number of validation axes a candidate offset must score
+     * before we accept the slot. Bumped from the original 3 after the
+     * second validator pass found a single-S_IFMT-axis match at @+32
+     * winning over the real stat at @+48 — combining mode + uid/gid +
+     * nlink + blksize + timespec sanity makes accidental matches
+     * essentially impossible.
+     */
+    private const MIN_AXES = 4;
+    private const HIGH_AXES = 5;
+
+    /** Plausible st_blksize values — Linux fs blocksizes. */
+    private const VALID_BLKSIZES = [
+        512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072,
+        262144, 524288, 1048576,
+    ];
 
     #[\Override]
     public function name(): string
@@ -172,6 +190,17 @@ final class StatDetector implements ShapeDetector
             }
         }
 
+        // st_blksize @ +56 (8). Standard Linux fs blocksizes are powers
+        // of two from 512 to 1 MiB. Random uint64s essentially never hit
+        // that whitelist, so this axis is a strong false-positive killer.
+        if ($visible >= 64) {
+            /** @var array{1: int} $bs */
+            $bs = unpack('P', substr($fp, $offset + 56, 8));
+            if (in_array($bs[1], self::VALID_BLKSIZES, true)) {
+                $axes++;
+            }
+        }
+
         // Timespecs at +72 / +88 / +104. Visible at all?
         if ($visible >= 80) {
             $now = time();
@@ -204,11 +233,11 @@ final class StatDetector implements ShapeDetector
             }
         }
 
-        if ($axes < 3) {
+        if ($axes < self::MIN_AXES) {
             return null;
         }
 
-        $confidence = $axes >= 4
+        $confidence = $axes >= self::HIGH_AXES
             ? ShapeDetection::CONFIDENCE_HIGH
             : ShapeDetection::CONFIDENCE_MEDIUM;
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Detect Linux glibc `struct stat`-shaped buffers.
+ *
+ * Layout (Linux x86_64 glibc, 144 B):
+ *
+ *   +0    dev_t     st_dev      (8)
+ *   +8    ino_t     st_ino      (8)
+ *   +16   nlink_t   st_nlink    (8)
+ *   +24   mode_t    st_mode     (4)
+ *   +28   uid_t     st_uid      (4)
+ *   +32   gid_t     st_gid      (4)
+ *   +36   int       __pad0      (4)
+ *   +40   dev_t     st_rdev     (8)
+ *   +48   off_t     st_size     (8)
+ *   +56   blksize_t st_blksize  (8)
+ *   +64   blkcnt_t  st_blocks   (8)
+ *   +72   timespec  st_atim     (16: sec + nsec)
+ *   +88   timespec  st_mtim     (16)
+ *   +104  timespec  st_ctim     (16)
+ *   +120  long      __unused[3] (24)
+ *
+ * The validator's issue #88 leak holds a struct stat at offset 48 inside
+ * a 192 B slot (uv_fs_t.statbuf field) and at offset 80 inside a 224 B
+ * slot. Detection must therefore scan a few candidate offsets — we try
+ * the most plausible ones (0, 16, 32, 40, 48, 64, 80) up to the largest
+ * offset that still leaves room for the 144 B struct in the slot.
+ *
+ * Confidence axes (the design's HIGH bar is "all five aligned"):
+ *   1. mode has S_IFMT bits set (regular file / dir / symlink / …)
+ *   2. uid + gid are sub-2^24 (Linux convention; bigger means garbage)
+ *   3. nlink is 1..2^16 (huge nlinks are nonsense for a real inode)
+ *   4. at least one timespec has tv_sec within ±50 years of now
+ *   5. that same timespec's tv_nsec is < 1e9
+ *
+ * Three-axis match → MEDIUM, four-or-more → HIGH. Below 3 → null.
+ *
+ * Detector returns the offset where the stat was found in the label
+ * so users can `inspector:memory:peek` straight at the right region:
+ * `struct stat @+48 (mode 0o100644, size 0)`.
+ */
+final class StatDetector implements ShapeDetector
+{
+    private const STAT_SIZE = 144;
+    private const SECONDS_PER_YEAR = 31_557_600;
+    private const TIME_WINDOW_YEARS = 50;
+    /** Linux S_IFMT mask covers bits 12..15 of mode. */
+    private const S_IFMT = 0xF000;
+
+    /**
+     * Candidate offsets to scan. Includes natural boundaries (0, multiples
+     * of 8) plus the ones the validator's traffic actually exhibited
+     * (48 for 192 B uv_fs_t, 80 for 224 B uv_fs_t variants).
+     */
+    private const OFFSETS = [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80];
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'StatDetector';
+    }
+
+    #[\Override]
+    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+    {
+        // Must fit a struct stat somewhere — even with offset 0 we need
+        // the full 144 B.
+        if ($bin_size < self::STAT_SIZE) {
+            return null;
+        }
+        $fp_len = strlen($fingerprint);
+
+        $best = null;
+        foreach (self::OFFSETS as $offset) {
+            if ($offset + self::STAT_SIZE > $bin_size) {
+                continue;
+            }
+            // Visible window for this candidate: how much of the stat
+            // does the fingerprint cover?
+            $visible_end = min($fp_len, $offset + self::STAT_SIZE);
+            $visible = $visible_end - $offset;
+            if ($visible < 36) {
+                // Below mode + uid + gid we can't even start scoring.
+                continue;
+            }
+            $hit = $this->tryAtOffset($fingerprint, $offset, $visible);
+            if ($hit === null) {
+                continue;
+            }
+            if (
+                $best === null
+                || $this->scoreOf($hit) > $this->scoreOf($best)
+            ) {
+                $best = $hit;
+            }
+        }
+        return $best;
+    }
+
+    /**
+     * @return ShapeDetection|null
+     */
+    private function tryAtOffset(string $fp, int $offset, int $visible): ?ShapeDetection
+    {
+        // st_mode @ +24 (4), st_uid @ +28 (4), st_gid @ +32 (4)
+        /** @var array{1: int} $m */
+        $m = unpack('V', substr($fp, $offset + 24, 4));
+        $mode = $m[1];
+        if (($mode & self::S_IFMT) === 0) {
+            return null;
+        }
+
+        /** @var array{1: int} $u */
+        $u = unpack('V', substr($fp, $offset + 28, 4));
+        $uid = $u[1];
+        /** @var array{1: int} $g */
+        $g = unpack('V', substr($fp, $offset + 32, 4));
+        $gid = $g[1];
+        $axes = 1; // mode passed
+        if ($uid < 0x1000000 && $gid < 0x1000000) {
+            $axes++;
+        }
+
+        // st_nlink @ +16 (8 on x86_64). Only count if visible.
+        if ($visible >= 24) {
+            /** @var array{1: int} $n */
+            $n = unpack('P', substr($fp, $offset + 16, 8));
+            $nlink = $n[1];
+            if ($nlink >= 1 && $nlink < 0x10000) {
+                $axes++;
+            }
+        }
+
+        // Timespecs at +72 / +88 / +104. Visible at all?
+        if ($visible >= 80) {
+            $now = time();
+            $window = self::TIME_WINDOW_YEARS * self::SECONDS_PER_YEAR;
+            $any_time_ok = false;
+            $any_nsec_ok = false;
+            foreach ([72, 88, 104] as $ts_off) {
+                if ($visible < $ts_off + 16) {
+                    break;
+                }
+                /** @var array{1: int} $sec */
+                $sec = unpack('P', substr($fp, $offset + $ts_off, 8));
+                /** @var array{1: int} $nsec */
+                $nsec = unpack('P', substr($fp, $offset + $ts_off + 8, 8));
+                if (
+                    $sec[1] > 0
+                    && abs($sec[1] - $now) <= $window
+                ) {
+                    $any_time_ok = true;
+                }
+                if ($nsec[1] >= 0 && $nsec[1] < 1_000_000_000) {
+                    $any_nsec_ok = true;
+                }
+            }
+            if ($any_time_ok) {
+                $axes++;
+            }
+            if ($any_nsec_ok) {
+                $axes++;
+            }
+        }
+
+        if ($axes < 3) {
+            return null;
+        }
+
+        $confidence = $axes >= 4
+            ? ShapeDetection::CONFIDENCE_HIGH
+            : ShapeDetection::CONFIDENCE_MEDIUM;
+
+        // Format mode as octal so the user's eye can match it against
+        // their `peek` output (validator showed mode 0o100644).
+        $size_label = '';
+        if ($visible >= 56) {
+            /** @var array{1: int} $sz */
+            $sz = unpack('P', substr($fp, $offset + 48, 8));
+            $size_label = sprintf(', size %d', $sz[1]);
+        }
+
+        return new ShapeDetection(
+            label: sprintf(
+                'struct stat @+%d (mode 0o%o%s)',
+                $offset,
+                $mode,
+                $size_label,
+            ),
+            confidence: $confidence,
+        );
+    }
+
+    private function scoreOf(ShapeDetection $d): int
+    {
+        return $d->confidence === ShapeDetection::CONFIDENCE_HIGH ? 2 : 1;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
@@ -112,8 +112,11 @@ final class StatDetector implements ShapeDetector
     }
 
     #[\Override]
-    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-    {
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection {
         // Must fit a struct stat somewhere — even with offset 0 we need
         // the full 144 B.
         if ($bin_size < self::STAT_SIZE) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetector.php
@@ -62,6 +62,25 @@ final class StatDetector implements ShapeDetector
     private const S_IFMT = 0xF000;
 
     /**
+     * Exact S_IFMT values for the 7 POSIX file types. The mode field
+     * must mask down to *exactly* one of these — anything else is
+     * garbage. The validator's issue #88 retest landed on the +24
+     * candidate offset because the loose `mode & S_IFMT != 0` check
+     * accepted `0o177000` (= 0xfe00, which is actually `st_dev` read
+     * at the wrong offset). Strict membership rejects that and lets
+     * the +48 candidate (the real stat) win.
+     */
+    private const VALID_S_IFMT = [
+        0o100000, // S_IFREG  regular file
+        0o040000, // S_IFDIR  directory
+        0o020000, // S_IFCHR  character device
+        0o060000, // S_IFBLK  block device
+        0o010000, // S_IFIFO  FIFO
+        0o120000, // S_IFLNK  symlink
+        0o140000, // S_IFSOCK socket
+    ];
+
+    /**
      * Candidate offsets to scan. Includes natural boundaries (0, multiples
      * of 8) plus the ones the validator's traffic actually exhibited
      * (48 for 192 B uv_fs_t, 80 for 224 B uv_fs_t variants).
@@ -85,6 +104,7 @@ final class StatDetector implements ShapeDetector
         $fp_len = strlen($fingerprint);
 
         $best = null;
+        $best_axes = -1;
         foreach (self::OFFSETS as $offset) {
             if ($offset + self::STAT_SIZE > $bin_size) {
                 continue;
@@ -97,30 +117,37 @@ final class StatDetector implements ShapeDetector
                 // Below mode + uid + gid we can't even start scoring.
                 continue;
             }
-            $hit = $this->tryAtOffset($fingerprint, $offset, $visible);
-            if ($hit === null) {
+            $candidate = $this->tryAtOffset($fingerprint, $offset, $visible);
+            if ($candidate === null) {
                 continue;
             }
-            if (
-                $best === null
-                || $this->scoreOf($hit) > $this->scoreOf($best)
-            ) {
-                $best = $hit;
+            // Tiebreaker: when two offsets pass, the one that earned
+            // more validation axes wins. Without this, +24 and +48 can
+            // both look HIGH and the first-encountered one (+24) is
+            // taken; with tighter S_IFMT the +24 case usually rejects
+            // outright now, but keep the granular score so future
+            // similar shapes don't regress.
+            [$detection, $axes] = $candidate;
+            if ($axes > $best_axes) {
+                $best = $detection;
+                $best_axes = $axes;
             }
         }
         return $best;
     }
 
     /**
-     * @return ShapeDetection|null
+     * @return array{0: ShapeDetection, 1: int}|null Detection + axis
+     *     count that earned it (so the caller can rank multi-offset
+     *     matches granularly).
      */
-    private function tryAtOffset(string $fp, int $offset, int $visible): ?ShapeDetection
+    private function tryAtOffset(string $fp, int $offset, int $visible): ?array
     {
         // st_mode @ +24 (4), st_uid @ +28 (4), st_gid @ +32 (4)
         /** @var array{1: int} $m */
         $m = unpack('V', substr($fp, $offset + 24, 4));
         $mode = $m[1];
-        if (($mode & self::S_IFMT) === 0) {
+        if (!in_array($mode & self::S_IFMT, self::VALID_S_IFMT, true)) {
             return null;
         }
 
@@ -194,19 +221,17 @@ final class StatDetector implements ShapeDetector
             $size_label = sprintf(', size %d', $sz[1]);
         }
 
-        return new ShapeDetection(
-            label: sprintf(
-                'struct stat @+%d (mode 0o%o%s)',
-                $offset,
-                $mode,
-                $size_label,
+        return [
+            new ShapeDetection(
+                label: sprintf(
+                    'struct stat @+%d (mode 0o%o%s)',
+                    $offset,
+                    $mode,
+                    $size_label,
+                ),
+                confidence: $confidence,
             ),
-            confidence: $confidence,
-        );
-    }
-
-    private function scoreOf(ShapeDetection $d): int
-    {
-        return $d->confidence === ShapeDetection::CONFIDENCE_HIGH ? 2 : 1;
+            $axes,
+        ];
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/SymbolResolverInterface.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/SymbolResolverInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Resolve a remote-process address to a symbol name + offset within that
+ * symbol — `["execute_ex", 0x123]` style.
+ *
+ * Companion to {@see ModuleResolverInterface}: the module resolver
+ * answers "which library?", this one answers "which function?".
+ * Detectors should consult both; symbol-level info promotes a
+ * {@see FunctionPointerDetector} verdict from "func_ptr (libphp.so)"
+ * to "func_ptr (libphp.so:execute_ex+0x123)" — the validator's
+ * "is this an opcode handler or a libuv callback?" question landing
+ * with one row of compare output.
+ *
+ * Implementations are allowed to be slow on first call (the default
+ * adapter parses each module's ELF symbol table) but should cache.
+ */
+interface SymbolResolverInterface
+{
+    /**
+     * @return array{0: string, 1: int}|null `[symbol_name, offset]`
+     *     where offset is the byte distance from the symbol start.
+     *     Null when the address doesn't fall inside any known symbol.
+     */
+    public function resolve(int $address): ?array;
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
@@ -62,8 +62,11 @@ final class ZendStringDetector implements ShapeDetector
     }
 
     #[\Override]
-    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-    {
+    public function detect(
+        string $fingerprint,
+        int $bin_size,
+        ?DetectorContext $context = null,
+    ): ?ShapeDetection {
         $fp_len = strlen($fingerprint);
         if ($bin_size < self::MIN_BIN || $fp_len < 24) {
             return null;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+/**
+ * Detect zend_string headers.
+ *
+ * A `zend_string` is laid out as:
+ *
+ *   +0..+7   zend_refcounted_h gc  (refcount u32 + u32 type_info)
+ *   +8..+15  zend_ulong h          (hash, may be 0 for never-hashed)
+ *   +16..+23 size_t len            (string length, NUL excluded)
+ *   +24..    char val[1]           (payload, NUL terminated)
+ *
+ * On the 24 B fingerprint we see the whole header but not the payload
+ * NUL terminator, so this stays MED on a header-only match. Validation:
+ * `len` must fit inside the slot (`len + 24 + 1 (NUL) <= bin_size`),
+ * `gc.refcount` must be a small positive count (we accept ≤ 2^28 to
+ * tolerate interned strings with synthetic refcounts), and the string
+ * is rejected if it would obviously overflow the bin.
+ *
+ * For very small bins (8 B / 16 B) the header doesn't even fit, so the
+ * detector skips them. Bins ≥ 32 B are the realistic targets — typical
+ * PHP-internal short strings ("__construct", property names, …) live
+ * there.
+ */
+final class ZendStringDetector implements ShapeDetector
+{
+    private const MIN_BIN = 32;
+
+    /** Refcount sanity ceiling (2^28); above this it's almost certainly garbage. */
+    private const MAX_REFCOUNT = 0x10000000;
+
+    #[\Override]
+    public function name(): string
+    {
+        return 'ZendStringDetector';
+    }
+
+    #[\Override]
+    public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+    {
+        if ($bin_size < self::MIN_BIN || strlen($fingerprint) < 24) {
+            return null;
+        }
+
+        // gc.refcount: u32 LE at offset 0
+        /** @var array{1: int} $rc */
+        $rc = unpack('V', substr($fingerprint, 0, 4));
+        $refcount = $rc[1];
+        if ($refcount === 0 || $refcount > self::MAX_REFCOUNT) {
+            return null;
+        }
+
+        // type_info at offset 4 (u32). Top byte is the zval-type-tag
+        // analogue; for zend_string it's IS_STRING (6) when the string
+        // is reachable from a zval, but interned-string headers carry
+        // GC_FLAGS in the high bits. The common case has the LOW byte
+        // of type_info either 6 (IS_STRING) or 0 (when used as a raw
+        // refcounted slot before promotion). We don't gate on this —
+        // too many variants — but we do reject obvious garbage where
+        // type_info is all 1s.
+        /** @var array{1: int} $ti */
+        $ti = unpack('V', substr($fingerprint, 4, 4));
+        if ($ti[1] === 0xFFFFFFFF) {
+            return null;
+        }
+
+        // len at offset 16 (size_t LE). Must fit in the slot with a
+        // null terminator. Allow zero-length strings (rare but legal
+        // for sentinel use).
+        /** @var array{1: int} $ln */
+        $ln = unpack('P', substr($fingerprint, 16, 8));
+        $len = $ln[1];
+        if ($len < 0) {
+            return null;
+        }
+        $payload_capacity = $bin_size - 24 - 1; // header + NUL
+        if ($len > $payload_capacity) {
+            return null;
+        }
+
+        return new ShapeDetection(
+            label: sprintf('zend_string(len=%d)', $len),
+            confidence: ShapeDetection::CONFIDENCE_MEDIUM,
+        );
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetector.php
@@ -14,26 +14,30 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
 
 /**
- * Detect zend_string headers.
+ * Detect zend_string headers + payload.
  *
- * A `zend_string` is laid out as:
+ * Layout (Linux x86_64 PHP 7.x / 8.x):
  *
  *   +0..+7   zend_refcounted_h gc  (refcount u32 + u32 type_info)
  *   +8..+15  zend_ulong h          (hash, may be 0 for never-hashed)
  *   +16..+23 size_t len            (string length, NUL excluded)
  *   +24..    char val[1]           (payload, NUL terminated)
  *
- * On the 24 B fingerprint we see the whole header but not the payload
- * NUL terminator, so this stays MED on a header-only match. Validation:
- * `len` must fit inside the slot (`len + 24 + 1 (NUL) <= bin_size`),
- * `gc.refcount` must be a small positive count (we accept ≤ 2^28 to
- * tolerate interned strings with synthetic refcounts), and the string
- * is rejected if it would obviously overflow the bin.
+ * Header-only validation is far too permissive — the validator's
+ * issue #88 run found 1842 `zend_string(len=2)` matches against a real
+ * count of 27. Tightening adds, in order of cheapness:
  *
- * For very small bins (8 B / 16 B) the header doesn't even fit, so the
- * detector skips them. Bins ≥ 32 B are the realistic targets — typical
- * PHP-internal short strings ("__construct", property names, …) live
- * there.
+ *  1. NUL-terminator at `+24+len` (rejects most false positives by
+ *     itself — random bytes almost never have a NUL exactly there).
+ *  2. ASCII-printable ratio of payload ≥ 70% (PHP-internal strings
+ *     are ASCII-clean; binary buffers fail this).
+ *  3. DJB2 hash check when `gc.h` is non-zero (the high "computed
+ *     marker" bit is masked off so PHP-version differences don't
+ *     break the comparison). On match, promote MEDIUM → HIGH.
+ *
+ * For strings whose payload extends past the fingerprint horizon, the
+ * strict checks degrade gracefully — the detector keeps the MEDIUM
+ * verdict on header-only match.
  */
 final class ZendStringDetector implements ShapeDetector
 {
@@ -41,6 +45,15 @@ final class ZendStringDetector implements ShapeDetector
 
     /** Refcount sanity ceiling (2^28); above this it's almost certainly garbage. */
     private const MAX_REFCOUNT = 0x10000000;
+
+    /** Minimum ratio of printable bytes in a payload to accept as a real string. */
+    private const PRINTABLE_RATIO_THRESHOLD = 0.7;
+
+    /**
+     * Lower bit mask for DJB2 hash comparison — strips the high
+     * "computed marker" bit that PHP toggles on stored hashes.
+     */
+    private const HASH_LOW_MASK = 0x7FFFFFFFFFFFFFFF;
 
     #[\Override]
     public function name(): string
@@ -51,7 +64,8 @@ final class ZendStringDetector implements ShapeDetector
     #[\Override]
     public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
     {
-        if ($bin_size < self::MIN_BIN || strlen($fingerprint) < 24) {
+        $fp_len = strlen($fingerprint);
+        if ($bin_size < self::MIN_BIN || $fp_len < 24) {
             return null;
         }
 
@@ -63,37 +77,95 @@ final class ZendStringDetector implements ShapeDetector
             return null;
         }
 
-        // type_info at offset 4 (u32). Top byte is the zval-type-tag
-        // analogue; for zend_string it's IS_STRING (6) when the string
-        // is reachable from a zval, but interned-string headers carry
-        // GC_FLAGS in the high bits. The common case has the LOW byte
-        // of type_info either 6 (IS_STRING) or 0 (when used as a raw
-        // refcounted slot before promotion). We don't gate on this —
-        // too many variants — but we do reject obvious garbage where
-        // type_info is all 1s.
+        // type_info at offset 4 — reject only obvious garbage (all 1s).
         /** @var array{1: int} $ti */
         $ti = unpack('V', substr($fingerprint, 4, 4));
         if ($ti[1] === 0xFFFFFFFF) {
             return null;
         }
 
-        // len at offset 16 (size_t LE). Must fit in the slot with a
-        // null terminator. Allow zero-length strings (rare but legal
-        // for sentinel use).
+        // h at offset 8 (size_t LE), len at offset 16.
+        /** @var array{1: int} $hv */
+        $hv = unpack('P', substr($fingerprint, 8, 8));
+        $hash = $hv[1];
         /** @var array{1: int} $ln */
         $ln = unpack('P', substr($fingerprint, 16, 8));
         $len = $ln[1];
-        if ($len < 0) {
+
+        $payload_capacity = $bin_size - 24 - 1; // header + NUL
+        if ($len < 0 || $len > $payload_capacity) {
             return null;
         }
-        $payload_capacity = $bin_size - 24 - 1; // header + NUL
-        if ($len > $payload_capacity) {
-            return null;
+
+        // Header passes; promote confidence based on payload-side
+        // validation when the bytes are reachable from the fingerprint.
+        $confidence = ShapeDetection::CONFIDENCE_MEDIUM;
+
+        $nul_offset = 24 + $len;
+        $needed = $nul_offset + 1;
+
+        if ($needed <= $fp_len) {
+            // Strict NUL terminator check — single-byte test that
+            // alone eliminates almost all false positives.
+            if ($fingerprint[$nul_offset] !== "\x00") {
+                return null;
+            }
+
+            $payload = $len > 0 ? substr($fingerprint, 24, $len) : '';
+            if ($payload !== '' && !$this->isPrintableEnough($payload)) {
+                return null;
+            }
+
+            // Hash promotion to HIGH — only when gc.h is set.
+            if ($hash !== 0 && $len > 0 && $this->djb2Matches($payload, $hash)) {
+                $confidence = ShapeDetection::CONFIDENCE_HIGH;
+            }
         }
 
         return new ShapeDetection(
             label: sprintf('zend_string(len=%d)', $len),
-            confidence: ShapeDetection::CONFIDENCE_MEDIUM,
+            confidence: $confidence,
         );
+    }
+
+    private function isPrintableEnough(string $payload): bool
+    {
+        $printable = 0;
+        $len = strlen($payload);
+        for ($i = 0; $i < $len; $i++) {
+            $byte = ord($payload[$i]);
+            // Standard ASCII printable + a couple of common harmless
+            // controls used in PHP-internal strings (NUL inside name
+            // mangling for protected/private props, plus tab/newline).
+            if (
+                ($byte >= 0x20 && $byte < 0x7f)
+                || $byte === 0x00
+                || $byte === 0x09
+                || $byte === 0x0a
+            ) {
+                $printable++;
+            }
+        }
+        return ($printable / $len) >= self::PRINTABLE_RATIO_THRESHOLD;
+    }
+
+    /**
+     * PHP's zend_inline_hash_func / DJB2 variant.
+     *
+     * The stored hash on a zend_string may carry a high "computed
+     * marker" bit (Z_HASH_VAL); compare via the low mask so PHP-version
+     * differences don't break the comparison.
+     */
+    private function djb2Matches(string $payload, int $stored_hash): bool
+    {
+        $hash = 5381;
+        $len = strlen($payload);
+        for ($i = 0; $i < $len; $i++) {
+            // ((hash << 5) + hash) + byte, modulo 2^64. PHP's int is
+            // 64-bit signed; `&` with the low mask keeps the result
+            // positive and matching zend_ulong semantics.
+            $hash = (($hash << 5) + $hash + ord($payload[$i])) & self::HASH_LOW_MASK;
+        }
+        return ($stored_hash & self::HASH_LOW_MASK) === ($hash & self::HASH_LOW_MASK);
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
+
 /**
  * A run of like-shaped live small-bin slots observed at constant stride.
  *
@@ -20,6 +22,11 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
  * cheap structural similarity that, combined with the stride / count, is
  * enough to surface "16,000 copies of one shape in bin[32 B]" without any
  * detector knowing what the shape is.
+ *
+ * When the detector pipeline (Detector\\*) recognises the bytes as a
+ * known structure it attaches a {@see ShapeDetection} to label the
+ * group; downstream renderers can show "Bucket(zval IS_STRING)" or
+ * "zend_string(len=11)" instead of bare hex.
  */
 final class PeriodicGroup
 {
@@ -30,6 +37,7 @@ final class PeriodicGroup
         public readonly int $stride,
         public readonly string $fingerprint_hex,
         public readonly int $sample_addr,
+        public readonly ?ShapeDetection $detection = null,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
@@ -33,6 +33,17 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
  * PHP-claimed data that the detectors matched by accident; a group with
  * `reachability = ORPHAN` is the leak signal and gets promoted to HIGH
  * confidence in the report.
+ *
+ * Caveat: the verdict is computed by checking slot-start addresses
+ * against the root walker's `address_map` keys (see
+ * {@see PeriodicityDetector::detect}'s `$reachable_set` parameter
+ * docblock). That comparison is exact for shapes where the slot IS
+ * the graph node (zend_string, zend_object) and undercount-biased
+ * for shapes where the slot is a containing struct addressed by an
+ * inner pointer. So `REACHABLE` means "slot start matched a known
+ * node address"; `ORPHAN` is "no slot address matched any node",
+ * which is still a strong leak signal but doesn't preclude a
+ * pointer-into-the-middle being held somewhere.
  */
 final class PeriodicGroup
 {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
@@ -27,9 +27,26 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
  * known structure it attaches a {@see ShapeDetection} to label the
  * group; downstream renderers can show "Bucket(zval IS_STRING)" or
  * "zend_string(len=11)" instead of bare hex.
+ *
+ * Reachability is the design's negative-evidence rule (orphan-allocation
+ * doc, section C). A group with `reachability = REACHABLE` is normal
+ * PHP-claimed data that the detectors matched by accident; a group with
+ * `reachability = ORPHAN` is the leak signal and gets promoted to HIGH
+ * confidence in the report.
  */
 final class PeriodicGroup
 {
+    public const REACHABILITY_ORPHAN = 'orphan';
+    public const REACHABILITY_REACHABLE = 'reachable';
+    public const REACHABILITY_MIXED = 'mixed';
+
+    /**
+     * @param list<int> $sample_addrs Up to 16 addresses sampled from the
+     *     group (head + tail of the sorted address list). Lets a later
+     *     reachability annotator probe membership without having kept the
+     *     full address list around. Always includes {@see $sample_addr}
+     *     as the first entry.
+     */
     public function __construct(
         public readonly int $bin_num,
         public readonly int $bin_size,
@@ -38,6 +55,27 @@ final class PeriodicGroup
         public readonly string $fingerprint_hex,
         public readonly int $sample_addr,
         public readonly ?ShapeDetection $detection = null,
+        public readonly array $sample_addrs = [],
+        public readonly ?string $reachability = null,
+        public readonly int $reachable_samples = 0,
+        public readonly int $sampled_count = 0,
     ) {
+    }
+
+    /**
+     * Promote/demote shape detection confidence using the reachability
+     * verdict. An ORPHAN group with a MED detection earns HIGH; a
+     * REACHABLE group earns nothing extra (the design's negative-evidence
+     * rule says these are coincidental matches).
+     */
+    public function effectiveConfidence(): ?string
+    {
+        if ($this->detection === null) {
+            return null;
+        }
+        if ($this->reachability === self::REACHABILITY_ORPHAN) {
+            return ShapeDetection::CONFIDENCE_HIGH;
+        }
+        return $this->detection->confidence;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicGroup.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+/**
+ * A run of like-shaped live small-bin slots observed at constant stride.
+ *
+ * "Like-shaped" means the slots share the same first-24-byte fingerprint —
+ * cheap structural similarity that, combined with the stride / count, is
+ * enough to surface "16,000 copies of one shape in bin[32 B]" without any
+ * detector knowing what the shape is.
+ */
+final class PeriodicGroup
+{
+    public function __construct(
+        public readonly int $bin_num,
+        public readonly int $bin_size,
+        public readonly int $count,
+        public readonly int $stride,
+        public readonly string $fingerprint_hex,
+        public readonly int $sample_addr,
+    ) {
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -46,13 +46,27 @@ final class PeriodicityDetector
      * @param list<ShapeDetector>|null $detectors When null, the built-in
      *     PHP-shape detectors are used. Pass an empty list to disable
      *     detection entirely (tests / future opt-out).
-     * @param array<int, mixed>|null $reachable_set When set, the keys of
-     *     this map are addresses claimed by the root walker; each group's
-     *     samples are probed and the result attached as
-     *     {@see PeriodicGroup::$reachability}. The design's negative-
-     *     evidence rule (C, "ReachabilityFilter"): groups whose samples
-     *     are all reachable were matched by accident and downstream
-     *     callers should suppress them as leak signals.
+     * @param array<int, mixed>|null $reachable_set When set, the keys
+     *     of this map are addresses the root walker emitted as
+     *     graph nodes (in practice this is `$ctx->address_map`).
+     *
+     *     Note this is NOT a true "is-reachable" oracle — slot start
+     *     and root-graph node address only coincide for shapes where
+     *     the slot IS the node (zend_string, zend_object headers).
+     *     For shapes where the slot is a containing struct and the
+     *     root graph addresses an inner pointer, the lookup misses
+     *     even though the slot is logically reachable.
+     *
+     *     Result: `reachable_count` is **undercount-biased** — it's
+     *     a "root-node-address-matched count", not a true reachable
+     *     count. The ORPHAN verdict still has high specificity (a
+     *     slot whose address never matches any root node really is
+     *     unrooted) but the REACHABLE verdict only tells you "the
+     *     root walker pinned exactly this address", not "this slot
+     *     is held by something the root walker reached."
+     *
+     *     A future enhancement could swap in a MemoryLocations range-
+     *     overlap probe for true reachability; tracked separately.
      * @return list<PeriodicGroup>
      */
     public static function detect(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
+
+/**
+ * Periodicity detection over bin-walker output.
+ *
+ * Pure function over `[bin_num][chunk_addr] => list<{addr, fingerprint}>`
+ * — kept separate from the walker so the algorithm can be tested without
+ * having to spin up a PHP target / FFI memory reader.
+ *
+ * Picked up by {@see ZendMmBinWalker::detectPeriodicGroups} after it
+ * collects per-bin live-slot fingerprints from the chunk page maps.
+ */
+final class PeriodicityDetector
+{
+    /**
+     * Minimum same-shape repeat count before a periodic group is reported.
+     *
+     * Below this, the run is statistical noise — keep findings actionable.
+     */
+    public const PERIODIC_THRESHOLD = 32;
+
+    /**
+     * @param array<int, array<int, list<array{addr: int, fp: string}>>> $live_by_bin_by_chunk
+     * @return list<PeriodicGroup>
+     */
+    public static function detect(
+        array $live_by_bin_by_chunk,
+        int $threshold = self::PERIODIC_THRESHOLD,
+    ): array {
+        $out = [];
+        foreach ($live_by_bin_by_chunk as $bin_num => $by_chunk) {
+            $bin_size = ZendMmBinsInfo::getSize($bin_num);
+            foreach ($by_chunk as $slots) {
+                /** @var array<string, list<int>> $by_fp */
+                $by_fp = [];
+                foreach ($slots as $s) {
+                    $by_fp[$s['fp']][] = $s['addr'];
+                }
+                foreach ($by_fp as $fp => $addrs) {
+                    if (count($addrs) < $threshold) {
+                        continue;
+                    }
+                    sort($addrs);
+                    $stride = self::modeStride($addrs);
+                    if ($stride === 0) {
+                        continue;
+                    }
+                    $out[] = new PeriodicGroup(
+                        bin_num: $bin_num,
+                        bin_size: $bin_size,
+                        count: count($addrs),
+                        stride: $stride,
+                        fingerprint_hex: bin2hex($fp),
+                        sample_addr: $addrs[0],
+                    );
+                }
+            }
+        }
+        usort(
+            $out,
+            static fn(PeriodicGroup $a, PeriodicGroup $b) => $b->count <=> $a->count,
+        );
+        return $out;
+    }
+
+    /** @param list<int> $sorted_addrs */
+    public static function modeStride(array $sorted_addrs): int
+    {
+        $n = count($sorted_addrs);
+        if ($n < 2) {
+            return 0;
+        }
+        /** @var array<int, int> $counts */
+        $counts = [];
+        for ($i = 1; $i < $n; $i++) {
+            $delta = $sorted_addrs[$i] - $sorted_addrs[$i - 1];
+            if ($delta <= 0) {
+                continue;
+            }
+            $counts[$delta] = ($counts[$delta] ?? 0) + 1;
+        }
+        if ($counts === []) {
+            return 0;
+        }
+        arsort($counts);
+        /** @var int $mode */
+        $mode = array_key_first($counts);
+        return $mode;
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
 
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorRegistry;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
@@ -59,6 +60,7 @@ final class PeriodicityDetector
         int $threshold = self::PERIODIC_THRESHOLD,
         ?array $detectors = null,
         ?array $reachable_set = null,
+        ?DetectorContext $context = null,
     ): array {
         if ($detectors === null) {
             $detectors = DetectorRegistry::defaults();
@@ -81,7 +83,7 @@ final class PeriodicityDetector
                     if ($stride === 0) {
                         continue;
                     }
-                    $detection = DetectorRegistry::pickBest($detectors, $fp, $bin_size);
+                    $detection = DetectorRegistry::pickBest($detectors, $fp, $bin_size, $context);
                     $samples = self::sampleAddresses($addrs);
                     $verdict = self::classifyReachability($samples, $reachable_set);
                     $reachable_count = $verdict[0];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
 
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\BucketDetector;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ZendStringDetector;
 
 /**
  * Periodicity detection over bin-walker output.
@@ -36,12 +40,19 @@ final class PeriodicityDetector
 
     /**
      * @param array<int, array<int, list<array{addr: int, fp: string}>>> $live_by_bin_by_chunk
+     * @param list<ShapeDetector>|null $detectors When null, the built-in
+     *     PHP-shape detectors are used. Pass an empty list to disable
+     *     detection entirely (tests / future opt-out).
      * @return list<PeriodicGroup>
      */
     public static function detect(
         array $live_by_bin_by_chunk,
         int $threshold = self::PERIODIC_THRESHOLD,
+        ?array $detectors = null,
     ): array {
+        if ($detectors === null) {
+            $detectors = self::defaultDetectors();
+        }
         $out = [];
         foreach ($live_by_bin_by_chunk as $bin_num => $by_chunk) {
             $bin_size = ZendMmBinsInfo::getSize($bin_num);
@@ -60,6 +71,7 @@ final class PeriodicityDetector
                     if ($stride === 0) {
                         continue;
                     }
+                    $detection = self::pickBestDetection($detectors, $fp, $bin_size);
                     $out[] = new PeriodicGroup(
                         bin_num: $bin_num,
                         bin_size: $bin_size,
@@ -67,6 +79,7 @@ final class PeriodicityDetector
                         stride: $stride,
                         fingerprint_hex: bin2hex($fp),
                         sample_addr: $addrs[0],
+                        detection: $detection,
                     );
                 }
             }
@@ -76,6 +89,55 @@ final class PeriodicityDetector
             static fn(PeriodicGroup $a, PeriodicGroup $b) => $b->count <=> $a->count,
         );
         return $out;
+    }
+
+    /** @return list<ShapeDetector> */
+    private static function defaultDetectors(): array
+    {
+        return [
+            new BucketDetector(),
+            new ZendStringDetector(),
+        ];
+    }
+
+    /**
+     * Pick the highest-confidence detection from the registered detectors.
+     * Confidence-first per the design's selection rule
+     * (HIGH > MEDIUM > LOW), then first-registered wins on tie. Detectors
+     * that return null are skipped.
+     *
+     * @param list<ShapeDetector> $detectors
+     */
+    private static function pickBestDetection(
+        array $detectors,
+        string $fp,
+        int $bin_size,
+    ): ?ShapeDetection {
+        $best = null;
+        foreach ($detectors as $d) {
+            $hit = $d->detect($fp, $bin_size);
+            if ($hit === null) {
+                continue;
+            }
+            if ($best === null) {
+                $best = $hit;
+                continue;
+            }
+            if (self::confidenceRank($hit->confidence) > self::confidenceRank($best->confidence)) {
+                $best = $hit;
+            }
+        }
+        return $best;
+    }
+
+    private static function confidenceRank(string $c): int
+    {
+        return match ($c) {
+            ShapeDetection::CONFIDENCE_HIGH => 3,
+            ShapeDetection::CONFIDENCE_MEDIUM => 2,
+            ShapeDetection::CONFIDENCE_LOW => 1,
+            default => 0,
+        };
     }
 
     /** @param list<int> $sorted_addrs */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -38,17 +38,28 @@ final class PeriodicityDetector
      */
     public const PERIODIC_THRESHOLD = 32;
 
+    /** Cap on per-group address samples kept for later reachability probes. */
+    public const MAX_SAMPLES = 16;
+
     /**
      * @param array<int, array<int, list<array{addr: int, fp: string}>>> $live_by_bin_by_chunk
      * @param list<ShapeDetector>|null $detectors When null, the built-in
      *     PHP-shape detectors are used. Pass an empty list to disable
      *     detection entirely (tests / future opt-out).
+     * @param array<int, mixed>|null $reachable_set When set, the keys of
+     *     this map are addresses claimed by the root walker; each group's
+     *     samples are probed and the result attached as
+     *     {@see PeriodicGroup::$reachability}. The design's negative-
+     *     evidence rule (C, "ReachabilityFilter"): groups whose samples
+     *     are all reachable were matched by accident and downstream
+     *     callers should suppress them as leak signals.
      * @return list<PeriodicGroup>
      */
     public static function detect(
         array $live_by_bin_by_chunk,
         int $threshold = self::PERIODIC_THRESHOLD,
         ?array $detectors = null,
+        ?array $reachable_set = null,
     ): array {
         if ($detectors === null) {
             $detectors = self::defaultDetectors();
@@ -72,6 +83,10 @@ final class PeriodicityDetector
                         continue;
                     }
                     $detection = self::pickBestDetection($detectors, $fp, $bin_size);
+                    $samples = self::sampleAddresses($addrs);
+                    $verdict = self::classifyReachability($samples, $reachable_set);
+                    $reachable_count = $verdict[0];
+                    $reachability = $verdict[1];
                     $out[] = new PeriodicGroup(
                         bin_num: $bin_num,
                         bin_size: $bin_size,
@@ -80,6 +95,10 @@ final class PeriodicityDetector
                         fingerprint_hex: bin2hex($fp),
                         sample_addr: $addrs[0],
                         detection: $detection,
+                        sample_addrs: $samples,
+                        reachability: $reachability,
+                        reachable_samples: $reachable_count,
+                        sampled_count: count($samples),
                     );
                 }
             }
@@ -89,6 +108,56 @@ final class PeriodicityDetector
             static fn(PeriodicGroup $a, PeriodicGroup $b) => $b->count <=> $a->count,
         );
         return $out;
+    }
+
+    /**
+     * Take up to MAX_SAMPLES addresses from the head and tail of the
+     * sorted list. Cheap, deterministic, and gives the reachability
+     * filter both ends of the run — extension leaks tend to be
+     * uniformly unreachable, so even a head-only sample would catch
+     * most cases, but tail coverage saves us from misclassifying mixed
+     * regions where only the start of the page is claimed.
+     *
+     * @param list<int> $sorted_addrs
+     * @return list<int>
+     */
+    private static function sampleAddresses(array $sorted_addrs): array
+    {
+        $n = count($sorted_addrs);
+        if ($n <= self::MAX_SAMPLES) {
+            return $sorted_addrs;
+        }
+        $half = (int)floor(self::MAX_SAMPLES / 2);
+        $head = array_slice($sorted_addrs, 0, $half);
+        $tail = array_slice($sorted_addrs, -$half);
+        $merged = array_values(array_unique(array_merge($head, $tail)));
+        return $merged;
+    }
+
+    /**
+     * @param list<int> $samples
+     * @param array<int, mixed>|null $reachable_set
+     * @return array{0: int, 1: ?string}
+     */
+    private static function classifyReachability(array $samples, ?array $reachable_set): array
+    {
+        if ($reachable_set === null || $samples === []) {
+            return [0, null];
+        }
+        $reachable_count = 0;
+        foreach ($samples as $addr) {
+            if (isset($reachable_set[$addr])) {
+                $reachable_count++;
+            }
+        }
+        $sample_count = count($samples);
+        if ($reachable_count === 0) {
+            return [0, PeriodicGroup::REACHABILITY_ORPHAN];
+        }
+        if ($reachable_count === $sample_count) {
+            return [$reachable_count, PeriodicGroup::REACHABILITY_REACHABLE];
+        }
+        return [$reachable_count, PeriodicGroup::REACHABILITY_MIXED];
     }
 
     /** @return list<ShapeDetector> */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetector.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
 
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmBinsInfo;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\BucketDetector;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorRegistry;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
-use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ZendStringDetector;
 
 /**
  * Periodicity detection over bin-walker output.
@@ -62,7 +61,7 @@ final class PeriodicityDetector
         ?array $reachable_set = null,
     ): array {
         if ($detectors === null) {
-            $detectors = self::defaultDetectors();
+            $detectors = DetectorRegistry::defaults();
         }
         $out = [];
         foreach ($live_by_bin_by_chunk as $bin_num => $by_chunk) {
@@ -82,7 +81,7 @@ final class PeriodicityDetector
                     if ($stride === 0) {
                         continue;
                     }
-                    $detection = self::pickBestDetection($detectors, $fp, $bin_size);
+                    $detection = DetectorRegistry::pickBest($detectors, $fp, $bin_size);
                     $samples = self::sampleAddresses($addrs);
                     $verdict = self::classifyReachability($samples, $reachable_set);
                     $reachable_count = $verdict[0];
@@ -158,55 +157,6 @@ final class PeriodicityDetector
             return [$reachable_count, PeriodicGroup::REACHABILITY_REACHABLE];
         }
         return [$reachable_count, PeriodicGroup::REACHABILITY_MIXED];
-    }
-
-    /** @return list<ShapeDetector> */
-    private static function defaultDetectors(): array
-    {
-        return [
-            new BucketDetector(),
-            new ZendStringDetector(),
-        ];
-    }
-
-    /**
-     * Pick the highest-confidence detection from the registered detectors.
-     * Confidence-first per the design's selection rule
-     * (HIGH > MEDIUM > LOW), then first-registered wins on tie. Detectors
-     * that return null are skipped.
-     *
-     * @param list<ShapeDetector> $detectors
-     */
-    private static function pickBestDetection(
-        array $detectors,
-        string $fp,
-        int $bin_size,
-    ): ?ShapeDetection {
-        $best = null;
-        foreach ($detectors as $d) {
-            $hit = $d->detect($fp, $bin_size);
-            if ($hit === null) {
-                continue;
-            }
-            if ($best === null) {
-                $best = $hit;
-                continue;
-            }
-            if (self::confidenceRank($hit->confidence) > self::confidenceRank($best->confidence)) {
-                $best = $hit;
-            }
-        }
-        return $best;
-    }
-
-    private static function confidenceRank(string $c): int
-    {
-        return match ($c) {
-            ShapeDetection::CONFIDENCE_HIGH => 3,
-            ShapeDetection::CONFIDENCE_MEDIUM => 2,
-            ShapeDetection::CONFIDENCE_LOW => 1,
-            default => 0,
-        };
     }
 
     /** @param list<int> $sorted_addrs */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -18,8 +18,12 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoFree;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoLarge;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoSmall;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorRegistry;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ModuleResolverInterface;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ProcessMemoryMapModuleResolver;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -78,13 +82,23 @@ final class ZendMmBinWalker
      *     verdict (orphan / reachable / mixed) — the design's negative-
      *     evidence rule. When null, reachability stays unknown and
      *     downstream callers fall back to the pre-filter behaviour.
+     * @param ProcessMemoryMap|null $memory_map Optional process memory map
+     *     of the target. When supplied, FunctionPointerDetector resolves
+     *     `.text` pointers to module names — without it the per-slot scan
+     *     can still classify shapes that don't depend on module info.
      */
     public function walk(
         int $pid,
         ZendMmChunk $main_chunk,
         Dereferencer $dereferencer,
         ?array $reachable_set = null,
+        ?ProcessMemoryMap $memory_map = null,
     ): BinWalkResult {
+        $context = new DetectorContext(
+            module_resolver: $memory_map !== null
+                ? new ProcessMemoryMapModuleResolver($memory_map)
+                : null,
+        );
         $heap = $main_chunk->heap_slot;
         $free_heads = $heap->getFreeSlotHeads();
 
@@ -247,6 +261,7 @@ final class ZendMmBinWalker
                             $this->detectors,
                             $fp,
                             $bin_size,
+                            $context,
                         );
                         if ($detection === null) {
                             // Slot didn't match any detector — record it
@@ -303,6 +318,7 @@ final class ZendMmBinWalker
             $live_by_bin_by_chunk,
             detectors: $this->detectors,
             reachable_set: $reachable_set,
+            context: $context,
         );
 
         return new BinWalkResult(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -23,6 +23,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorRegistry;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ModuleResolverInterface;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ProcessMemoryMapModuleResolver;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\SymbolResolverInterface;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
@@ -86,6 +87,12 @@ final class ZendMmBinWalker
      *     of the target. When supplied, FunctionPointerDetector resolves
      *     `.text` pointers to module names — without it the per-slot scan
      *     can still classify shapes that don't depend on module info.
+     * @param SymbolResolverInterface|null $symbol_resolver Optional ELF
+     *     symbol resolver. When supplied alongside `$memory_map`,
+     *     FunctionPointerDetector promotes labels from
+     *     `func_ptr (libphp.so)` to `func_ptr (libphp.so:execute_ex+0x123)`
+     *     — the validator's "is this an opcode handler or a libuv
+     *     callback?" question landing as a single row of compare output.
      */
     public function walk(
         int $pid,
@@ -93,11 +100,13 @@ final class ZendMmBinWalker
         Dereferencer $dereferencer,
         ?array $reachable_set = null,
         ?ProcessMemoryMap $memory_map = null,
+        ?SymbolResolverInterface $symbol_resolver = null,
     ): BinWalkResult {
         $context = new DetectorContext(
             module_resolver: $memory_map !== null
                 ? new ProcessMemoryMapModuleResolver($memory_map)
                 : null,
+            symbol_resolver: $symbol_resolver,
         );
         $heap = $main_chunk->heap_slot;
         $free_heads = $heap->getFreeSlotHeads();

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -37,20 +37,28 @@ final class ZendMmBinWalker
 {
     /**
      * Fingerprint length: prefix bytes captured per slot for shape grouping
-     * + detector input. 128 B is enough to reach struct stat's `st_mode`
-     * (offset 0x40 on Linux x86_64) — the discriminating field for a
-     * StatDetector. The previous 24 B window collapsed all-zeros leak
-     * shapes to a single bucket because the per-slot identity bytes
-     * (gc/h/len for zend_string, st_mode for stat, …) live past the
-     * fingerprint horizon.
+     * + detector input. 192 B reaches `struct stat`'s timespec fields when
+     * the stat is embedded at offset ≤ 48 inside a 192 B / 224 B slot —
+     * the leak shape validation surfaced for amphp/file issue #88.
+     * StatDetector and the tightened ZendStringDetector both rely on bytes
+     * past the previous 128 B horizon (NUL terminator + payload of short
+     * interned strings, st_atim / st_mtim / st_ctim of stat).
      */
-    private const FINGERPRINT_BYTES = 128;
+    private const FINGERPRINT_BYTES = 192;
 
     /** Per-page chunk page count (2 MiB / 4 KiB). */
     private const PAGES_PER_CHUNK = ZendMmChunk::SIZE / ZendMmChunk::PAGE_SIZE;
 
     /** Defensive cap on freelist length per bin (a chunk holds at most 512 8 B slots). */
     private const FREELIST_WALK_LIMIT = 200_000;
+
+    /**
+     * Cap on per-(bin, shape) sample addresses kept for the
+     * `inspector:memory:bin-query` drill-down. Persisted in the rmem
+     * summary so a user can ask "give me 16 sample addresses of
+     * Bucket(IS_STRING) in bin[3]" and pipe them through `memory:peek`.
+     */
+    public const PER_SHAPE_SAMPLE_CAP = 256;
 
     /** @var list<ShapeDetector> */
     private readonly array $detectors;
@@ -146,6 +154,16 @@ final class ZendMmBinWalker
 
         /** @var array<int, int> */
         $bin_unclassified_counts = [];
+
+        /**
+         * Per-(bin, label) sample addresses for `memory:bin-query`
+         * drill-down. Cap at PER_SHAPE_SAMPLE_CAP per group to bound
+         * the rmem summary size — a few hundred addresses is plenty
+         * for "give me one to peek at".
+         *
+         * @var array<int, array<string, list<int>>>
+         */
+        $bin_shape_addrs = [];
 
         foreach ($main_chunk->iterateChunks($dereferencer) as $chunk) {
             $walked_chunk_count++;
@@ -260,6 +278,12 @@ final class ZendMmBinWalker
                                 $bin_shape_counts[$bin_num][$label]['confidence']
                                     = $detection->confidence;
                             }
+                            // Sample address for drill-down — first N
+                            // encountered addresses are kept, rest dropped.
+                            $existing_samples = $bin_shape_addrs[$bin_num][$label] ?? [];
+                            if (count($existing_samples) < self::PER_SHAPE_SAMPLE_CAP) {
+                                $bin_shape_addrs[$bin_num][$label][] = $slot_addr;
+                            }
                         }
                     }
                 }
@@ -288,6 +312,7 @@ final class ZendMmBinWalker
             partial: $partial,
             bin_shape_counts: $bin_shape_counts,
             bin_unclassified_counts: $bin_unclassified_counts,
+            bin_shape_addrs: $bin_shape_addrs,
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+use FFI;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoFree;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoLarge;
+use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoSmall;
+use Reli\Lib\Process\MemoryReader\MemoryReaderException;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\Process\Pointer\Dereferencer;
+
+/**
+ * Enumerate every live ZendMM small-bin / large-run allocation.
+ *
+ * Walks `chunk->map` for every chunk reachable from the heap's main chunk,
+ * subtracts the per-bin freelists (`heap->free_slot[bin]`) and emits a
+ * histogram + a list of periodic groups.
+ *
+ * See docs/internals/design-orphan-allocation-analysis.md (sections A and D).
+ */
+final class ZendMmBinWalker
+{
+    /** Fingerprint length (first N bytes of the slot used as a shape key). */
+    private const FINGERPRINT_BYTES = 24;
+
+    /** Per-page chunk page count (2 MiB / 4 KiB). */
+    private const PAGES_PER_CHUNK = ZendMmChunk::SIZE / ZendMmChunk::PAGE_SIZE;
+
+    /** Defensive cap on freelist length per bin (a chunk holds at most 512 8 B slots). */
+    private const FREELIST_WALK_LIMIT = 200_000;
+
+    public function __construct(
+        private MemoryReaderInterface $memory_reader,
+    ) {
+    }
+
+    public function walk(
+        int $pid,
+        ZendMmChunk $main_chunk,
+        Dereferencer $dereferencer,
+    ): BinWalkResult {
+        $heap = $main_chunk->heap_slot;
+        $free_heads = $heap->getFreeSlotHeads();
+
+        // free_set[bin_num] => map<int $address, true>
+        /** @var array<int, array<int, true>> $free_set */
+        $free_set = [];
+        $partial = false;
+        foreach ($free_heads as $bin_num => $head) {
+            $set = [];
+            $cursor = $head;
+            $walked = 0;
+            while ($cursor !== 0) {
+                if (isset($set[$cursor])) {
+                    // Cycle in freelist — corrupt or already-visited node.
+                    $partial = true;
+                    break;
+                }
+                $set[$cursor] = true;
+                $walked++;
+                if ($walked > self::FREELIST_WALK_LIMIT) {
+                    $partial = true;
+                    break;
+                }
+                $next = $this->readPointerAt($pid, $cursor);
+                if ($next === null) {
+                    $partial = true;
+                    break;
+                }
+                $cursor = $next;
+            }
+            $free_set[$bin_num] = $set;
+        }
+
+        /** @var array<int, array{count: int, total_bytes: int}> $histogram */
+        $histogram = [];
+        $large_run_count = 0;
+        $large_run_bytes = 0;
+        $live_small_slot_count = 0;
+        $live_small_slot_bytes = 0;
+        $walked_chunk_count = 0;
+
+        /**
+         * Per-bin live slot capture used for periodicity detection.
+         *
+         * Keyed by `[bin_num][chunk_addr] => list<{addr,fingerprint}>`. Slots
+         * are appended in address order, so the consumer can scan for runs of
+         * constant stride directly.
+         *
+         * @var array<int, array<int, list<array{addr: int, fp: string}>>>
+         */
+        $live_by_bin_by_chunk = [];
+
+        foreach ($main_chunk->iterateChunks($dereferencer) as $chunk) {
+            $walked_chunk_count++;
+            $chunk_addr = $chunk->getPointer()->address;
+            $page = 0;
+            while ($page < self::PAGES_PER_CHUNK) {
+                try {
+                    $info = $chunk->map->getPageInfo($page);
+                } catch (\Throwable) {
+                    // Bogus map entry — stop walking this chunk.
+                    $partial = true;
+                    break;
+                }
+                if ($info instanceof ZendMmPageInfoFree) {
+                    $page++;
+                    continue;
+                }
+                if ($info instanceof ZendMmPageInfoLarge) {
+                    $n = $info->getLargePagesCount();
+                    if ($n <= 0 || $page + $n > self::PAGES_PER_CHUNK) {
+                        $partial = true;
+                        break;
+                    }
+                    $large_run_count++;
+                    $large_run_bytes += $n * ZendMmChunk::PAGE_SIZE;
+                    $page += $n;
+                    continue;
+                }
+                // Remaining branch: small-bin run.
+
+                $bin_num = $info->getBinNum();
+                $bin_size = $info->getBinSize();
+                $bin_pages = $info->getBinPages();
+                $elements = $info->getBinElements();
+                if ($bin_size <= 0 || $bin_pages <= 0 || $elements <= 0) {
+                    $partial = true;
+                    break;
+                }
+                if ($page + $bin_pages > self::PAGES_PER_CHUNK) {
+                    $partial = true;
+                    break;
+                }
+
+                $run_addr = $chunk_addr + $page * ZendMmChunk::PAGE_SIZE;
+                $run_bytes = $bin_pages * ZendMmChunk::PAGE_SIZE;
+
+                $run_blob = $this->readBytes($pid, $run_addr, $run_bytes);
+
+                $bin_free_set = $free_set[$bin_num] ?? [];
+
+                for ($i = 0; $i < $elements; $i++) {
+                    $slot_addr = $run_addr + $i * $bin_size;
+                    if (isset($bin_free_set[$slot_addr])) {
+                        continue;
+                    }
+                    $live_small_slot_count++;
+                    $live_small_slot_bytes += $bin_size;
+                    if (!isset($histogram[$bin_num])) {
+                        $histogram[$bin_num] = ['count' => 0, 'total_bytes' => 0];
+                    }
+                    $histogram[$bin_num]['count']++;
+                    $histogram[$bin_num]['total_bytes'] += $bin_size;
+
+                    if ($run_blob !== null) {
+                        $offset = $i * $bin_size;
+                        $fp_len = $bin_size < self::FINGERPRINT_BYTES
+                            ? $bin_size
+                            : self::FINGERPRINT_BYTES;
+                        $fp = substr($run_blob, $offset, $fp_len);
+                        $live_by_bin_by_chunk[$bin_num][$chunk_addr][] = [
+                            'addr' => $slot_addr,
+                            'fp' => $fp,
+                        ];
+                    }
+                }
+
+                $page += $bin_pages;
+            }
+        }
+
+        ksort($histogram);
+        $periodic_groups = PeriodicityDetector::detect($live_by_bin_by_chunk);
+
+        return new BinWalkResult(
+            small_bin_histogram: $histogram,
+            large_run_count: $large_run_count,
+            large_run_bytes: $large_run_bytes,
+            live_small_slot_count: $live_small_slot_count,
+            live_small_slot_bytes: $live_small_slot_bytes,
+            periodic_groups: $periodic_groups,
+            walked_chunk_count: $walked_chunk_count,
+            partial: $partial,
+        );
+    }
+
+    private function readPointerAt(int $pid, int $address): ?int
+    {
+        $bytes = $this->readBytes($pid, $address, 8);
+        if ($bytes === null) {
+            return null;
+        }
+        /** @var array{1: int} $unpacked */
+        $unpacked = unpack('P', $bytes);
+        return $unpacked[1];
+    }
+
+    private function readBytes(int $pid, int $address, int $size): ?string
+    {
+        if ($size <= 0) {
+            return '';
+        }
+        try {
+            $cdata = $this->memory_reader->read($pid, $address, $size);
+        } catch (MemoryReaderException) {
+            return null;
+        } catch (\Throwable) {
+            return null;
+        }
+        return FFI::string($cdata, $size);
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -18,6 +18,8 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoFree;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoLarge;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmPageInfoSmall;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorRegistry;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector;
 use Reli\Lib\Process\MemoryReader\MemoryReaderException;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -33,8 +35,16 @@ use Reli\Lib\Process\Pointer\Dereferencer;
  */
 final class ZendMmBinWalker
 {
-    /** Fingerprint length (first N bytes of the slot used as a shape key). */
-    private const FINGERPRINT_BYTES = 24;
+    /**
+     * Fingerprint length: prefix bytes captured per slot for shape grouping
+     * + detector input. 128 B is enough to reach struct stat's `st_mode`
+     * (offset 0x40 on Linux x86_64) — the discriminating field for a
+     * StatDetector. The previous 24 B window collapsed all-zeros leak
+     * shapes to a single bucket because the per-slot identity bytes
+     * (gc/h/len for zend_string, st_mode for stat, …) live past the
+     * fingerprint horizon.
+     */
+    private const FINGERPRINT_BYTES = 128;
 
     /** Per-page chunk page count (2 MiB / 4 KiB). */
     private const PAGES_PER_CHUNK = ZendMmChunk::SIZE / ZendMmChunk::PAGE_SIZE;
@@ -42,9 +52,15 @@ final class ZendMmBinWalker
     /** Defensive cap on freelist length per bin (a chunk holds at most 512 8 B slots). */
     private const FREELIST_WALK_LIMIT = 200_000;
 
+    /** @var list<ShapeDetector> */
+    private readonly array $detectors;
+
+    /** @param list<ShapeDetector>|null $detectors */
     public function __construct(
         private MemoryReaderInterface $memory_reader,
+        ?array $detectors = null,
     ) {
+        $this->detectors = $detectors ?? DetectorRegistry::defaults();
     }
 
     /**
@@ -112,6 +128,24 @@ final class ZendMmBinWalker
          * @var array<int, array<int, list<array{addr: int, fp: string}>>>
          */
         $live_by_bin_by_chunk = [];
+
+        /**
+         * Per-bin shape tally — feeds the "Per-bin Shape Detection"
+         * report section. Tracks every detector hit, separately from the
+         * fingerprint-grouped periodic groups, so content-varying shapes
+         * (Bucket entries with per-entry hash + key) get counted instead
+         * of being shrugged off because they don't form a periodic run.
+         *
+         * @var array<int, array<string, array{
+         *     count: int,
+         *     reachable_count: int,
+         *     confidence: string
+         * }>>
+         */
+        $bin_shape_counts = [];
+
+        /** @var array<int, int> */
+        $bin_unclassified_counts = [];
 
         foreach ($main_chunk->iterateChunks($dereferencer) as $chunk) {
             $walked_chunk_count++;
@@ -185,6 +219,48 @@ final class ZendMmBinWalker
                             'addr' => $slot_addr,
                             'fp' => $fp,
                         ];
+
+                        // Per-slot detector scan — independent of periodic
+                        // grouping, so Bucket entries (same shape, different
+                        // hash + key per slot) count even though they never
+                        // form a same-fingerprint run.
+                        $detection = DetectorRegistry::pickBest(
+                            $this->detectors,
+                            $fp,
+                            $bin_size,
+                        );
+                        if ($detection === null) {
+                            $bin_unclassified_counts[$bin_num]
+                                = ($bin_unclassified_counts[$bin_num] ?? 0) + 1;
+                        } else {
+                            $label = $detection->label;
+                            if (!isset($bin_shape_counts[$bin_num][$label])) {
+                                $bin_shape_counts[$bin_num][$label] = [
+                                    'count' => 0,
+                                    'reachable_count' => 0,
+                                    'confidence' => $detection->confidence,
+                                ];
+                            }
+                            $bin_shape_counts[$bin_num][$label]['count']++;
+                            if (
+                                $reachable_set !== null
+                                && isset($reachable_set[$slot_addr])
+                            ) {
+                                $bin_shape_counts[$bin_num][$label]['reachable_count']++;
+                            }
+                            // Promote stored confidence if this slot earned a
+                            // higher one — same-label slots can earn different
+                            // confidences when one detector returns HIGH and
+                            // another MEDIUM for distinct content variants.
+                            $stored = $bin_shape_counts[$bin_num][$label]['confidence'];
+                            if (
+                                DetectorRegistry::confidenceRank($detection->confidence)
+                                > DetectorRegistry::confidenceRank($stored)
+                            ) {
+                                $bin_shape_counts[$bin_num][$label]['confidence']
+                                    = $detection->confidence;
+                            }
+                        }
                     }
                 }
 
@@ -193,8 +269,11 @@ final class ZendMmBinWalker
         }
 
         ksort($histogram);
+        ksort($bin_shape_counts);
+        ksort($bin_unclassified_counts);
         $periodic_groups = PeriodicityDetector::detect(
             $live_by_bin_by_chunk,
+            detectors: $this->detectors,
             reachable_set: $reachable_set,
         );
 
@@ -207,6 +286,8 @@ final class ZendMmBinWalker
             periodic_groups: $periodic_groups,
             walked_chunk_count: $walked_chunk_count,
             partial: $partial,
+            bin_shape_counts: $bin_shape_counts,
+            bin_unclassified_counts: $bin_unclassified_counts,
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -47,10 +47,19 @@ final class ZendMmBinWalker
     ) {
     }
 
+    /**
+     * @param array<int, mixed>|null $reachable_set Optional address→nodeId
+     *     map (the keys are what matters) recovered from the root walker's
+     *     `address_map`. When supplied, periodic groups gain a reachability
+     *     verdict (orphan / reachable / mixed) — the design's negative-
+     *     evidence rule. When null, reachability stays unknown and
+     *     downstream callers fall back to the pre-filter behaviour.
+     */
     public function walk(
         int $pid,
         ZendMmChunk $main_chunk,
         Dereferencer $dereferencer,
+        ?array $reachable_set = null,
     ): BinWalkResult {
         $heap = $main_chunk->heap_slot;
         $free_heads = $heap->getFreeSlotHeads();
@@ -184,7 +193,10 @@ final class ZendMmBinWalker
         }
 
         ksort($histogram);
-        $periodic_groups = PeriodicityDetector::detect($live_by_bin_by_chunk);
+        $periodic_groups = PeriodicityDetector::detect(
+            $live_by_bin_by_chunk,
+            reachable_set: $reachable_set,
+        );
 
         return new BinWalkResult(
             small_bin_histogram: $histogram,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -144,6 +144,10 @@ final class ZendMmBinWalker
          * (Bucket entries with per-entry hash + key) get counted instead
          * of being shrugged off because they don't form a periodic run.
          *
+         * Slots that no detector matched land under the special label
+         * `unclassified` — kept inside the same map so bin-query can
+         * surface addresses for them via --shape=unclassified.
+         *
          * @var array<int, array<string, array{
          *     count: int,
          *     reachable_count: int,
@@ -151,9 +155,6 @@ final class ZendMmBinWalker
          * }>>
          */
         $bin_shape_counts = [];
-
-        /** @var array<int, int> */
-        $bin_unclassified_counts = [];
 
         /**
          * Per-(bin, label) sample addresses for `memory:bin-query`
@@ -248,42 +249,46 @@ final class ZendMmBinWalker
                             $bin_size,
                         );
                         if ($detection === null) {
-                            $bin_unclassified_counts[$bin_num]
-                                = ($bin_unclassified_counts[$bin_num] ?? 0) + 1;
+                            // Slot didn't match any detector — record it
+                            // under the special `unclassified` label so
+                            // bin-query --shape=unclassified can drill in.
+                            $label = 'unclassified';
+                            $confidence = 'low';
                         } else {
                             $label = $detection->label;
-                            if (!isset($bin_shape_counts[$bin_num][$label])) {
-                                $bin_shape_counts[$bin_num][$label] = [
-                                    'count' => 0,
-                                    'reachable_count' => 0,
-                                    'confidence' => $detection->confidence,
-                                ];
-                            }
-                            $bin_shape_counts[$bin_num][$label]['count']++;
-                            if (
-                                $reachable_set !== null
-                                && isset($reachable_set[$slot_addr])
-                            ) {
-                                $bin_shape_counts[$bin_num][$label]['reachable_count']++;
-                            }
-                            // Promote stored confidence if this slot earned a
-                            // higher one — same-label slots can earn different
-                            // confidences when one detector returns HIGH and
-                            // another MEDIUM for distinct content variants.
-                            $stored = $bin_shape_counts[$bin_num][$label]['confidence'];
-                            if (
-                                DetectorRegistry::confidenceRank($detection->confidence)
-                                > DetectorRegistry::confidenceRank($stored)
-                            ) {
-                                $bin_shape_counts[$bin_num][$label]['confidence']
-                                    = $detection->confidence;
-                            }
-                            // Sample address for drill-down — first N
-                            // encountered addresses are kept, rest dropped.
-                            $existing_samples = $bin_shape_addrs[$bin_num][$label] ?? [];
-                            if (count($existing_samples) < self::PER_SHAPE_SAMPLE_CAP) {
-                                $bin_shape_addrs[$bin_num][$label][] = $slot_addr;
-                            }
+                            $confidence = $detection->confidence;
+                        }
+
+                        if (!isset($bin_shape_counts[$bin_num][$label])) {
+                            $bin_shape_counts[$bin_num][$label] = [
+                                'count' => 0,
+                                'reachable_count' => 0,
+                                'confidence' => $confidence,
+                            ];
+                        }
+                        $bin_shape_counts[$bin_num][$label]['count']++;
+                        if (
+                            $reachable_set !== null
+                            && isset($reachable_set[$slot_addr])
+                        ) {
+                            $bin_shape_counts[$bin_num][$label]['reachable_count']++;
+                        }
+                        // Promote stored confidence if this slot earned a
+                        // higher one — same-label slots can earn different
+                        // confidences when one detector returns HIGH and
+                        // another MEDIUM for distinct content variants.
+                        $stored = $bin_shape_counts[$bin_num][$label]['confidence'];
+                        if (
+                            DetectorRegistry::confidenceRank($confidence)
+                            > DetectorRegistry::confidenceRank($stored)
+                        ) {
+                            $bin_shape_counts[$bin_num][$label]['confidence'] = $confidence;
+                        }
+                        // Sample address for drill-down — first N
+                        // encountered addresses are kept, rest dropped.
+                        $existing_samples = $bin_shape_addrs[$bin_num][$label] ?? [];
+                        if (count($existing_samples) < self::PER_SHAPE_SAMPLE_CAP) {
+                            $bin_shape_addrs[$bin_num][$label][] = $slot_addr;
                         }
                     }
                 }
@@ -294,7 +299,6 @@ final class ZendMmBinWalker
 
         ksort($histogram);
         ksort($bin_shape_counts);
-        ksort($bin_unclassified_counts);
         $periodic_groups = PeriodicityDetector::detect(
             $live_by_bin_by_chunk,
             detectors: $this->detectors,
@@ -311,7 +315,6 @@ final class ZendMmBinWalker
             walked_chunk_count: $walked_chunk_count,
             partial: $partial,
             bin_shape_counts: $bin_shape_counts,
-            bin_unclassified_counts: $bin_unclassified_counts,
             bin_shape_addrs: $bin_shape_addrs,
         );
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/ZendMmBinWalker.php
@@ -111,6 +111,28 @@ final class ZendMmBinWalker
         $heap = $main_chunk->heap_slot;
         $free_heads = $heap->getFreeSlotHeads();
 
+        // The heap is supposed to be eagerly loaded by the caller so
+        // every bin's free-list head is readable. If we got an empty
+        // list it means the heap landed on the lazy-CData path
+        // somewhere upstream — treating that as "no free slots" would
+        // mark every freed slot as live and run the per-slot detector
+        // pipeline against garbage bytes, producing dramatic false
+        // positives. Bail with an empty histogram + `partial = true`
+        // so report / compare can show the bin walker didn't run
+        // rather than silently lying.
+        if (count($free_heads) !== 30) {
+            return new BinWalkResult(
+                small_bin_histogram: [],
+                large_run_count: 0,
+                large_run_bytes: 0,
+                live_small_slot_count: 0,
+                live_small_slot_bytes: 0,
+                periodic_groups: [],
+                walked_chunk_count: 0,
+                partial: true,
+            );
+        }
+
         // free_set[bin_num] => map<int $address, true>
         /** @var array<int, array<int, true>> $free_set */
         $free_set = [];

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -18,6 +18,9 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
 
 final class CollectedMemories
 {
+    /** Region map computed lazily on first access; cached afterwards. */
+    private ?RegionMap $region_map = null;
+
     public function __construct(
         public MemoryLocations $chunk_memory_locations,
         public MemoryLocations $huge_memory_locations,
@@ -38,5 +41,13 @@ final class CollectedMemories
         public int $chunks_mostly_empty_count = 0,
         public ?BinWalkResult $bin_walk_result = null,
     ) {
+    }
+
+    public function getRegionMap(): RegionMap
+    {
+        if ($this->region_map === null) {
+            $this->region_map = RegionMap::fromCollectedMemories($this);
+        }
+        return $this->region_map;
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/CollectedMemories.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
 
 final class CollectedMemories
@@ -35,6 +36,7 @@ final class CollectedMemories
         public int $last_chunks_delete_count = 0,
         public int $chunks_total_free_bytes = 0,
         public int $chunks_mostly_empty_count = 0,
+        public ?BinWalkResult $bin_walk_result = null,
     ) {
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -370,6 +370,10 @@ final class MemoryLocationsCollector
         // per-bin live-allocation histogram and any periodic same-shape
         // groups. Foundation for the orphan-allocation analysis path
         // (see docs/internals/design-orphan-allocation-analysis.md).
+        // The region map snapshot (B.2) is built unconditionally — it's
+        // a couple of hundred entries even on heavy daemons, so the
+        // cost is negligible and lets the comparison path emit
+        // "+728 KiB at 0x..." callouts without round-tripping the rdump.
         //
         // Runs AFTER the DFS so we can hand the root walker's
         // `address_map` to the bin walker as the reachability filter

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -37,7 +37,12 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefin
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
+use Reli\Lib\Dwarf\NativeSymbolResolver;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\NativeSymbolResolverAdapter;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\SymbolResolverInterface;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
@@ -56,6 +61,7 @@ final class MemoryLocationsCollector
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private PhpZendMemoryManagerChunkFinder $chunk_finder,
         private ?ProcessMemoryMapCreatorInterface $process_memory_map_creator = null,
+        private ?BinaryAnalysisCache $binary_analysis_cache = null,
     ) {
     }
 
@@ -396,6 +402,14 @@ final class MemoryLocationsCollector
                 Log::debug('process memory map fetch failed', ['exception' => $e]);
             }
         }
+        // Build a symbol resolver only when /proc/<pid>/exe is reachable
+        // (i.e., a live target). For rdump-driven analyze the pid is the
+        // original target's pid which is meaningless on the analyzing
+        // host; without an accessible binary on disk we'd just thrash
+        // through file-not-found per slot. The module-level resolver
+        // (FunctionPointerDetector falls back to module names) still
+        // works in that case.
+        $symbol_resolver = $this->buildSymbolResolver($pid, $process_memory_map);
         $bin_walk_result = null;
         try {
             $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
@@ -404,6 +418,7 @@ final class MemoryLocationsCollector
                 $dereferencer,
                 $ctx->address_map,
                 $process_memory_map,
+                $symbol_resolver,
             );
         } catch (\Throwable $e) {
             Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
@@ -431,6 +446,43 @@ final class MemoryLocationsCollector
             $chunks_mostly_empty_count,
             $bin_walk_result,
         );
+    }
+
+    /**
+     * Build the symbol resolver used by FunctionPointerDetector when
+     * available. Returns null when:
+     *
+     * - The memory map isn't available (no module identification)
+     * - /proc/{pid}/exe isn't accessible (rdump-driven analyze, where
+     *   the target's binaries aren't laid out on the analyzing host)
+     * - NativeSymbolResolver instantiation throws for any reason
+     *
+     * The "resolver per analyze" lifetime is fine: NativeSymbolResolver
+     * caches per-binary results internally, and the analyze pass
+     * touches each binary once.
+     */
+    private function buildSymbolResolver(
+        int $pid,
+        ?ProcessMemoryMap $process_memory_map,
+    ): ?SymbolResolverInterface {
+        if ($process_memory_map === null) {
+            return null;
+        }
+        $process_root = "/proc/{$pid}/root";
+        if (!@is_readable("/proc/{$pid}/exe")) {
+            return null;
+        }
+        try {
+            $native = new NativeSymbolResolver(
+                memoryMap: $process_memory_map,
+                processRoot: $process_root,
+                binaryAnalysisCache: $this->binary_analysis_cache,
+            );
+            return new NativeSymbolResolverAdapter($native);
+        } catch (\Throwable $e) {
+            Log::debug('symbol resolver build failed', ['exception' => $e]);
+            return null;
+        }
     }
 
     private function collectRealCallStackOnMemoryLimitViolation(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -38,6 +38,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
 use Reli\Lib\Process\Pointer\Dereferencer;
 use Reli\Lib\Process\Pointer\Pointer;
@@ -54,6 +55,7 @@ final class MemoryLocationsCollector
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private PhpZendMemoryManagerChunkFinder $chunk_finder,
+        private ?ProcessMemoryMapCreatorInterface $process_memory_map_creator = null,
     ) {
     }
 
@@ -379,7 +381,21 @@ final class MemoryLocationsCollector
         // `address_map` to the bin walker as the reachability filter
         // (design's "negative-evidence rule"). Without it, periodic
         // groups can't tell normal claimed data from orphan leaks.
-        // Non-fatal — a failure here must not abort the analyze run.
+        //
+        // The process memory map (when available) lets
+        // FunctionPointerDetector resolve `.text` pointers to module
+        // names — the validator's "is this libuv or libphp?" question.
+        // Both sources are best-effort; bin walker failures must not
+        // abort the analyze run.
+        $process_memory_map = null;
+        if ($this->process_memory_map_creator !== null) {
+            try {
+                $process_memory_map = $this->process_memory_map_creator
+                    ->getProcessMemoryMap($pid);
+            } catch (\Throwable $e) {
+                Log::debug('process memory map fetch failed', ['exception' => $e]);
+            }
+        }
         $bin_walk_result = null;
         try {
             $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
@@ -387,6 +403,7 @@ final class MemoryLocationsCollector
                 $zend_mm_main_chunk,
                 $dereferencer,
                 $ctx->address_map,
+                $process_memory_map,
             );
         } catch (\Throwable $e) {
             Log::debug('ZendMmBinWalker failed', ['exception' => $e]);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -160,21 +160,6 @@ final class MemoryLocationsCollector
             }
             $walked_chunk_count++;
         }
-        // Walk the small-bin freelists + chunk page maps to recover the
-        // per-bin live-allocation histogram and any periodic same-shape
-        // groups. This is the foundation for the orphan-allocation
-        // analysis path (see docs/internals/design-orphan-allocation-analysis.md).
-        // Non-fatal — a failure here must not abort the analyze run.
-        $bin_walk_result = null;
-        try {
-            $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
-                $pid,
-                $zend_mm_main_chunk,
-                $dereferencer,
-            );
-        } catch (\Throwable $e) {
-            Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
-        }
 
         $huge_memory_locations = new MemoryLocations();
         $huge_total_bytes = 0;
@@ -379,6 +364,28 @@ final class MemoryLocationsCollector
                 $eg,
                 $ctx,
             );
+        }
+
+        // Walk the small-bin freelists + chunk page maps to recover the
+        // per-bin live-allocation histogram and any periodic same-shape
+        // groups. Foundation for the orphan-allocation analysis path
+        // (see docs/internals/design-orphan-allocation-analysis.md).
+        //
+        // Runs AFTER the DFS so we can hand the root walker's
+        // `address_map` to the bin walker as the reachability filter
+        // (design's "negative-evidence rule"). Without it, periodic
+        // groups can't tell normal claimed data from orphan leaks.
+        // Non-fatal — a failure here must not abort the analyze run.
+        $bin_walk_result = null;
+        try {
+            $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
+                $pid,
+                $zend_mm_main_chunk,
+                $dereferencer,
+                $ctx->address_map,
+            );
+        } catch (\Throwable $e) {
+            Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
         }
 
         $context_pools->clear();

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -39,6 +39,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
 use Reli\Lib\Dwarf\NativeSymbolResolver;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\File\PathResolver\ProcessPathResolver;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\NativeSymbolResolverAdapter;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\SymbolResolverInterface;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
@@ -62,6 +63,7 @@ final class MemoryLocationsCollector
         private PhpZendMemoryManagerChunkFinder $chunk_finder,
         private ?ProcessMemoryMapCreatorInterface $process_memory_map_creator = null,
         private ?BinaryAnalysisCache $binary_analysis_cache = null,
+        private ?ProcessPathResolver $process_path_resolver = null,
     ) {
     }
 
@@ -449,17 +451,30 @@ final class MemoryLocationsCollector
     }
 
     /**
-     * Build the symbol resolver used by FunctionPointerDetector when
-     * available. Returns null when:
+     * Build the symbol resolver used by FunctionPointerDetector.
      *
-     * - The memory map isn't available (no module identification)
-     * - /proc/{pid}/exe isn't accessible (rdump-driven analyze, where
-     *   the target's binaries aren't laid out on the analyzing host)
-     * - NativeSymbolResolver instantiation throws for any reason
+     * Routes through the autowired {@see ProcessPathResolver}, the same
+     * primitive {@see \Reli\Inspector\MemoryDump\DumpFileMemoryReader}
+     * uses to look up paths recorded inside an rdump. Three cases shake
+     * out from the same code path:
      *
-     * The "resolver per analyze" lifetime is fine: NativeSymbolResolver
-     * caches per-binary results internally, and the analyze pass
-     * touches each binary once.
+     *  - Live target: the default
+     *    {@see \Reli\Lib\File\PathResolver\ContainerAwarePathResolver}
+     *    maps `/<path>` to `/proc/{pid}/root/<path>` (kernel-provided
+     *    chroot view, follows mount namespaces correctly).
+     *  - Offline rdump with `--dependency-root <dir>`:
+     *    {@see \Reli\Lib\File\PathResolver\MappedPathResolver} (set up
+     *    by MemoryDumpReaderFactory) maps `/<path>` to `<dir>/<path>`,
+     *    matching the coredump-reader convention.
+     *  - Offline rdump without `--dependency-root`: same MappedPathResolver
+     *    with no mappings, so `/<path>` resolves unchanged — the typical
+     *    "analyzing on the same machine where the binaries live"
+     *    workflow falls into this branch automatically.
+     *
+     * Returns null when the path resolver can't surface any binary
+     * (e.g. analyzing an rdump from a different host without
+     * `--dependency-root`) so the per-slot scan doesn't thrash through
+     * file-not-found syscalls.
      */
     private function buildSymbolResolver(
         int $pid,
@@ -468,8 +483,11 @@ final class MemoryLocationsCollector
         if ($process_memory_map === null) {
             return null;
         }
-        $process_root = "/proc/{$pid}/root";
-        if (!@is_readable("/proc/{$pid}/exe")) {
+        if ($this->process_path_resolver === null) {
+            return null;
+        }
+        $process_root = $this->probeProcessRoot($pid);
+        if (!$this->hasReachableModule($process_memory_map, $process_root)) {
             return null;
         }
         try {
@@ -483,6 +501,56 @@ final class MemoryLocationsCollector
             Log::debug('symbol resolver build failed', ['exception' => $e]);
             return null;
         }
+    }
+
+    /**
+     * Derive the binary-lookup prefix the way NativeSymbolResolver
+     * expects (a string concatenated to a leading `/<path>`). Probes
+     * the {@see ProcessPathResolver} with a sentinel and strips the
+     * sentinel back off — works uniformly for the live
+     * `/proc/<pid>/root` resolver and the offline MappedPathResolver
+     * with `[/ => --dependency-root]`.
+     */
+    private function probeProcessRoot(int $pid): string
+    {
+        assert($this->process_path_resolver !== null);
+        $sentinel = '/__reli_probe__';
+        $resolved = $this->process_path_resolver->resolve($pid, $sentinel);
+        if (str_ends_with($resolved, $sentinel)) {
+            return substr($resolved, 0, -strlen($sentinel));
+        }
+        return '';
+    }
+
+    /**
+     * Cheap check: is at least one named module from the memory map
+     * actually readable through the chosen `process_root`? When false,
+     * the symbol resolver would just thrash through file-not-found
+     * per slot — better to bail and let FunctionPointerDetector fall
+     * back to module-level labels.
+     */
+    private function hasReachableModule(
+        ProcessMemoryMap $process_memory_map,
+        string $process_root,
+    ): bool {
+        $candidates = $process_memory_map->findByNameRegex('\\.so\\b|/(php|php-fpm|frankenphp|httpd|apache2)$');
+        if ($candidates === []) {
+            // No real-binary mappings (e.g. CLI with statically linked
+            // PHP). We can still try with the executable mapping as a
+            // fallback — those always exist for any live process.
+            $candidates = $process_memory_map->findByNameRegex('^/');
+        }
+        foreach (array_slice($candidates, 0, 4) as $area) {
+            $name = $area->name;
+            if ($name === '' || $name[0] === '[') {
+                continue;
+            }
+            $path = $process_root . $name;
+            if (@is_readable($path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private function collectRealCallStackOnMemoryLimitViolation(

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -121,6 +121,12 @@ final class MemoryLocationsCollector
      * @param \Reli\Inspector\MemoryDump\FastPath\FastPathReader|null $fast_path
      *     Optional fast-path reader for dump analysis. When provided,
      *     hot collector jobs use string-buffer reads instead of FFI.
+     * @param bool $disable_bin_walk When true, skip the ZendMM bin
+     *     walker that powers the orphan-allocation analysis pipeline
+     *     (per-bin histogram, periodic groups, shape detection,
+     *     region map). Reclaims the ~17% wall-time the walker adds at
+     *     analyze time on heaps where the orphan-allocation features
+     *     aren't needed.
      */
     public function collectAll(
         ProcessSpecifier $process_specifier,
@@ -131,6 +137,7 @@ final class MemoryLocationsCollector
         ?int $bg_address = null,
         ?ContextTreeSink $sink = null,
         ?\Reli\Inspector\MemoryDump\FastPath\FastPathReader $fast_path = null,
+        bool $disable_bin_walk = false,
     ): CollectedMemories {
         $pid = $process_specifier->pid;
         $php_version = $target_php_settings->php_version;
@@ -411,17 +418,19 @@ final class MemoryLocationsCollector
         // resolution still works in that case.
         $symbol_resolver = $this->buildSymbolResolver($pid, $process_memory_map);
         $bin_walk_result = null;
-        try {
-            $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
-                $pid,
-                $zend_mm_main_chunk,
-                $dereferencer,
-                $ctx->address_map,
-                $process_memory_map,
-                $symbol_resolver,
-            );
-        } catch (\Throwable $e) {
-            Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
+        if (!$disable_bin_walk) {
+            try {
+                $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
+                    $pid,
+                    $zend_mm_main_chunk,
+                    $dereferencer,
+                    $ctx->address_map,
+                    $process_memory_map,
+                    $symbol_resolver,
+                );
+            } catch (\Throwable $e) {
+                Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
+            }
         }
 
         $context_pools->clear();

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -61,9 +61,9 @@ final class MemoryLocationsCollector
         private MemoryReaderInterface $memory_reader,
         private ZendTypeReaderCreator $zend_type_reader_creator,
         private PhpZendMemoryManagerChunkFinder $chunk_finder,
-        private ?ProcessMemoryMapCreatorInterface $process_memory_map_creator = null,
-        private ?BinaryAnalysisCache $binary_analysis_cache = null,
-        private ?ProcessPathResolver $process_path_resolver = null,
+        private ProcessMemoryMapCreatorInterface $process_memory_map_creator,
+        private BinaryAnalysisCache $binary_analysis_cache,
+        private ProcessPathResolver $process_path_resolver,
     ) {
     }
 
@@ -396,21 +396,19 @@ final class MemoryLocationsCollector
         // Both sources are best-effort; bin walker failures must not
         // abort the analyze run.
         $process_memory_map = null;
-        if ($this->process_memory_map_creator !== null) {
-            try {
-                $process_memory_map = $this->process_memory_map_creator
-                    ->getProcessMemoryMap($pid);
-            } catch (\Throwable $e) {
-                Log::debug('process memory map fetch failed', ['exception' => $e]);
-            }
+        try {
+            $process_memory_map = $this->process_memory_map_creator
+                ->getProcessMemoryMap($pid);
+        } catch (\Throwable $e) {
+            Log::debug('process memory map fetch failed', ['exception' => $e]);
         }
-        // Build a symbol resolver only when /proc/<pid>/exe is reachable
-        // (i.e., a live target). For rdump-driven analyze the pid is the
-        // original target's pid which is meaningless on the analyzing
-        // host; without an accessible binary on disk we'd just thrash
-        // through file-not-found per slot. The module-level resolver
-        // (FunctionPointerDetector falls back to module names) still
-        // works in that case.
+        // Build a symbol resolver only when the process memory map is
+        // available AND at least one named module is reachable through
+        // the process path resolver. Both live (`/proc/<pid>/root`) and
+        // offline (`--dependency-root` MappedPathResolver) paths land
+        // here uniformly; the only reason to bail is "rdump from
+        // different host without --dependency-root" — module-level
+        // resolution still works in that case.
         $symbol_resolver = $this->buildSymbolResolver($pid, $process_memory_map);
         $bin_walk_result = null;
         try {
@@ -483,9 +481,6 @@ final class MemoryLocationsCollector
         if ($process_memory_map === null) {
             return null;
         }
-        if ($this->process_path_resolver === null) {
-            return null;
-        }
         $process_root = $this->probeProcessRoot($pid);
         if (!$this->hasReachableModule($process_memory_map, $process_root)) {
             return null;
@@ -513,7 +508,6 @@ final class MemoryLocationsCollector
      */
     private function probeProcessRoot(int $pid): string
     {
-        assert($this->process_path_resolver !== null);
         $sentinel = '/__reli_probe__';
         $resolved = $this->process_path_resolver->resolve($pid, $sentinel);
         if (str_ends_with($resolved, $sentinel)) {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -25,6 +25,8 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendExecutorGlobals;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\VmStackMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArenaMemoryLocation;
@@ -158,6 +160,22 @@ final class MemoryLocationsCollector
             }
             $walked_chunk_count++;
         }
+        // Walk the small-bin freelists + chunk page maps to recover the
+        // per-bin live-allocation histogram and any periodic same-shape
+        // groups. This is the foundation for the orphan-allocation
+        // analysis path (see docs/internals/design-orphan-allocation-analysis.md).
+        // Non-fatal — a failure here must not abort the analyze run.
+        $bin_walk_result = null;
+        try {
+            $bin_walk_result = (new ZendMmBinWalker($this->memory_reader))->walk(
+                $pid,
+                $zend_mm_main_chunk,
+                $dereferencer,
+            );
+        } catch (\Throwable $e) {
+            Log::debug('ZendMmBinWalker failed', ['exception' => $e]);
+        }
+
         $huge_memory_locations = new MemoryLocations();
         $huge_total_bytes = 0;
         foreach ($zend_mm_main_chunk->heap_slot->iterateHugeList($dereferencer) as $huge_list) {
@@ -383,6 +401,7 @@ final class MemoryLocationsCollector
             $last_chunks_delete_count,
             $chunks_total_free_bytes,
             $chunks_mostly_empty_count,
+            $bin_walk_result,
         );
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/RegionMap.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/RegionMap.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
+
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
+
+/**
+ * Snapshot of the address ranges reli observed at analyze time.
+ *
+ * One row per (kind, start_address) tuple from the four region kinds the
+ * collector tracks: ZendMM chunks, huge allocations, VM stacks,
+ * and compiler arena chains. Persisted in the rmem summary so the
+ * comparison path can diff "added/grown/shrunk/removed" ranges across
+ * snapshots — the design's region-map delta (B.2). Without it the user
+ * has to text-diff two `inspector:memory:dump:inspect` runs by hand,
+ * which is the manual workflow the issue #88 investigation flagged.
+ */
+final class RegionMap
+{
+    public const KIND_CHUNK = 'chunk';
+    public const KIND_HUGE = 'huge';
+    public const KIND_VM_STACK = 'vm_stack';
+    public const KIND_COMPILER_ARENA = 'compiler_arena';
+
+    /**
+     * @param list<array{kind: string, address: int, size: int}> $entries
+     */
+    public function __construct(
+        public readonly array $entries,
+    ) {
+    }
+
+    public static function fromCollectedMemories(CollectedMemories $cm): self
+    {
+        $entries = [];
+        self::extract($entries, $cm->chunk_memory_locations, self::KIND_CHUNK);
+        self::extract($entries, $cm->huge_memory_locations, self::KIND_HUGE);
+        self::extract($entries, $cm->vm_stack_memory_locations, self::KIND_VM_STACK);
+        self::extract($entries, $cm->compiler_arena_memory_locations, self::KIND_COMPILER_ARENA);
+        return new self($entries);
+    }
+
+    /**
+     * @param list<array{kind: string, address: int, size: int}> $entries
+     * @param-out list<array{kind: string, address: int, size: int}> $entries
+     */
+    private static function extract(array &$entries, MemoryLocations $locations, string $kind): void
+    {
+        foreach ($locations->memory_locations as $loc) {
+            if ($loc->size <= 0) {
+                continue;
+            }
+            $entries[] = [
+                'kind' => $kind,
+                'address' => $loc->address,
+                'size' => $loc->size,
+            ];
+        }
+    }
+
+    /**
+     * @return list<array{kind: string, address: int, size: int}>
+     */
+    public function toSummaryArray(): array
+    {
+        return $this->entries;
+    }
+}

--- a/tests/Command/Inspector/MemoryBinQueryCommandTest.php
+++ b/tests/Command/Inspector/MemoryBinQueryCommandTest.php
@@ -130,6 +130,34 @@ class MemoryBinQueryCommandTest extends BaseTestCase
         $this->assertStringNotContainsString('0x0000000000001000', $display);
     }
 
+    public function testListsAddressesForUnclassifiedShape(): void
+    {
+        // Validator's drill-down ask: when shape detectors miss a slot,
+        // it lands under `unclassified` and the user can still pull
+        // sample addresses to peek at.
+        $this->writeRmemWithShapeCounts([
+            3 => [
+                'unclassified' => [
+                    'count' => 2044,
+                    'reachable_count' => 0,
+                    'confidence' => 'low',
+                    'sample_addrs' => [0x7f00deadbeef, 0x7f00deadcafe],
+                ],
+            ],
+        ]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--bin' => '3',
+            '--shape' => 'unclassified',
+        ]);
+        $this->assertSame(0, $rc);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('unclassified', $display);
+        $this->assertStringContainsString('0x00007f00deadbeef', $display);
+        $this->assertStringContainsString('0x00007f00deadcafe', $display);
+    }
+
     public function testFailsWhenBinUnknown(): void
     {
         $this->writeRmemWithShapeCounts([

--- a/tests/Command/Inspector/MemoryBinQueryCommandTest.php
+++ b/tests/Command/Inspector/MemoryBinQueryCommandTest.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\StringDict;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Writer;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MemoryBinQueryCommandTest extends BaseTestCase
+{
+    private string $rmem_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rmem_path = tempnam(sys_get_temp_dir(), 'reli_binq_test_') . '.rmem';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->rmem_path);
+        parent::tearDown();
+    }
+
+    public function testListBinsRendersBinsAndShapes(): void
+    {
+        $this->writeRmemWithShapeCounts([
+            3 => [
+                'Bucket(zval IS_STRING)' => [
+                    'count' => 2150,
+                    'reachable_count' => 150,
+                    'confidence' => 'high',
+                    'sample_addrs' => [0x7f0000001000, 0x7f0000001020],
+                ],
+            ],
+            13 => [
+                'struct stat @+0' => [
+                    'count' => 567,
+                    'reachable_count' => 0,
+                    'confidence' => 'high',
+                    'sample_addrs' => [0x7f0000002000],
+                ],
+            ],
+        ]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--list-bins' => true,
+        ]);
+        $this->assertSame(0, $rc);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Bin', $display);
+        $this->assertStringContainsString('Bucket(zval IS_STRING)(2150)', $display);
+        $this->assertStringContainsString('struct stat @+0(567)', $display);
+    }
+
+    public function testListsSampleAddressesForGivenBin(): void
+    {
+        $this->writeRmemWithShapeCounts([
+            3 => [
+                'Bucket(zval IS_STRING)' => [
+                    'count' => 2150,
+                    'reachable_count' => 150,
+                    'confidence' => 'high',
+                    'sample_addrs' => [
+                        0x7f0000001000,
+                        0x7f0000001020,
+                        0x7f0000001040,
+                        0x7f0000001060,
+                    ],
+                ],
+            ],
+        ]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--bin' => '3',
+            '--sample' => '2',
+        ]);
+        $this->assertSame(0, $rc);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('0x00007f0000001000', $display);
+        $this->assertStringContainsString('0x00007f0000001020', $display);
+        // Beyond --sample=2 the rest are summarised, not printed.
+        $this->assertStringNotContainsString('0x00007f0000001040', $display);
+        $this->assertStringContainsString('2 more sample addresses available', $display);
+    }
+
+    public function testFiltersByShape(): void
+    {
+        $this->writeRmemWithShapeCounts([
+            3 => [
+                'Bucket(zval IS_STRING)' => [
+                    'count' => 2150,
+                    'reachable_count' => 150,
+                    'confidence' => 'high',
+                    'sample_addrs' => [0x1000],
+                ],
+                'Bucket(uninit?)' => [
+                    'count' => 50,
+                    'reachable_count' => 0,
+                    'confidence' => 'low',
+                    'sample_addrs' => [0x2000],
+                ],
+            ],
+        ]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--bin' => '3',
+            '--shape' => 'Bucket(uninit?)',
+        ]);
+        $this->assertSame(0, $rc);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Bucket(uninit?)', $display);
+        $this->assertStringContainsString('0x0000000000002000', $display);
+        $this->assertStringNotContainsString('0x0000000000001000', $display);
+    }
+
+    public function testFailsWhenBinUnknown(): void
+    {
+        $this->writeRmemWithShapeCounts([
+            3 => [
+                'X' => [
+                    'count' => 1,
+                    'reachable_count' => 0,
+                    'confidence' => 'medium',
+                    'sample_addrs' => [],
+                ],
+            ],
+        ]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--bin' => '99',
+        ]);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString('no captures for bin 99', $tester->getDisplay());
+    }
+
+    public function testFailsWhenNoBinShapeCountsEntry(): void
+    {
+        $this->writeRmemWithShapeCounts([]);
+        $tester = new CommandTester(new MemoryBinQueryCommand());
+        $rc = $tester->execute([
+            'rmem-file' => $this->rmem_path,
+            '--bin' => '3',
+        ]);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString(
+            'no bin_shape_counts entry',
+            $tester->getDisplay(),
+        );
+    }
+
+    /**
+     * Build a minimal rmem file containing only a string dictionary +
+     * a summary section with a `bin_shape_counts` entry. Mirrors the
+     * shape produced by analyze.
+     *
+     * @param array<int, array<string, array{
+     *     count: int,
+     *     reachable_count: int,
+     *     confidence: string,
+     *     sample_addrs: list<int>
+     * }>> $shape_counts Pass [] to write a summary without the entry.
+     */
+    private function writeRmemWithShapeCounts(array $shape_counts): void
+    {
+        $dict = new StringDict();
+        $writer = new Writer($this->rmem_path);
+        try {
+            if ($shape_counts === []) {
+                // Empty summary section.
+                $writer->writeSection(Format::SECTION_STRING_DICT, $dict->serialize(), $dict->count());
+                $writer->writeSection(Format::SECTION_SUMMARY, pack('V', 0), 0);
+                return;
+            }
+            $payload = [
+                'bin' => array_map(
+                    static function (int $bin_num, array $shapes): array {
+                        $rows = [];
+                        foreach ($shapes as $label => $row) {
+                            $rows[] = [
+                                'label' => $label,
+                                'count' => $row['count'],
+                                'reachable_count' => $row['reachable_count'],
+                                'confidence' => $row['confidence'],
+                                'sample_addrs' => $row['sample_addrs'],
+                            ];
+                        }
+                        return [
+                            'bin_num' => $bin_num,
+                            'shapes' => $rows,
+                            'unclassified' => 0,
+                        ];
+                    },
+                    array_keys($shape_counts),
+                    array_values($shape_counts),
+                ),
+            ];
+            $key_id = $dict->intern('bin_shape_counts');
+            $val_id = $dict->intern((string)json_encode($payload));
+            $writer->writeSection(Format::SECTION_STRING_DICT, $dict->serialize(), $dict->count());
+            $summary = pack('V', 1) . pack('VV', $key_id, $val_id);
+            $writer->writeSection(Format::SECTION_SUMMARY, $summary, 1);
+        } finally {
+            $writer->finish();
+        }
+    }
+}

--- a/tests/Command/Inspector/MemoryPeekCommandTest.php
+++ b/tests/Command/Inspector/MemoryPeekCommandTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use Reli\BaseTestCase;
+use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MemoryPeekCommandTest extends BaseTestCase
+{
+    private string $rdump_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rdump_path = tempnam(sys_get_temp_dir(), 'reli_peek_test_') . '.rdump';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->rdump_path);
+        parent::tearDown();
+    }
+
+    public function testRequiresExactlyOneSource(): void
+    {
+        $tester = $this->buildTester();
+        $rc = $tester->execute(['--address' => '0x1000', '--length' => '16']);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString(
+            'exactly one of --pid or --rdump',
+            $tester->getDisplay(),
+        );
+    }
+
+    public function testRejectsBadAddress(): void
+    {
+        $this->writeMinimalRdump([]);
+        $tester = $this->buildTester();
+        $rc = $tester->execute([
+            '--rdump' => $this->rdump_path,
+            '--address' => 'garbage',
+            '--length' => '16',
+        ]);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString('could not parse address', $tester->getDisplay());
+    }
+
+    public function testRejectsLengthOverCap(): void
+    {
+        $this->writeMinimalRdump([]);
+        $tester = $this->buildTester();
+        $rc = $tester->execute([
+            '--rdump' => $this->rdump_path,
+            '--address' => '0x1000',
+            '--length' => (string)(64 * 1024 + 1),
+        ]);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString('capped', $tester->getDisplay());
+    }
+
+    public function testReadsSliceFromRdumpRegion(): void
+    {
+        $payload = "Hello, reli! " . str_repeat("\x41", 64);
+        $this->writeMinimalRdump([
+            ['address' => 0x7f0000000000, 'data' => $payload],
+        ]);
+        $tester = $this->buildTester();
+        $rc = $tester->execute([
+            '--rdump' => $this->rdump_path,
+            '--address' => '0x7f0000000000',
+            '--length' => (string)strlen($payload),
+        ]);
+        $this->assertSame(0, $rc);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString(sprintf('%d bytes from 0x7f0000000000', strlen($payload)), $display);
+        // The "Hello, reli! " prefix lands in the ASCII gutter of the
+        // first hexdump row.
+        $this->assertStringContainsString('|Hello, reli! AAA', $display);
+    }
+
+    public function testReadsMidRegionSlice(): void
+    {
+        $payload = str_repeat("A", 16) . str_repeat("B", 16) . str_repeat("C", 16);
+        $this->writeMinimalRdump([
+            ['address' => 0x1000, 'data' => $payload],
+        ]);
+        $tester = $this->buildTester();
+        // Read 16 bytes starting 16 bytes in — should land squarely on
+        // the "B" run.
+        $rc = $tester->execute([
+            '--rdump' => $this->rdump_path,
+            '--address' => '0x1010',
+            '--length' => '16',
+        ]);
+        $this->assertSame(0, $rc);
+        $this->assertStringContainsString('|BBBBBBBBBBBBBBBB|', $tester->getDisplay());
+    }
+
+    public function testFailsWhenAddressNotInAnyRegion(): void
+    {
+        $this->writeMinimalRdump([
+            ['address' => 0x1000, 'data' => 'XYZ'],
+        ]);
+        $tester = $this->buildTester();
+        $rc = $tester->execute([
+            '--rdump' => $this->rdump_path,
+            '--address' => '0x2000',
+            '--length' => '16',
+        ]);
+        $this->assertSame(1, $rc);
+        $this->assertStringContainsString(
+            'is not covered by any region',
+            $tester->getDisplay(),
+        );
+    }
+
+    private function buildTester(): CommandTester
+    {
+        $reader = $this->createMock(MemoryReaderInterface::class);
+        return new CommandTester(new MemoryPeekCommand($reader));
+    }
+
+    /**
+     * Write a minimal rdump file containing only the regions necessary
+     * to exercise the peek command. memory_map is empty (count = 0);
+     * region count + each region's (address, size, data) follow the
+     * v2 header.
+     *
+     * @param list<array{address: int, data: string}> $regions
+     */
+    private function writeMinimalRdump(array $regions): void
+    {
+        $fp = fopen($this->rdump_path, 'wb');
+        if ($fp === false) {
+            $this->fail('failed to open rdump tmp');
+        }
+        try {
+            fwrite($fp, "RDUMP\0\0\0");
+            // version = 2
+            fwrite($fp, pack('V', 2));
+            // php_version (length-prefixed string)
+            $this->writeString($fp, '8.4');
+            // pid, eg, cg, rss
+            fwrite($fp, pack('P', 1));
+            fwrite($fp, pack('P', 0));
+            fwrite($fp, pack('P', 0));
+            fwrite($fp, pack('P', 0));
+            // memory_map_count = 0, region_count = N
+            fwrite($fp, pack('V', 0));
+            fwrite($fp, pack('V', count($regions)));
+            foreach ($regions as $r) {
+                fwrite($fp, pack('P', $r['address']));
+                fwrite($fp, pack('P', strlen($r['data'])));
+                fwrite($fp, $r['data']);
+            }
+        } finally {
+            fclose($fp);
+        }
+    }
+
+    /** @param resource $fp */
+    private function writeString($fp, string $s): void
+    {
+        fwrite($fp, pack('V', strlen($s)));
+        fwrite($fp, $s);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Comparison/BinHistogramSnapshotTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Comparison/BinHistogramSnapshotTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+use Reli\BaseTestCase;
+
+class BinHistogramSnapshotTest extends BaseTestCase
+{
+    public function testDecodesValidPayload(): void
+    {
+        $json = json_encode([
+            'histogram' => [
+                '3' => ['count' => 100, 'total_bytes' => 3200],
+                '13' => ['count' => 50, 'total_bytes' => 9600],
+            ],
+            'live_small_slot_count' => 150,
+            'live_small_slot_bytes' => 12_800,
+            'large_run_count' => 1,
+            'large_run_bytes' => 8 * 4096,
+            'walked_chunk_count' => 1,
+            'partial' => false,
+        ]);
+
+        $decoded = BinHistogramSnapshot::decode($json);
+        $this->assertNotNull($decoded);
+        // Bin numbers come back as ints (PHP json_decode yields string keys
+        // for stringified ints; the decoder normalises).
+        $this->assertSame([3, 13], array_keys($decoded['histogram']));
+        $this->assertSame(100, $decoded['histogram'][3]['count']);
+        $this->assertSame(3200, $decoded['histogram'][3]['total_bytes']);
+        $this->assertSame(150, $decoded['live_small_slot_count']);
+        $this->assertSame(false, $decoded['partial']);
+    }
+
+    public function testReturnsNullForGarbage(): void
+    {
+        $this->assertNull(BinHistogramSnapshot::decode(''));
+        $this->assertNull(BinHistogramSnapshot::decode('not json'));
+        $this->assertNull(BinHistogramSnapshot::decode('{}'));
+        $this->assertNull(BinHistogramSnapshot::decode('{"histogram": "wrong"}'));
+    }
+
+    public function testEmptyHistogramIsValid(): void
+    {
+        $decoded = BinHistogramSnapshot::decode(json_encode(['histogram' => []]));
+        $this->assertNotNull($decoded);
+        $this->assertSame([], $decoded['histogram']);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
@@ -372,6 +372,73 @@ class ComparisonGeneratorTest extends BaseTestCase
         $this->assertSame([], $result->region_deltas);
     }
 
+    public function testCompareBinShapeCountsPicksUpContentVaryingLeak(): void
+    {
+        // T1: 619 Buckets baseline. T2: 2,810 Buckets (the issue #88
+        // shape: per-connection Bucket entries with distinct hashes
+        // and key pointers — content-varying, so the periodic-group
+        // path skips them entirely).
+        $this->buildDb($this->baseline_path, [
+            ['bin_shape_counts' => json_encode([
+                'bin' => [[
+                    'bin_num' => 3,
+                    'shapes' => [[
+                        'label' => 'Bucket(zval IS_STRING)',
+                        'count' => 619,
+                        'reachable_count' => 600,
+                        'confidence' => 'medium',
+                    ]],
+                    'unclassified' => 0,
+                ]],
+            ])],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['bin_shape_counts' => json_encode([
+                'bin' => [[
+                    'bin_num' => 3,
+                    'shapes' => [[
+                        'label' => 'Bucket(zval IS_STRING)',
+                        'count' => 2810,
+                        'reachable_count' => 600,
+                        'confidence' => 'medium',
+                    ]],
+                    'unclassified' => 0,
+                ]],
+            ])],
+        ]);
+
+        $result = $this->compare();
+        $this->assertCount(1, $result->bin_shape_deltas);
+        $delta = $result->bin_shape_deltas[0];
+        $this->assertSame(3, $delta->bin_num);
+        $this->assertSame('Bucket(zval IS_STRING)', $delta->shape);
+        $this->assertSame(2191, $delta->count_delta);
+        // All the new copies are orphan — that's the leak signal.
+        $this->assertSame(2191, $delta->orphan_count_delta);
+        $this->assertSame(0, $delta->reachable_count_delta);
+    }
+
+    public function testCompareBinShapeCountsSkipsUnchangedShapes(): void
+    {
+        $payload = json_encode([
+            'bin' => [[
+                'bin_num' => 3,
+                'shapes' => [[
+                    'label' => 'X',
+                    'count' => 10,
+                    'reachable_count' => 5,
+                    'confidence' => 'medium',
+                ]],
+                'unclassified' => 0,
+            ]],
+        ]);
+        $this->buildDb($this->baseline_path, [['bin_shape_counts' => $payload]]);
+        $this->buildDb($this->target_path, [['bin_shape_counts' => $payload]]);
+
+        $result = $this->compare();
+        $this->assertSame([], $result->bin_shape_deltas);
+    }
+
     public function testComparisonResultToArray(): void
     {
         $this->buildDb($this->baseline_path, [

--- a/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
@@ -234,6 +234,94 @@ class ComparisonGeneratorTest extends BaseTestCase
         $this->assertContains('dominant_class', $resolved_kinds);
     }
 
+    public function testCompareBinHistogramEmitsDeltas(): void
+    {
+        $this->buildDb($this->baseline_path, [
+            ['zend_mm_heap_usage' => 1_000_000],
+            // Bin walker recorded 5,000 32 B slots and 100 192 B slots.
+            ['bin_walk' => json_encode([
+                'histogram' => [
+                    3 => ['count' => 5000, 'total_bytes' => 5000 * 32],
+                    13 => ['count' => 100, 'total_bytes' => 100 * 192],
+                ],
+            ])],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['zend_mm_heap_usage' => 1_500_000],
+            // Bin 3 grew significantly; bin 13 unchanged; bin 7 (64 B) is new.
+            ['bin_walk' => json_encode([
+                'histogram' => [
+                    3 => ['count' => 21_000, 'total_bytes' => 21_000 * 32],
+                    13 => ['count' => 100, 'total_bytes' => 100 * 192],
+                    7 => ['count' => 50, 'total_bytes' => 50 * 64],
+                ],
+            ])],
+        ]);
+
+        $result = $this->compare();
+
+        $this->assertNotEmpty($result->bin_deltas);
+        // Sorted by |bytes_delta| desc, so bin 3 lands first.
+        $this->assertSame(3, $result->bin_deltas[0]->bin_num);
+        $this->assertSame(32, $result->bin_deltas[0]->bin_size);
+        $this->assertSame(16_000, $result->bin_deltas[0]->count_delta);
+        $this->assertSame(16_000 * 32, $result->bin_deltas[0]->bytes_delta);
+
+        // Unchanged bin (13) is omitted entirely.
+        $bin_nums = array_map(
+            static fn(BinDelta $d) => $d->bin_num,
+            $result->bin_deltas,
+        );
+        $this->assertNotContains(13, $bin_nums);
+        $this->assertContains(7, $bin_nums);
+    }
+
+    public function testUnaccountedDeltaFiringWhenHeapGrowsButTypesFlat(): void
+    {
+        $this->buildDb($this->baseline_path, [
+            ['zend_mm_heap_usage' => 10_000_000],
+        ]);
+        $this->buildDb($this->target_path, [
+            // Heap +1 MiB but no typed allocations changed (the dbs have no
+            // location data, so the type breakdown is empty on both sides).
+            ['zend_mm_heap_usage' => 11_048_576],
+        ]);
+
+        $result = $this->compare();
+
+        $this->assertNotNull($result->unaccounted_finding);
+        $this->assertSame('unaccounted_heap_delta', $result->unaccounted_finding->kind);
+        $this->assertGreaterThan(0, $result->unaccounted_finding->impact_bytes);
+    }
+
+    public function testUnaccountedDeltaSilentWhenHeapShrunk(): void
+    {
+        $this->buildDb($this->baseline_path, [
+            ['zend_mm_heap_usage' => 11_000_000],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['zend_mm_heap_usage' => 10_000_000],
+        ]);
+
+        $result = $this->compare();
+        $this->assertNull($result->unaccounted_finding);
+    }
+
+    public function testUnaccountedDeltaSilentWhenHeapBarelyMoved(): void
+    {
+        // Heap +50 KiB on a 10 MiB baseline — both below 1% and below
+        // 100 KiB, so the synthetic finding stays quiet.
+        $this->buildDb($this->baseline_path, [
+            ['zend_mm_heap_usage' => 10_000_000],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['zend_mm_heap_usage' => 10_050_000],
+        ]);
+
+        $result = $this->compare();
+        $this->assertNull($result->unaccounted_finding);
+    }
+
     public function testComparisonResultToArray(): void
     {
         $this->buildDb($this->baseline_path, [

--- a/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Comparison/ComparisonGeneratorTest.php
@@ -322,6 +322,56 @@ class ComparisonGeneratorTest extends BaseTestCase
         $this->assertNull($result->unaccounted_finding);
     }
 
+    public function testCompareRegionMapEmitsCategorisedDeltas(): void
+    {
+        $this->buildDb($this->baseline_path, [
+            ['region_map' => json_encode([
+                ['kind' => 'chunk', 'address' => 0x10000000, 'size' => 2 * 1024 * 1024],
+                ['kind' => 'chunk', 'address' => 0x20000000, 'size' => 2 * 1024 * 1024],
+                ['kind' => 'huge', 'address' => 0x30000000, 'size' => 1 * 1024 * 1024],
+            ])],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['region_map' => json_encode([
+                // 0x10000000 unchanged → no delta row
+                ['kind' => 'chunk', 'address' => 0x10000000, 'size' => 2 * 1024 * 1024],
+                // 0x20000000 grew (matches the issue #88 leak shape)
+                ['kind' => 'chunk', 'address' => 0x20000000, 'size' => (2 * 1024 * 1024) + 728 * 1024],
+                // 0x30000000 huge removed
+                // 0x40000000 chunk added
+                ['kind' => 'chunk', 'address' => 0x40000000, 'size' => 2 * 1024 * 1024],
+            ])],
+        ]);
+
+        $result = $this->compare();
+
+        $this->assertNotEmpty($result->region_deltas);
+        $changes = array_map(static fn(RegionDelta $d) => $d->change, $result->region_deltas);
+        $this->assertContains(RegionDelta::CHANGE_GROWN, $changes);
+        $this->assertContains(RegionDelta::CHANGE_ADDED, $changes);
+        $this->assertContains(RegionDelta::CHANGE_REMOVED, $changes);
+
+        // Sorted by |size_delta| desc — chunk add (+2 MiB) leads.
+        $this->assertSame(RegionDelta::CHANGE_ADDED, $result->region_deltas[0]->change);
+        $this->assertSame(0x40000000, $result->region_deltas[0]->address);
+
+        // Unchanged regions don't appear.
+        $addresses = array_map(static fn(RegionDelta $d) => $d->address, $result->region_deltas);
+        $this->assertNotContains(0x10000000, $addresses);
+    }
+
+    public function testCompareRegionMapEmptyWhenBothMissing(): void
+    {
+        $this->buildDb($this->baseline_path, [
+            ['memory_get_usage' => 100],
+        ]);
+        $this->buildDb($this->target_path, [
+            ['memory_get_usage' => 200],
+        ]);
+        $result = $this->compare();
+        $this->assertSame([], $result->region_deltas);
+    }
+
     public function testComparisonResultToArray(): void
     {
         $this->buildDb($this->baseline_path, [

--- a/tests/Inspector/Output/MemoryOutput/Comparison/RegionMapSnapshotTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Comparison/RegionMapSnapshotTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Comparison;
+
+use Reli\BaseTestCase;
+
+class RegionMapSnapshotTest extends BaseTestCase
+{
+    public function testDecodesValidRows(): void
+    {
+        $json = json_encode([
+            ['kind' => 'chunk', 'address' => 0x7f0000000000, 'size' => 2 * 1024 * 1024],
+            ['kind' => 'huge', 'address' => 0x7f1000000000, 'size' => 728 * 1024],
+        ]);
+        $decoded = RegionMapSnapshot::decode($json);
+        $this->assertNotNull($decoded);
+        $this->assertCount(2, $decoded);
+        $this->assertSame('chunk', $decoded[0]['kind']);
+        $this->assertSame(0x7f0000000000, $decoded[0]['address']);
+        $this->assertSame(2 * 1024 * 1024, $decoded[0]['size']);
+    }
+
+    public function testReturnsNullForInvalidJson(): void
+    {
+        $this->assertNull(RegionMapSnapshot::decode(''));
+        $this->assertNull(RegionMapSnapshot::decode('{not json'));
+    }
+
+    public function testSkipsMalformedRows(): void
+    {
+        $json = json_encode([
+            ['kind' => 'chunk', 'address' => 100, 'size' => 200],
+            ['kind' => 'no_size', 'address' => 300],
+            'string row',
+            ['address' => 400, 'size' => 500], // missing kind
+        ]);
+        $decoded = RegionMapSnapshot::decode($json);
+        $this->assertNotNull($decoded);
+        $this->assertCount(1, $decoded);
+        $this->assertSame('chunk', $decoded[0]['kind']);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/BinHistogramPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/BinHistogramPassTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+class BinHistogramPassTest extends BaseTestCase
+{
+    public function testEmitsNoFindingsWithoutBinWalkSummary(): void
+    {
+        $pass = new BinHistogramPass([['memory_get_usage' => 1024]]);
+        $this->assertSame([], $pass->analyze());
+    }
+
+    public function testEmitsNoFindingsForEmptyHistogram(): void
+    {
+        $pass = new BinHistogramPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [],
+                'live_small_slot_count' => 0,
+                'live_small_slot_bytes' => 0,
+                'large_run_count' => 0,
+                'large_run_bytes' => 0,
+                'walked_chunk_count' => 1,
+                'partial' => false,
+            ]),
+        ]]);
+        $this->assertSame([], $pass->analyze());
+    }
+
+    public function testEmitsOverviewAndPerBinFindings(): void
+    {
+        $pass = new BinHistogramPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [
+                    3 => ['count' => 16041, 'total_bytes' => 16041 * 32],
+                    13 => ['count' => 234, 'total_bytes' => 234 * 192],
+                ],
+                'live_small_slot_count' => 16041 + 234,
+                'live_small_slot_bytes' => 16041 * 32 + 234 * 192,
+                'large_run_count' => 1,
+                'large_run_bytes' => 8 * 4096,
+                'walked_chunk_count' => 2,
+                'partial' => false,
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+
+        $this->assertNotEmpty($findings);
+        $kinds = array_map(static fn(Finding $f) => $f->kind, $findings);
+        $this->assertContains('bin_histogram_overview', $kinds);
+        $this->assertContains('bin_histogram_entry', $kinds);
+
+        $entries = array_values(array_filter(
+            $findings,
+            static fn(Finding $f) => $f->kind === 'bin_histogram_entry',
+        ));
+        $this->assertCount(2, $entries);
+
+        // Both entries are info-level (rendering data, not actionable).
+        foreach ($entries as $f) {
+            $this->assertSame(FindingSeverity::Info, $f->severity);
+        }
+
+        // Bin sizes resolved through ZendMmBinsInfo (3 → 32, 13 → 192).
+        $bin_sizes = array_map(
+            static fn(Finding $f) => $f->facts['bin_size'],
+            $entries,
+        );
+        sort($bin_sizes);
+        $this->assertSame([32, 192], $bin_sizes);
+    }
+
+    public function testTolemoratesPlainArrayValues(): void
+    {
+        // The pass also accepts the array straight from CollectedMemories
+        // (no JSON round-trip), so in-process pipelines stay clean.
+        $pass = new BinHistogramPass([[
+            'bin_walk' => [
+                'histogram' => [3 => ['count' => 100, 'total_bytes' => 3200]],
+                'live_small_slot_count' => 100,
+                'live_small_slot_bytes' => 3200,
+                'large_run_count' => 0,
+                'large_run_bytes' => 0,
+                'walked_chunk_count' => 1,
+                'partial' => false,
+            ],
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertNotEmpty($findings);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPassTest.php
@@ -94,4 +94,89 @@ class BinPeriodicityPassTest extends BaseTestCase
         $findings = $pass->analyze();
         $this->assertCount(1, $findings);
     }
+
+    public function testOrphanHotspotIsHighSeverity(): void
+    {
+        // Orphan + dominates the bin = strongest leak signal we can
+        // emit without going to a bytes-level decoder.
+        $pass = new BinPeriodicityPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [3 => ['count' => 16000, 'total_bytes' => 16000 * 32]],
+            ]),
+            'bin_walk_periodic_groups' => json_encode([
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 16000,
+                    'stride' => 32,
+                    'fingerprint' => '',
+                    'sample_addr' => 0,
+                    'reachability' => 'orphan',
+                    'reachable_samples' => 0,
+                    'sampled_count' => 16,
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_periodic_hotspot', $findings[0]->kind);
+        $this->assertSame(FindingSeverity::High, $findings[0]->severity);
+    }
+
+    public function testReachableGroupDemotedToInfo(): void
+    {
+        // Same shape, dominates the bin, but every sample is claimed
+        // by reli's root walker — this is normal data the detectors
+        // matched by accident. Demote out of the hotspot bucket.
+        $pass = new BinPeriodicityPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [3 => ['count' => 16000, 'total_bytes' => 16000 * 32]],
+            ]),
+            'bin_walk_periodic_groups' => json_encode([
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 16000,
+                    'stride' => 32,
+                    'fingerprint' => '',
+                    'sample_addr' => 0,
+                    'reachability' => 'reachable',
+                    'reachable_samples' => 16,
+                    'sampled_count' => 16,
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_periodic_reachable', $findings[0]->kind);
+        $this->assertSame(FindingSeverity::Info, $findings[0]->severity);
+    }
+
+    public function testOrphanWithoutHotspotIsInfoOrphanKind(): void
+    {
+        // Orphan, but only 100 of 1000 slots in the bin — not a hotspot,
+        // so this is a candidate, not a confirmed leak.
+        $pass = new BinPeriodicityPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [3 => ['count' => 1000, 'total_bytes' => 32000]],
+            ]),
+            'bin_walk_periodic_groups' => json_encode([
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 100,
+                    'stride' => 32,
+                    'fingerprint' => '',
+                    'sample_addr' => 0,
+                    'reachability' => 'orphan',
+                    'reachable_samples' => 0,
+                    'sampled_count' => 16,
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_periodic_orphan', $findings[0]->kind);
+        $this->assertSame(FindingSeverity::Info, $findings[0]->severity);
+    }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/BinPeriodicityPassTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
+
+class BinPeriodicityPassTest extends BaseTestCase
+{
+    public function testEmitsNothingWithoutGroups(): void
+    {
+        $pass = new BinPeriodicityPass([['memory_get_usage' => 1]]);
+        $this->assertSame([], $pass->analyze());
+    }
+
+    public function testEmitsHotspotWhenGroupDominatesBin(): void
+    {
+        $pass = new BinPeriodicityPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [3 => ['count' => 16000, 'total_bytes' => 16000 * 32]],
+                'live_small_slot_count' => 16000,
+                'live_small_slot_bytes' => 16000 * 32,
+                'large_run_count' => 0,
+                'large_run_bytes' => 0,
+                'walked_chunk_count' => 1,
+                'partial' => false,
+            ]),
+            'bin_walk_periodic_groups' => json_encode([
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 16000,
+                    'stride' => 32,
+                    'fingerprint' => str_repeat('ab', 24),
+                    'sample_addr' => 0x7f0000000000,
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_periodic_hotspot', $findings[0]->kind);
+        $this->assertSame(FindingSeverity::Medium, $findings[0]->severity);
+    }
+
+    public function testEmitsInfoWhenGroupDoesNotDominate(): void
+    {
+        $pass = new BinPeriodicityPass([[
+            'bin_walk' => json_encode([
+                'histogram' => [3 => ['count' => 1000, 'total_bytes' => 32000]],
+            ]),
+            'bin_walk_periodic_groups' => json_encode([
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 100,
+                    'stride' => 32,
+                    'fingerprint' => '',
+                    'sample_addr' => 0,
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_periodic_group', $findings[0]->kind);
+        $this->assertSame(FindingSeverity::Info, $findings[0]->severity);
+    }
+
+    public function testToleratesArrayInputWithoutJsonRoundTrip(): void
+    {
+        $pass = new BinPeriodicityPass([[
+            'bin_walk_periodic_groups' => [
+                [
+                    'bin_num' => 3,
+                    'bin_size' => 32,
+                    'count' => 50,
+                    'stride' => 32,
+                    'fingerprint' => '',
+                    'sample_addr' => 0,
+                ],
+            ],
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+    }
+}

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/BinShapePassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/BinShapePassTest.php
@@ -26,6 +26,9 @@ class BinShapePassTest extends BaseTestCase
 
     public function testEmitsBinShapeCountFinding(): void
     {
+        // Unclassified slots live inside `shapes` under the literal
+        // label "unclassified" — the data model the validator's
+        // bin-query drill-down relies on.
         $pass = new BinShapePass([[
             'bin_shape_counts' => json_encode([
                 'bin' => [
@@ -38,8 +41,13 @@ class BinShapePassTest extends BaseTestCase
                                 'reachable_count' => 150,
                                 'confidence' => 'medium',
                             ],
+                            [
+                                'label' => 'unclassified',
+                                'count' => 601,
+                                'reachable_count' => 0,
+                                'confidence' => 'low',
+                            ],
                         ],
-                        'unclassified' => 601,
                     ],
                 ],
             ]),
@@ -48,14 +56,43 @@ class BinShapePassTest extends BaseTestCase
         // One bin_shape_count + one bin_shape_unclassified.
         $this->assertCount(2, $findings);
         $kinds = array_map(static fn(Finding $f) => $f->kind, $findings);
-        $this->assertSame(['bin_shape_count', 'bin_shape_unclassified'], $kinds);
+        $this->assertContains('bin_shape_count', $kinds);
+        $this->assertContains('bin_shape_unclassified', $kinds);
 
-        $shape_finding = $findings[0];
+        $shape_finding = array_values(array_filter(
+            $findings,
+            static fn(Finding $f) => $f->kind === 'bin_shape_count',
+        ))[0];
         $this->assertSame(2150, $shape_finding->facts['count']);
         $this->assertSame(2000, $shape_finding->facts['orphan_count']);
         $this->assertSame(150, $shape_finding->facts['reachable_count']);
         // 2150 / (2150 + 601) ≈ 78.2%
         $this->assertEqualsWithDelta(78.2, $shape_finding->facts['percentage'], 0.5);
+    }
+
+    public function testUnclassifiedRowEmitsUnclassifiedFinding(): void
+    {
+        $pass = new BinShapePass([[
+            'bin_shape_counts' => json_encode([
+                'bin' => [
+                    [
+                        'bin_num' => 3,
+                        'shapes' => [
+                            [
+                                'label' => 'unclassified',
+                                'count' => 200,
+                                'reachable_count' => 5,
+                                'confidence' => 'low',
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+        $this->assertSame('bin_shape_unclassified', $findings[0]->kind);
+        $this->assertSame(200, $findings[0]->facts['count']);
     }
 
     public function testToleratesArrayInput(): void
@@ -73,7 +110,6 @@ class BinShapePassTest extends BaseTestCase
                                 'confidence' => 'high',
                             ],
                         ],
-                        'unclassified' => 0,
                     ],
                 ],
             ],

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/BinShapePassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/BinShapePassTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
+
+use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\Report\Finding;
+
+class BinShapePassTest extends BaseTestCase
+{
+    public function testEmitsNothingWithoutPayload(): void
+    {
+        $pass = new BinShapePass([['memory_get_usage' => 1]]);
+        $this->assertSame([], $pass->analyze());
+    }
+
+    public function testEmitsBinShapeCountFinding(): void
+    {
+        $pass = new BinShapePass([[
+            'bin_shape_counts' => json_encode([
+                'bin' => [
+                    [
+                        'bin_num' => 3,
+                        'shapes' => [
+                            [
+                                'label' => 'Bucket(zval IS_STRING)',
+                                'count' => 2150,
+                                'reachable_count' => 150,
+                                'confidence' => 'medium',
+                            ],
+                        ],
+                        'unclassified' => 601,
+                    ],
+                ],
+            ]),
+        ]]);
+        $findings = $pass->analyze();
+        // One bin_shape_count + one bin_shape_unclassified.
+        $this->assertCount(2, $findings);
+        $kinds = array_map(static fn(Finding $f) => $f->kind, $findings);
+        $this->assertSame(['bin_shape_count', 'bin_shape_unclassified'], $kinds);
+
+        $shape_finding = $findings[0];
+        $this->assertSame(2150, $shape_finding->facts['count']);
+        $this->assertSame(2000, $shape_finding->facts['orphan_count']);
+        $this->assertSame(150, $shape_finding->facts['reachable_count']);
+        // 2150 / (2150 + 601) ≈ 78.2%
+        $this->assertEqualsWithDelta(78.2, $shape_finding->facts['percentage'], 0.5);
+    }
+
+    public function testToleratesArrayInput(): void
+    {
+        $pass = new BinShapePass([[
+            'bin_shape_counts' => [
+                'bin' => [
+                    [
+                        'bin_num' => 3,
+                        'shapes' => [
+                            [
+                                'label' => 'X',
+                                'count' => 10,
+                                'reachable_count' => 0,
+                                'confidence' => 'high',
+                            ],
+                        ],
+                        'unclassified' => 0,
+                    ],
+                ],
+            ],
+        ]]);
+        $findings = $pass->analyze();
+        $this->assertCount(1, $findings);
+    }
+}

--- a/tests/Lib/Dwarf/NativeSymbolResolverTest.php
+++ b/tests/Lib/Dwarf/NativeSymbolResolverTest.php
@@ -118,6 +118,60 @@ class NativeSymbolResolverTest extends BaseTestCase
         $this->assertTrue(true); // no crash
     }
 
+    public function testStrippedBinaryFallsBackToDynsymWithoutDebugFile(): void
+    {
+        // Validator's scenario, distilled: main binary has only .dynsym
+        // (the sandbox PHP_BINARY case), no separate debug file. The
+        // 3-step chain should:
+        //   1. try main .symtab — null (stripped)
+        //   2. try debug file .symtab — null (no debug locator hit)
+        //   3. fall through to main .dynsym — non-null
+        // Pre-fix this only worked because the chain returned on
+        // dynsym at step 1; the structural change preserves that
+        // outcome while making the debug-file slot reachable for
+        // distros that DO have a -dbgsym companion.
+        //
+        // We assert the *structural* outcome — `resolve` doesn't throw
+        // when run against a real memory map — and let the lower-layer
+        // {@see \Reli\Lib\Elf\SymbolResolver\Elf64ReverseSymbolResolverTest}
+        // pin the dynsym-reachability invariant directly against PHP_BINARY's
+        // bytes. That layer is portable across CI environments where this
+        // process's `/proc/self/maps` contents and exported-symbol layout
+        // can vary.
+        $maps_raw = file_get_contents('/proc/self/maps');
+        $parser = new \Reli\Lib\Process\MemoryMap\ProcessMemoryMapParser(
+            new \Reli\Lib\String\LineFetcher(),
+        );
+        $map = $parser->parse($maps_raw);
+
+        $resolver = new NativeSymbolResolver($map);
+        $php_areas = $map->findByNameRegex(preg_quote(PHP_BINARY, '/'));
+        if ($php_areas === []) {
+            $this->markTestSkipped('PHP_BINARY not directly mapped');
+        }
+        $exec_area = null;
+        foreach ($php_areas as $area) {
+            if ($area->attribute->execute) {
+                $exec_area = $area;
+                break;
+            }
+        }
+        if ($exec_area === null) {
+            $this->markTestSkipped('PHP_BINARY has no executable mapping');
+        }
+
+        // Probe inside the executable region; the assertion is only that
+        // the resolver doesn't throw / crash. Whether the dynsym hits
+        // depends on the build-specific exported-symbol layout and is
+        // covered separately by Elf64ReverseSymbolResolverTest.
+        $base = hexdec($exec_area->begin);
+        $end = hexdec($exec_area->end);
+        for ($offset = 0x1000; $offset < $end - $base && $offset < 0x10000; $offset += 0x1000) {
+            $resolver->resolve($base + $offset);
+        }
+        $this->assertTrue(true);
+    }
+
     public function testDiskCacheRoundtrip(): void
     {
         $maps_raw = file_get_contents('/proc/self/maps');

--- a/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
+++ b/tests/Lib/Elf/SymbolResolver/Elf64ReverseSymbolResolverTest.php
@@ -222,4 +222,49 @@ class Elf64ReverseSymbolResolverTest extends BaseTestCase
         $resolver = Elf64ReverseSymbolResolver::fromArray([]);
         $this->assertNull($resolver->resolve(0x1000));
     }
+
+    public function testLoadSymtabReturnsNullForStrippedBinary(): void
+    {
+        // The validator's scenario: distro-shipped PHP has only
+        // `.dynsym`, no `.symtab`. The split methods make this
+        // observable so NativeSymbolResolver can sequence the
+        // separate-debug-file lookup between the two.
+        $binary = file_get_contents(PHP_BINARY);
+        if ($binary === false) {
+            $this->markTestSkipped('Cannot read PHP binary');
+        }
+        $hasSymtab = (bool)preg_match('/\\.symtab/', $binary);
+        if ($hasSymtab) {
+            $this->markTestSkipped(
+                'PHP binary has .symtab — this assertion only meaningful'
+                . ' against a stripped binary',
+            );
+        }
+        $parser = new Elf64Parser(new LittleEndianReader());
+        $resolver = Elf64ReverseSymbolResolver::loadSymtabFromBinary(
+            $parser,
+            new StringByteReader($binary),
+        );
+        $this->assertNull($resolver);
+    }
+
+    public function testLoadDynsymAlwaysWorksForRealBinary(): void
+    {
+        // .dynsym is always present in any dynamically linked ELF —
+        // this is the last-resort path FunctionPointerDetector falls
+        // back to when neither main nor debug carry .symtab.
+        $binary = file_get_contents(PHP_BINARY);
+        if ($binary === false) {
+            $this->markTestSkipped('Cannot read PHP binary');
+        }
+        $parser = new Elf64Parser(new LittleEndianReader());
+        $resolver = Elf64ReverseSymbolResolver::loadDynsymFromBinary(
+            $parser,
+            new StringByteReader($binary),
+        );
+        $this->assertNotNull($resolver);
+        // dynsym always carries `execute_ex` — it's an exported entry
+        // used by extensions like Xdebug.
+        $this->assertNotEmpty($resolver->toArray());
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
@@ -18,15 +18,20 @@ use Reli\BaseTestCase;
 class BucketDetectorTest extends BaseTestCase
 {
     /**
-     * Build a 24 B fingerprint with the given zval-type byte at offset 8.
+     * Build a 32 B fingerprint with the given zval-type byte at offset 8.
+     *
+     * Uses a plausible userspace pointer (8-aligned, well below the
+     * 2^47 ceiling) at +0..+7 so the new pointer-sanity check passes
+     * for pointer-bearing types. Hash is non-zero so the all-zero
+     * "Bucket(uninit?)" branch isn't taken.
      */
     private function fp(int $type_byte): string
     {
-        // value: 8 bytes, type/type_info: 8 bytes (type at +8), hash: 8 bytes
-        $val = pack('P', 0x1234567890abcdef);
-        $type = pack('CCCCV', $type_byte, 0, 0, 0, 0); // type_byte at offset 0
-        $hash = pack('P', 0xdeadbeefcafebabe);
-        return $val . $type . $hash;
+        $val = pack('P', 0x00007ffe1234c000);
+        $type = pack('CCCCV', $type_byte, 0, 0, 0, 0);
+        $hash = pack('P', 0xcafebabe);
+        $key = pack('P', 0x00007ffe1234d000);
+        return $val . $type . $hash . $key;
     }
 
     public function testRejectsNonThirtyTwoByteBins(): void
@@ -55,19 +60,58 @@ class BucketDetectorTest extends BaseTestCase
     public function testRejectsInvalidZvalType(): void
     {
         $detector = new BucketDetector();
-        // Type byte 99 is well outside the [0, 21] zval-type whitelist.
+        // Type byte 99 is well past the deep-internal cutoff (15).
         $this->assertNull($detector->detect($this->fp(99), 32));
     }
 
-    public function testHandlesAllValidZvalTypeRange(): void
+    public function testHandlesValidZvalTypeRange(): void
     {
         $detector = new BucketDetector();
-        for ($i = 0; $i <= 21; $i++) {
+        // Types 0..15 are all the symbols we accept (incl. the new
+        // IS_INDIRECT/IS_PTR/IS_ALIAS_PTR mappings).
+        for ($i = 0; $i <= 15; $i++) {
             $this->assertNotNull(
                 $detector->detect($this->fp($i), 32),
                 "type byte {$i} should be accepted",
             );
         }
-        $this->assertNull($detector->detect($this->fp(22), 32));
+        // 16+ rejects (deep internals).
+        $this->assertNull($detector->detect($this->fp(16), 32));
+    }
+
+    public function testRejectsPointerTypeWithZeroValue(): void
+    {
+        $detector = new BucketDetector();
+        // Pointer-bearing types (IS_STRING etc) with value=0 reject —
+        // the validator's "+15 each in 13 zval_type variants" garbage
+        // is exactly this shape.
+        $zero_val = pack('P', 0)
+            . pack('CCCCV', 6 /* IS_STRING */, 0, 0, 0, 0)
+            . pack('P', 0xcafebabe)
+            . pack('P', 0x00007ffe1234d000);
+        $this->assertNull($detector->detect($zero_val, 32));
+    }
+
+    public function testCollapsesAllZeroBucketToUninitLabel(): void
+    {
+        $detector = new BucketDetector();
+        $all_zero = str_repeat("\x00", 32);
+        $hit = $detector->detect($all_zero, 32);
+        $this->assertNotNull($hit);
+        $this->assertSame('Bucket(uninit?)', $hit->label);
+    }
+
+    public function testSymbolicatesIndirectAndPtr(): void
+    {
+        $detector = new BucketDetector();
+        $hit_indirect = $detector->detect($this->fp(13), 32);
+        $this->assertNotNull($hit_indirect);
+        $this->assertStringContainsString('IS_INDIRECT', $hit_indirect->label);
+        $hit_ptr = $detector->detect($this->fp(14), 32);
+        $this->assertNotNull($hit_ptr);
+        $this->assertStringContainsString('IS_PTR', $hit_ptr->label);
+        $hit_alias = $detector->detect($this->fp(15), 32);
+        $this->assertNotNull($hit_alias);
+        $this->assertStringContainsString('IS_ALIAS_PTR', $hit_alias->label);
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
@@ -101,17 +101,21 @@ class BucketDetectorTest extends BaseTestCase
         $this->assertSame('Bucket(uninit?)', $hit->label);
     }
 
-    public function testSymbolicatesIndirectAndPtr(): void
+    public function testInternalTypesKeepGenericLabel(): void
     {
+        // Bytes 11..15 are version-dependent in PHP source — without a
+        // PHP-version-aware DetectorContext we can't pick a symbolic
+        // name (IS_INDIRECT lives at byte 12 in PHP 8.x, byte 13 in
+        // 7.3/7.4, byte 15 in 7.0). The detector falls back to the
+        // raw `zval_type=N` digit instead of guessing the label.
         $detector = new BucketDetector();
-        $hit_indirect = $detector->detect($this->fp(13), 32);
-        $this->assertNotNull($hit_indirect);
-        $this->assertStringContainsString('IS_INDIRECT', $hit_indirect->label);
-        $hit_ptr = $detector->detect($this->fp(14), 32);
-        $this->assertNotNull($hit_ptr);
-        $this->assertStringContainsString('IS_PTR', $hit_ptr->label);
-        $hit_alias = $detector->detect($this->fp(15), 32);
-        $this->assertNotNull($hit_alias);
-        $this->assertStringContainsString('IS_ALIAS_PTR', $hit_alias->label);
+        foreach ([11, 12, 13, 14, 15] as $type_byte) {
+            $hit = $detector->detect($this->fp($type_byte), 32);
+            $this->assertNotNull($hit);
+            $this->assertStringContainsString(
+                "zval_type={$type_byte}",
+                $hit->label,
+            );
+        }
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/BucketDetectorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+
+class BucketDetectorTest extends BaseTestCase
+{
+    /**
+     * Build a 24 B fingerprint with the given zval-type byte at offset 8.
+     */
+    private function fp(int $type_byte): string
+    {
+        // value: 8 bytes, type/type_info: 8 bytes (type at +8), hash: 8 bytes
+        $val = pack('P', 0x1234567890abcdef);
+        $type = pack('CCCCV', $type_byte, 0, 0, 0, 0); // type_byte at offset 0
+        $hash = pack('P', 0xdeadbeefcafebabe);
+        return $val . $type . $hash;
+    }
+
+    public function testRejectsNonThirtyTwoByteBins(): void
+    {
+        $detector = new BucketDetector();
+        $this->assertNull($detector->detect($this->fp(6), 16));
+        $this->assertNull($detector->detect($this->fp(6), 64));
+    }
+
+    public function testRejectsShortFingerprint(): void
+    {
+        $detector = new BucketDetector();
+        $this->assertNull($detector->detect(str_repeat("\x00", 10), 32));
+    }
+
+    public function testAcceptsValidZvalType(): void
+    {
+        $detector = new BucketDetector();
+        $hit = $detector->detect($this->fp(6), 32); // IS_STRING
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('Bucket', $hit->label);
+        $this->assertStringContainsString('IS_STRING', $hit->label);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
+    }
+
+    public function testRejectsInvalidZvalType(): void
+    {
+        $detector = new BucketDetector();
+        // Type byte 99 is well outside the [0, 21] zval-type whitelist.
+        $this->assertNull($detector->detect($this->fp(99), 32));
+    }
+
+    public function testHandlesAllValidZvalTypeRange(): void
+    {
+        $detector = new BucketDetector();
+        for ($i = 0; $i <= 21; $i++) {
+            $this->assertNotNull(
+                $detector->detect($this->fp($i), 32),
+                "type byte {$i} should be accepted",
+            );
+        }
+        $this->assertNull($detector->detect($this->fp(22), 32));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetectorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+
+class FunctionPointerDetectorTest extends BaseTestCase
+{
+    public function testReturnsNullWithoutContext(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $this->assertNull($detector->detect($fp, 32));
+    }
+
+    public function testReturnsNullWithoutModuleResolver(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(module_resolver: null);
+        $this->assertNull($detector->detect($fp, 32, $ctx));
+    }
+
+    public function testReturnsNullForNonExecutablePointer(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: false, module: null),
+        );
+        $this->assertNull($detector->detect($fp, 32, $ctx));
+    }
+
+    public function testReturnsHighWhenInsideNamedExecutableModule(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libuv.so.1'),
+        );
+        $hit = $detector->detect($fp, 32, $ctx);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+        $this->assertStringContainsString('libuv.so.1', $hit->label);
+    }
+
+    public function testReturnsMediumForAnonExecutableMapping(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: null),
+        );
+        $hit = $detector->detect($fp, 32, $ctx);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
+        $this->assertStringContainsString('anon-exec', $hit->label);
+    }
+
+    public function testRejectsBelowTextMin(): void
+    {
+        $detector = new FunctionPointerDetector();
+        // 0x42 isn't a userspace pointer at all — short-circuit before
+        // even consulting the resolver.
+        $fp = pack('P', 0x42) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libuv.so.1'),
+        );
+        $this->assertNull($detector->detect($fp, 32, $ctx));
+    }
+
+    public function testRejectsAboveTextMax(): void
+    {
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x800000000000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libuv.so.1'),
+        );
+        $this->assertNull($detector->detect($fp, 32, $ctx));
+    }
+
+    private function fakeResolver(bool $executable, ?string $module): ModuleResolverInterface
+    {
+        return new class ($executable, $module) implements ModuleResolverInterface {
+            public function __construct(
+                private bool $executable,
+                private ?string $module,
+            ) {
+            }
+
+            public function moduleBasenameFor(int $address): ?string
+            {
+                return $this->module;
+            }
+
+            public function isExecutable(int $address): bool
+            {
+                return $this->executable;
+            }
+        };
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/FunctionPointerDetectorTest.php
@@ -90,6 +90,54 @@ class FunctionPointerDetectorTest extends BaseTestCase
         $this->assertNull($detector->detect($fp, 32, $ctx));
     }
 
+    public function testSymbolLevelPromotionWithOffset(): void
+    {
+        // The validator's "is this libphp or libuv?" question — when
+        // both module + symbol resolver land hits, the label carries
+        // module:symbol+offset so a single line of compare output
+        // resolves the leak source.
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c123) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libphp.so'),
+            symbol_resolver: $this->fakeSymbolResolver('execute_ex', 0x123),
+        );
+        $hit = $detector->detect($fp, 32, $ctx);
+        $this->assertNotNull($hit);
+        $this->assertSame('func_ptr (libphp.so:execute_ex+0x123)', $hit->label);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
+
+    public function testSymbolLevelPromotionExactSymbolStart(): void
+    {
+        // Offset 0 is rendered without the +0xN suffix.
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libphp.so'),
+            symbol_resolver: $this->fakeSymbolResolver('zend_objects_store_del_ref', 0),
+        );
+        $hit = $detector->detect($fp, 32, $ctx);
+        $this->assertNotNull($hit);
+        $this->assertSame('func_ptr (libphp.so:zend_objects_store_del_ref)', $hit->label);
+    }
+
+    public function testFallsBackToModuleLabelWhenSymbolMisses(): void
+    {
+        // When the symbol resolver returns null (anonymous JIT trampoline
+        // landing inside a known module, or a binary with stripped
+        // symbols), the label stays at module-level.
+        $detector = new FunctionPointerDetector();
+        $fp = pack('P', 0x00007ffe1234c000) . str_repeat("\x00", 24);
+        $ctx = new DetectorContext(
+            module_resolver: $this->fakeResolver(executable: true, module: 'libphp.so'),
+            symbol_resolver: $this->fakeSymbolResolver(null, 0),
+        );
+        $hit = $detector->detect($fp, 32, $ctx);
+        $this->assertNotNull($hit);
+        $this->assertSame('func_ptr (libphp.so)', $hit->label);
+    }
+
     private function fakeResolver(bool $executable, ?string $module): ModuleResolverInterface
     {
         return new class ($executable, $module) implements ModuleResolverInterface {
@@ -107,6 +155,22 @@ class FunctionPointerDetectorTest extends BaseTestCase
             public function isExecutable(int $address): bool
             {
                 return $this->executable;
+            }
+        };
+    }
+
+    private function fakeSymbolResolver(?string $name, int $offset): SymbolResolverInterface
+    {
+        return new class ($name, $offset) implements SymbolResolverInterface {
+            public function __construct(
+                private ?string $name,
+                private int $offset,
+            ) {
+            }
+
+            public function resolve(int $address): ?array
+            {
+                return $this->name === null ? null : [$this->name, $this->offset];
             }
         };
     }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetectorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+
+class OpArrayDetectorTest extends BaseTestCase
+{
+    /**
+     * Build a 32 B sub-block whose first 8 bytes look like a `.text`
+     * pointer; remaining 24 bytes are arbitrary small ints (the validator's
+     * issue #88 hex showed `[.text ptr][24 B small ints]` per opcode).
+     */
+    private function block(int $textPtr): string
+    {
+        return pack('P', $textPtr) . pack('PPP', 0, 0, 0);
+    }
+
+    public function testRejectsBinTooSmallForMinHits(): void
+    {
+        $detector = new OpArrayDetector();
+        // 64 B fits 2 blocks; need 3 → reject.
+        $this->assertNull($detector->detect(str_repeat("\x00", 64), 64));
+    }
+
+    public function testEmitsMediumOnThreeBlockRun(): void
+    {
+        $detector = new OpArrayDetector();
+        $bytes = $this->block(0x00007ffe1234c000)
+            . $this->block(0x00007ffe1234c100)
+            . $this->block(0x00007ffe1234c200);
+        $this->assertSame(96, strlen($bytes));
+        $hit = $detector->detect($bytes, 96);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
+        $this->assertStringContainsString('3 ×', $hit->label);
+    }
+
+    public function testEmitsHighOnFiveBlockRun(): void
+    {
+        $detector = new OpArrayDetector();
+        $bytes = '';
+        for ($i = 0; $i < 7; $i++) {
+            $bytes .= $this->block(0x00007ffe1234c000 + $i * 0x100);
+        }
+        $this->assertSame(224, strlen($bytes));
+        $hit = $detector->detect($bytes, 224);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+        $this->assertStringContainsString('7 ×', $hit->label);
+    }
+
+    public function testStopsAtFirstNonPointerBlock(): void
+    {
+        $detector = new OpArrayDetector();
+        // Two valid blocks then a small int — the run is broken at
+        // block 3, so only 2 blocks count → below MIN_HITS → reject.
+        $bytes = $this->block(0x00007ffe1234c000)
+            . $this->block(0x00007ffe1234c100)
+            . pack('P', 0x42) . pack('PPP', 0, 0, 0);
+        $this->assertNull($detector->detect($bytes, 96));
+    }
+
+    public function testRejectsAllZeroBuffer(): void
+    {
+        $detector = new OpArrayDetector();
+        $this->assertNull($detector->detect(str_repeat("\x00", 224), 224));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/OpArrayDetectorTest.php
@@ -77,4 +77,26 @@ class OpArrayDetectorTest extends BaseTestCase
         $detector = new OpArrayDetector();
         $this->assertNull($detector->detect(str_repeat("\x00", 224), 224));
     }
+
+    public function testAcceptsByteAlignedHandlerPointers(): void
+    {
+        // Validator's issue #88 retest: opcode handler addresses end
+        // in arbitrary bytes (0x5a, 0xee, 0xb5, 0xe0, 0x01) because
+        // execute_ex's computed-goto labels land at byte-granular
+        // offsets. The previous 4-byte alignment check rejected these
+        // and left bin[14] 1037-slot unclassified; relaxing the check
+        // restores the match.
+        $detector = new OpArrayDetector();
+        $bytes = $this->block(0x00005570b9eab05a) // ends in 0x5a
+            . $this->block(0x00005570b9ea92ee)    // ends in 0xee
+            . $this->block(0x00005570b9eabdb5)    // ends in 0xb5
+            . $this->block(0x00005570b9ea78e0)    // ends in 0xe0
+            . $this->block(0x00005570b9ea7701);   // ends in 0x01
+        $this->assertSame(160, strlen($bytes));
+        $hit = $detector->detect($bytes, 160);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('5 ×', $hit->label);
+        // 5 hits → HIGH per the detector's threshold.
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ProcessMemoryMapModuleResolverTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ProcessMemoryMapModuleResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
+
+class ProcessMemoryMapModuleResolverTest extends BaseTestCase
+{
+    public function testResolvesNamedExecutableModule(): void
+    {
+        $resolver = new ProcessMemoryMapModuleResolver(new ProcessMemoryMap([
+            $this->area('0x7f0000000000', '0x7f0000200000', '/usr/lib/libuv.so.1', execute: true),
+        ]));
+        $this->assertSame('libuv.so.1', $resolver->moduleBasenameFor(0x7f0000001000));
+        $this->assertTrue($resolver->isExecutable(0x7f0000001000));
+    }
+
+    public function testSkipsAnonymousMappingNames(): void
+    {
+        // [heap], [stack], [vdso] etc. are not "modules" — the resolver
+        // should ignore them so the detector falls into the anon-exec
+        // branch (MEDIUM rather than HIGH).
+        $resolver = new ProcessMemoryMapModuleResolver(new ProcessMemoryMap([
+            $this->area('0x7f0000000000', '0x7f0000200000', '[heap]', execute: true),
+        ]));
+        $this->assertNull($resolver->moduleBasenameFor(0x7f0000001000));
+        $this->assertTrue($resolver->isExecutable(0x7f0000001000));
+    }
+
+    public function testReturnsNullWhenAddressNotMapped(): void
+    {
+        $resolver = new ProcessMemoryMapModuleResolver(new ProcessMemoryMap([
+            $this->area('0x7f0000000000', '0x7f0000200000', '/usr/lib/libuv.so.1', execute: true),
+        ]));
+        $this->assertNull($resolver->moduleBasenameFor(0x7f0000300000));
+        $this->assertFalse($resolver->isExecutable(0x7f0000300000));
+    }
+
+    public function testIsExecutableFalseForRoMapping(): void
+    {
+        $resolver = new ProcessMemoryMapModuleResolver(new ProcessMemoryMap([
+            $this->area('0x7f0000000000', '0x7f0000200000', '/usr/lib/libfoo.so', execute: false),
+        ]));
+        $this->assertFalse($resolver->isExecutable(0x7f0000001000));
+    }
+
+    private function area(
+        string $begin,
+        string $end,
+        string $name,
+        bool $execute = true,
+    ): ProcessMemoryArea {
+        return new ProcessMemoryArea(
+            begin: $begin,
+            end: $end,
+            file_offset: '0',
+            attribute: new ProcessMemoryAttribute(
+                read: true,
+                write: false,
+                execute: $execute,
+                protected: false,
+            ),
+            device_id: '00:00',
+            inode_num: 0,
+            name: $name,
+        );
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+
+class StatDetectorTest extends BaseTestCase
+{
+    private const S_IFREG = 0x8000;
+
+    /**
+     * Build a Linux glibc struct stat (144 B) with realistic field
+     * values. tv_sec is set to the current epoch, tv_nsec to 0.
+     */
+    private function statBytes(
+        int $mode = self::S_IFREG | 0o644,
+        int $uid = 1000,
+        int $gid = 1000,
+        int $nlink = 1,
+        int $size = 0,
+    ): string {
+        $now = time();
+        // 144 bytes total. Layout per struct stat (Linux x86_64 glibc).
+        $bytes  = pack('P', 0);            // st_dev
+        $bytes .= pack('P', 0);            // st_ino
+        $bytes .= pack('P', $nlink);       // st_nlink
+        $bytes .= pack('VVVV', $mode, $uid, $gid, 0); // mode, uid, gid, __pad0
+        $bytes .= pack('P', 0);            // st_rdev
+        $bytes .= pack('P', $size);        // st_size
+        $bytes .= pack('P', 4096);         // st_blksize
+        $bytes .= pack('P', 0);            // st_blocks
+        $bytes .= pack('PP', $now, 0);     // st_atim
+        $bytes .= pack('PP', $now, 0);     // st_mtim
+        $bytes .= pack('PP', $now, 0);     // st_ctim
+        $bytes .= pack('PPP', 0, 0, 0);    // __unused[3]
+        // sanity: 144 bytes
+        if (strlen($bytes) !== 144) {
+            throw new \LogicException('struct stat size mismatch in test fixture');
+        }
+        return $bytes;
+    }
+
+    public function testDetectsStatAtOffsetZero(): void
+    {
+        $detector = new StatDetector();
+        // 144 B bin (smallest that fits a stat at offset 0).
+        $hit = $detector->detect($this->statBytes(), 144);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('struct stat', $hit->label);
+        $this->assertStringContainsString('@+0', $hit->label);
+        // mode + uid + gid + nlink + tv_sec + tv_nsec = 6 axes → HIGH.
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
+
+    public function testDetectsStatAtOffset48In192Bin(): void
+    {
+        // The validator's exact issue #88 leak shape: 192 B uv_fs_t with
+        // statbuf at offset 48.
+        $detector = new StatDetector();
+        $prefix = str_repeat("\x00", 48);
+        $bytes = $prefix . $this->statBytes();
+        $this->assertSame(192, strlen($bytes));
+        $hit = $detector->detect($bytes, 192);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('@+48', $hit->label);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
+
+    public function testDetectsStatAtOffset80In224Bin(): void
+    {
+        $detector = new StatDetector();
+        $prefix = str_repeat("\x00", 80);
+        $bytes = $prefix . $this->statBytes();
+        $this->assertSame(224, strlen($bytes));
+        $hit = $detector->detect($bytes, 224);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('@+80', $hit->label);
+    }
+
+    public function testRejectsAllZeroBuffer(): void
+    {
+        $detector = new StatDetector();
+        $this->assertNull($detector->detect(str_repeat("\x00", 192), 192));
+    }
+
+    public function testRejectsBufferWithoutFileType(): void
+    {
+        $detector = new StatDetector();
+        // mode = 0o644 alone (no S_IFREG / S_IFDIR / etc) — file type
+        // bits clear, must reject.
+        $bytes = $this->statBytes(mode: 0o644);
+        $this->assertNull($detector->detect($bytes, 144));
+    }
+
+    public function testRejectsBufferWithAbsurdUid(): void
+    {
+        // mode passes, but uid is 0xFFFFFFFF — Linux uids are < 2^24.
+        // Should not earn HIGH (uid axis fails). MEDIUM is acceptable
+        // when 3+ axes still pass.
+        $detector = new StatDetector();
+        $bytes = $this->statBytes(uid: 0xFFFFFFFE, gid: 0xFFFFFFFE);
+        $hit = $detector->detect($bytes, 144);
+        // mode + nlink + tv_sec + tv_nsec = 4 axes → still HIGH.
+        // uid+gid axis fails so hit's confidence may be MED if other
+        // axes also have issues. Just ensure it's not HIGH with all
+        // garbage.
+        $this->assertNotNull($hit);
+    }
+
+    public function testRejectsBinTooSmallForStruct(): void
+    {
+        $detector = new StatDetector();
+        $this->assertNull($detector->detect($this->statBytes(), 128));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
@@ -153,4 +153,64 @@ class StatDetectorTest extends BaseTestCase
         $this->assertNotNull($hit);
         $this->assertStringContainsString('@+48', $hit->label);
     }
+
+    public function testRejectsModeWithMultipleSIfmtBitsSet(): void
+    {
+        // Validator's second-pass false positive: mode = 0o714171 has
+        // bits OR-ed across multiple file-type masks, so the strict
+        // "must equal exactly one S_IFMT" check rejects.
+        $detector = new StatDetector();
+        $bytes = $this->statBytes(mode: 0o714171);
+        $this->assertNull($detector->detect($bytes, 144));
+    }
+
+    public function testRejectsSingleAxisGarbage(): void
+    {
+        // mode passes S_IFMT but uid/gid/nlink/blksize/timestamps are
+        // all garbage — only 1 axis matches, below MIN_AXES (=4).
+        // The previous detector would have accepted this with confidence
+        // MEDIUM at a wrong offset; the bumped axis cutoff rejects.
+        $detector = new StatDetector();
+        $now = time();
+        $window = 100 * 31_557_600; // way beyond ±50 yr → tv_sec rejects
+        $garbage = pack('P', 0)        // st_dev
+            . pack('P', 0)             // st_ino
+            . pack('P', 0xFFFFFFFFFFFFFFFF) // st_nlink absurd
+            . pack('VVVV', 0o100644, 0xFFFFFFFE, 0xFFFFFFFE, 0) // mode OK, uid/gid garbage
+            . pack('P', 0)             // st_rdev
+            . pack('P', 0)             // st_size
+            . pack('P', 7)             // st_blksize: not in whitelist
+            . pack('P', 0)             // st_blocks
+            . pack('PP', $now + $window, 1_000_000_001) // tv_sec way out, tv_nsec absurd
+            . pack('PP', 0, 1_000_000_001)
+            . pack('PP', 0, 1_000_000_001)
+            . pack('PPP', 0, 0, 0);
+        $this->assertSame(144, strlen($garbage));
+        $this->assertNull($detector->detect($garbage, 144));
+    }
+
+    public function testRejectsBogusBlksize(): void
+    {
+        // Real stat layout but blksize = 7 (not a power of two between
+        // 512 and 1 MiB). Drops the blksize axis, but 5 other axes
+        // pass (mode, uid/gid, nlink, tv_sec, tv_nsec) → still HIGH.
+        // Confirms the blksize axis is *additive*, not blocking.
+        $detector = new StatDetector();
+        $now = time();
+        $bytes = pack('P', 0)
+            . pack('P', 0)
+            . pack('P', 1)             // nlink=1
+            . pack('VVVV', 0o100644, 1000, 1000, 0)
+            . pack('P', 0)
+            . pack('P', 0)
+            . pack('P', 7)             // blksize invalid
+            . pack('P', 0)
+            . pack('PP', $now, 0)
+            . pack('PP', $now, 0)
+            . pack('PP', $now, 0)
+            . pack('PPP', 0, 0, 0);
+        $hit = $detector->detect($bytes, 144);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/StatDetectorTest.php
@@ -123,4 +123,34 @@ class StatDetectorTest extends BaseTestCase
         $detector = new StatDetector();
         $this->assertNull($detector->detect($this->statBytes(), 128));
     }
+
+    public function testRejectsModeWithBogusSIfmtBits(): void
+    {
+        // The validator's first-pass false-positive: detector accepted
+        // mode = 0o177000 because the loose `& S_IFMT != 0` check
+        // passed. With strict S_IFMT membership the bogus value is
+        // rejected, letting the +48 candidate (real stat) win.
+        $detector = new StatDetector();
+        $bytes = $this->statBytes(mode: 0o177000);
+        $this->assertNull($detector->detect($bytes, 144));
+    }
+
+    public function testPicksOffset48OverOffset24WhenBothPlausible(): void
+    {
+        // Issue #88 leak shape: 48 bytes of garbage prefix (one of which
+        // happens to look like a regular file mode at +24 in the slot,
+        // i.e. offset 0 of a stat at +24) followed by a real struct
+        // stat at +48. With the strict S_IFMT check the +24 candidate
+        // either rejects outright or scores fewer axes than +48.
+        $detector = new StatDetector();
+        $real_stat = $this->statBytes();
+        // 48 B prefix that is NOT a plausible stat (mode bytes at
+        // prefix offset +24 are 0).
+        $prefix = str_repeat("\x00", 48);
+        $bytes = $prefix . $real_stat;
+        $this->assertSame(192, strlen($bytes));
+        $hit = $detector->detect($bytes, 192);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('@+48', $hit->label);
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetectorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector;
+
+use Reli\BaseTestCase;
+
+class ZendStringDetectorTest extends BaseTestCase
+{
+    /**
+     * Build a zend_string-like 24 B header.
+     */
+    private function fp(int $refcount, int $type_info, int $len): string
+    {
+        return pack('VVPP', $refcount, $type_info, 0, $len);
+    }
+
+    public function testRejectsTooSmallBin(): void
+    {
+        $detector = new ZendStringDetector();
+        $this->assertNull($detector->detect($this->fp(1, 6, 5), 16));
+    }
+
+    public function testAcceptsPlausibleHeader(): void
+    {
+        $detector = new ZendStringDetector();
+        // 32 B bin: payload capacity = 32 - 24 - 1 = 7 bytes; len = 5 fits.
+        $hit = $detector->detect($this->fp(1, 6, 5), 32);
+        $this->assertNotNull($hit);
+        $this->assertStringContainsString('zend_string', $hit->label);
+        $this->assertStringContainsString('len=5', $hit->label);
+    }
+
+    public function testRejectsZeroRefcount(): void
+    {
+        $detector = new ZendStringDetector();
+        $this->assertNull($detector->detect($this->fp(0, 6, 5), 32));
+    }
+
+    public function testRejectsAbsurdRefcount(): void
+    {
+        $detector = new ZendStringDetector();
+        // 0xFFFFFFFF is way beyond the sanity ceiling — clear garbage.
+        $this->assertNull($detector->detect($this->fp(0xFFFFFFFF, 6, 5), 32));
+    }
+
+    public function testRejectsAllOnesTypeInfo(): void
+    {
+        $detector = new ZendStringDetector();
+        $this->assertNull($detector->detect($this->fp(1, 0xFFFFFFFF, 5), 32));
+    }
+
+    public function testRejectsOverflowingLength(): void
+    {
+        $detector = new ZendStringDetector();
+        // 32 B bin, payload capacity = 7, len = 100 cannot fit.
+        $this->assertNull($detector->detect($this->fp(1, 6, 100), 32));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/Detector/ZendStringDetectorTest.php
@@ -18,52 +18,118 @@ use Reli\BaseTestCase;
 class ZendStringDetectorTest extends BaseTestCase
 {
     /**
-     * Build a zend_string-like 24 B header.
+     * Build a zend_string-like 24 B header (no payload — strict checks
+     * gracefully degrade because the NUL terminator falls past the
+     * fingerprint horizon).
      */
-    private function fp(int $refcount, int $type_info, int $len): string
+    private function header(int $refcount, int $type_info, int $len): string
     {
         return pack('VVPP', $refcount, $type_info, 0, $len);
+    }
+
+    /**
+     * Build a full-slot fingerprint: header + payload + NUL terminator
+     * + zero-padding to fill the slot.
+     */
+    private function full(int $refcount, int $hash, string $payload, int $bin_size): string
+    {
+        $header = pack('VVPP', $refcount, 6, $hash, strlen($payload));
+        $body = $header . $payload . "\x00";
+        return $body . str_repeat("\x00", max(0, $bin_size - strlen($body)));
     }
 
     public function testRejectsTooSmallBin(): void
     {
         $detector = new ZendStringDetector();
-        $this->assertNull($detector->detect($this->fp(1, 6, 5), 16));
+        $this->assertNull($detector->detect($this->header(1, 6, 5), 16));
     }
 
-    public function testAcceptsPlausibleHeader(): void
+    public function testHeaderOnlyMatchReturnsMediumWhenPayloadOutsideFingerprint(): void
     {
         $detector = new ZendStringDetector();
-        // 32 B bin: payload capacity = 32 - 24 - 1 = 7 bytes; len = 5 fits.
-        $hit = $detector->detect($this->fp(1, 6, 5), 32);
+        // 24 B fingerprint can't see the NUL at +29; falls back to
+        // MEDIUM-on-header-only.
+        $hit = $detector->detect($this->header(1, 6, 5), 32);
         $this->assertNotNull($hit);
-        $this->assertStringContainsString('zend_string', $hit->label);
-        $this->assertStringContainsString('len=5', $hit->label);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
     }
 
     public function testRejectsZeroRefcount(): void
     {
         $detector = new ZendStringDetector();
-        $this->assertNull($detector->detect($this->fp(0, 6, 5), 32));
+        $this->assertNull($detector->detect($this->header(0, 6, 5), 32));
     }
 
     public function testRejectsAbsurdRefcount(): void
     {
         $detector = new ZendStringDetector();
-        // 0xFFFFFFFF is way beyond the sanity ceiling — clear garbage.
-        $this->assertNull($detector->detect($this->fp(0xFFFFFFFF, 6, 5), 32));
+        $this->assertNull($detector->detect($this->header(0xFFFFFFFF, 6, 5), 32));
     }
 
     public function testRejectsAllOnesTypeInfo(): void
     {
         $detector = new ZendStringDetector();
-        $this->assertNull($detector->detect($this->fp(1, 0xFFFFFFFF, 5), 32));
+        $this->assertNull($detector->detect($this->header(1, 0xFFFFFFFF, 5), 32));
     }
 
     public function testRejectsOverflowingLength(): void
     {
         $detector = new ZendStringDetector();
-        // 32 B bin, payload capacity = 7, len = 100 cannot fit.
-        $this->assertNull($detector->detect($this->fp(1, 6, 100), 32));
+        $this->assertNull($detector->detect($this->header(1, 6, 100), 32));
+    }
+
+    public function testRejectsMissingNulTerminator(): void
+    {
+        $detector = new ZendStringDetector();
+        // 64 B bin, claim len=5, but write garbage at +29 instead of NUL.
+        $header = pack('VVPP', 1, 6, 0, 5);
+        $payload = 'hello';
+        $broken = $header . $payload . "X" . str_repeat("\x00", 64 - 30);
+        $this->assertNull($detector->detect($broken, 64));
+    }
+
+    public function testRejectsNonPrintablePayload(): void
+    {
+        $detector = new ZendStringDetector();
+        // len=5, NUL at right place, but payload is binary garbage.
+        $bin = $this->full(1, 0, "\xff\xfe\xfd\xfc\xfb", 64);
+        $this->assertNull($detector->detect($bin, 64));
+    }
+
+    public function testAcceptsPrintablePayloadAtMedium(): void
+    {
+        $detector = new ZendStringDetector();
+        // hash = 0 → no DJB2 promotion.
+        $bin = $this->full(1, 0, 'hello', 64);
+        $hit = $detector->detect($bin, 64);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
+        $this->assertStringContainsString('len=5', $hit->label);
+    }
+
+    public function testPromotesToHighOnDjb2Match(): void
+    {
+        $detector = new ZendStringDetector();
+        $payload = 'hello';
+        // Compute DJB2 the same way the detector does.
+        $hash = 5381;
+        $len = strlen($payload);
+        for ($i = 0; $i < $len; $i++) {
+            $hash = (($hash << 5) + $hash + ord($payload[$i])) & 0x7FFFFFFFFFFFFFFF;
+        }
+        $bin = $this->full(1, $hash, $payload, 64);
+        $hit = $detector->detect($bin, 64);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_HIGH, $hit->confidence);
+    }
+
+    public function testHashMismatchKeepsMedium(): void
+    {
+        $detector = new ZendStringDetector();
+        // Set a non-zero hash that doesn't match DJB2('hello').
+        $bin = $this->full(1, 0xdeadbeef, 'hello', 64);
+        $hit = $detector->detect($bin, 64);
+        $this->assertNotNull($hit);
+        $this->assertSame(ShapeDetection::CONFIDENCE_MEDIUM, $hit->confidence);
     }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+use Reli\BaseTestCase;
+
+class PeriodicityDetectorTest extends BaseTestCase
+{
+    public function testReturnsEmptyForNoData(): void
+    {
+        $this->assertSame([], PeriodicityDetector::detect([]));
+    }
+
+    public function testIgnoresGroupBelowThreshold(): void
+    {
+        $bin = 3; // 32-byte bin
+        $slots = [];
+        for ($i = 0; $i < 5; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'A'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertSame([], $groups);
+    }
+
+    public function testEmitsGroupAboveThreshold(): void
+    {
+        $bin = 3;
+        $slots = [];
+        for ($i = 0; $i < 100; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'A'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertSame(100, $groups[0]->count);
+        $this->assertSame(32, $groups[0]->stride);
+        $this->assertSame(32, $groups[0]->bin_size);
+        $this->assertSame(0x1000, $groups[0]->sample_addr);
+        $this->assertSame(bin2hex('A'), $groups[0]->fingerprint_hex);
+    }
+
+    public function testSplitsByFingerprint(): void
+    {
+        $bin = 3;
+        $slots = [];
+        for ($i = 0; $i < 50; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'A'];
+        }
+        // Interleaved with shape B (also 50, but should not pool with A).
+        for ($i = 0; $i < 50; $i++) {
+            $slots[] = ['addr' => 0x2000 + $i * 32, 'fp' => 'B'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x0 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(2, $groups);
+        // Both should have count 50 and stride 32.
+        foreach ($groups as $g) {
+            $this->assertSame(50, $g->count);
+            $this->assertSame(32, $g->stride);
+        }
+    }
+
+    public function testSortsByCountDescending(): void
+    {
+        $bin = 3;
+        $small = [];
+        for ($i = 0; $i < 40; $i++) {
+            $small[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'small'];
+        }
+        $big = [];
+        for ($i = 0; $i < 200; $i++) {
+            $big[] = ['addr' => 0x10000 + $i * 32, 'fp' => 'big'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x0 => array_merge($small, $big)]],
+            threshold: 32,
+        );
+        $this->assertCount(2, $groups);
+        $this->assertSame(200, $groups[0]->count);
+        $this->assertSame(40, $groups[1]->count);
+    }
+
+    public function testModeStrideOfEmptyOrSingleton(): void
+    {
+        $this->assertSame(0, PeriodicityDetector::modeStride([]));
+        $this->assertSame(0, PeriodicityDetector::modeStride([100]));
+    }
+
+    public function testModeStridePicksMostFrequent(): void
+    {
+        // Mostly 32-byte stride with one 64-byte gap; mode is 32.
+        $addrs = [0, 32, 64, 96, 128, 192, 224, 256];
+        $this->assertSame(32, PeriodicityDetector::modeStride($addrs));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorTest.php
@@ -110,4 +110,107 @@ class PeriodicityDetectorTest extends BaseTestCase
         $addrs = [0, 32, 64, 96, 128, 192, 224, 256];
         $this->assertSame(32, PeriodicityDetector::modeStride($addrs));
     }
+
+    public function testReachabilityNullByDefault(): void
+    {
+        $bin = 3;
+        $slots = [];
+        for ($i = 0; $i < 50; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'A'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertNull($groups[0]->reachability);
+        $this->assertSame(0, $groups[0]->reachable_samples);
+    }
+
+    public function testReachabilityOrphanWhenNoSampleClaimed(): void
+    {
+        $bin = 3;
+        $slots = [];
+        for ($i = 0; $i < 50; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'A'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+            reachable_set: [],
+        );
+        $this->assertCount(1, $groups);
+        $this->assertSame(PeriodicGroup::REACHABILITY_ORPHAN, $groups[0]->reachability);
+        $this->assertSame(0, $groups[0]->reachable_samples);
+        $this->assertGreaterThan(0, $groups[0]->sampled_count);
+    }
+
+    public function testReachabilityReachableWhenAllSamplesClaimed(): void
+    {
+        $bin = 3;
+        $slots = [];
+        $reachable = [];
+        for ($i = 0; $i < 50; $i++) {
+            $addr = 0x1000 + $i * 32;
+            $slots[] = ['addr' => $addr, 'fp' => 'A'];
+            $reachable[$addr] = 1;
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+            reachable_set: $reachable,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertSame(PeriodicGroup::REACHABILITY_REACHABLE, $groups[0]->reachability);
+        $this->assertSame($groups[0]->sampled_count, $groups[0]->reachable_samples);
+    }
+
+    public function testReachabilityMixedWhenSomeSamplesClaimed(): void
+    {
+        $bin = 3;
+        $slots = [];
+        $reachable = [];
+        for ($i = 0; $i < 50; $i++) {
+            $addr = 0x1000 + $i * 32;
+            $slots[] = ['addr' => $addr, 'fp' => 'A'];
+            // Claim every other slot — guaranteed to hit head + tail
+            // samples, so the verdict must be MIXED.
+            if ($i % 2 === 0) {
+                $reachable[$addr] = 1;
+            }
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x1000 => $slots]],
+            threshold: 32,
+            reachable_set: $reachable,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertSame(PeriodicGroup::REACHABILITY_MIXED, $groups[0]->reachability);
+    }
+
+    public function testSampleAddrsCappedAtMaxSamples(): void
+    {
+        $bin = 3;
+        $slots = [];
+        for ($i = 0; $i < 200; $i++) {
+            $slots[] = ['addr' => 0x10000 + $i * 32, 'fp' => 'A'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin => [0x10000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertLessThanOrEqual(
+            PeriodicityDetector::MAX_SAMPLES,
+            count($groups[0]->sample_addrs),
+        );
+        // Head-and-tail sampling: first sample is the lowest address,
+        // last is the highest. That's the property the reachability
+        // filter relies on.
+        $this->assertSame(0x10000, $groups[0]->sample_addrs[0]);
+        $this->assertSame(
+            0x10000 + 199 * 32,
+            $groups[0]->sample_addrs[count($groups[0]->sample_addrs) - 1],
+        );
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk;
+
+use Reli\BaseTestCase;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\BucketDetector;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetection;
+
+/**
+ * Integration cover for the detector pipeline running inside the
+ * periodicity detector — same shape grouped by fingerprint, fed through
+ * the registered detectors, best label attached to the PeriodicGroup.
+ */
+class PeriodicityDetectorWithDetectorsTest extends BaseTestCase
+{
+    public function testDetectorRunsAndAttachesShapeToGroup(): void
+    {
+        // 32 B bin (bin_num = 3), build a Bucket-like fingerprint with
+        // IS_STRING (type byte 6) at offset 8.
+        $fp = pack('P', 0x1) . pack('CCCCV', 6, 0, 0, 0, 0) . pack('P', 0xdead);
+        $this->assertSame(24, strlen($fp));
+
+        $bin_num = 3;
+        $slots = [];
+        for ($i = 0; $i < 100; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => $fp];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin_num => [0x1000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertNotNull($groups[0]->detection);
+        $this->assertStringContainsString('Bucket', $groups[0]->detection->label);
+    }
+
+    public function testNoDetectionWhenBytesDoNotMatchAnyShape(): void
+    {
+        // 32 B bin with type byte 99 — outside zval whitelist; also no
+        // valid zend_string header (refcount=0).
+        $fp = str_repeat("\x00", 8) . chr(99) . str_repeat("\x00", 15);
+        $this->assertSame(24, strlen($fp));
+
+        $bin_num = 3;
+        $slots = [];
+        for ($i = 0; $i < 100; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => $fp];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin_num => [0x1000 => $slots]],
+            threshold: 32,
+        );
+        $this->assertCount(1, $groups);
+        $this->assertNull($groups[0]->detection);
+    }
+
+    public function testEmptyDetectorsListDisablesInference(): void
+    {
+        $fp = pack('P', 0x1) . pack('CCCCV', 6, 0, 0, 0, 0) . pack('P', 0xdead);
+        $bin_num = 3;
+        $slots = [];
+        for ($i = 0; $i < 100; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => $fp];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin_num => [0x1000 => $slots]],
+            threshold: 32,
+            detectors: [],
+        );
+        $this->assertCount(1, $groups);
+        $this->assertNull($groups[0]->detection);
+    }
+
+    public function testHigherConfidenceWinsOnTie(): void
+    {
+        // Synthetic detectors: one always returns LOW, one always
+        // returns HIGH. Ensure the HIGH wins regardless of registration
+        // order.
+        $low = new class implements \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector {
+            public function name(): string
+            {
+                return 'low';
+            }
+
+            public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+            {
+                return new ShapeDetection('low_match', ShapeDetection::CONFIDENCE_LOW);
+            }
+        };
+        $high = new class implements \Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\ShapeDetector {
+            public function name(): string
+            {
+                return 'high';
+            }
+
+            public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
+            {
+                return new ShapeDetection('high_match', ShapeDetection::CONFIDENCE_HIGH);
+            }
+        };
+
+        $bin_num = 3;
+        $slots = [];
+        for ($i = 0; $i < 50; $i++) {
+            $slots[] = ['addr' => 0x1000 + $i * 32, 'fp' => 'shape'];
+        }
+        $groups = PeriodicityDetector::detect(
+            [$bin_num => [0x1000 => $slots]],
+            threshold: 32,
+            detectors: [$low, $high],
+        );
+        $this->assertCount(1, $groups);
+        $this->assertNotNull($groups[0]->detection);
+        $this->assertSame('high_match', $groups[0]->detection->label);
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
@@ -107,8 +107,11 @@ class PeriodicityDetectorWithDetectorsTest extends BaseTestCase
                 return 'low';
             }
 
-            public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-            {
+            public function detect(
+                string $fingerprint,
+                int $bin_size,
+                ?\Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorContext $context = null,
+            ): ?ShapeDetection {
                 return new ShapeDetection('low_match', ShapeDetection::CONFIDENCE_LOW);
             }
         };
@@ -118,8 +121,11 @@ class PeriodicityDetectorWithDetectorsTest extends BaseTestCase
                 return 'high';
             }
 
-            public function detect(string $fingerprint, int $bin_size): ?ShapeDetection
-            {
+            public function detect(
+                string $fingerprint,
+                int $bin_size,
+                ?\Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\Detector\DetectorContext $context = null,
+            ): ?ShapeDetection {
                 return new ShapeDetection('high_match', ShapeDetection::CONFIDENCE_HIGH);
             }
         };

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/BinWalk/PeriodicityDetectorWithDetectorsTest.php
@@ -28,8 +28,15 @@ class PeriodicityDetectorWithDetectorsTest extends BaseTestCase
     {
         // 32 B bin (bin_num = 3), build a Bucket-like fingerprint with
         // IS_STRING (type byte 6) at offset 8.
-        $fp = pack('P', 0x1) . pack('CCCCV', 6, 0, 0, 0, 0) . pack('P', 0xdead);
-        $this->assertSame(24, strlen($fp));
+        // Plausible userspace pointer at +0..+7 so the tightened
+        // BucketDetector accepts it. Hash is non-zero so we skip the
+        // all-zero "Bucket(uninit?)" branch. Padded to 32 B so the
+        // key field at +24..+31 reads as 0 (NULL key, accepted).
+        $fp = pack('P', 0x00007ffe1234c000)
+            . pack('CCCCV', 6, 0, 0, 0, 0)
+            . pack('P', 0xdead)
+            . pack('P', 0);
+        $this->assertSame(32, strlen($fp));
 
         $bin_num = 3;
         $slots = [];
@@ -67,7 +74,14 @@ class PeriodicityDetectorWithDetectorsTest extends BaseTestCase
 
     public function testEmptyDetectorsListDisablesInference(): void
     {
-        $fp = pack('P', 0x1) . pack('CCCCV', 6, 0, 0, 0, 0) . pack('P', 0xdead);
+        // Plausible userspace pointer at +0..+7 so the tightened
+        // BucketDetector accepts it. Hash is non-zero so we skip the
+        // all-zero "Bucket(uninit?)" branch. Padded to 32 B so the
+        // key field at +24..+31 reads as 0 (NULL key, accepted).
+        $fp = pack('P', 0x00007ffe1234c000)
+            . pack('CCCCV', 6, 0, 0, 0, 0)
+            . pack('P', 0xdead)
+            . pack('P', 0);
         $bin_num = 3;
         $slots = [];
         for ($i = 0; $i < 100; $i++) {

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -217,7 +217,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -455,7 +458,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $collected_memories = $memory_locations_collector->collectAll(
             new ProcessSpecifier($pid),
@@ -622,7 +628,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -775,7 +784,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -944,7 +956,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $error = json_decode($error_json, true);
         $sink = new ArrayContextTreeSink();
@@ -1110,7 +1125,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $error = json_decode($error_json, true);
         $sink = new ArrayContextTreeSink();
@@ -1302,7 +1320,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $error = json_decode($error_json, true);
         $sink = new ArrayContextTreeSink();
@@ -1431,7 +1452,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $memory_locations_collector->collectAll(
@@ -1720,7 +1744,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $tmp_path = tempnam(sys_get_temp_dir(), 'reli_test_gen_') . '.sqlite3';
         $driver = new SqliteDriver($tmp_path);
@@ -1894,7 +1921,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $collected_memories = $memory_locations_collector->collectAll(
             new ProcessSpecifier($pid),
@@ -2027,7 +2057,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -2177,7 +2210,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -2328,7 +2364,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -2512,7 +2551,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -2763,7 +2805,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $collected_memories = $memory_locations_collector->collectAll(
@@ -2965,7 +3010,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $memory_locations_collector->collectAll(
@@ -3180,7 +3228,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $sink = new ArrayContextTreeSink();
         $memory_locations_collector->collectAll(
@@ -3585,7 +3636,10 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                 ProcessMemoryMapCreator::create(),
                 $type_reader_creator,
                 $php_globals_finder
-            )
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $collected_memories = $memory_locations_collector->collectAll(
             new ProcessSpecifier($pid),

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -188,6 +188,9 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
                 $type_reader_creator,
                 $php_globals_finder,
             ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $tmp_path = tempnam(sys_get_temp_dir(), 'reli_test_pdo_') . '.sqlite3';
         $driver = new \Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver($tmp_path);

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -330,6 +330,9 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
                 $type_reader_creator,
                 $php_globals_finder,
             ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
         );
         $tmp_path = tempnam(sys_get_temp_dir(), 'reli_test_mysql_') . '.sqlite3';
         $driver = new \Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver($tmp_path);


### PR DESCRIPTION
## Summary

This PR implements a comprehensive orphan allocation analysis system to detect and classify C-extension-side emalloc'd memory that is not reachable from PHP's object graph. The implementation walks ZendMM bin allocators, detects allocation shapes using pattern matching, and surfaces unaccounted memory deltas in memory comparison reports.

## Key Changes

### Core Infrastructure
- **ZendMmBinWalker**: New allocator-side walker that enumerates live small-bin and large-run allocations by traversing chunk maps and subtracting freelists
- **Shape Detection Pipeline**: Pluggable detector system with implementations for:
  - `StatDetector`: Detects Linux glibc `struct stat` buffers (144 B)
  - `BucketDetector`: Identifies HashTable Bucket headers (32 B slots)
  - `ZendStringDetector`: Detects zend_string headers with payload validation
  - `FunctionPointerDetector`: HIGH-confidence detection via symbol resolution
  - `OpArrayDetector`: Identifies 32-byte-stride structures with code-segment pointers
- **PeriodicityDetector**: Groups same-fingerprinted allocations to identify repeated struct leaks (e.g., "N copies of the same struct")

### Reporting & Analysis
- **BinHistogramPass**: Surfaces per-bin live-allocation distribution as findings
- **BinPeriodicityPass**: Highlights periodic allocation runs as hotspots when they dominate a bin
- **BinShapePass**: Reports per-shape allocation tallies and unclassified counts
- **ComparisonGenerator**: Extended to compare bin histograms, region maps, and shape counts between baseline/target snapshots
- **TextComparisonFormatter**: Renders bin deltas, region changes, and shape statistics in comparison output

### User-Facing Commands
- **MemoryPeekCommand**: Raw byte reader for live targets or rdump files with hexdump output (replaces manual `/proc/<pid>/mem` inspection)
- **MemoryBinQueryCommand**: Drill-down query to list sample addresses for specific bins/shapes, piping naturally into `memory:peek`

### Data Structures
- `BinWalkResult`: Captures histogram and periodic group output
- `PeriodicGroup`: Represents runs of like-fingerprinted allocations
- `BinHistogramSnapshot`, `BinShapeCountsSnapshot`, `RegionMapSnapshot`: Snapshot classes for comparison
- `BinDelta`, `BinShapeDelta`, `RegionDelta`: Delta objects for reporting changes

### Supporting Infrastructure
- **DetectorContext**: Passes module/symbol resolvers to detectors
- **ProcessMemoryMapModuleResolver**: Maps addresses to loaded modules for function pointer validation
- **NativeSymbolResolverAdapter**: Bridges to existing symbol resolution infrastructure
- **RegionMap**: Tracks address range groupings for region-level analysis

## Implementation Details

- **Fingerprinting**: 192-byte prefix capture per slot enables shape grouping and detector input; reaches embedded structs at typical offsets
- **Confidence Scoring**: Detectors emit confidence levels (HIGH/MEDIUM/LOW) based on validation tightness
- **Periodicity Threshold**: Groups with ≥32 slots trigger hotspot classification; configurable per analysis
- **Sample Capping**: Per-(bin, shape) sample addresses capped at analysis time to bound output size
- **Symbol Resolution**: Fallback chain for stripped binaries: `.symtab` → `.dynsym` → debug file
- **Unaccounted Detection**: Identifies memory deltas not explained by typed allocations

## Testing

Comprehensive test coverage added for:
- Detector implementations (stat, bucket, zend_string, function pointer, oparray)
- Periodicity detection algorithm
- Report generation passes
- Command-line interfaces
- Comparison generation and formatting

https://claude.ai/code/session_01UxJvNBsUe8pQSjRdvQdpY6