### PR TITLE
Gate verbose bin diagnostic tables behind opt-in flag

### DIFF
--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -80,6 +80,14 @@ final class MemoryReportCommand extends ReliCommand
             'run all analysis passes (default: on; --no-full-analysis to limit for very large snapshots)',
             true,
         );
+        $this->addOption(
+            'bin-detail',
+            null,
+            InputOption::VALUE_NEGATABLE,
+            'include verbose per-bin diagnostic tables (periodic groups,'
+            . ' per-bin shape detection) in the text report (default: off)',
+            false,
+        );
         $this->addMemoryLimitOption();
         // Advanced / tuning options.
         // These mostly matter on large snapshots (multi-GB SQLite, OOM, slow
@@ -286,8 +294,10 @@ final class MemoryReportCommand extends ReliCommand
             );
         }
 
+        $bin_detail = (bool)$input->getOption('bin-detail');
+
         $formatter = match ($format) {
-            'report' => new TextReportFormatter(),
+            'report' => new TextReportFormatter($bin_detail),
             'report-json' => new JsonReportFormatter($pretty),
             default => throw new \RuntimeException(
                 "Unsupported format: {$format} (supported: report, report-json)"

--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -23,6 +23,17 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\UniformSiblingDetector;
 
 final class TextReportFormatter implements ReportFormatterInterface
 {
+    public function __construct(
+        // Gate the verbose per-bin diagnostic tables (Periodic Groups,
+        // Per-bin Shape Detection) behind an opt-in. They are useful when
+        // hunting a specific leak but too long for an always-on summary;
+        // the bin histogram itself stays on. `bin_periodic_hotspot`
+        // findings are surfaced separately in the Actionable section, so
+        // the leak signal is preserved when this is off.
+        private bool $bin_detail = false,
+    ) {
+    }
+
     /** @psalm-suppress InvalidOperand */
     #[\Override]
     public function format(ReportResult $result): string
@@ -324,7 +335,7 @@ final class TextReportFormatter implements ReportFormatterInterface
 
         // Periodic groups — runs of like-shaped slots that are the
         // signature of "extension X is leaking copies of struct Y".
-        if ($bin_periodic_groups !== []) {
+        if ($this->bin_detail && $bin_periodic_groups !== []) {
             $lines[] = '=== ZendMM Periodic Groups ===';
             $lines[] = '';
             $lines[] = sprintf(
@@ -414,7 +425,7 @@ final class TextReportFormatter implements ReportFormatterInterface
         // periodic-group path skips because their bytes don't match
         // slot-to-slot. Grouped by bin so the user reads "what's in
         // this bin?" in one block.
-        if ($bin_shape_counts !== []) {
+        if ($this->bin_detail && $bin_shape_counts !== []) {
             /** @var array<int, list<Finding>> $by_bin */
             $by_bin = [];
             foreach ($bin_shape_counts as $f) {

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -1212,4 +1212,110 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringContainsString('[retained_approximate]', $output);
         $this->assertStringNotContainsString('=== Observations', $output);
     }
+
+    public function testBinDetailSectionsAreHiddenByDefault(): void
+    {
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bin_histogram_overview',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'ZendMM live: 1.00 MB in 1,000 small slots',
+                facts: [],
+            ),
+            new Finding(
+                kind: 'bin_histogram_entry',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'bin[32 B]: 100 live (3.20 KB)',
+                facts: [
+                    'bin_num' => 1,
+                    'bin_size' => 32,
+                    'count' => 100,
+                    'total_bytes' => 3200,
+                ],
+            ),
+            new Finding(
+                kind: 'bin_periodic_group',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'periodic group',
+                facts: [
+                    'bin_size' => 32,
+                    'count' => 50,
+                    'stride' => 32,
+                    'sample_addr' => 0x7f0000000000,
+                    'fingerprint' => 'abcd',
+                    'inferred_shape' => 'Bucket(IS_STRING)',
+                    'inferred_confidence' => 'high',
+                    'reachability' => 'orphan',
+                ],
+            ),
+            new Finding(
+                kind: 'bin_shape_count',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'shape count',
+                facts: [
+                    'bin_num' => 1,
+                    'shape' => 'Bucket(IS_STRING)',
+                    'confidence' => 'high',
+                    'count' => 50,
+                    'percentage' => 76.0,
+                    'orphan_count' => 30,
+                    'reachable_count' => 20,
+                ],
+            ),
+        ]);
+
+        $output = (new TextReportFormatter())->format($result);
+
+        // Histogram itself stays on (the user keeps the compact summary).
+        $this->assertStringContainsString('=== ZendMM Bin Histogram ===', $output);
+        // Verbose per-bin diagnostic tables are gated off by default.
+        $this->assertStringNotContainsString('=== ZendMM Periodic Groups ===', $output);
+        $this->assertStringNotContainsString('=== Per-bin Shape Detection ===', $output);
+    }
+
+    public function testBinDetailSectionsAppearWhenEnabled(): void
+    {
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'bin_periodic_group',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'periodic group',
+                facts: [
+                    'bin_size' => 32,
+                    'count' => 50,
+                    'stride' => 32,
+                    'sample_addr' => 0x7f0000000000,
+                    'fingerprint' => 'abcd',
+                    'inferred_shape' => 'Bucket(IS_STRING)',
+                    'inferred_confidence' => 'high',
+                    'reachability' => 'orphan',
+                ],
+            ),
+            new Finding(
+                kind: 'bin_shape_count',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'shape count',
+                facts: [
+                    'bin_num' => 1,
+                    'shape' => 'Bucket(IS_STRING)',
+                    'confidence' => 'high',
+                    'count' => 50,
+                    'percentage' => 76.0,
+                    'orphan_count' => 30,
+                    'reachable_count' => 20,
+                ],
+            ),
+        ]);
+
+        $output = (new TextReportFormatter(bin_detail: true))->format($result);
+
+        $this->assertStringContainsString('=== ZendMM Periodic Groups ===', $output);
+        $this->assertStringContainsString('=== Per-bin Shape Detection ===', $output);
+    }
 }


### PR DESCRIPTION
## Summary
Add an optional `--bin-detail` flag to the memory report command that controls whether verbose per-bin diagnostic tables are included in the text report output. By default, these detailed sections are hidden to keep the report concise, while the bin histogram summary remains always visible.

## Key Changes
- Added `bin_detail` constructor parameter to `TextReportFormatter` (defaults to `false`)
- Gated "ZendMM Periodic Groups" and "Per-bin Shape Detection" sections behind the `bin_detail` flag
- Added `--bin-detail` command-line option to `MemoryReportCommand` (negatable, defaults to `false`)
- Wired the command-line option through to the formatter instance

## Implementation Details
- The bin histogram overview itself remains always visible, preserving the compact summary
- Detailed diagnostic tables are only rendered when `bin_detail` is explicitly enabled
- The `bin_periodic_hotspot` findings are still surfaced separately in the Actionable section, so leak signal is preserved even when detailed tables are off
- Added comprehensive test coverage for both default (hidden) and enabled (visible) states

https://claude.ai/code/session_013gLPP9vGRYJn8pgMinFVQx