### PR TITLE
fix(integer-index-merger): drop promoted entry from non-last chunk

### DIFF
--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -1220,12 +1220,11 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      * enabled — at 100K rows on the rbt:analyze trace, the
      * IntegerIndexMerger spends ~0.49s building three integer
      * indexes via PHP-side leaf assembly while the CREATE INDEX
-     * machinery in C only takes ~0.28s for the same three. L is
-     * still correct (5K integrity_check passes, COUNT(*) matches
-     * full-scan); it just isn't a wall-clock win at this scale
-     * with the current PHP-only implementation. Off by default
-     * until the followups in docs/internals/format-direct-merge.md
-     * land. Enable with RELI_FORMAT_DIRECT_INDEX=1.
+     * machinery in C only takes ~0.28s for the same three. It
+     * just isn't a wall-clock win at this scale with the current
+     * PHP-only implementation. Off by default until the followups
+     * in docs/internals/format-direct-merge.md land. Enable with
+     * RELI_FORMAT_DIRECT_INDEX=1.
      *
      * @param array<int, array<string, mixed>> $summary
      */

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -177,25 +177,27 @@ final class IntegerIndexMerger
                 $chunk = array_slice($level, $i, $max_children);
                 $is_last_chunk = ($i + $max_children >= $n);
                 if ($is_last_chunk) {
-                    $chunk_rightmost = $remaining_rightmost;
-                } else {
-                    // The last entry of this chunk gets promoted to
-                    // become the divider in the next-level interior
-                    // cell; its child becomes that interior cell's
-                    // rightmost descendant for this internal page.
-                    $last = $chunk[count($chunk) - 1];
-                    $chunk_rightmost = $last['pgno'];
-                }
-                $page = $this->buildInteriorPage($chunk, $chunk_rightmost, $page_size);
-                $pgno = $this->main->appendPage($page);
-                if ($is_last_chunk) {
-                    $rightmost = $pgno;
+                    $page = $this->buildInteriorPage($chunk, $remaining_rightmost, $page_size);
+                    $rightmost = $this->main->appendPage($page);
                     break; // no divider needed for the last chunk; it's the rightmost of the next level
                 }
-                // The cell that gets promoted up: divider = the
-                // promoted entry from the last leaf in this chunk.
-                $promoted = $chunk[count($chunk) - 1]['divider_payload'];
-                $next[] = ['pgno' => $pgno, 'divider_payload' => $promoted];
+                // The last entry of this chunk is *removed* from the
+                // chunk before it gets passed to buildInteriorPage:
+                // its pgno becomes this internal page's
+                // rightmost-child pointer (lives in the page header,
+                // not as a cell), and its divider becomes the divider
+                // promoted up to the parent level. Leaving it in
+                // $chunk would write it as both cell N-1 and as the
+                // rightmost pointer, so its pgno gets referenced
+                // twice on the page — exactly the corruption shape
+                // PRAGMA integrity_check reports as
+                // "page X cell N-1: 2nd reference to page Y" and
+                // "wrong # of entries in index ...".
+                $last = array_pop($chunk);
+                \assert($last !== null); // $chunk had $max_children entries
+                $page = $this->buildInteriorPage($chunk, $last['pgno'], $page_size);
+                $pgno = $this->main->appendPage($page);
+                $next[] = ['pgno' => $pgno, 'divider_payload' => $last['divider_payload']];
             }
             $level = $next;
         }

--- a/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
+++ b/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
+
+use Reli\BaseTestCase;
+
+/**
+ * Regression test for the duplicate-rightmost interior-cell bug in
+ * IntegerIndexMerger that surfaced on PR #773 once any indexed table
+ * crossed ~7K rows (validation report:
+ * docs/internals/pr-773-sqlite-output-validation.md).
+ *
+ * For a non-final chunk in the interior-tree assembly the last entry's
+ * pgno was used as the chunk's rightmost-child pointer while still
+ * remaining a cell in the same chunk, so that pgno appeared on the
+ * resulting interior page twice — once as cell index `max_children-1`
+ * and once as the rightmost pointer in the page header. PRAGMA
+ * integrity_check reported it as
+ * "page X cell N: 2nd reference to page Y" plus
+ * "wrong # of entries in index ...", and queries that picked the
+ * corrupt index as a covering index returned over-counted results.
+ *
+ * The fixture writes a single sort run with enough sorted (key, rowid)
+ * pairs to push the leaf level past `max_children = 123` so the
+ * interior-tree loop fires, then walks the resulting index b-tree
+ * directly. Pre-fix the walker finds a page reachable through two
+ * different parents and the entry total exceeds the input row count;
+ * post-fix every page is reached exactly once and the entry total
+ * equals the input row count exactly.
+ *
+ * `integrity_check` is intentionally not the assertion vehicle here:
+ * the production caller (PdoMemoryOutput::allocateRun) creates the
+ * empty index *before* any rows are inserted into the table, so the
+ * merger overwrites a fresh empty rootpage with no orphans. A
+ * synthetic test that lets SQLite auto-build the index first leaves
+ * "Page X: never used" lines in integrity_check unrelated to this
+ * bug; the structural walker checks the property the bug actually
+ * violates.
+ *
+ * @psalm-suppress PossiblyInvalidArrayAccess
+ */
+class IntegerIndexMergerInteriorChunkingTest extends BaseTestCase
+{
+    public function testInteriorChunkingProducesValidIndex(): void
+    {
+        // 25K rows × ~177 cells/leaf for the (1, 8-byte, 8-byte)
+        // index payload shape => ~141 leaves, comfortably above
+        // max_children = 123 so the interior-tree loop runs at least
+        // once. Pre-fix the resulting tree has the duplicate-pgno
+        // shape on the first interior page; post-fix the tree is
+        // structurally clean.
+        $row_count = 25000;
+        // ≥ 2^47 forces RecordEncoder into the 8-byte-int branch
+        // (type code 6); the 6-byte branch (type code 5) packs ~215
+        // cells per leaf and 25K rows would only produce ~116
+        // leaves, below the max_children = 123 threshold the bug
+        // hides behind.
+        $base_key = 1 << 50;
+
+        $base = tempnam(sys_get_temp_dir(), 'iim_');
+        self::assertNotFalse($base);
+        $main_path = $base . '_main.sqlite3';
+        $sort_run_path = $base . '_run';
+
+        try {
+            // Mirror the production setup in PdoMemoryOutput::allocateRun:
+            // create the empty index before the table has any rows so the
+            // merger overwrites a brand-new empty rootpage rather than a
+            // SQLite-built tree we'd then orphan.
+            $main = new \PDO("sqlite:{$main_path}");
+            $main->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $main->exec('PRAGMA page_size = 4096');
+            $main->exec('CREATE TABLE t (run_id INTEGER, k INTEGER, v INTEGER)');
+            $main->exec('CREATE INDEX idx_t_run_k ON t(run_id, k)');
+            $rootpage = (int)$main->query(
+                "SELECT rootpage FROM sqlite_master WHERE name = 'idx_t_run_k'"
+            )->fetchColumn();
+            unset($main);
+
+            $writer = new SortRunWriter($sort_run_path);
+            // Strictly ascending (key, rowid) — the merger contract.
+            // 8-byte-wide values keep the encoded payload in the
+            // 8-byte-int branch of RecordEncoder, matching real-world
+            // dump sizing.
+            for ($i = 0; $i < $row_count; $i++) {
+                $writer->append($base_key + $i, $base_key + $i);
+            }
+            $writer->close();
+
+            $main_writer = Writer::open($main_path);
+            $merger = new IntegerIndexMerger(
+                $main_writer,
+                [new SortRunReader($sort_run_path)],
+                run_id: 1,
+            );
+            $merger->merge($rootpage);
+            $main_writer->close($main_path);
+
+            [$visited_pages, $entry_count] = $this->walkIndex($main_path, $rootpage);
+
+            // The actual bug: at least one page was reachable from
+            // two distinct parents. Pre-fix the walker raises on
+            // re-entering an already-visited page; post-fix every
+            // page is reached exactly once.
+            self::assertSame(
+                count($visited_pages),
+                count(array_unique($visited_pages)),
+                'each page in the index b-tree must be reached exactly once',
+            );
+
+            // The user-visible bug: covering-index COUNT(*) over-counts.
+            // Total b-tree entries = leaf cells + interior cells (the
+            // promoted dividers); should equal the input row count.
+            self::assertSame(
+                $row_count,
+                $entry_count,
+                'merged index must carry exactly one entry per input row',
+            );
+        } finally {
+            @unlink($main_path);
+            @unlink($sort_run_path);
+        }
+    }
+
+    /**
+     * Walk the index b-tree rooted at `$rootpage` and return the list
+     * of every page visited (in DFS order) and the total number of
+     * b-tree entries (leaf cells + interior-page divider cells).
+     *
+     * Throws \RuntimeException at the first page that gets walked into
+     * twice — that is the structural shape of the duplicate-pgno bug.
+     *
+     * @return array{list<int>, int}
+     */
+    private function walkIndex(string $path, int $rootpage): array
+    {
+        $reader = Reader::open($path);
+        $visited = [];
+        $entries = 0;
+        $this->walkIndexPage($reader, $rootpage, $visited, $entries);
+        return [$visited, $entries];
+    }
+
+    /**
+     * @param list<int> $visited
+     */
+    private function walkIndexPage(Reader $reader, int $pgno, array &$visited, int &$entries): void
+    {
+        if (in_array($pgno, $visited, true)) {
+            throw new \RuntimeException(
+                "page {$pgno} reached twice during index walk — duplicate-pgno corruption",
+            );
+        }
+        $visited[] = $pgno;
+
+        $page = $reader->readPage($pgno);
+        $btree_offset = $pgno === 1 ? Format::HEADER_SIZE : 0;
+        $type = ord($page[$btree_offset]);
+        $cell_count = (int)unpack('n', substr($page, $btree_offset + Format::PG_CELL_COUNT, 2))[1];
+        $entries += $cell_count;
+
+        if ($type === Format::BTREE_LEAF_INDEX) {
+            return;
+        }
+        if ($type !== Format::BTREE_INTERIOR_INDEX) {
+            throw new \RuntimeException(
+                sprintf('expected index b-tree page at %d, got type 0x%02x', $pgno, $type),
+            );
+        }
+
+        $rightmost = (int)unpack('N', substr($page, $btree_offset + Format::PG_RIGHTMOST_PTR, 4))[1];
+        $cell_ptr_array_offset = $btree_offset + 12; // 8-byte hdr + 4-byte rightmost
+        for ($i = 0; $i < $cell_count; $i++) {
+            $cell_ptr = (int)unpack(
+                'n',
+                substr($page, $cell_ptr_array_offset + $i * 2, 2),
+            )[1];
+            // Interior index cell: u32 left_child_pgno + varint payload_size + payload
+            $child_pgno = (int)unpack('N', substr($page, $cell_ptr, 4))[1];
+            $this->walkIndexPage($reader, $child_pgno, $visited, $entries);
+        }
+        $this->walkIndexPage($reader, $rightmost, $visited, $entries);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the duplicate-rightmost interior-cell bug in `IntegerIndexMerger`
that `claude/test-sqlite-memory-TziEO`'s validation report
(`docs/internals/pr-773-sqlite-output-validation.md`) identified as the
reason `RELI_FORMAT_DIRECT_INDEX=1` deterministically corrupts the
three integer indexes once any indexed table crosses ~7K rows.

For a non-final chunk in the interior-tree assembly, the last entry's
`pgno` was used as the chunk's rightmost-child pointer **while the
entry stayed in `$chunk`** and became cell index `max_children-1` on
the same page. `PRAGMA integrity_check` reported it as
`"page X cell N: 2nd reference to page Y"` plus
`"wrong # of entries in index ..."`, and any covering-index `COUNT(*)`
or `WHERE` lookup against an affected index over-counted by the
number of duplicate page references.

- **Fix** (`IntegerIndexMerger.php:178-200`): pop the last entry out
  of `$chunk` before passing the chunk to `buildInteriorPage` so its
  `pgno` only appears once on the resulting interior page (in the
  rightmost-pointer slot), and use its `divider_payload` as the
  divider promoted to the parent level. Mirrors the analogous
  `array_pop` already used for the leaf-level promotion at
  `IntegerIndexMerger.php:103-108`.
- **Regression test**: `IntegerIndexMergerInteriorChunkingTest`
  pins the structural property the bug violates (no page reachable
  through two parents; total entries == input row count) by walking
  the merger's index b-tree directly. 25K rows × 8-byte ints push
  the leaf level past `max_children = 123`, so a regression of the
  `array_pop` or of the `buildInteriorPage` assumption is caught
  here rather than only via real-world dumps. Verified pre-fix the
  walker raises `"page 126 reached twice during index walk"`.
- **Docblock**: drop the stale "L is still correct (5K
  integrity_check passes, COUNT(*) matches full-scan)" clause from
  `PdoMemoryOutput::allocateRun` — the validation report shows the
  bug surfaces above ~7K rows in any of the three indexed tables, so
  that sentence was misleading.

`integrity_check` is intentionally not the assertion vehicle in the
new test: the production caller (`PdoMemoryOutput::allocateRun`)
creates the empty index *before* any rows are inserted, so the
merger overwrites a fresh empty rootpage with no orphans. A
synthetic test that lets SQLite auto-build the index first leaves
"Page X: never used" lines in `integrity_check` unrelated to this
bug; the structural walker checks the property the bug actually
violates.

## Test plan

- [x] `php vendor/bin/phpunit --filter IntegerIndexMergerInteriorChunkingTest` — passes post-fix; fails with `"page 126 reached twice during index walk"` pre-fix (verified by stashing the fix and re-running)
- [x] `php vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/SqliteRaw/` — 33/33 green (100K assertions)
- [x] `php vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/` — 414/414 green
- [x] `php vendor/bin/psalm.phar src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php` — clean
- [x] `php vendor/bin/phpcs --standard=PSR12 src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php` — clean
- [x] Re-run the full `tests/scripts/sqlite-validation/` matrix from `claude/test-sqlite-memory-TziEO` against this branch to confirm `RELI_FORMAT_DIRECT_INDEX=1` now produces byte-identical, integrity-clean output (deferred — driver scripts live on the test branch, not on this fix branch)

https://claude.ai/code/session_01EtUAzB1yacaBkRK4meh4S8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXoDtcG6xKfoNH7CkW8kck)_