### PR TITLE
fix(memory-command): refuse to overwrite existing sqlite3 output

### DIFF
--- a/src/Command/Inspector/MemoryCommand.php
+++ b/src/Command/Inspector/MemoryCommand.php
@@ -81,6 +81,29 @@ final class MemoryCommand extends ReliCommand
         }
         Log::info('start memory command');
         $memory_profiler_settings = $this->memory_profiler_settings_from_console_input->createSettings($input);
+
+        // Mirror MemoryExportSqliteCommand's guard: refuse to overwrite
+        // an existing sqlite3 output rather than ingest into a DB that
+        // already carries reli's schema. The SqliteRaw shard merger
+        // assumes a single-leaf sqlite_master, which holds for a fresh
+        // DB but not for a re-run into an already-populated reli DB —
+        // the second capture would die mid-merge with
+        // SqliteRaw\Reader::loadSqliteMaster's
+        // "sqlite_master root is not a leaf (type 0x05); not yet
+        // supported" instead of doing anything user-meaningful.
+        if (
+            $memory_profiler_settings->output_format === 'sqlite3'
+            && $memory_profiler_settings->output_path !== null
+            && file_exists($memory_profiler_settings->output_path)
+        ) {
+            $output->writeln(
+                '<error>Output already exists: '
+                . $memory_profiler_settings->output_path
+                . ' (refusing to overwrite)</error>'
+            );
+            return 1;
+        }
+
         $target_php_settings = $this->target_php_settings_from_console_input->createSettings($input);
         $target_process_settings = $this->target_process_settings_from_console_input->createSettings($input);
 

--- a/tests/Command/Inspector/MemoryCommandOverwriteGuardTest.php
+++ b/tests/Command/Inspector/MemoryCommandOverwriteGuardTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Command\Inspector;
+
+use DI\ContainerBuilder;
+use Reli\BaseTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Unit-level coverage for the `inspector:memory` command's
+ * refuse-to-overwrite guard on sqlite3 output.
+ *
+ * Round-2 SQLite-output validation
+ * (`docs/internals/pr-773-sqlite-output-validation-round2.md`)
+ * surfaced that re-running `inspector:memory -f sqlite3 -o existing.db`
+ * crashes mid-merge in `SqliteRaw\Reader::loadSqliteMaster` with
+ * "sqlite_master root is not a leaf (type 0x05); not yet supported"
+ * because the SqliteRaw shard merger assumes a single-leaf
+ * `sqlite_master`, which only holds for a fresh DB.
+ *
+ * The guard mirrors the one already in `MemoryExportSqliteCommand`:
+ * if `output_format=sqlite3` and the output path exists, refuse with
+ * a clear message instead of crashing. The test drives both the
+ * explicit `--output-format=sqlite3` shape and the auto-detect-from-
+ * extension shape, since most users hit the bug via the latter.
+ *
+ * Uses the real DI container to wire up the command's nine
+ * collaborators: the guard is supposed to short-circuit before any
+ * of them are touched, so a non-existent --pid is fine — if the
+ * guard ever regresses, the command would proceed past it and fail
+ * with a process-related error instead of returning 1, which the
+ * test catches as a wrong exit code or wrong output text.
+ */
+class MemoryCommandOverwriteGuardTest extends BaseTestCase
+{
+    public function testRefusesToOverwriteExistingSqlite3Output(): void
+    {
+        $existing_path = tempnam(sys_get_temp_dir(), 'reli_overwrite_guard_');
+        self::assertNotFalse($existing_path);
+        try {
+            self::assertFileExists($existing_path);
+
+            $command = $this->createCommand();
+            $exit_code = $command->run(
+                new ArrayInput([
+                    '--pid' => '1',
+                    '--output' => $existing_path,
+                    '--output-format' => 'sqlite3',
+                ]),
+                $buffered_output = new BufferedOutput(),
+            );
+
+            self::assertSame(1, $exit_code);
+            self::assertStringContainsString('refusing to overwrite', $buffered_output->fetch());
+        } finally {
+            @unlink($existing_path);
+        }
+    }
+
+    public function testRefusesWhenSqlite3FormatIsAutoDetectedFromExtension(): void
+    {
+        // No --output-format flag — settings detect 'sqlite3' from the
+        // .sqlite3 extension. The guard must catch that path too,
+        // otherwise users who rely on extension-based detection (the
+        // common case) would still hit the crashing ingest.
+        $base = tempnam(sys_get_temp_dir(), 'reli_overwrite_guard_');
+        self::assertNotFalse($base);
+        $existing_path = $base . '.sqlite3';
+        rename($base, $existing_path);
+        try {
+            self::assertFileExists($existing_path);
+
+            $command = $this->createCommand();
+            $exit_code = $command->run(
+                new ArrayInput([
+                    '--pid' => '1',
+                    '--output' => $existing_path,
+                ]),
+                $buffered_output = new BufferedOutput(),
+            );
+
+            self::assertSame(1, $exit_code);
+            self::assertStringContainsString('refusing to overwrite', $buffered_output->fetch());
+        } finally {
+            @unlink($existing_path);
+        }
+    }
+
+    private function createCommand(): MemoryCommand
+    {
+        $container = (new ContainerBuilder())
+            ->addDefinitions(__DIR__ . '/../../../config/di.php')
+            ->build();
+        /** @var MemoryCommand $command */
+        $command = $container->make(MemoryCommand::class);
+        return $command;
+    }
+}


### PR DESCRIPTION
## Summary

Round-2 SQLite-output validation
(`docs/internals/pr-773-sqlite-output-validation-round2.md`) showed
that re-running `inspector:memory -f sqlite3 -o existing.sqlite3`
crashes mid-merge in `SqliteRaw\Reader::loadSqliteMaster`:

```
sqlite_master root is not a leaf (type 0x05); not yet supported
```

The shard merger assumes a single-leaf `sqlite_master`, which holds
for a fresh DB but not for one that already carries reli's full
24-entry schema. Affects every flag combination (`default`, `sm`,
`pi`, `fd`, `sm_pi`, `sm_fd`, `pi_fd`, `all`).

This PR applies **option 1** from the validation report's resolution
list: the same refuse-to-overwrite guard `MemoryExportSqliteCommand`
already has (`MemoryExportSqliteCommand.php:87-92`), but only for
sqlite3 — the format that crashes. The guard runs against the
*resolved* `output_format`, so the common case of relying on
extension-based auto-detection (`-o foo.sqlite3` with no
`--output-format`) is also covered. `mysql` / `postgresql` / `json`
/ `rmem` / `report{,-json}` are unchanged — none of them go through
the SqliteRaw shard merger.

**Why option 1 over option 2**: properly supporting
multi-run-into-same-DB (the schema clearly intends to:
`runs.run_id` is autoincrement, every per-run table has a `run_id`
column, `createTables` uses `CREATE TABLE IF NOT EXISTS`) is a
separate feature. It needs `Reader::loadSqliteMaster` taught to
walk multi-leaf `sqlite_master` plus end-to-end verification that
shard ingest stamps the freshly-allocated `run_id` on every row,
plus tests with `inspector:memory:compare` exercising the
multi-snapshot workflow. That's the better long-term fix and is
explicitly out of scope here; this PR just stops the crashing UX.

## What changes

- **`MemoryCommand.php:83-104`**: refuse to overwrite when
  `output_format === 'sqlite3'` and `output_path` is non-null and
  the file exists. Same error-message wording as
  `MemoryExportSqliteCommand` for UX consistency. Runs after
  `createSettings` (so the resolved format is used) but before
  any process resolution / target inspection / sink construction.

- **`MemoryCommandOverwriteGuardTest`** (new): two cases —
  explicit `--output-format=sqlite3` and auto-detect from
  `.sqlite3` extension. Uses the real DI container to wire the
  command's nine collaborators; the test pins that the guard
  short-circuits before any of them is touched, by passing a
  non-existent PID and asserting the command returns `1` with
  `refusing to overwrite` rather than crashing inside
  `PhpVersionDetector` with a process-resolution error.

## Behaviour change for one corner case

Per the validation report, with no fix:

| Existing output                                          | Behaviour |
|----------------------------------------------------------|-----------|
| File doesn't exist                                       | succeeds |
| 0-byte file                                              | succeeds (treated as fresh DB) |
| Pre-existing unrelated SQLite file                       | succeeds (reli tables added alongside) |
| Existing reli-schema DB                                  | **crashes** in `Reader::loadSqliteMaster` |

With this PR's blanket refuse-on-exists guard:

| Existing output                                          | Behaviour |
|----------------------------------------------------------|-----------|
| File doesn't exist                                       | succeeds |
| 0-byte file                                              | refuses |
| Pre-existing unrelated SQLite file                       | refuses |
| Existing reli-schema DB                                  | refuses |

The 0-byte and pre-existing-unrelated-file cases are now refused
where they previously worked. The trade-off is intentional:
neither case is documented behaviour, the workaround is a single
`rm`, and this brings `inspector:memory -f sqlite3` exactly in
line with `inspector:memory:export-sqlite`. Inconsistency between
the two for the same output type is what users will hit first.
The JSON-overwrite case (separately flagged in the validation
report) is unchanged — that's a long-standing UX asymmetry, not
in scope here.

## Test plan

- [x] `php vendor/bin/phpunit --filter MemoryCommandOverwriteGuardTest` — 2/2 green; verified the test fails pre-fix by stashing the fix and re-running (proceeds past the guard and crashes inside `PhpVersionDetector::decidePhpVersion`)
- [x] `php vendor/bin/phpunit --exclude-group target-version` — green for the unit suite (3 unrelated failures: `FrankenPhpNativeTraceCollectorTest`, `FrankenPhpCallTraceReaderTest`, `ModPhpCallTraceReaderTest` — all need Docker images unavailable in this sandbox)
- [x] `php vendor/bin/psalm.phar src/Command/Inspector/MemoryCommand.php tests/Command/Inspector/MemoryCommandOverwriteGuardTest.php` — clean
- [x] `php vendor/bin/phpcs --standard=PSR12 src/Command/Inspector/MemoryCommand.php tests/Command/Inspector/MemoryCommandOverwriteGuardTest.php` — clean (one pre-existing >120-char line on a docblock unrelated to this change)
- [ ] Re-run `tests/scripts/sqlite-validation/test_multirun_live.sh` from `claude/test-sqlite-memory-TziEO` against this branch to confirm the second `inspector:memory` capture now exits with the friendly "refusing to overwrite" message (deferred — driver scripts live on the test branch, not on this fix branch)

https://claude.ai/code/session_01EtUAzB1yacaBkRK4meh4S8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXoDtcG6xKfoNH7CkW8kck)_