### PR TITLE
Use database-agnostic auto-increment for context_edges id column

### DIFF
--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -178,15 +178,18 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             )
         ');
 
-        // `id INTEGER PRIMARY KEY` is the rowid alias on a regular
-        // ROWID table — no extra storage cost, but it gives report-time
-        // chunked loaders a stable, indexable column they can paginate
-        // by (`WHERE run_id = ? AND id > ? LIMIT N`) without SQLite's
-        // planner mistakenly using the (run_id, *) covering indexes
-        // and post-filtering rowid per chunk.
+        // On SQLite, `id INTEGER PRIMARY KEY` is the rowid alias on a
+        // regular ROWID table — no extra storage cost, but it gives
+        // report-time chunked loaders a stable, indexable column they
+        // can paginate by (`WHERE run_id = ? AND id > ? LIMIT N`)
+        // without SQLite's planner mistakenly using the (run_id, *)
+        // covering indexes and post-filtering rowid per chunk. Use
+        // `{$autoId}` so PostgreSQL/MySQL get a SERIAL/AUTO_INCREMENT
+        // default — INSERTs below omit `id` and the literal would
+        // leave them with a NOT NULL violation.
         $db->exec("
             CREATE TABLE IF NOT EXISTS context_edges (
-                id INTEGER PRIMARY KEY,
+                id {$autoId},
                 run_id INTEGER NOT NULL,
                 parent_node_id INTEGER,
                 child_node_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
Updated the `context_edges` table schema to use a database-agnostic auto-increment column definition instead of SQLite-specific `INTEGER PRIMARY KEY`, enabling proper support for PostgreSQL and MySQL.

## Changes
- Replaced hardcoded `id INTEGER PRIMARY KEY` with `id {$autoId}` placeholder in the `context_edges` table creation
- Updated the accompanying comment to clarify the rationale: while `INTEGER PRIMARY KEY` is optimal for SQLite (serving as a rowid alias with no extra storage cost), it doesn't provide auto-increment behavior in PostgreSQL/MySQL, causing NOT NULL violations on INSERTs that omit the `id` column
- The `{$autoId}` variable expands to the appropriate syntax for each database (SERIAL for PostgreSQL, AUTO_INCREMENT for MySQL)

## Implementation Details
The change maintains SQLite's performance characteristics while ensuring cross-database compatibility. Since INSERTs in the codebase omit the `id` column, the database must provide a default value—which `{$autoId}` enables for all supported databases.

https://claude.ai/code/session_01N6CgnLKqpFRNsXBn23XaKK