### PR TITLE
fix(memory-output): use driver-aware auto-id for context_edges (0.12.x backport)

### DIFF
--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -178,15 +178,18 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             )
         ');
 
-        // `id INTEGER PRIMARY KEY` is the rowid alias on a regular
-        // ROWID table — no extra storage cost, but it gives report-time
-        // chunked loaders a stable, indexable column they can paginate
-        // by (`WHERE run_id = ? AND id > ? LIMIT N`) without SQLite's
-        // planner mistakenly using the (run_id, *) covering indexes
-        // and post-filtering rowid per chunk.
+        // On SQLite, `id INTEGER PRIMARY KEY` is the rowid alias on a
+        // regular ROWID table — no extra storage cost, but it gives
+        // report-time chunked loaders a stable, indexable column they
+        // can paginate by (`WHERE run_id = ? AND id > ? LIMIT N`)
+        // without SQLite's planner mistakenly using the (run_id, *)
+        // covering indexes and post-filtering rowid per chunk. Use
+        // `{$autoId}` so PostgreSQL/MySQL get a SERIAL/AUTO_INCREMENT
+        // default — INSERTs below omit `id` and the literal would
+        // leave them with a NOT NULL violation.
         $db->exec("
             CREATE TABLE IF NOT EXISTS context_edges (
-                id INTEGER PRIMARY KEY,
+                id {$autoId},
                 run_id INTEGER NOT NULL,
                 parent_node_id INTEGER,
                 child_node_id INTEGER NOT NULL,


### PR DESCRIPTION
Backport of the PostgreSQL/MySQL `inspector:memory -f postgresql|mysql` fix to the 0.12.x line. Same bug shape as on `main` — predates 0.13.0, so 0.12.x is affected too.

## Summary

- `PdoMemoryOutput::createTables` declared `context_edges.id` with the literal `INTEGER PRIMARY KEY` while the sister tables `context_node_locations` and `context_node_attributes` correctly used the driver-aware `{$autoId}` substitution.
- On SQLite the literal is the rowid alias and self-assigns on insert. On PostgreSQL it's just `INTEGER NOT NULL` with no default — every `inspector:memory -f postgresql` invocation fails with a NOT NULL violation. MySQL silently drops `AUTO_INCREMENT` and fails the same way.
- Substitute `{$autoId}` for `context_edges` so PostgreSQL gets `SERIAL PRIMARY KEY` and MySQL gets `INTEGER PRIMARY KEY AUTO_INCREMENT`. SqliteDriver returns exactly `'INTEGER PRIMARY KEY'`, so the SQLite path is byte-identical and the rowid-alias pagination optimisation in the report-time chunked loaders is preserved.
- Surfaced by the round-3 SQLite-output validation report on `claude/test-sqlite-memory-TziEO`.

## Test plan

- [x] `php vendor/bin/phpunit tests/Inspector/Output/MemoryOutput/` — 352 tests / 1323 assertions OK
- [x] `php vendor/bin/psalm.phar src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php` — No errors
- [x] `php vendor/bin/phpcs --standard=PSR12 src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php` — clean
- [ ] Manual smoke: `inspector:memory -f postgresql` against any PHP target (`docker run postgres` + a real PHP target — not exercisable in the sandbox here, see the round-3 report on `claude/test-sqlite-memory-TziEO` for a recipe)

https://claude.ai/code/session_01EtUAzB1yacaBkRK4meh4S8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6CgnLKqpFRNsXBn23XaKK)_