### PR TITLE
perf(memory-output): hide L behind PIB, partition merge for the largest integer index

### DIFF
--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -888,15 +888,19 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         // any failure throws; we let those bubble up because the
         // serial fallback would write on top of orphan index pages
         // and break integrity_check.
-        // When a sidecar is attached, leave one CPU for it so the
-        // sidecar isn't time-sliced against the worker pool. Without
-        // this the L sidecar's wall-clock balloons (e.g. 0.85 s →
-        // 1.4 s on a 4-core box because 4 PIB workers + parent + L
-        // all compete for cores) and partly defeats the
-        // parallel-with-createIndexes win.
+        // When a sidecar is attached, leave CPU slots for it so it
+        // isn't time-sliced against the worker pool. Without this
+        // the L sidecar's wall-clock balloons (e.g. 0.85 s → 1.4 s
+        // on a 4-core box) and partly defeats the parallel win.
+        // The L sidecar may itself fork up to one process per
+        // integer index when parallel-L is enabled — reserve a
+        // matching number of CPU slots in that case.
         $worker_count = $this->defaultWorkerCount();
         if ($sidecar !== null) {
-            $worker_count = max(1, $worker_count - 1);
+            $reserve = self::lParallelEnabled()
+                ? count(self::integerIndexSpecs())
+                : 1;
+            $worker_count = max(1, $worker_count - $reserve);
         }
         $result = ParallelIndexBuilder::build(
             $db_path,
@@ -1940,45 +1944,196 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             return [];
         }
 
+        // Session mode with multiple jobs and enough cores: fork
+        // one sub-sidecar per integer index so they build in
+        // parallel. Each child claims its own pgno range from the
+        // shared counter and pwrites disjoint pages — the wall-
+        // clock collapses from sum(per-index times) to
+        // max(per-index time).
+        //
+        // Gated on a core threshold: on a 4-core box the 3 L sub-
+        // forks + 3 PIB workers exceed the core count, so the OS
+        // time-slices everything and the largest L job stretches
+        // from 0.5 s to 1.5 s+. The break-even moves below 4 cores
+        // only on small captures where PIB doesn't have much to
+        // do anyway. RELI_L_PARALLEL=1 force-enables; =0 force-
+        // disables.
+        if (
+            $counter_path !== null
+            && count($jobs) > 1
+            && function_exists('pcntl_fork')
+            && function_exists('pcntl_waitpid')
+            && self::lParallelEnabled()
+        ) {
+            return $this->mergeIntegerIndexesParallel($main_path, $counter_path, $jobs);
+        }
+
+        return $this->mergeIntegerIndexesSequential($main_path, $counter_path, $jobs);
+    }
+
+    /**
+     * True when the per-index L parallelisation should run. Defaults
+     * to on for >= 8 cores (3 L sub-forks + 4-5 PIB workers fits
+     * comfortably), off below that. Override with RELI_L_PARALLEL=1
+     * (force on) or RELI_L_PARALLEL=0 (force off).
+     */
+    private static function lParallelEnabled(): bool
+    {
+        $env = getenv('RELI_L_PARALLEL');
+        if ($env === '1') {
+            return true;
+        }
+        if ($env === '0') {
+            return false;
+        }
+        $cores = 4;
+        if (is_readable('/proc/cpuinfo')) {
+            $cpuinfo = @file_get_contents('/proc/cpuinfo');
+            if (is_string($cpuinfo) && $cpuinfo !== '') {
+                $cores = max(1, substr_count($cpuinfo, "\nprocessor\t") + 1);
+            }
+        }
+        return $cores >= 8;
+    }
+
+    /**
+     * Sequential (in-process) integer-index merge. One writer; one
+     * job after another. Used when there's only one job, when
+     * pcntl is unavailable, or when running outside the PIB
+     * session (no shared counter to coordinate parallel forks).
+     *
+     * @param list<array{name: string, sort_runs: list<SortRunReader>}> $jobs
+     * @return array<string, int>
+     */
+    private function mergeIntegerIndexesSequential(
+        string $main_path,
+        ?string $counter_path,
+        array $jobs,
+    ): array {
         $writer = $counter_path !== null
             ? SqliteRawWriter::openForPatchInSession($main_path, $counter_path)
             : SqliteRawWriter::openForPatch($main_path);
-        // Build a single empty-index-leaf placeholder (type 0x0a,
-        // 0 cells) we can re-use as the appendPage payload that
-        // claims each index's rootpage. The merger overwrites the
-        // placeholder via writePage immediately after, so the
-        // bytes never end up on disk; we just need a page-sized
-        // buffer that satisfies appendPage's strict size check.
-        $page_size = $writer->page_size;
-        $cc = $page_size === 65536 ? 0 : $page_size;
-        $empty_leaf = chr(SqliteRawFormat::BTREE_LEAF_INDEX)
-            . pack('n', 0)
-            . pack('n', 0)
-            . pack('n', $cc)
-            . "\x00"
-            . str_repeat("\x00", $page_size - 8);
+        $empty_leaf = self::emptyIndexLeafPage($writer->page_size);
         $populated = [];
         foreach ($jobs as $job) {
-            // Claim this index's rootpage. In session mode this
-            // pulls a pgno from the shared counter; in sequential
-            // mode it appends at end-of-file. Either way the
-            // merger writePage's the real root content over our
-            // placeholder before close().
             $rootpage = $writer->appendPage($empty_leaf);
             $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
             try {
                 $merger->merge($rootpage);
                 $populated[$job['name']] = $rootpage;
             } catch (OverflowNotSupportedException $_e) {
-                // Caller's fallback path will rebuild the index via
-                // a normal CREATE INDEX. The placeholder leaf at
-                // $rootpage is harmless (it'll be left as a free
-                // leaf, no sqlite_master entry refers to it).
                 continue;
             }
         }
         $writer->close($main_path);
         return $populated;
+    }
+
+    /**
+     * Per-index parallel integer-index merge. One fork per job,
+     * each running a session-mode writer that claims pgnos from
+     * the same shared counter as the orchestrator's other cohort
+     * processes (PIB workers, when applicable). Children
+     * communicate their claimed rootpage back to the parent via
+     * a 4-byte big-endian temp file — small, no PHP serialise
+     * overhead.
+     *
+     * @param list<array{name: string, sort_runs: list<SortRunReader>}> $jobs
+     * @return array<string, int>
+     */
+    private function mergeIntegerIndexesParallel(
+        string $main_path,
+        string $counter_path,
+        array $jobs,
+    ): array {
+        /** @var list<array{int, int, string}> $pids [pid, job_index, job_name] */
+        $pids = [];
+        $result_paths = [];
+        foreach ($jobs as $i => $job) {
+            $result_paths[$i] = $main_path . '.l_sub_' . $i;
+            @unlink($result_paths[$i]);
+            $pid = pcntl_fork();
+            if ($pid === -1) {
+                foreach ($pids as [$running_pid, $_idx, $_name]) {
+                    posix_kill($running_pid, SIGTERM);
+                    pcntl_waitpid($running_pid, $_status);
+                }
+                foreach ($result_paths as $rp) {
+                    @unlink($rp);
+                }
+                throw new \RuntimeException('L sub-sidecar fork failed');
+            }
+            if ($pid === 0) {
+                $exit_code = 0;
+                try {
+                    $writer = SqliteRawWriter::openForPatchInSession($main_path, $counter_path);
+                    $empty_leaf = self::emptyIndexLeafPage($writer->page_size);
+                    $rootpage = $writer->appendPage($empty_leaf);
+                    $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
+                    try {
+                        $merger->merge($rootpage);
+                        file_put_contents($result_paths[$i], pack('N', $rootpage));
+                    } catch (OverflowNotSupportedException $_e) {
+                        // Fall through with an empty result so the
+                        // caller knows this index didn't populate;
+                        // the placeholder leaf at $rootpage is
+                        // harmless (no sqlite_master entry refers
+                        // to it).
+                    }
+                    $writer->close($main_path);
+                } catch (\Throwable $e) {
+                    fwrite(STDERR, "L sub-sidecar {$job['name']}: " . $e->getMessage() . "\n");
+                    $exit_code = 1;
+                }
+                exit($exit_code);
+            }
+            $pids[] = [$pid, $i, $job['name']];
+        }
+
+        $populated = [];
+        $any_failure = false;
+        foreach ($pids as [$pid, $i, $name]) {
+            pcntl_waitpid($pid, $status);
+            $code = pcntl_wifexited($status) ? pcntl_wexitstatus($status) : 1;
+            if ($code !== 0) {
+                $any_failure = true;
+                @unlink($result_paths[$i]);
+                continue;
+            }
+            $data = file_exists($result_paths[$i])
+                ? (string)file_get_contents($result_paths[$i])
+                : '';
+            @unlink($result_paths[$i]);
+            if (strlen($data) >= 4) {
+                $rootpage = (int)unpack('N', substr($data, 0, 4))[1];
+                $populated[$name] = $rootpage;
+            }
+            // Empty $data means the merger threw OverflowNotSupported
+            // and the caller's fallback path will rebuild the index.
+        }
+
+        if ($any_failure) {
+            throw new \RuntimeException('L sub-sidecar failed');
+        }
+
+        return $populated;
+    }
+
+    /**
+     * One-time-built empty-index-leaf page (type 0x0a, 0 cells).
+     * Used as the placeholder bytes for `appendPage` when claiming
+     * a fresh rootpage — the merger immediately overwrites it via
+     * `writePage` so the placeholder bytes never end up on disk.
+     */
+    private static function emptyIndexLeafPage(int $page_size): string
+    {
+        $cc = $page_size === 65536 ? 0 : $page_size;
+        return chr(SqliteRawFormat::BTREE_LEAF_INDEX)
+            . pack('n', 0)
+            . pack('n', 0)
+            . pack('n', $cc)
+            . "\x00"
+            . str_repeat("\x00", $page_size - 8);
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -1473,8 +1473,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             // After the table data is in the shard, dump sort-run
             // files for each integer index. These get k-way merged
             // by the main process to skip the SQL CREATE INDEX
-            // sort phase entirely.
-            $this->dumpIntegerIndexSortRuns($shard, $shard_path);
+            // sort phase entirely. Worker also pre-encodes the leaf
+            // cell bytes against the freshly-allocated run_id so the
+            // merger doesn't have to re-encode in the critical path.
+            $this->dumpIntegerIndexSortRuns($shard, $shard_path, $run_id);
         } catch (\Throwable $e) {
             $shard->rollBack();
             throw $e;
@@ -1672,7 +1674,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         // through them see the real data.
         if (!$needs_sql_fallback && self::formatDirectIndexEnabled()) {
             unset($db);
-            $this->mergeIntegerIndexes($shard_paths, $main_path, $run_id);
+            $this->mergeIntegerIndexes($shard_paths, $main_path);
             $db = $this->driver->createConnection();
             $db->exec('PRAGMA synchronous = OFF');
             $db->exec('PRAGMA temp_store = MEMORY');
@@ -1741,10 +1743,13 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      *
      * @psalm-suppress MixedAssignment
      */
-    private function dumpIntegerIndexSortRuns(\PDO $shard, string $shard_path): void
+    private function dumpIntegerIndexSortRuns(\PDO $shard, string $shard_path, int $run_id): void
     {
         foreach (self::integerIndexSpecs() as [$index_name, $table, $key_column]) {
-            $writer = new SortRunWriter(self::sortRunPath($shard_path, $index_name));
+            $writer = new SortRunWriter(
+                self::sortRunPath($shard_path, $index_name),
+                $run_id,
+            );
             $stmt = $shard->prepare(
                 "SELECT {$key_column}, rowid FROM {$table} ORDER BY {$key_column}, rowid"
             );
@@ -1773,15 +1778,18 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     private function mergeIntegerIndexes(
         array $shard_paths,
         string $main_path,
-        int $run_id,
     ): void {
+        // Resolve all integer-index rootpages and collect sort runs
+        // up front so we can run a single open(main) → merge×3 →
+        // close(main) cycle. Per-index open/close used to read the
+        // 88 MB main file twice and rewrite it once per iteration —
+        // ~0.6 s of pure IO per index, dwarfing the actual merge.
+        $reader = SqliteRawReader::open($main_path);
+        /** @var list<array{rootpage: int, sort_runs: list<SortRunReader>}> $jobs */
+        $jobs = [];
         foreach (self::integerIndexSpecs() as [$index_name, $_table, $_key]) {
-            $reader = SqliteRawReader::open($main_path);
-            $rootpage = $reader->findSchemaEntry($index_name);
-            if ($rootpage === null) {
-                // Index wasn't created — caller bug. Skip rather than
-                // throw, so an unexpected schema doesn't prevent the
-                // rest of the merge from completing.
+            $entry = $reader->findSchemaEntry($index_name);
+            if ($entry === null) {
                 continue;
             }
             $sort_runs = [];
@@ -1794,19 +1802,28 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             if ($sort_runs === []) {
                 continue;
             }
-            $writer = SqliteRawWriter::open($main_path);
-            $merger = new IntegerIndexMerger($writer, $sort_runs, $run_id);
+            $jobs[] = ['rootpage' => $entry['rootpage'], 'sort_runs' => $sort_runs];
+        }
+        unset($reader);
+
+        if ($jobs === []) {
+            return;
+        }
+
+        $writer = SqliteRawWriter::open($main_path);
+        foreach ($jobs as $job) {
+            $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
             try {
-                $merger->merge($rootpage['rootpage']);
+                $merger->merge($job['rootpage']);
             } catch (OverflowNotSupportedException $_e) {
-                // Should not happen for our 3-int payloads; if it
-                // does, leave SQLite's CREATE INDEX (run by
-                // createIndexes after this) build the index in the
-                // normal way.
+                // Leave SQLite's CREATE INDEX (run after this) build
+                // the index in the normal way; the failed merger
+                // didn't write anything to the rootpage so the
+                // skip-and-fall-through is safe.
                 continue;
             }
-            $writer->close($main_path);
         }
+        $writer->close($main_path);
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -1810,7 +1810,7 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             return;
         }
 
-        $writer = SqliteRawWriter::open($main_path);
+        $writer = SqliteRawWriter::openForPatch($main_path);
         foreach ($jobs as $job) {
             $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
             try {

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -776,9 +776,19 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $phase('createViews');
     }
 
+    /**
+     * Default-on toggle for the parallel CREATE INDEX path. Off only
+     * when explicitly disabled via `RELI_PARALLEL_INDEX=0`; the
+     * pre-flight inside {@see tryParallelCreateIndexes} already
+     * returns false on environments that can't support it (non-SQLite
+     * driver, FFI / pcntl missing), so callers fall back to the
+     * serial createIndexes path automatically. The env-var kill
+     * switch is kept so users hitting an unforeseen edge can opt
+     * back to serial without recompiling.
+     */
     private static function parallelIndexEnabled(): bool
     {
-        return getenv('RELI_PARALLEL_INDEX') === '1';
+        return getenv('RELI_PARALLEL_INDEX') !== '0';
     }
 
     /**
@@ -806,6 +816,31 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             return false;
         }
         $specs = self::userIndexSpecs();
+
+        // Skip indexes that already exist — format-direct L pre-
+        // creates the 3 integer indexes via IntegerIndexMerger, and
+        // a 2nd-or-later capture into the same DB carries the
+        // 0.13.x sqlite_master entries from previous runs. Either
+        // case would trip the writable_schema INSERT with a
+        // duplicate-name conflict.
+        $existing = [];
+        $existing_stmt = $db->query(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+        );
+        if ($existing_stmt !== false) {
+            /** @var array{name: string} $row */
+            foreach ($existing_stmt as $row) {
+                $existing[$row['name']] = true;
+            }
+        }
+        $specs = array_values(array_filter(
+            $specs,
+            static fn (array $s): bool => !isset($existing[$s['name']]),
+        ));
+        if ($specs === []) {
+            return true;
+        }
+
         $db_path = $this->driver->path();
 
         // Reservation budget per index, tuned to the largest source
@@ -1548,10 +1583,21 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 static fn (string $p): SqliteRawReader => SqliteRawReader::open($p),
                 array_values($shard_paths),
             );
+            // Open main once to resolve all 4 rootpages — used to be
+            // SqliteRawReader::open($main_path) per table iteration,
+            // which reread the whole main file 4 times. Cheap when
+            // main is empty-schema only, but extra ms per merge that
+            // we don't need to spend, and quadratic with re-ingest
+            // into a populated main DB.
+            $main_reader = SqliteRawReader::open($main_path);
+            $rootpages = [];
+            foreach ($tables as $table) {
+                $rootpages[$table] = $main_reader->tableRootpage($table);
+            }
+            unset($main_reader);
             $merger = new TableMerger($writer, $shard_readers);
             foreach ($tables as $table) {
-                $rootpage = SqliteRawReader::open($main_path)->tableRootpage($table);
-                $merger->merge($table, $rootpage);
+                $merger->merge($table, $rootpages[$table]);
             }
             $writer->close($main_path);
         } catch (OverflowNotSupportedException $_e) {
@@ -1569,15 +1615,17 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
         if (!$needs_sql_fallback) {
             // Format-direct table copy bypasses the b-tree machinery,
-            // so the auto-indexes that the PRIMARY KEYs maintain are
-            // still the empty leaves they were at CREATE TABLE time.
-            // REINDEX rebuilds them from the freshly-merged table
-            // data. Workers already wrote canonical run_id values,
-            // so no UPDATE round-trip is needed.
+            // so the auto-index of the only data table with a
+            // compound PK (context_nodes) is still the empty leaf it
+            // was at CREATE TABLE time and needs REINDEX. The other
+            // three data tables use `id INTEGER PRIMARY KEY`, which
+            // is a rowid alias with no separate autoindex, so they
+            // need nothing here. The summary tables (summary,
+            // location_types_summary, class_objects_summary) are
+            // populated through the regular SQLite INSERT path
+            // (allocateRun + the post-merge inserts below), so SQLite
+            // maintains their autoindexes itself.
             $db->exec('REINDEX context_nodes');
-            $db->exec('REINDEX summary');
-            $db->exec('REINDEX location_types_summary');
-            $db->exec('REINDEX class_objects_summary');
         }
 
         if ($needs_sql_fallback) {
@@ -1642,7 +1690,14 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         // derived like idx_context_nodes_canonical) get built the
         // normal way. CREATE INDEX IF NOT EXISTS on the integer
         // indexes is a no-op since they already exist.
-        $this->createIndexes($db);
+        if (self::parallelIndexEnabled() && $this->tryParallelCreateIndexes($db)) {
+            // Parallel CREATE INDEX via subset-cp shards landed all
+            // remaining indexes; format-direct L (if enabled) already
+            // pre-created the 3 integer ones and they were filtered
+            // out of the parallel batch.
+        } else {
+            $this->createIndexes($db);
+        }
         $this->createViews($db);
     }
 

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -19,6 +19,7 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\PdoDriverInterface;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Output\MemoryOutput\SqliteRaw\CellTooLargeException;
+use Reli\Inspector\Output\MemoryOutput\SqliteRaw\Format as SqliteRawFormat;
 use Reli\Inspector\Output\MemoryOutput\SqliteRaw\IntegerIndexMerger;
 use Reli\Inspector\Output\MemoryOutput\SqliteRaw\OverflowNotSupportedException;
 use Reli\Inspector\Output\MemoryOutput\SqliteRaw\ParallelIndexBuilder;
@@ -810,19 +811,17 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      * shard, then page-relocates the index back into main via
      * shared mmap.
      */
-    private function tryParallelCreateIndexes(\PDO $db): bool
+    private function tryParallelCreateIndexes(\PDO $db, ?\Closure $sidecar = null): bool
     {
         if (!$this->driver instanceof SqliteDriver) {
             return false;
         }
         $specs = self::userIndexSpecs();
 
-        // Skip indexes that already exist — format-direct L pre-
-        // creates the 3 integer indexes via IntegerIndexMerger, and
-        // a 2nd-or-later capture into the same DB carries the
-        // 0.13.x sqlite_master entries from previous runs. Either
-        // case would trip the writable_schema INSERT with a
-        // duplicate-name conflict.
+        // Skip indexes that already exist — re-ingest into a
+        // populated 0.13.x DB carries sqlite_master entries from
+        // previous runs that would trip the writable_schema INSERT
+        // with a duplicate-name conflict.
         $existing = [];
         $existing_stmt = $db->query(
             "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
@@ -833,11 +832,27 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 $existing[$row['name']] = true;
             }
         }
+        // When the format-direct integer-index sidecar is attached,
+        // it owns the 3 integer indexes — exclude them from the PIB
+        // worker specs so PIB doesn't build them in parallel and
+        // produce duplicate sqlite_master rows.
+        if ($sidecar !== null) {
+            foreach (self::integerIndexSpecs() as [$index_name, $_table, $_key]) {
+                $existing[$index_name] = true;
+            }
+        }
         $specs = array_values(array_filter(
             $specs,
             static fn (array $s): bool => !isset($existing[$s['name']]),
         ));
         if ($specs === []) {
+            // No PIB work to do. If a sidecar was supplied, run it
+            // serially here — we don't have a session to host it
+            // in. Caller's loop arranges the same fallback when
+            // PIB's pre-flight bails (FFI/pcntl unavailable).
+            if ($sidecar !== null) {
+                return false;
+            }
             return true;
         }
 
@@ -873,11 +888,22 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         // any failure throws; we let those bubble up because the
         // serial fallback would write on top of orphan index pages
         // and break integrity_check.
+        // When a sidecar is attached, leave one CPU for it so the
+        // sidecar isn't time-sliced against the worker pool. Without
+        // this the L sidecar's wall-clock balloons (e.g. 0.85 s →
+        // 1.4 s on a 4-core box because 4 PIB workers + parent + L
+        // all compete for cores) and partly defeats the
+        // parallel-with-createIndexes win.
+        $worker_count = $this->defaultWorkerCount();
+        if ($sidecar !== null) {
+            $worker_count = max(1, $worker_count - 1);
+        }
         $result = ParallelIndexBuilder::build(
             $db_path,
             $specs,
-            $this->defaultWorkerCount(),
+            $worker_count,
             $reservation,
+            $sidecar,
         );
         return $result !== null;
     }
@@ -1314,11 +1340,13 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         $db->exec('PRAGMA synchronous = OFF');
         $db->exec('PRAGMA temp_store = MEMORY');
         $this->createTables($db);
-        if (self::formatDirectIndexEnabled()) {
-            foreach (self::integerIndexSpecs() as [$index_name, $table, $key]) {
-                $db->exec("CREATE INDEX IF NOT EXISTS {$index_name} ON {$table}(run_id, {$key})");
-            }
-        }
+        // Integer indexes (the L-path's pre-allocated rootpages)
+        // used to be created here. They are now created in
+        // mergeShards after summary inserts run, so the planner
+        // can't pick the empty rootpages for queries during the
+        // intervening summary phase. Moving the CREATE INDEX out
+        // also lets L run as a ParallelIndexBuilder sidecar
+        // concurrent with the C-side CREATE INDEX path.
         $db->beginTransaction();
         $run_id = $this->insertRun($db);
         $this->insertSummary($db, $run_id, $summary);
@@ -1664,22 +1692,6 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             $db->commit();
         }
 
-        // Format-direct integer index merge (gated, off by default).
-        // When enabled, has to run BEFORE the summary inserts:
-        // the integer indexes' rootpages were pre-allocated but
-        // currently hold an empty leaf, and SQLite's planner
-        // happily uses them for queries like `SELECT ... WHERE
-        // run_id = ?`, which then returns zero rows. Populating
-        // the indexes first means subsequent SELECTs that route
-        // through them see the real data.
-        if (!$needs_sql_fallback && self::formatDirectIndexEnabled()) {
-            unset($db);
-            $this->mergeIntegerIndexes($shard_paths, $main_path);
-            $db = $this->driver->createConnection();
-            $db->exec('PRAGMA synchronous = OFF');
-            $db->exec('PRAGMA temp_store = MEMORY');
-        }
-
         $db->beginTransaction();
         $this->insertLocationTypesSummaryFromDb($db, $run_id);
         $this->insertClassObjectsSummaryFromDb($db, $run_id);
@@ -1688,19 +1700,119 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
         $this->driver->afterBulkInsert($db);
 
-        // The remaining indexes (text-keyed, partial, post-merge-
-        // derived like idx_context_nodes_canonical) get built the
-        // normal way. CREATE INDEX IF NOT EXISTS on the integer
-        // indexes is a no-op since they already exist.
-        if (self::parallelIndexEnabled() && $this->tryParallelCreateIndexes($db)) {
-            // Parallel CREATE INDEX via subset-cp shards landed all
-            // remaining indexes; format-direct L (if enabled) already
-            // pre-created the 3 integer ones and they were filtered
-            // out of the parallel batch.
+        // Pre-create the integer-index rootpages so the L path has
+        // somewhere to writePage() into. Done after summaries run
+        // so the empty rootpages don't mislead the planner during
+        // those queries. CREATE INDEX on a populated table is a
+        // real cost — but only when L is enabled, otherwise the
+        // serial createIndexes / parallel CREATE INDEX path below
+        // builds these indexes itself. Gate by $needs_sql_fallback
+        // because the SQL fallback path doesn't want format-direct
+        // anything.
+        $l_eligible = !$needs_sql_fallback && self::formatDirectIndexEnabled();
+
+        // L runs as a sidecar of ParallelIndexBuilder when both are
+        // available — its work overlaps with the C-side CREATE INDEX
+        // phase that builds the remaining 7 indexes, and both
+        // claim pgnos from the same shared atomic counter so their
+        // page allocations never collide. The sidecar emits its
+        // `index_name => rootpage` map to a temp file because the
+        // parent then has to register those rootpages in
+        // sqlite_master via writable_schema (skipping CREATE INDEX
+        // entirely avoids ~0.4 s of wasted C-side index build that
+        // L would just overwrite). Falls back to a sequential L
+        // before the serial createIndexes path when parallel-index
+        // can't run.
+        $sidecar = null;
+        $sidecar_result_path = null;
+        if ($l_eligible) {
+            $sidecar_result_path = $main_path . '.l_meta';
+            @unlink($sidecar_result_path);
+            $shard_paths_for_sidecar = $shard_paths;
+            $main_path_for_sidecar = $main_path;
+            $result_path_for_sidecar = $sidecar_result_path;
+            $sidecar = function (string $counter_path) use (
+                $shard_paths_for_sidecar,
+                $main_path_for_sidecar,
+                $result_path_for_sidecar
+            ): void {
+                $rootpages = $this->mergeIntegerIndexes(
+                    $shard_paths_for_sidecar,
+                    $main_path_for_sidecar,
+                    $counter_path,
+                );
+                file_put_contents(
+                    $result_path_for_sidecar,
+                    serialize($rootpages),
+                );
+            };
+        }
+
+        $parallel_landed = self::parallelIndexEnabled()
+            && $this->tryParallelCreateIndexes($db, $sidecar);
+
+        if ($parallel_landed) {
+            if (
+                $l_eligible
+                && $sidecar_result_path !== null
+                && file_exists($sidecar_result_path)
+            ) {
+                $payload = (string)file_get_contents($sidecar_result_path);
+                @unlink($sidecar_result_path);
+                /** @var array<string, int> $rootpages */
+                $rootpages = unserialize($payload);
+                $this->insertIntegerIndexSchemaEntries($db, $rootpages);
+            }
         } else {
+            // Serial path: run L sequentially first (claims its own
+            // rootpages and emits them back to us), then the serial
+            // createIndexes builds the remaining 7 indexes.
+            if ($l_eligible) {
+                unset($db);
+                $rootpages = $this->mergeIntegerIndexes($shard_paths, $main_path);
+                $db = $this->driver->createConnection();
+                $db->exec('PRAGMA synchronous = OFF');
+                $db->exec('PRAGMA temp_store = MEMORY');
+                $this->insertIntegerIndexSchemaEntries($db, $rootpages);
+            }
             $this->createIndexes($db);
         }
         $this->createViews($db);
+    }
+
+    /**
+     * Insert sqlite_master rows for the integer indexes L just
+     * populated. Mirrors {@see ParallelIndexBuilder}'s post-fork
+     * writable_schema step. Each entry's rootpage was claimed by
+     * the merger (sequential or session mode), and its name /
+     * tbl_name / sql come from {@see integerIndexSpecs}. The
+     * schema_cookie bumps as a side effect of writable_schema, so
+     * freshly-opened PDO connections re-parse and see the new
+     * indexes.
+     *
+     * @param array<string, int> $rootpages index_name => rootpage
+     */
+    private function insertIntegerIndexSchemaEntries(\PDO $db, array $rootpages): void
+    {
+        if ($rootpages === []) {
+            return;
+        }
+        $db->exec('PRAGMA writable_schema = ON');
+        try {
+            $stmt = $db->prepare(
+                'INSERT INTO sqlite_master (type, name, tbl_name, rootpage, sql)'
+                . ' VALUES (?, ?, ?, ?, ?)'
+            );
+            foreach (self::integerIndexSpecs() as [$index_name, $table, $key]) {
+                if (!isset($rootpages[$index_name])) {
+                    continue;
+                }
+                $sql = "CREATE INDEX {$index_name} ON {$table}(run_id, {$key})";
+                $stmt->execute(['index', $index_name, $table, $rootpages[$index_name], $sql]);
+            }
+        } finally {
+            $db->exec('PRAGMA writable_schema = OFF');
+        }
     }
 
     /**
@@ -1775,23 +1887,42 @@ final class PdoMemoryOutput implements MemoryOutputInterface
      *
      * @param array<int, string> $shard_paths shard index => path
      */
+    /**
+     * Build the integer-only indexes from the per-shard sort runs.
+     *
+     * Always claims a fresh rootpage pgno for each index via the
+     * writer's `appendPage` (placeholder empty leaf, immediately
+     * overwritten by the merger), so the caller never has to pre-
+     * `CREATE INDEX` to allocate the rootpage — that CREATE INDEX
+     * would do the C-side index build only for L to overwrite the
+     * result, ~0.4 s of pure waste at our table sizes.
+     *
+     * Sequential mode (counter_path null): writer uses patch mode,
+     * appended pages are dense at the end of the file.
+     *
+     * Session mode (counter_path supplied): writer uses session
+     * mode, appended pages claim pgnos from the shared atomic
+     * counter so they don't collide with parallel cohort processes
+     * (typically {@see ParallelIndexBuilder} workers).
+     *
+     * Returns the `index_name => rootpage` map for indexes the
+     * merger populated. The caller is responsible for inserting
+     * the corresponding sqlite_master rows via writable_schema.
+     *
+     * @return array<string, int>
+     */
+    /**
+     * @param array<int, string> $shard_paths shard index => path
+     * @return array<string, int> index_name => rootpage
+     */
     private function mergeIntegerIndexes(
         array $shard_paths,
         string $main_path,
-    ): void {
-        // Resolve all integer-index rootpages and collect sort runs
-        // up front so we can run a single open(main) → merge×3 →
-        // close(main) cycle. Per-index open/close used to read the
-        // 88 MB main file twice and rewrite it once per iteration —
-        // ~0.6 s of pure IO per index, dwarfing the actual merge.
-        $reader = SqliteRawReader::open($main_path);
-        /** @var list<array{rootpage: int, sort_runs: list<SortRunReader>}> $jobs */
+        ?string $counter_path = null,
+    ): array {
+        /** @var list<array{name: string, sort_runs: list<SortRunReader>}> $jobs */
         $jobs = [];
         foreach (self::integerIndexSpecs() as [$index_name, $_table, $_key]) {
-            $entry = $reader->findSchemaEntry($index_name);
-            if ($entry === null) {
-                continue;
-            }
             $sort_runs = [];
             foreach ($shard_paths as $shard_path) {
                 $run_path = self::sortRunPath($shard_path, $index_name);
@@ -1802,28 +1933,52 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             if ($sort_runs === []) {
                 continue;
             }
-            $jobs[] = ['rootpage' => $entry['rootpage'], 'sort_runs' => $sort_runs];
+            $jobs[] = ['name' => $index_name, 'sort_runs' => $sort_runs];
         }
-        unset($reader);
 
         if ($jobs === []) {
-            return;
+            return [];
         }
 
-        $writer = SqliteRawWriter::openForPatch($main_path);
+        $writer = $counter_path !== null
+            ? SqliteRawWriter::openForPatchInSession($main_path, $counter_path)
+            : SqliteRawWriter::openForPatch($main_path);
+        // Build a single empty-index-leaf placeholder (type 0x0a,
+        // 0 cells) we can re-use as the appendPage payload that
+        // claims each index's rootpage. The merger overwrites the
+        // placeholder via writePage immediately after, so the
+        // bytes never end up on disk; we just need a page-sized
+        // buffer that satisfies appendPage's strict size check.
+        $page_size = $writer->page_size;
+        $cc = $page_size === 65536 ? 0 : $page_size;
+        $empty_leaf = chr(SqliteRawFormat::BTREE_LEAF_INDEX)
+            . pack('n', 0)
+            . pack('n', 0)
+            . pack('n', $cc)
+            . "\x00"
+            . str_repeat("\x00", $page_size - 8);
+        $populated = [];
         foreach ($jobs as $job) {
+            // Claim this index's rootpage. In session mode this
+            // pulls a pgno from the shared counter; in sequential
+            // mode it appends at end-of-file. Either way the
+            // merger writePage's the real root content over our
+            // placeholder before close().
+            $rootpage = $writer->appendPage($empty_leaf);
             $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
             try {
-                $merger->merge($job['rootpage']);
+                $merger->merge($rootpage);
+                $populated[$job['name']] = $rootpage;
             } catch (OverflowNotSupportedException $_e) {
-                // Leave SQLite's CREATE INDEX (run after this) build
-                // the index in the normal way; the failed merger
-                // didn't write anything to the rootpage so the
-                // skip-and-fall-through is safe.
+                // Caller's fallback path will rebuild the index via
+                // a normal CREATE INDEX. The placeholder leaf at
+                // $rootpage is harmless (it'll be left as a free
+                // leaf, no sqlite_master entry refers to it).
                 continue;
             }
         }
         $writer->close($main_path);
+        return $populated;
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -2030,6 +2030,24 @@ final class PdoMemoryOutput implements MemoryOutputInterface
     }
 
     /**
+     * How many partitions to split the largest integer index into
+     * when the inner-partition path is enabled. Default off
+     * (`= 1` ↔ no partitioning); `RELI_L_PARTITION_COUNT=4` etc.
+     * lights it. Only kicks in for the partition-eligible (largest)
+     * index; the smaller integer indexes remain a single sub-fork
+     * each — they finish quickly enough that splitting them costs
+     * more in fork + sampling overhead than it saves.
+     */
+    private static function lPartitionCount(): int
+    {
+        $env = getenv('RELI_L_PARTITION_COUNT');
+        if (is_string($env) && ctype_digit($env)) {
+            return max(1, (int)$env);
+        }
+        return 1;
+    }
+
+    /**
      * Per-index parallel integer-index merge. One fork per job,
      * each running a session-mode writer that claims pgnos from
      * the same shared counter as the orchestrator's other cohort
@@ -2046,6 +2064,28 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         string $counter_path,
         array $jobs,
     ): array {
+        // If inner-partition is enabled, identify the largest job
+        // by total sort-run row count and route just that one
+        // through the partitioned path. The other jobs stay one-
+        // sub-sidecar-per-job because they're small enough that
+        // the per-partition fork + sampling + assembly overhead
+        // would exceed the savings.
+        $partition_count = self::lPartitionCount();
+        $partition_target_idx = -1;
+        if ($partition_count > 1) {
+            $max_rows = 0;
+            foreach ($jobs as $i => $job) {
+                $total = 0;
+                foreach ($job['sort_runs'] as $run) {
+                    $total += $run->count();
+                }
+                if ($total > $max_rows) {
+                    $max_rows = $total;
+                    $partition_target_idx = $i;
+                }
+            }
+        }
+
         /** @var list<array{int, int, string}> $pids [pid, job_index, job_name] */
         $pids = [];
         $result_paths = [];
@@ -2066,21 +2106,23 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             if ($pid === 0) {
                 $exit_code = 0;
                 try {
-                    $writer = SqliteRawWriter::openForPatchInSession($main_path, $counter_path);
-                    $empty_leaf = self::emptyIndexLeafPage($writer->page_size);
-                    $rootpage = $writer->appendPage($empty_leaf);
-                    $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
-                    try {
-                        $merger->merge($rootpage);
-                        file_put_contents($result_paths[$i], pack('N', $rootpage));
-                    } catch (OverflowNotSupportedException $_e) {
-                        // Fall through with an empty result so the
-                        // caller knows this index didn't populate;
-                        // the placeholder leaf at $rootpage is
-                        // harmless (no sqlite_master entry refers
-                        // to it).
+                    if ($i === $partition_target_idx && $partition_count > 1) {
+                        $rootpage = $this->mergeOneIndexPartitioned(
+                            $main_path,
+                            $counter_path,
+                            $job,
+                            $partition_count,
+                        );
+                    } else {
+                        $rootpage = $this->mergeOneIndex(
+                            $main_path,
+                            $counter_path,
+                            $job,
+                        );
                     }
-                    $writer->close($main_path);
+                    if ($rootpage !== null) {
+                        file_put_contents($result_paths[$i], pack('N', $rootpage));
+                    }
                 } catch (\Throwable $e) {
                     fwrite(STDERR, "L sub-sidecar {$job['name']}: " . $e->getMessage() . "\n");
                     $exit_code = 1;
@@ -2105,8 +2147,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 : '';
             @unlink($result_paths[$i]);
             if (strlen($data) >= 4) {
-                $rootpage = (int)unpack('N', substr($data, 0, 4))[1];
-                $populated[$name] = $rootpage;
+                $unpacked = unpack('N', substr($data, 0, 4));
+                if ($unpacked !== false) {
+                    $populated[$name] = (int)$unpacked[1];
+                }
             }
             // Empty $data means the merger threw OverflowNotSupported
             // and the caller's fallback path will rebuild the index.
@@ -2117,6 +2161,188 @@ final class PdoMemoryOutput implements MemoryOutputInterface
         }
 
         return $populated;
+    }
+
+    /**
+     * Build one integer index in-process. Returns the claimed
+     * rootpage, or null if the merger bailed (overflow / no data).
+     *
+     * @param array{name: string, sort_runs: list<SortRunReader>} $job
+     */
+    private function mergeOneIndex(
+        string $main_path,
+        string $counter_path,
+        array $job,
+    ): ?int {
+        $writer = SqliteRawWriter::openForPatchInSession($main_path, $counter_path);
+        $empty_leaf = self::emptyIndexLeafPage($writer->page_size);
+        $rootpage = $writer->appendPage($empty_leaf);
+        $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
+        $populated = null;
+        try {
+            $merger->merge($rootpage);
+            $populated = $rootpage;
+        } catch (OverflowNotSupportedException $_e) {
+            // Fall through; the placeholder leaf at $rootpage is
+            // harmless (no sqlite_master entry refers to it).
+        }
+        $writer->close($main_path);
+        return $populated;
+    }
+
+    /**
+     * Build one integer index by partitioning the (key, rowid)
+     * stream across `$partition_count` forked workers and
+     * assembling the resulting leaf list into a single interior
+     * tree at the end.
+     *
+     * Phases:
+     *   1. Sample 64 keys from each sort run, combine, sort, pick
+     *      the (`partition_count - 1`) quantile boundaries — the
+     *      key range each partition will own.
+     *   2. Fork one worker per partition; each builds its leaves
+     *      via {@see IntegerIndexMerger::extractLeavesForRange}.
+     *      Workers share the same SharedPgnoCounter so their
+     *      claimed leaf pgnos never collide. Each emits a
+     *      serialised `{leaves, rightmost_pgno}` payload to a
+     *      temp file.
+     *   3. Wait, collect leaves from every partition into one
+     *      ordered list (concatenation works because the key-
+     *      range boundaries make partitions key-disjoint and
+     *      already in global order).
+     *   4. Claim a fresh rootpage and call
+     *      {@see IntegerIndexMerger::assembleInteriorTree} to
+     *      build the interior level on top of the merged leaves.
+     *
+     * Theoretical wall-clock for the single index: max(per-
+     * partition merge times) instead of sum. The smaller integer
+     * indexes don't get this treatment — the gain wouldn't pay
+     * for the per-fork overhead at their size.
+     *
+     * @param array{name: string, sort_runs: list<SortRunReader>} $job
+     */
+    private function mergeOneIndexPartitioned(
+        string $main_path,
+        string $counter_path,
+        array $job,
+        int $partition_count,
+    ): ?int {
+        // Phase 1: sample boundaries.
+        /** @var list<int> $samples */
+        $samples = [];
+        foreach ($job['sort_runs'] as $run) {
+            foreach ($run->sampleKeys(64) as $k) {
+                $samples[] = $k;
+            }
+        }
+        if (count($samples) < $partition_count) {
+            // Not enough data to partition meaningfully — fall
+            // back to single-process merge.
+            return $this->mergeOneIndex($main_path, $counter_path, $job);
+        }
+        sort($samples);
+        $boundaries = [];
+        $samples_count = count($samples);
+        for ($p = 1; $p < $partition_count; $p++) {
+            $idx = (int)floor($samples_count * $p / $partition_count);
+            if ($idx >= $samples_count) {
+                $idx = $samples_count - 1;
+            }
+            $boundaries[] = $samples[$idx];
+        }
+        // Deduplicate adjacent boundaries — if the dataset has
+        // fewer distinct keys than partitions, some boundaries
+        // collapse and the affected partition would be empty.
+        $boundaries = array_values(array_unique($boundaries));
+        $effective_partition_count = count($boundaries) + 1;
+        if ($effective_partition_count < 2) {
+            return $this->mergeOneIndex($main_path, $counter_path, $job);
+        }
+
+        // Phase 2: fork partition workers.
+        /** @var array<int, int> $part_pids partition_idx => pid */
+        $part_pids = [];
+        $partition_paths = [];
+        for ($p = 0; $p < $effective_partition_count; $p++) {
+            $partition_paths[$p] = $main_path . '.l_part_' . $job['name'] . '_' . $p;
+            @unlink($partition_paths[$p]);
+            $low = $p === 0 ? null : $boundaries[$p - 1];
+            $high = $p === $effective_partition_count - 1 ? null : $boundaries[$p];
+            $is_global_rightmost = $p === $effective_partition_count - 1;
+            $pid = pcntl_fork();
+            if ($pid === -1) {
+                foreach ($part_pids as $running_pid) {
+                    posix_kill($running_pid, SIGTERM);
+                    pcntl_waitpid($running_pid, $_status);
+                }
+                foreach ($partition_paths as $pp) {
+                    @unlink($pp);
+                }
+                throw new \RuntimeException('L partition fork failed');
+            }
+            if ($pid === 0) {
+                $exit_code = 0;
+                try {
+                    $writer = SqliteRawWriter::openForPatchInSession($main_path, $counter_path);
+                    $merger = new IntegerIndexMerger($writer, $job['sort_runs']);
+                    $result = $merger->extractLeavesForRange($low, $high, $is_global_rightmost);
+                    $writer->close($main_path);
+                    file_put_contents($partition_paths[$p], serialize($result));
+                } catch (\Throwable $e) {
+                    fwrite(
+                        STDERR,
+                        "L partition {$job['name']}#{$p}: " . $e->getMessage() . "\n",
+                    );
+                    $exit_code = 1;
+                }
+                exit($exit_code);
+            }
+            $part_pids[$p] = $pid;
+        }
+
+        // Phase 3: collect leaves in partition order.
+        /** @var list<array{pgno: int, divider_payload: string}> $all_leaves */
+        $all_leaves = [];
+        $rightmost_pgno = null;
+        $any_failure = false;
+        for ($p = 0; $p < $effective_partition_count; $p++) {
+            pcntl_waitpid($part_pids[$p], $status);
+            $code = pcntl_wifexited($status) ? pcntl_wexitstatus($status) : 1;
+            if ($code !== 0) {
+                $any_failure = true;
+                @unlink($partition_paths[$p]);
+                continue;
+            }
+            $payload = file_exists($partition_paths[$p])
+                ? (string)file_get_contents($partition_paths[$p])
+                : '';
+            @unlink($partition_paths[$p]);
+            if ($payload === '') {
+                continue;
+            }
+            /** @var array{leaves: list<array{pgno: int, divider_payload: string}>, rightmost_pgno: ?int} $result */
+            $result = unserialize($payload);
+            foreach ($result['leaves'] as $leaf) {
+                $all_leaves[] = $leaf;
+            }
+            if ($result['rightmost_pgno'] !== null) {
+                $rightmost_pgno = $result['rightmost_pgno'];
+            }
+        }
+        if ($any_failure) {
+            throw new \RuntimeException('L partition worker failed for ' . $job['name']);
+        }
+
+        // Phase 4: claim rootpage, assemble interior tree.
+        $writer = SqliteRawWriter::openForPatchInSession($main_path, $counter_path);
+        $empty_leaf = self::emptyIndexLeafPage($writer->page_size);
+        $rootpage = $writer->appendPage($empty_leaf);
+        // Empty merger (no sort runs) — assembleInteriorTree only
+        // touches the writer.
+        $merger = new IntegerIndexMerger($writer, []);
+        $merger->assembleInteriorTree($all_leaves, $rightmost_pgno, $rootpage);
+        $writer->close($main_path);
+        return $rootpage;
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -1771,6 +1771,18 @@ final class PdoMemoryOutput implements MemoryOutputInterface
             // Serial path: run L sequentially first (claims its own
             // rootpages and emits them back to us), then the serial
             // createIndexes builds the remaining 7 indexes.
+            //
+            // After L's writable_schema INSERT we close + reopen the
+            // PDO handle before createIndexes runs. Reason: SQLite's
+            // schema-cache lives on the PDO connection, and a
+            // writable_schema INSERT made via the same connection
+            // *doesn't* update that connection's cache. The next
+            // CREATE INDEX IF NOT EXISTS would then see the cache
+            // saying "missing", try to create, and trip a
+            // sqlite_master duplicate-name violation against the
+            // row L just inserted — surfaced as
+            // `malformed database schema (...) - index ... already
+            // exists` on the next DB open.
             if ($l_eligible) {
                 unset($db);
                 $rootpages = $this->mergeIntegerIndexes($shard_paths, $main_path);
@@ -1778,6 +1790,10 @@ final class PdoMemoryOutput implements MemoryOutputInterface
                 $db->exec('PRAGMA synchronous = OFF');
                 $db->exec('PRAGMA temp_store = MEMORY');
                 $this->insertIntegerIndexSchemaEntries($db, $rootpages);
+                unset($db);
+                $db = $this->driver->createConnection();
+                $db->exec('PRAGMA synchronous = OFF');
+                $db->exec('PRAGMA temp_store = MEMORY');
             }
             $this->createIndexes($db);
         }

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -18,11 +18,15 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
  * shape (run_id INTEGER, key INTEGER, rowid INTEGER).
  *
  * Inputs are SortRun files dumped by workers, one per shard, each
- * already sorted by (key, rowid). The merger streams them through a
- * heap-of-iterators, encodes each merged record as a SQLite index
- * leaf cell (with the supplied real run_id prepended), and writes
- * the resulting b-tree to main, overwriting the empty index rootpage
- * SQLite created at CREATE INDEX time.
+ * already sorted by (key, rowid) AND already carrying the
+ * fully-encoded SQLite leaf cell for its row (since v2 of the
+ * sort-run format). The merger streams them through a
+ * heap-of-iterators and writes the cells verbatim into a freshly
+ * assembled b-tree at the empty index rootpage SQLite created at
+ * CREATE INDEX time. Per-row record encoding now happens once per
+ * row in the worker that produced the row, not per row in main —
+ * the encoding work parallelises across workers and the merge in
+ * main is heap-pull + memcpy.
  *
  * Index leaf cell shape:
  *   varint payload_size
@@ -35,9 +39,10 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
  *           entry in the left subtree)
  *
  * The merger refuses overflow (cell payload bigger than the inline
- * threshold). For 3-int payloads the encoded record is ≤ 26 bytes,
+ * threshold). For 3-int payloads the encoded record is ≤ 28 bytes,
  * comfortably below the 4061-byte inline limit, so overflow doesn't
- * happen in practice.
+ * happen in practice — the SortRunWriter's u8 cell_len field also
+ * caps any record at 255 bytes upstream.
  *
  * @psalm-suppress MixedArgument
  * @psalm-suppress MixedAssignment
@@ -61,7 +66,6 @@ final class IntegerIndexMerger
     public function __construct(
         private Writer $main,
         private array $sort_runs,
-        private int $run_id,
     ) {
     }
 
@@ -85,17 +89,33 @@ final class IntegerIndexMerger
         $payloads = [];
         $cells_size = 0;
 
-        foreach ($this->mergeStream() as [$key, $rowid]) {
-            $payload = RecordEncoder::encodeIntegerRow([$this->run_id, $key, $rowid]);
-            if (strlen($payload) > $inline_max) {
+        foreach ($this->mergeStream() as [$_key, $_rowid, $cell]) {
+            // $cell is the worker-encoded leaf cell:
+            //   varint(payload_size) + payload(record bytes).
+            // Strip the size varint to get the payload bytes — we
+            // need the raw payload as the divider when promoting,
+            // and we need the cell as a unit when packing leaves.
+            $cell_len = strlen($cell);
+            // Payload size in our records is < 128 so the size
+            // varint is one byte; we still bail to the generic
+            // varint reader for any record that lies in the
+            // multi-byte range, just in case.
+            $size_byte = ord($cell[0]);
+            if ($size_byte < 0x80) {
+                $payload_size = $size_byte;
+                $sz_len = 1;
+            } else {
+                [$payload_size, $sz_len] = Format::readVarint($cell, 0);
+            }
+            if ($payload_size > $inline_max) {
                 throw new OverflowNotSupportedException(
                     'integer index payload exceeds inline threshold ('
-                    . strlen($payload) . ' > ' . $inline_max . ')'
+                    . $payload_size . ' > ' . $inline_max . ')'
                 );
             }
-            $cell = Format::writeVarint(strlen($payload)) . $payload;
+            $payload = substr($cell, $sz_len, $payload_size);
 
-            $needed = 8 + (count($cells) + 1) * 2 + $cells_size + strlen($cell);
+            $needed = 8 + (count($cells) + 1) * 2 + $cells_size + $cell_len;
             if ($needed > $page_size && count($cells) > 0) {
                 // Promote the last cell as the divider; emit the
                 // remaining cells (still ≥ 1 because we required
@@ -136,7 +156,7 @@ final class IntegerIndexMerger
             }
             $cells[] = $cell;
             $payloads[] = $payload;
-            $cells_size += strlen($cell);
+            $cells_size += $cell_len;
         }
 
         // Final partial buffer becomes the rightmost leaf; no
@@ -213,8 +233,11 @@ final class IntegerIndexMerger
     }
 
     /**
-     * K-way merge generator. Yields each (key, rowid) in ascending
-     * order across all sort runs.
+     * K-way merge generator. Yields each (key, rowid, cell) in
+     * ascending (key, rowid) order across all sort runs. `cell` is
+     * the worker-encoded SQLite leaf cell bytes for that row,
+     * ready to drop into the result leaf without further per-row
+     * encoding work.
      *
      * Uses a manual array-backed binary min-heap with three parallel
      * arrays (keys / rowids / source-indexes) instead of
@@ -224,7 +247,7 @@ final class IntegerIndexMerger
      * dominates the merge time. The manual heap stays in pure PHP
      * but does only int comparisons inline, no method dispatch.
      *
-     * @return \Generator<int, array{int, int}>
+     * @return \Generator<int, array{int, int, string}>
      */
     private function mergeStream(): \Generator
     {
@@ -237,29 +260,29 @@ final class IntegerIndexMerger
 
         foreach ($this->sort_runs as $i => $run) {
             if ($run->hasMore()) {
-                [$k, $r] = $run->peek();
+                [$k, $r, $_c] = $run->peek();
                 $keys[] = $k;
                 $rowids[] = $r;
                 $sources[] = $i;
             }
         }
         $size = count($keys);
-        // No initial sift-up needed: source iterators were inserted
-        // in worker order, but the merge contract only requires the
-        // heap property eventually. Heapify the array.
         for ($i = ($size >> 1) - 1; $i >= 0; $i--) {
             $this->siftDown($keys, $rowids, $sources, $i, $size);
         }
 
         while ($size > 0) {
-            $top_key = $keys[0];
-            $top_rowid = $rowids[0];
             $top_source = $sources[0];
-            yield [$top_key, $top_rowid];
+            // Re-peek the cell bytes from the source — the heap only
+            // tracks (key, rowid) so we don't have to copy variable
+            // strings around on every sift-down. The peek is just an
+            // array index into the reader's pre-decoded arrays.
+            [$top_key, $top_rowid, $top_cell] = $this->sort_runs[$top_source]->peek();
+            yield [$top_key, $top_rowid, $top_cell];
 
             $this->sort_runs[$top_source]->advance();
             if ($this->sort_runs[$top_source]->hasMore()) {
-                [$nk, $nr] = $this->sort_runs[$top_source]->peek();
+                [$nk, $nr, $_nc] = $this->sort_runs[$top_source]->peek();
                 $keys[0] = $nk;
                 $rowids[0] = $nr;
                 // sources[0] stays the same — we're just replacing the
@@ -321,87 +344,6 @@ final class IntegerIndexMerger
         $keys[$i] = $k;
         $rowids[$i] = $r;
         $sources[$i] = $s;
-    }
-
-    /**
-     * Decode a leaf cell back to (key, rowid). Used to compute the
-     * "max key in this leaf" record we hand the interior page.
-     *
-     * @return array{int, int}
-     */
-    private function lastDecoded(string $cell): array
-    {
-        [$payload_size, $sz_len] = Format::readVarint($cell, 0);
-        $payload_offset = $sz_len;
-
-        // Record header: varint header_size, then varint type codes.
-        [$_header_size, $hl] = Format::readVarint($cell, $payload_offset);
-        $hdr = $payload_offset + $hl;
-        $type_codes = [];
-        $end = $payload_offset + $_header_size;
-        while ($hdr < $end) {
-            [$tc, $tl] = Format::readVarint($cell, $hdr);
-            $type_codes[] = $tc;
-            $hdr += $tl;
-        }
-        // Skip column 0 (run_id) body.
-        $body = $end;
-        $body += $this->bodySizeFor($type_codes[0]);
-        $key = $this->decodeIntegerColumn($cell, $body, $type_codes[1]);
-        $body += $this->bodySizeFor($type_codes[1]);
-        $rowid = $this->decodeIntegerColumn($cell, $body, $type_codes[2]);
-        return [$key, $rowid];
-    }
-
-    private function bodySizeFor(int $type_code): int
-    {
-        return match (true) {
-            $type_code === 0, $type_code === 8, $type_code === 9 => 0,
-            $type_code === 1 => 1,
-            $type_code === 2 => 2,
-            $type_code === 3 => 3,
-            $type_code === 4 => 4,
-            $type_code === 5 => 6,
-            $type_code === 6 => 8,
-            default => throw new \RuntimeException("unsupported type code in lastDecoded: {$type_code}"),
-        };
-    }
-
-    private function decodeIntegerColumn(string $bytes, int $offset, int $type_code): int
-    {
-        switch ($type_code) {
-            case 0:
-                return 0;
-            case 8:
-                return 0;
-            case 9:
-                return 1;
-            case 1:
-                $b = ord($bytes[$offset]);
-                return $b >= 128 ? $b - 256 : $b;
-            case 2:
-                $v = (int)unpack('n', substr($bytes, $offset, 2))[1];
-                return $v >= 0x8000 ? $v - 0x10000 : $v;
-            case 3:
-                $bs = unpack('C3', substr($bytes, $offset, 3));
-                $v = ($bs[1] << 16) | ($bs[2] << 8) | $bs[3];
-                return $v >= 0x800000 ? $v - 0x1000000 : $v;
-            case 4:
-                $v = (int)unpack('N', substr($bytes, $offset, 4))[1];
-                return $v >= 0x80000000 ? $v - 0x100000000 : $v;
-            case 5:
-                $bs = unpack('C6', substr($bytes, $offset, 6));
-                $v = ($bs[1] << 40) | ($bs[2] << 32) | ($bs[3] << 24)
-                    | ($bs[4] << 16) | ($bs[5] << 8) | $bs[6];
-                if ($v >= (1 << 47)) {
-                    $v -= (1 << 48);
-                }
-                return $v;
-            case 6:
-                return (int)unpack('J', substr($bytes, $offset, 8))[1];
-            default:
-                throw new \RuntimeException("unsupported integer type code: {$type_code}");
-        }
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -123,6 +123,14 @@ final class IntegerIndexMerger
         /** @var list<string> $payloads */
         $payloads = [];
         $cells_size = 0;
+        // Most-recent flushed leaf — kept around so the tail block
+        // can re-absorb the previously-promoted cell + the lone tail
+        // cell back into it when a non-rightmost partition's tail
+        // ends up with exactly one cell. See the bug-B note in the
+        // tail block below.
+        /** @var list<string>|null $prev_full_cells */
+        $prev_full_cells = null;
+        $prev_pgno = 0;
 
         foreach ($this->mergeStream() as [$key, $_rowid, $cell]) {
             if ($low_inclusive !== null && $key < $low_inclusive) {
@@ -167,6 +175,12 @@ final class IntegerIndexMerger
                 $promoted_payload = $payloads[count($payloads) - 1];
                 $promoted_cell = $cells[count($cells) - 1];
                 $promoted_cell_size = strlen($promoted_cell);
+                // Snapshot the full cell list (still including the
+                // promoted cell) so the tail block can put it back
+                // into the leaf if it ends up with a single tail
+                // cell that would otherwise duplicate as both leaf
+                // entry and interior divider.
+                $full_cells_before_pop = $cells;
                 $cells_size -= $promoted_cell_size;
                 array_pop($cells);
                 array_pop($payloads);
@@ -194,6 +208,8 @@ final class IntegerIndexMerger
                         'divider_payload' => $promoted_payload,
                     ];
                 }
+                $prev_full_cells = $full_cells_before_pop;
+                $prev_pgno = $pgno;
                 $cells = [];
                 $payloads = [];
                 $cells_size = 0;
@@ -219,21 +235,61 @@ final class IntegerIndexMerger
                 $promoted_cell_size = strlen($promoted_cell);
                 array_pop($cells);
                 array_pop($payloads);
-                if ($cells === []) {
-                    // Single-cell-leaf case: keep the only cell in
-                    // the leaf and use it as the divider too. The
-                    // next partition's first cell strictly compares
-                    // greater, so the divider key is correctly
-                    // "max key in left subtree".
-                    $cells[] = $promoted_cell;
-                    $payloads[] = $promoted_payload;
+                if ($cells === [] && $prev_full_cells !== null) {
+                    // Bug B: when a non-rightmost partition's
+                    // entry count is (272 * k + 1) for k ≥ 1 — i.e.
+                    // a full leaf cycle plus one orphan cell — the
+                    // tail is exactly one cell. Promoting it as
+                    // the divider and also keeping it in the leaf
+                    // (the old fallback) writes the same cell twice
+                    // into the b-tree (once in the leaf, once in
+                    // the parent interior page) and trips
+                    // PRAGMA integrity_check with "wrong # of
+                    // entries in index". The cell is also visible
+                    // to a full-table scan as an extra row whose
+                    // rowid duplicates an existing one — silent
+                    // table corruption everything except
+                    // integrity_check happily ignores.
+                    //
+                    // Fix: re-absorb the lone cell into the
+                    // previously-flushed leaf. The old leaf had
+                    // 271 cells in the page + 1 promoted divider
+                    // = 272 entries; we re-build it with all 272
+                    // cells in the page, overwrite the leaf at the
+                    // same pgno, and let the lone tail cell take
+                    // over as the new divider. Total entries are
+                    // unchanged (271 + 1 → 272 + 1, but the
+                    // previously-promoted cell got moved from
+                    // interior back into the leaf so the count is
+                    // identical).
+                    $merged_page = $this->buildLeafPage(
+                        $prev_full_cells,
+                        $page_size,
+                    );
+                    $this->main->writePage($prev_pgno, $merged_page);
+                    $last_idx = count($leaves_with_dividers) - 1;
+                    $leaves_with_dividers[$last_idx]['divider_payload']
+                        = $promoted_payload;
+                } else {
+                    if ($cells === []) {
+                        // Single-cell-leaf with no previous leaf to
+                        // merge into: the partition has exactly one
+                        // entry. Keep the cell in the leaf and use
+                        // it as the divider too — produces the same
+                        // +1 inflation as the legacy fallback, but
+                        // the partition-with-1-entry corner is rare
+                        // in practice (would need the boundary
+                        // sampler to bracket a 1-key range).
+                        $cells[] = $promoted_cell;
+                        $payloads[] = $promoted_payload;
+                    }
+                    $page = $this->buildLeafPage($cells, $page_size);
+                    $pgno = $this->main->appendPage($page);
+                    $leaves_with_dividers[] = [
+                        'pgno' => $pgno,
+                        'divider_payload' => $promoted_payload,
+                    ];
                 }
-                $page = $this->buildLeafPage($cells, $page_size);
-                $pgno = $this->main->appendPage($page);
-                $leaves_with_dividers[] = [
-                    'pgno' => $pgno,
-                    'divider_payload' => $promoted_payload,
-                ];
             }
         }
 

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -267,12 +267,18 @@ final class IntegerIndexMerger
                         $page_size,
                     );
                     $this->main->writePage($prev_pgno, $merged_page);
-                    $last_idx = count($leaves_with_dividers) - 1;
-                    \assert($last_idx >= 0); // $prev_pgno !== 0 implies the
-                    //                          loop already pushed at least
-                    //                          one leaf.
-                    $leaves_with_dividers[$last_idx]['divider_payload']
-                        = $promoted_payload;
+                    // Replace the previous leaf's divider payload by
+                    // popping the old entry and re-pushing with the
+                    // lone tail cell as the new divider. Pop+push
+                    // preserves the `list<…>` shape psalm tracks; an
+                    // indexed `[…]['divider_payload'] = …` write
+                    // widens it to `array<int, …>` and breaks the
+                    // declared return type.
+                    array_pop($leaves_with_dividers);
+                    $leaves_with_dividers[] = [
+                        'pgno' => $prev_pgno,
+                        'divider_payload' => $promoted_payload,
+                    ];
                 } else {
                     if ($cells === []) {
                         // Single-cell-leaf with no previous leaf to

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -69,8 +69,43 @@ final class IntegerIndexMerger
     ) {
     }
 
+    /**
+     * Build the index and write its root at `$main_index_rootpage`.
+     */
     public function merge(int $main_index_rootpage): void
     {
+        ['leaves' => $leaves_with_dividers, 'rightmost_pgno' => $rightmost_pgno] =
+            $this->extractLeavesForRange(null, null, true);
+        $this->assembleInteriorTree(
+            $leaves_with_dividers,
+            $rightmost_pgno,
+            $main_index_rootpage,
+        );
+    }
+
+    /**
+     * Build leaves for the (key, rowid) entries that fall inside
+     * `[$low_inclusive, $high_exclusive)`, using the existing k-way
+     * merge over the supplied sort runs and the same SQLite leaf
+     * encoding that {@see merge} uses. Used for the parallel-
+     * partition path: each partition worker invokes this with its
+     * own key window and emits its leaves to the shared writer.
+     *
+     * `$is_global_rightmost` controls how the partition's last leaf
+     * is treated:
+     *   - true : the last leaf is the global rightmost, no
+     *            promotion (returned via `rightmost_pgno`).
+     *   - false: the last leaf gets its last cell promoted as the
+     *            divider into the next partition (added to the
+     *            `leaves` list, `rightmost_pgno` is null).
+     *
+     * @return array{leaves: list<array{pgno: int, divider_payload: string}>, rightmost_pgno: ?int}
+     */
+    public function extractLeavesForRange(
+        ?int $low_inclusive,
+        ?int $high_exclusive,
+        bool $is_global_rightmost,
+    ): array {
         $page_size = $this->main->page_size;
         $inline_max = $page_size - 35;
 
@@ -89,7 +124,16 @@ final class IntegerIndexMerger
         $payloads = [];
         $cells_size = 0;
 
-        foreach ($this->mergeStream() as [$_key, $_rowid, $cell]) {
+        foreach ($this->mergeStream() as [$key, $_rowid, $cell]) {
+            if ($low_inclusive !== null && $key < $low_inclusive) {
+                continue;
+            }
+            if ($high_exclusive !== null && $key >= $high_exclusive) {
+                // Sort runs are sorted by (key, rowid), so once we
+                // pass `$high_exclusive` no later entry can fall
+                // back into our window.
+                break;
+            }
             // $cell is the worker-encoded leaf cell:
             //   varint(payload_size) + payload(record bytes).
             // Strip the size varint to get the payload bytes — we
@@ -159,24 +203,71 @@ final class IntegerIndexMerger
             $cells_size += $cell_len;
         }
 
-        // Final partial buffer becomes the rightmost leaf; no
-        // promotion (the rightmost has no divider in the interior
-        // page — the rightmost-child pointer lives in the page
-        // header instead).
-        $rightmost_pgno = 0;
+        // Final partial buffer. If this is the global rightmost
+        // partition the last leaf carries no divider (its content
+        // is the rightmost-child pointer in the parent interior
+        // page); otherwise we promote its last cell as the divider
+        // into the next partition.
+        $rightmost_pgno = null;
         if (count($cells) > 0) {
-            $page = $this->buildLeafPage($cells, $page_size);
-            $rightmost_pgno = $this->main->appendPage($page);
+            if ($is_global_rightmost) {
+                $page = $this->buildLeafPage($cells, $page_size);
+                $rightmost_pgno = $this->main->appendPage($page);
+            } else {
+                $promoted_payload = $payloads[count($payloads) - 1];
+                $promoted_cell = $cells[count($cells) - 1];
+                $promoted_cell_size = strlen($promoted_cell);
+                array_pop($cells);
+                array_pop($payloads);
+                if ($cells === []) {
+                    // Single-cell-leaf case: keep the only cell in
+                    // the leaf and use it as the divider too. The
+                    // next partition's first cell strictly compares
+                    // greater, so the divider key is correctly
+                    // "max key in left subtree".
+                    $cells[] = $promoted_cell;
+                    $payloads[] = $promoted_payload;
+                }
+                $page = $this->buildLeafPage($cells, $page_size);
+                $pgno = $this->main->appendPage($page);
+                $leaves_with_dividers[] = [
+                    'pgno' => $pgno,
+                    'divider_payload' => $promoted_payload,
+                ];
+            }
         }
 
-        if ($leaves_with_dividers === [] && $rightmost_pgno === 0) {
-            // No data — leave the empty leaf in place.
-            return;
-        }
+        return ['leaves' => $leaves_with_dividers, 'rightmost_pgno' => $rightmost_pgno];
+    }
 
-        if ($leaves_with_dividers === [] && $rightmost_pgno !== 0) {
+    /**
+     * Build the interior tree on top of an already-laid-out leaf
+     * level, write the resulting root at `$main_index_rootpage`.
+     *
+     * `$leaves_with_dividers` is the ordered list of non-rightmost
+     * leaves with their promoted divider payloads. `$rightmost_pgno`
+     * is the global rightmost leaf (or null if the entire range
+     * is empty).
+     *
+     * @param list<array{pgno: int, divider_payload: string}> $leaves_with_dividers
+     */
+    public function assembleInteriorTree(
+        array $leaves_with_dividers,
+        ?int $rightmost_pgno,
+        int $main_index_rootpage,
+    ): void {
+        $page_size = $this->main->page_size;
+
+        if ($leaves_with_dividers === []) {
+            if ($rightmost_pgno === null) {
+                // No data — leave the empty leaf in place.
+                return;
+            }
             // Only one leaf; copy it over the rootpage.
-            $this->main->writePage($main_index_rootpage, $this->main->readPage($rightmost_pgno));
+            $this->main->writePage(
+                $main_index_rootpage,
+                $this->main->readPage($rightmost_pgno),
+            );
             return;
         }
 
@@ -184,9 +275,18 @@ final class IntegerIndexMerger
         // the leaves, then recurse upward.
         /** @var list<array{pgno: int, divider_payload: string}> $level */
         $level = $leaves_with_dividers;
-        // The very last child of this level is the rightmost leaf
-        // (which has no divider).
-        $rightmost = $rightmost_pgno;
+        // The very last child of this level is the rightmost leaf.
+        // If a non-rightmost-only partition trail returned no
+        // explicit rightmost, fall back to treating the last entry
+        // in $leaves_with_dividers as it (its divider becomes
+        // unused at the top of the tree).
+        if ($rightmost_pgno === null) {
+            $last = array_pop($level);
+            \assert($last !== null);
+            $rightmost = $last['pgno'];
+        } else {
+            $rightmost = $rightmost_pgno;
+        }
 
         $max_children = $this->maxInteriorCellCount($page_size);
         while (count($level) >= $max_children) {

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMerger.php
@@ -268,6 +268,9 @@ final class IntegerIndexMerger
                     );
                     $this->main->writePage($prev_pgno, $merged_page);
                     $last_idx = count($leaves_with_dividers) - 1;
+                    \assert($last_idx >= 0); // $prev_pgno !== 0 implies the
+                    //                          loop already pushed at least
+                    //                          one leaf.
                     $leaves_with_dividers[$last_idx]['divider_payload']
                         = $promoted_payload;
                 } else {

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/ParallelIndexBuilder.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/ParallelIndexBuilder.php
@@ -113,6 +113,7 @@ final class ParallelIndexBuilder
         array $index_specs,
         int $worker_count,
         int $pages_per_index_reservation = self::PAGES_PER_INDEX_RESERVATION_FLOOR,
+        ?\Closure $sidecar = null,
     ): ?array {
         if (
             !extension_loaded('ffi')
@@ -122,6 +123,10 @@ final class ParallelIndexBuilder
             return null;
         }
         if ($index_specs === []) {
+            // Nothing to build. Even if a sidecar is supplied, the
+            // empty-specs path doesn't allocate page space for it,
+            // so the caller is expected to fall back to a serial
+            // path for the sidecar work in this corner.
             return [0];
         }
         $worker_count = max(1, min($worker_count, count($index_specs)));
@@ -200,6 +205,38 @@ final class ParallelIndexBuilder
         [$data_ptr, $data_len, $data_fd] = $data_res;
         [$meta_ptr, $meta_len, $meta_fd] = $meta_res;
 
+        // If the caller supplied a sidecar closure (typically the
+        // format-direct integer-index merge), fork it before the
+        // worker fan-out so it gets to share the same atomic pgno
+        // counter and ftruncated file region. The sidecar is a
+        // peer of the workers, not nested inside them — it pwrites
+        // to disjoint pgno ranges via the same counter and cleans
+        // up its own writer.
+        $sidecar_pid = null;
+        if ($sidecar !== null) {
+            $sidecar_pid = pcntl_fork();
+            if ($sidecar_pid === -1) {
+                LibcFileWriter::munmap($data_ptr, $data_len);
+                LibcFileWriter::munmap($meta_ptr, $meta_len);
+                LibcFileWriter::close($data_fd);
+                LibcFileWriter::close($meta_fd);
+                @unlink($meta_path);
+                @unlink($counter_path);
+                throw new \RuntimeException(
+                    'ParallelIndexBuilder: pcntl_fork failed for sidecar'
+                );
+            }
+            if ($sidecar_pid === 0) {
+                try {
+                    $sidecar($counter_path);
+                    exit(0);
+                } catch (\Throwable $e) {
+                    fwrite(STDERR, 'ParallelIndexBuilder sidecar: ' . $e->getMessage() . "\n");
+                    exit(1);
+                }
+            }
+        }
+
         $any_failure = false;
         try {
             $pids = [];
@@ -242,6 +279,15 @@ final class ParallelIndexBuilder
             }
             foreach ($shard_paths as $sp) {
                 @unlink($sp);
+            }
+            if ($sidecar_pid !== null) {
+                pcntl_waitpid($sidecar_pid, $sidecar_status);
+                $sidecar_code = pcntl_wifexited($sidecar_status)
+                    ? pcntl_wexitstatus($sidecar_status)
+                    : 1;
+                if ($sidecar_code !== 0) {
+                    $any_failure = true;
+                }
             }
             if ($any_failure) {
                 throw new \RuntimeException(

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
@@ -14,72 +14,75 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 
 /**
- * Streaming reader for a SortRunWriter v2 file. Whole file is loaded
- * once and decoded into three parallel arrays (keys, rowids, cells)
- * up front; for our use case sort runs are bounded by shard size and
- * live for the duration of the merge.
+ * Streaming reader for a SortRunWriter v3 file.
  *
- * Decoding is one O(N) pass that resolves variable-length cell offsets
- * — the file format itself is variable-length per record, but at peek
- * time we only do array-index lookups, no per-record substr/unpack.
+ * The file lays each column out in its own contiguous section so we
+ * can bulk-`unpack` keys / rowids / cell offsets in three C-side
+ * calls instead of N small per-record substr+unpack. Cell bytes are
+ * concatenated in a single trailing section; per-record cell length
+ * is `cell_offsets[i+1] - cell_offsets[i]` (or
+ * `cell_data_size - cell_offsets[last]` for the last record), so we
+ * never have to store an explicit length array.
  *
  * @psalm-suppress MixedArgument
  * @psalm-suppress MixedAssignment
  * @psalm-suppress MixedArrayAccess
  * @psalm-suppress MixedReturnStatement
  * @psalm-suppress PossiblyInvalidArrayAccess
+ * @psalm-suppress MixedReturnTypeCoercion
  */
 final class SortRunReader
 {
     private int $count;
     private int $cursor = 0;
-    /** @var list<int> */
+    /** @var array<int, int> 1-indexed (PHP unpack convention) */
     private array $keys;
-    /** @var list<int> */
+    /** @var array<int, int> 1-indexed */
     private array $rowids;
-    /** @var list<string> */
-    private array $cells;
+    /** @var array<int, int> 1-indexed */
+    private array $cell_offsets;
+    private string $cell_data;
+    private int $cell_data_size;
 
     public function __construct(string $path)
     {
         $bytes = file_get_contents($path);
-        if ($bytes === false || strlen($bytes) < 4) {
+        if ($bytes === false || strlen($bytes) < 8) {
             throw new \RuntimeException("failed to open sort run file for read: {$path}");
         }
-        $this->count = (int)unpack('N', substr($bytes, 0, 4))[1];
+        $count = (int)unpack('N', substr($bytes, 0, 4))[1];
+        $cell_data_size = (int)unpack('N', substr($bytes, 4, 4))[1];
+        $this->count = $count;
+        $this->cell_data_size = $cell_data_size;
 
-        $keys = [];
-        $rowids = [];
-        $cells = [];
-        $cursor = 4;
-        $total = strlen($bytes);
-        for ($i = 0; $i < $this->count; $i++) {
-            if ($cursor + 17 > $total) {
-                throw new \RuntimeException(
-                    "sort run file truncated at record {$i} (offset {$cursor})"
-                );
-            }
-            $r = unpack('Jkey/Jrowid/Clen', substr($bytes, $cursor, 17));
-            $cursor += 17;
-            $cell_len = (int)$r['len'];
-            if ($cursor + $cell_len > $total) {
-                throw new \RuntimeException(
-                    "sort run file cell truncated at record {$i}"
-                );
-            }
-            $keys[] = (int)$r['key'];
-            $rowids[] = (int)$r['rowid'];
-            $cells[] = substr($bytes, $cursor, $cell_len);
-            $cursor += $cell_len;
-        }
-        if ($cursor !== $total) {
+        $expected = 8 + $count * 8 + $count * 8 + $count * 4 + $cell_data_size;
+        if (strlen($bytes) !== $expected) {
             throw new \RuntimeException(
-                "sort run file has trailing garbage: parsed {$cursor} bytes, file is {$total}"
+                "sort run file size mismatch: expected {$expected}, got " . strlen($bytes)
             );
         }
-        $this->keys = $keys;
-        $this->rowids = $rowids;
-        $this->cells = $cells;
+
+        if ($count > 0) {
+            $keys_off = 8;
+            $rowids_off = $keys_off + $count * 8;
+            $offsets_off = $rowids_off + $count * 8;
+            $cells_off = $offsets_off + $count * 4;
+            /** @var array<int, int> $keys */
+            $keys = unpack("J{$count}", $bytes, $keys_off);
+            /** @var array<int, int> $rowids */
+            $rowids = unpack("J{$count}", $bytes, $rowids_off);
+            /** @var array<int, int> $cell_offsets */
+            $cell_offsets = unpack("N{$count}", $bytes, $offsets_off);
+            $this->keys = $keys;
+            $this->rowids = $rowids;
+            $this->cell_offsets = $cell_offsets;
+            $this->cell_data = substr($bytes, $cells_off);
+        } else {
+            $this->keys = [];
+            $this->rowids = [];
+            $this->cell_offsets = [];
+            $this->cell_data = '';
+        }
     }
 
     public function count(): int
@@ -106,8 +109,14 @@ final class SortRunReader
         if (!$this->hasMore()) {
             throw new \RuntimeException('sort run reader is exhausted');
         }
-        $i = $this->cursor;
-        return [$this->keys[$i], $this->rowids[$i], $this->cells[$i]];
+        // unpack arrays are 1-indexed.
+        $i1 = $this->cursor + 1;
+        $offset = $this->cell_offsets[$i1];
+        $next_offset = $i1 < $this->count
+            ? $this->cell_offsets[$i1 + 1]
+            : $this->cell_data_size;
+        $cell = substr($this->cell_data, $offset, $next_offset - $offset);
+        return [$this->keys[$i1], $this->rowids[$i1], $cell];
     }
 
     public function advance(): void

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
@@ -14,9 +14,14 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 
 /**
- * Streaming reader for a SortRunWriter file. Whole file is loaded
- * into memory once at construction; for our use case sort runs are
- * bounded by shard size and live for the duration of the merge.
+ * Streaming reader for a SortRunWriter v2 file. Whole file is loaded
+ * once and decoded into three parallel arrays (keys, rowids, cells)
+ * up front; for our use case sort runs are bounded by shard size and
+ * live for the duration of the merge.
+ *
+ * Decoding is one O(N) pass that resolves variable-length cell offsets
+ * — the file format itself is variable-length per record, but at peek
+ * time we only do array-index lookups, no per-record substr/unpack.
  *
  * @psalm-suppress MixedArgument
  * @psalm-suppress MixedAssignment
@@ -26,9 +31,14 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
  */
 final class SortRunReader
 {
-    private string $bytes;
     private int $count;
     private int $cursor = 0;
+    /** @var list<int> */
+    private array $keys;
+    /** @var list<int> */
+    private array $rowids;
+    /** @var list<string> */
+    private array $cells;
 
     public function __construct(string $path)
     {
@@ -36,14 +46,40 @@ final class SortRunReader
         if ($bytes === false || strlen($bytes) < 4) {
             throw new \RuntimeException("failed to open sort run file for read: {$path}");
         }
-        $this->bytes = $bytes;
         $this->count = (int)unpack('N', substr($bytes, 0, 4))[1];
-        $expected_size = 4 + $this->count * 16;
-        if (strlen($bytes) !== $expected_size) {
+
+        $keys = [];
+        $rowids = [];
+        $cells = [];
+        $cursor = 4;
+        $total = strlen($bytes);
+        for ($i = 0; $i < $this->count; $i++) {
+            if ($cursor + 17 > $total) {
+                throw new \RuntimeException(
+                    "sort run file truncated at record {$i} (offset {$cursor})"
+                );
+            }
+            $r = unpack('Jkey/Jrowid/Clen', substr($bytes, $cursor, 17));
+            $cursor += 17;
+            $cell_len = (int)$r['len'];
+            if ($cursor + $cell_len > $total) {
+                throw new \RuntimeException(
+                    "sort run file cell truncated at record {$i}"
+                );
+            }
+            $keys[] = (int)$r['key'];
+            $rowids[] = (int)$r['rowid'];
+            $cells[] = substr($bytes, $cursor, $cell_len);
+            $cursor += $cell_len;
+        }
+        if ($cursor !== $total) {
             throw new \RuntimeException(
-                "sort run file truncated: expected {$expected_size}, got " . strlen($bytes)
+                "sort run file has trailing garbage: parsed {$cursor} bytes, file is {$total}"
             );
         }
+        $this->keys = $keys;
+        $this->rowids = $rowids;
+        $this->cells = $cells;
     }
 
     public function count(): int
@@ -57,18 +93,21 @@ final class SortRunReader
     }
 
     /**
-     * Peek the current (key, rowid). Does not advance the cursor.
+     * Peek the current (key, rowid, cell). Does not advance the cursor.
      *
-     * @return array{int, int}
+     * The cell is the SQLite leaf cell bytes (varint(payload_size) +
+     * payload), pre-encoded by the worker against a known run_id —
+     * the merger appends it verbatim into the resulting leaf.
+     *
+     * @return array{int, int, string}
      */
     public function peek(): array
     {
         if (!$this->hasMore()) {
             throw new \RuntimeException('sort run reader is exhausted');
         }
-        $offset = 4 + $this->cursor * 16;
-        $r = unpack('Jkey/Jrowid', substr($this->bytes, $offset, 16));
-        return [(int)$r['key'], (int)$r['rowid']];
+        $i = $this->cursor;
+        return [$this->keys[$i], $this->rowids[$i], $this->cells[$i]];
     }
 
     public function advance(): void

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
@@ -85,6 +85,31 @@ final class SortRunReader
         }
     }
 
+    /**
+     * Sample up to `$sample_count` keys uniformly across this sort
+     * run. Used by the parallel-partition path to derive global
+     * key boundaries by combining samples from every shard.
+     *
+     * @return list<int>
+     */
+    public function sampleKeys(int $sample_count): array
+    {
+        if ($this->count === 0 || $sample_count <= 0) {
+            return [];
+        }
+        $sample_count = min($sample_count, $this->count);
+        $samples = [];
+        for ($i = 0; $i < $sample_count; $i++) {
+            // 1-indexed array; pick uniformly across the run.
+            $idx = (int)floor(((float)$i + 0.5) * $this->count / $sample_count) + 1;
+            if ($idx > $this->count) {
+                $idx = $this->count;
+            }
+            $samples[] = $this->keys[$idx];
+        }
+        return $samples;
+    }
+
     public function count(): int
     {
         return $this->count;

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunReader.php
@@ -101,7 +101,7 @@ final class SortRunReader
         $samples = [];
         for ($i = 0; $i < $sample_count; $i++) {
             // 1-indexed array; pick uniformly across the run.
-            $idx = (int)floor(((float)$i + 0.5) * $this->count / $sample_count) + 1;
+            $idx = (int)floor(((float)$i + 0.5) * (float)$this->count / (float)$sample_count) + 1;
             if ($idx > $this->count) {
                 $idx = $this->count;
             }

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunWriter.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunWriter.php
@@ -16,23 +16,19 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 /**
  * Per-shard sort-run file for a single integer index.
  *
- * File layout (v2 — cells pre-encoded by the worker):
+ * File layout (v3 — parallel-array sections so the reader can bulk
+ * `unpack` each column in one C call):
  *   [u32 BE record count]
- *   record_count × [
- *     i64 BE key,          // sort key
- *     i64 BE rowid,        // tiebreaker
- *     u8 cell_len,         // bytes in the encoded cell that follows
- *     cell_len bytes cell  // SQLite leaf cell: varint(payload_size) + record_payload
- *   ]
+ *   [u32 BE cell_data_size]                        // bytes in the cell-data section
+ *   record_count × i64 BE key                      // sort key
+ *   record_count × i64 BE rowid                    // tiebreaker
+ *   record_count × u32 BE cell_offset              // offset within the cell-data section
+ *   cell_data_size bytes                           // concatenated SQLite leaf cell bytes
  *
- * The cell is encoded by the worker against the freshly-allocated
- * `run_id` passed to the constructor — that is the only run_id the
- * resulting index will ever carry, so encoding it once per worker (in
- * parallel) is strictly cheaper than the previous scheme where main
- * called `RecordEncoder::encodeIntegerRow([$run_id, $key, $rowid])`
- * per row in the k-way merge. The merger now does heap pull + memcpy
- * only and the per-row record-encoding cost moves off the critical
- * path entirely.
+ * The cell bytes are encoded by the worker against the constructor-
+ * supplied `run_id` — the only run_id the resulting index will ever
+ * carry — so encoding parallelises across shards and the merger does
+ * heap pull + memcpy only.
  *
  * Records must be appended in (key, rowid) ascending order — the
  * worker is expected to extract them in sorted order via
@@ -45,9 +41,7 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
  */
 final class SortRunWriter
 {
-    /** @var resource */
-    private $fh;
-    private int $count = 0;
+    private string $path;
     private bool $closed = false;
 
     /**
@@ -61,23 +55,25 @@ final class SortRunWriter
     private string $run_id_body;
 
     /**
-     * Output buffer: cells accumulate here and get flushed in 64 KiB
-     * chunks. fwrite once per row over hundreds of thousands of rows
-     * pays a fixed per-call overhead even with PHP's 8 KiB stream
-     * buffer in front; one flush per ~64 KiB amortises that to noise.
+     * Parallel buffers for the three column sections. Sized in
+     * proportion to the number of records — for our largest index
+     * (~700 K rows total / 4 shards ≈ 175 K per shard) the combined
+     * buffers are roughly 8.4 MB per writer, well within a worker's
+     * PHP memory budget. Cell-data is buffered in $cell_data so we
+     * can write the whole file in one shot at close().
+     *
+     * @var list<int>
      */
-    private const BUFFER_FLUSH_BYTES = 65536;
-    private string $buffer = '';
+    private array $keys = [];
+    /** @var list<int> */
+    private array $rowids = [];
+    /** @var list<int> */
+    private array $cell_offsets = [];
+    private string $cell_data = '';
 
     public function __construct(string $path, int $run_id)
     {
-        $fh = fopen($path, 'wb');
-        if ($fh === false) {
-            throw new \RuntimeException("failed to open sort run file for write: {$path}");
-        }
-        $this->fh = $fh;
-        // Reserve 4 bytes for the record count; rewritten at close.
-        fwrite($this->fh, "\x00\x00\x00\x00");
+        $this->path = $path;
 
         [$tc, $body] = self::encodeIntegerValue($run_id);
         $this->run_id = $run_id;
@@ -88,22 +84,10 @@ final class SortRunWriter
     public function append(int $key, int $rowid): void
     {
         $cell = $this->encodeCell($key, $rowid);
-        $cell_len = strlen($cell);
-        if ($cell_len > 255) {
-            // Three int64 columns plus the small constant-bytes overhead
-            // never reaches 256; if it does we've encoded something we
-            // didn't expect and the file format would silently truncate.
-            throw new \LengthException(
-                "encoded cell length {$cell_len} exceeds u8 range — "
-                . "integer index payload is not three small ints"
-            );
-        }
-        $this->buffer .= pack('JJ', $key, $rowid) . chr($cell_len) . $cell;
-        $this->count++;
-        if (strlen($this->buffer) >= self::BUFFER_FLUSH_BYTES) {
-            fwrite($this->fh, $this->buffer);
-            $this->buffer = '';
-        }
+        $this->keys[] = $key;
+        $this->rowids[] = $rowid;
+        $this->cell_offsets[] = strlen($this->cell_data);
+        $this->cell_data .= $cell;
     }
 
     public function close(): void
@@ -111,14 +95,27 @@ final class SortRunWriter
         if ($this->closed) {
             return;
         }
-        if ($this->buffer !== '') {
-            fwrite($this->fh, $this->buffer);
-            $this->buffer = '';
+        $count = count($this->keys);
+        $cell_data_size = strlen($this->cell_data);
+        $header = pack('N', $count) . pack('N', $cell_data_size);
+        // Bulk-pack each column in one C-side `pack(...)` call —
+        // J*/N* accept a list and emit the BE bytes in a single
+        // pass. The reader uses the symmetric bulk `unpack` to
+        // hydrate the columns at construction.
+        $keys_bytes = $count > 0 ? pack('J*', ...$this->keys) : '';
+        $rowids_bytes = $count > 0 ? pack('J*', ...$this->rowids) : '';
+        $offsets_bytes = $count > 0 ? pack('N*', ...$this->cell_offsets) : '';
+
+        $payload = $header . $keys_bytes . $rowids_bytes . $offsets_bytes . $this->cell_data;
+        if (file_put_contents($this->path, $payload) === false) {
+            throw new \RuntimeException("failed to write sort run file: {$this->path}");
         }
-        fflush($this->fh);
-        rewind($this->fh);
-        fwrite($this->fh, pack('N', $this->count));
-        fclose($this->fh);
+        // Free the buffers so a worker that holds many writers
+        // simultaneously isn't pinning their memory after close.
+        $this->keys = [];
+        $this->rowids = [];
+        $this->cell_offsets = [];
+        $this->cell_data = '';
         $this->closed = true;
     }
 
@@ -134,9 +131,7 @@ final class SortRunWriter
      * `varint(payload_size) + payload`. Specialised for the common
      * shape (key/rowid in int32 range) so the bulk of rows take a
      * single `pack` call; falls through to the general encoder for
-     * keys whose magnitude exceeds int32 (rare in our schema —
-     * node_id values comfortably fit, addresses don't but addresses
-     * never key these three indexes).
+     * keys whose magnitude exceeds int32.
      */
     private function encodeCell(int $key, int $rowid): string
     {
@@ -145,17 +140,11 @@ final class SortRunWriter
             && $rowid >= -2147483648 && $rowid <= 2147483647
         ) {
             // tc = 4 for both key and rowid → 4-byte signed BE bodies.
-            // header_inner = run_id_tc_varint + "\x04\x04"
-            // header_size  = 1 + strlen(run_id_tc_varint) + 2
-            //              = strlen(run_id_tc_varint) + 3 (always 4 for our run_ids)
-            // payload      = varint(header_size) + header_inner + run_id_body + key + rowid
             $inner = $this->run_id_tc_varint . "\x04\x04";
             $header_size = 1 + strlen($inner);
             $payload = chr($header_size) . $inner . $this->run_id_body
                 . pack('NN', $key & 0xffffffff, $rowid & 0xffffffff);
             $payload_size = strlen($payload);
-            // payload_size is always small (< 32) for our 3-int rows
-            // — single-byte varint covers everything.
             return chr($payload_size) . $payload;
         }
         // Fallback: full encoder (handles 6/8-byte int bodies for
@@ -206,8 +195,6 @@ final class SortRunWriter
     private static function writeVarintShort(int $v): string
     {
         if ($v < 0 || $v >= 0x80) {
-            // Defensive: type codes 0..9 cover everything we emit;
-            // anything larger is a bug in the caller.
             return Format::writeVarint($v);
         }
         return chr($v);

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunWriter.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/SortRunWriter.php
@@ -16,9 +16,23 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 /**
  * Per-shard sort-run file for a single integer index.
  *
- * File layout:
+ * File layout (v2 — cells pre-encoded by the worker):
  *   [u32 BE record count]
- *   record_count × [i64 BE key, i64 BE rowid]
+ *   record_count × [
+ *     i64 BE key,          // sort key
+ *     i64 BE rowid,        // tiebreaker
+ *     u8 cell_len,         // bytes in the encoded cell that follows
+ *     cell_len bytes cell  // SQLite leaf cell: varint(payload_size) + record_payload
+ *   ]
+ *
+ * The cell is encoded by the worker against the freshly-allocated
+ * `run_id` passed to the constructor — that is the only run_id the
+ * resulting index will ever carry, so encoding it once per worker (in
+ * parallel) is strictly cheaper than the previous scheme where main
+ * called `RecordEncoder::encodeIntegerRow([$run_id, $key, $rowid])`
+ * per row in the k-way merge. The merger now does heap pull + memcpy
+ * only and the per-row record-encoding cost moves off the critical
+ * path entirely.
  *
  * Records must be appended in (key, rowid) ascending order — the
  * worker is expected to extract them in sorted order via
@@ -36,7 +50,26 @@ final class SortRunWriter
     private int $count = 0;
     private bool $closed = false;
 
-    public function __construct(string $path)
+    /**
+     * Pre-encoded `run_id` portion of every cell's payload. Since
+     * run_id is constant for the lifetime of a sort run, we compute
+     * `[type_code_varint, body_bytes]` once in the constructor and
+     * reuse them for each appended cell.
+     */
+    private int $run_id;
+    private string $run_id_tc_varint;
+    private string $run_id_body;
+
+    /**
+     * Output buffer: cells accumulate here and get flushed in 64 KiB
+     * chunks. fwrite once per row over hundreds of thousands of rows
+     * pays a fixed per-call overhead even with PHP's 8 KiB stream
+     * buffer in front; one flush per ~64 KiB amortises that to noise.
+     */
+    private const BUFFER_FLUSH_BYTES = 65536;
+    private string $buffer = '';
+
+    public function __construct(string $path, int $run_id)
     {
         $fh = fopen($path, 'wb');
         if ($fh === false) {
@@ -45,18 +78,42 @@ final class SortRunWriter
         $this->fh = $fh;
         // Reserve 4 bytes for the record count; rewritten at close.
         fwrite($this->fh, "\x00\x00\x00\x00");
+
+        [$tc, $body] = self::encodeIntegerValue($run_id);
+        $this->run_id = $run_id;
+        $this->run_id_tc_varint = self::writeVarintShort($tc);
+        $this->run_id_body = $body;
     }
 
     public function append(int $key, int $rowid): void
     {
-        fwrite($this->fh, pack('JJ', $key, $rowid));
+        $cell = $this->encodeCell($key, $rowid);
+        $cell_len = strlen($cell);
+        if ($cell_len > 255) {
+            // Three int64 columns plus the small constant-bytes overhead
+            // never reaches 256; if it does we've encoded something we
+            // didn't expect and the file format would silently truncate.
+            throw new \LengthException(
+                "encoded cell length {$cell_len} exceeds u8 range — "
+                . "integer index payload is not three small ints"
+            );
+        }
+        $this->buffer .= pack('JJ', $key, $rowid) . chr($cell_len) . $cell;
         $this->count++;
+        if (strlen($this->buffer) >= self::BUFFER_FLUSH_BYTES) {
+            fwrite($this->fh, $this->buffer);
+            $this->buffer = '';
+        }
     }
 
     public function close(): void
     {
         if ($this->closed) {
             return;
+        }
+        if ($this->buffer !== '') {
+            fwrite($this->fh, $this->buffer);
+            $this->buffer = '';
         }
         fflush($this->fh);
         rewind($this->fh);
@@ -70,5 +127,89 @@ final class SortRunWriter
         if (!$this->closed) {
             $this->close();
         }
+    }
+
+    /**
+     * Encode one (run_id, key, rowid) record as a SQLite leaf cell:
+     * `varint(payload_size) + payload`. Specialised for the common
+     * shape (key/rowid in int32 range) so the bulk of rows take a
+     * single `pack` call; falls through to the general encoder for
+     * keys whose magnitude exceeds int32 (rare in our schema —
+     * node_id values comfortably fit, addresses don't but addresses
+     * never key these three indexes).
+     */
+    private function encodeCell(int $key, int $rowid): string
+    {
+        if (
+            $key >= -2147483648 && $key <= 2147483647
+            && $rowid >= -2147483648 && $rowid <= 2147483647
+        ) {
+            // tc = 4 for both key and rowid → 4-byte signed BE bodies.
+            // header_inner = run_id_tc_varint + "\x04\x04"
+            // header_size  = 1 + strlen(run_id_tc_varint) + 2
+            //              = strlen(run_id_tc_varint) + 3 (always 4 for our run_ids)
+            // payload      = varint(header_size) + header_inner + run_id_body + key + rowid
+            $inner = $this->run_id_tc_varint . "\x04\x04";
+            $header_size = 1 + strlen($inner);
+            $payload = chr($header_size) . $inner . $this->run_id_body
+                . pack('NN', $key & 0xffffffff, $rowid & 0xffffffff);
+            $payload_size = strlen($payload);
+            // payload_size is always small (< 32) for our 3-int rows
+            // — single-byte varint covers everything.
+            return chr($payload_size) . $payload;
+        }
+        // Fallback: full encoder (handles 6/8-byte int bodies for
+        // outlier keys whose magnitude exceeds int32).
+        $payload = RecordEncoder::encodeIntegerRow([$this->run_id, $key, $rowid]);
+        return Format::writeVarint(strlen($payload)) . $payload;
+    }
+
+    /**
+     * @return array{int, string} [type_code, body_bytes]
+     */
+    private static function encodeIntegerValue(int $v): array
+    {
+        if ($v === 0) {
+            return [8, ''];
+        }
+        if ($v === 1) {
+            return [9, ''];
+        }
+        if ($v >= -128 && $v <= 127) {
+            return [1, pack('c', $v)];
+        }
+        if ($v >= -32768 && $v <= 32767) {
+            return [2, pack('n', $v & 0xffff)];
+        }
+        if ($v >= -8388608 && $v <= 8388607) {
+            $u = $v & 0xffffff;
+            return [3, chr(($u >> 16) & 0xff) . chr(($u >> 8) & 0xff) . chr($u & 0xff)];
+        }
+        if ($v >= -2147483648 && $v <= 2147483647) {
+            return [4, pack('N', $v & 0xffffffff)];
+        }
+        if ($v >= -(1 << 47) && $v <= ((1 << 47) - 1)) {
+            $u = $v & 0xffffffffffff;
+            return [
+                5,
+                chr(($u >> 40) & 0xff) . chr(($u >> 32) & 0xff) . chr(($u >> 24) & 0xff)
+                . chr(($u >> 16) & 0xff) . chr(($u >> 8) & 0xff) . chr($u & 0xff),
+            ];
+        }
+        return [6, pack('J', $v)];
+    }
+
+    /**
+     * Single-byte varint emitter — type codes for our three columns
+     * are always < 128, so the varint is one byte.
+     */
+    private static function writeVarintShort(int $v): string
+    {
+        if ($v < 0 || $v >= 0x80) {
+            // Defensive: type codes 0..9 cover everything we emit;
+            // anything larger is a bug in the caller.
+            return Format::writeVarint($v);
+        }
+        return chr($v);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/TableMerger.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/TableMerger.php
@@ -157,32 +157,53 @@ final class TableMerger
     }
 
     /**
-     * Walk the cell pointer array, decode each cell's payload size
-     * varint, and return the maximum rowid (== last cell's rowid for
-     * a sane leaf, but compute it explicitly for safety). Throws
-     * if any cell would need an overflow chain.
+     * Verify no cell needs an overflow chain and return the leaf's
+     * maximum rowid.
+     *
+     * SQLite stores table-leaf cells in rowid order, so the last cell
+     * carries the leaf's max rowid by definition — no per-cell rowid
+     * scan needed. Overflow detection still has to look at every
+     * cell's payload-size varint, but most payloads encode in 1–2
+     * bytes (single-byte varint < 128, two-byte < 16384), so we
+     * inline the fast cases and fall back to the generic decoder only
+     * for the rare ≥3-byte varint. That removes one varint decode per
+     * cell and a function-call dispatch per byte for the common case,
+     * which is the dominant work of the merger over ~20K leaves.
      */
     private function verifyLeafAndGetMaxRowid(
         string $page,
         int $cell_count,
         int $inline_max,
     ): int {
-        $cell_ptr_array_offset = 8; // leaf pages: header is 8 bytes
-        $max_rowid = PHP_INT_MIN;
-        for ($i = 0; $i < $cell_count; $i++) {
-            $cell_offset = unpack('n', substr($page, $cell_ptr_array_offset + $i * 2, 2))[1];
-            $cell_offset = (int)$cell_offset;
-            [$payload_size, $sz_len] = Format::readVarint($page, $cell_offset);
+        // Cell pointer array: u16 BE offsets, packed contiguously
+        // starting at byte 8 (leaf header). Unpack the whole array in
+        // one native call instead of two ord() per cell.
+        /** @var array<int, int> $ptrs */
+        $ptrs = unpack("n{$cell_count}", $page, 8);
+        for ($i = 1; $i <= $cell_count; $i++) {
+            $cell_offset = $ptrs[$i];
+            $b0 = ord($page[$cell_offset]);
+            if ($b0 < 0x80) {
+                $payload_size = $b0;
+            } else {
+                $b1 = ord($page[$cell_offset + 1]);
+                if ($b1 < 0x80) {
+                    $payload_size = (($b0 & 0x7f) << 7) | $b1;
+                } else {
+                    [$payload_size, ] = Format::readVarint($page, $cell_offset);
+                }
+            }
             if ($payload_size > $inline_max) {
                 throw new OverflowNotSupportedException(
-                    "cell at offset {$cell_offset} has overflow chain (payload {$payload_size} > {$inline_max})"
+                    "cell at offset {$cell_offset} has overflow chain "
+                    . "(payload {$payload_size} > {$inline_max})"
                 );
             }
-            [$rowid, $_rowid_len] = Format::readVarint($page, $cell_offset + $sz_len);
-            if ($rowid > $max_rowid) {
-                $max_rowid = $rowid;
-            }
         }
+        // Last cell's rowid is the leaf's max rowid.
+        $last_offset = $ptrs[$cell_count];
+        [$_p, $sz_len] = Format::readVarint($page, $last_offset);
+        [$max_rowid, ] = Format::readVarint($page, $last_offset + $sz_len);
         return $max_rowid;
     }
 

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/Writer.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/Writer.php
@@ -61,13 +61,43 @@ final class Writer
     /** @var resource|null file handle for patch mode */
     private $fh = null;
 
-    /** @var list<string> appended page contents in order */
+    /** @var list<string> appended page contents (non-session mode) */
     private array $appended_pages = [];
+
+    /**
+     * Appended pages keyed by claimed pgno (session mode). When the
+     * writer is opened via {@see openForPatchInSession} new page
+     * numbers come from a `SharedPgnoCounter` shared with parallel
+     * cohort processes, so claims are not contiguous and we have to
+     * track them by pgno.
+     *
+     * @var array<int, string>
+     */
+    private array $session_appended_pages = [];
 
     /** @var array<int, string> 1-indexed page no => new page bytes */
     private array $rewritten_pages = [];
 
     private bool $patch_mode;
+
+    /**
+     * Counter path for {@see openForPatchInSession}. When non-null,
+     * `appendPage` claims pgnos via SharedPgnoCounter::claim instead
+     * of incrementing $page_count locally, and `close` skips the
+     * file-header bump (the orchestrator owns the header in
+     * shared-session mode).
+     */
+    private ?string $counter_path = null;
+
+    /**
+     * Local cache of pgnos pre-claimed from the shared counter. We
+     * batch claims to amortise the flock+fread+fwrite roundtrip per
+     * counter call — claiming one pgno at a time across ~12 K
+     * appended pages would burn ~600 ms in syscall overhead alone.
+     */
+    private const SESSION_CLAIM_BATCH = 512;
+    private int $session_next_pgno = 0;
+    private int $session_claim_remaining = 0;
 
     private function __construct(
         string $bytes,
@@ -107,6 +137,24 @@ final class Writer
             patch_mode: false,
             fh: null,
         );
+    }
+
+    /**
+     * Open in patch+session mode: like {@see openForPatch} but each
+     * `appendPage` claims a pgno from the supplied
+     * `SharedPgnoCounter` (shared with parallel cohort processes —
+     * typically ParallelIndexBuilder workers building the remaining
+     * indexes), and `close` skips the file-header bump because the
+     * orchestrator commits the header for the whole session at the
+     * end. Used to run the integer-index merge concurrently with
+     * the C-side CREATE INDEX path; both write to disjoint pgno
+     * ranges via the same atomic counter.
+     */
+    public static function openForPatchInSession(string $path, string $counter_path): self
+    {
+        $self = self::openForPatch($path);
+        $self->counter_path = $counter_path;
+        return $self;
     }
 
     /**
@@ -156,24 +204,71 @@ final class Writer
                 . ' bytes; got ' . strlen($data)
             );
         }
+        if ($this->counter_path !== null) {
+            // Session mode: claim a pgno from the shared atomic
+            // counter so we don't collide with parallel cohort
+            // processes (e.g. ParallelIndexBuilder workers). Batch
+            // claims to amortise the flock+fread+fwrite cost per
+            // counter call; the unused tail of the last batch is
+            // harmless because the orchestrator's final ftruncate
+            // shrinks the file back to the highest claimed pgno.
+            if ($this->session_claim_remaining === 0) {
+                $this->session_next_pgno = SharedPgnoCounter::claim(
+                    $this->counter_path,
+                    self::SESSION_CLAIM_BATCH,
+                );
+                $this->session_claim_remaining = self::SESSION_CLAIM_BATCH;
+            }
+            $pgno = $this->session_next_pgno;
+            $this->session_next_pgno++;
+            $this->session_claim_remaining--;
+            $this->session_appended_pages[$pgno] = $data;
+            if ($pgno > $this->page_count) {
+                $this->page_count = $pgno;
+            }
+            return $pgno;
+        }
         $this->appended_pages[] = $data;
         $this->page_count++;
         return $this->page_count;
     }
 
     /**
-     * Overwrite an existing page (1-indexed) with the given data.
+     * Overwrite an existing page (1-indexed) with the given data, or
+     * — in session mode — write to any pgno the caller has already
+     * claimed from the shared counter. Outside session mode the
+     * pgno must lie within `[1, page_count]` (the original or
+     * already-appended region).
      */
     public function writePage(int $pgno, string $data): void
     {
-        if ($pgno < 1 || $pgno > $this->page_count) {
-            throw new \OutOfRangeException("page {$pgno} out of range (1..{$this->page_count})");
+        if ($pgno < 1) {
+            throw new \OutOfRangeException("page {$pgno} out of range");
         }
         if (strlen($data) !== $this->page_size) {
             throw new \InvalidArgumentException(
                 'page must be exactly ' . $this->page_size
                 . ' bytes; got ' . strlen($data)
             );
+        }
+        if ($this->counter_path !== null) {
+            // Session mode: the caller is responsible for having
+            // claimed `$pgno` from the shared counter. Treat any
+            // pgno beyond the original-region cutoff as a session-
+            // appended page so close() pwrites it at the right
+            // offset and PIB's final ftruncate accounts for it.
+            if ($pgno > $this->original_page_count) {
+                $this->session_appended_pages[$pgno] = $data;
+                if ($pgno > $this->page_count) {
+                    $this->page_count = $pgno;
+                }
+            } else {
+                $this->rewritten_pages[$pgno] = $data;
+            }
+            return;
+        }
+        if ($pgno > $this->page_count) {
+            throw new \OutOfRangeException("page {$pgno} out of range (1..{$this->page_count})");
         }
         $this->rewritten_pages[$pgno] = $data;
     }
@@ -190,7 +285,10 @@ final class Writer
         if (isset($this->rewritten_pages[$pgno])) {
             return $this->rewritten_pages[$pgno];
         }
-        if ($pgno > $this->original_page_count) {
+        if (isset($this->session_appended_pages[$pgno])) {
+            return $this->session_appended_pages[$pgno];
+        }
+        if ($pgno > $this->original_page_count && $this->counter_path === null) {
             return $this->appended_pages[$pgno - 1 - $this->original_page_count];
         }
         $offset = ($pgno - 1) * $this->page_size;
@@ -225,6 +323,10 @@ final class Writer
      */
     public function close(string $path): void
     {
+        if ($this->counter_path !== null) {
+            $this->closeSession();
+            return;
+        }
         if ($this->patch_mode) {
             $this->closePatch($path);
             return;
@@ -257,6 +359,47 @@ final class Writer
         $payload = $bytes . implode('', $this->appended_pages);
         if (file_put_contents($path, $payload) === false) {
             throw new \RuntimeException("failed to write SQLite file: {$path}");
+        }
+    }
+
+    /**
+     * Session-mode close: pwrite each modified page (rewritten +
+     * session-appended) at the offset implied by its pgno, and skip
+     * the file-header bump entirely. The orchestrator that owns the
+     * `SharedPgnoCounter` is responsible for the final file size and
+     * header update once all cohort processes have committed.
+     */
+    private function closeSession(): void
+    {
+        \assert($this->fh !== null);
+        $fh = $this->fh;
+        try {
+            foreach ($this->rewritten_pages as $pgno => $data) {
+                $offset = ($pgno - 1) * $this->page_size;
+                if (fseek($fh, $offset) !== 0) {
+                    throw new \RuntimeException("failed to seek to page {$pgno}");
+                }
+                if (fwrite($fh, $data) !== $this->page_size) {
+                    throw new \RuntimeException("short write on page {$pgno}");
+                }
+            }
+            // Sort by pgno so the pwrite stream walks the file in
+            // monotonically increasing offsets — friendlier on the
+            // page cache and on filesystems whose extent allocator
+            // dislikes random-order writes into a sparse region.
+            ksort($this->session_appended_pages);
+            foreach ($this->session_appended_pages as $pgno => $data) {
+                $offset = ($pgno - 1) * $this->page_size;
+                if (fseek($fh, $offset) !== 0) {
+                    throw new \RuntimeException("failed to seek to page {$pgno}");
+                }
+                if (fwrite($fh, $data) !== $this->page_size) {
+                    throw new \RuntimeException("short write on page {$pgno}");
+                }
+            }
+        } finally {
+            fclose($fh);
+            $this->fh = null;
         }
     }
 

--- a/src/Inspector/Output/MemoryOutput/SqliteRaw/Writer.php
+++ b/src/Inspector/Output/MemoryOutput/SqliteRaw/Writer.php
@@ -16,12 +16,26 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 /**
  * Page-level writer for an existing SQLite database file.
  *
- * Builds in memory and flushes to disk on close(). The expected use is
- * a one-shot merge: open the file, append shard leaf pages, overwrite
- * the per-table rootpages with newly-built interior pages, update the
- * header, write back. The merger keeps the same sqlite_master.rootpage
- * values that SQLite assigned at CREATE TABLE time, so it never has
- * to round-trip through the schema table.
+ * Two open modes:
+ *
+ *   - {@see open}: builds in memory, flushes the whole file with one
+ *     file_put_contents on close. Simple, used by TableMerger when
+ *     the target starts empty so re-writing the existing region adds
+ *     no extra work.
+ *
+ *   - {@see openForPatch}: opens the file in `rb+` mode without
+ *     slurping it. Pages added via appendPage are buffered in memory;
+ *     pages overwritten via writePage are tracked separately. close()
+ *     pwrites only the modified pages plus the appended tail and
+ *     patches the in-place file header — the unmodified region of an
+ *     existing 88 MB output is left as-is on disk. Used by the
+ *     integer-index merge step which only touches a few index
+ *     rootpages and appends an index leaf tail to a file that's
+ *     already nearly final.
+ *
+ * The merger keeps the same sqlite_master.rootpage values that SQLite
+ * assigned at CREATE TABLE / CREATE INDEX time, so it never has to
+ * round-trip through the schema table.
  *
  * @psalm-suppress MixedAssignment
  * @psalm-suppress MixedArrayAccess
@@ -38,15 +52,14 @@ namespace Reli\Inspector\Output\MemoryOutput\SqliteRaw;
 final class Writer
 {
     /**
-     * Original bytes of the file at open() time. Subsequent appends
-     * accumulate in $appended_pages instead of being concat'd into a
-     * single string — `$bytes .= $page` is O(strlen($bytes)) per
-     * call, which becomes quadratic over thousands of appended pages.
-     * Pages overwritten via writePage() are tracked in
-     * $rewritten_pages so close() can apply them to the original
-     * region of the file.
+     * Original bytes of the file at open() time, populated only in
+     * the slurped mode. In patch mode this stays an empty string and
+     * existing pages are read lazily from $fh.
      */
-    private string $base_bytes;
+    private string $base_bytes = '';
+
+    /** @var resource|null file handle for patch mode */
+    private $fh = null;
 
     /** @var list<string> appended page contents in order */
     private array $appended_pages = [];
@@ -54,13 +67,21 @@ final class Writer
     /** @var array<int, string> 1-indexed page no => new page bytes */
     private array $rewritten_pages = [];
 
+    private bool $patch_mode;
+
     private function __construct(
         string $bytes,
         public readonly int $page_size,
         private int $original_page_count,
         private int $page_count,
+        bool $patch_mode,
+        mixed $fh,
     ) {
         $this->base_bytes = $bytes;
+        $this->patch_mode = $patch_mode;
+        if (is_resource($fh)) {
+            $this->fh = $fh;
+        }
     }
 
     public static function open(string $path): self
@@ -78,7 +99,48 @@ final class Writer
         $page_size_field = unpack('n', substr($bytes, Format::HDR_PAGE_SIZE, 2))[1];
         $page_size = $page_size_field === 1 ? 65536 : (int)$page_size_field;
         $page_count = (int)unpack('N', substr($bytes, Format::HDR_DB_PAGE_COUNT, 4))[1];
-        return new self($bytes, (int)$page_size, $page_count, $page_count);
+        return new self(
+            $bytes,
+            (int)$page_size,
+            $page_count,
+            $page_count,
+            patch_mode: false,
+            fh: null,
+        );
+    }
+
+    /**
+     * Open in patch mode: reads only the 100-byte header, leaves the
+     * rest of the file on disk. Subsequent appendPage / writePage
+     * calls are buffered; close() pwrites the modifications without
+     * rewriting the unchanged region.
+     */
+    public static function openForPatch(string $path): self
+    {
+        $fh = fopen($path, 'rb+');
+        if ($fh === false) {
+            throw new \RuntimeException("failed to open SQLite file for patch: {$path}");
+        }
+        $header = fread($fh, Format::HEADER_SIZE);
+        if ($header === false || strlen($header) < Format::HEADER_SIZE) {
+            fclose($fh);
+            throw new \RuntimeException("file is shorter than SQLite header: {$path}");
+        }
+        if (substr($header, 0, 16) !== Format::MAGIC) {
+            fclose($fh);
+            throw new \RuntimeException("not a SQLite database (bad magic): {$path}");
+        }
+        $page_size_field = unpack('n', substr($header, Format::HDR_PAGE_SIZE, 2))[1];
+        $page_size = $page_size_field === 1 ? 65536 : (int)$page_size_field;
+        $page_count = (int)unpack('N', substr($header, Format::HDR_DB_PAGE_COUNT, 4))[1];
+        return new self(
+            $header,
+            (int)$page_size,
+            $page_count,
+            $page_count,
+            patch_mode: true,
+            fh: $fh,
+        );
     }
 
     /**
@@ -132,6 +194,17 @@ final class Writer
             return $this->appended_pages[$pgno - 1 - $this->original_page_count];
         }
         $offset = ($pgno - 1) * $this->page_size;
+        if ($this->patch_mode) {
+            \assert($this->fh !== null);
+            if (fseek($this->fh, $offset) !== 0) {
+                throw new \RuntimeException("failed to seek to page {$pgno}");
+            }
+            $bytes = fread($this->fh, $this->page_size);
+            if ($bytes === false || strlen($bytes) !== $this->page_size) {
+                throw new \RuntimeException("short read on page {$pgno}");
+            }
+            return $bytes;
+        }
         return substr($this->base_bytes, $offset, $this->page_size);
     }
 
@@ -144,9 +217,19 @@ final class Writer
      * Finalise: bump the change counter, schema cookie (so cached
      * statements get invalidated), update the in-header page count,
      * and flush. After this the writer must not be used.
+     *
+     * In patch mode (opened via {@see openForPatch}) only the modified
+     * pages, the appended tail, and the header are pwritten — the
+     * unchanged region of the file is left as-is on disk. In slurped
+     * mode the whole file is rewritten.
      */
     public function close(string $path): void
     {
+        if ($this->patch_mode) {
+            $this->closePatch($path);
+            return;
+        }
+
         // Apply rewritten pages to the original region of the file.
         $bytes = $this->base_bytes;
         foreach ($this->rewritten_pages as $pgno => $data) {
@@ -165,6 +248,78 @@ final class Writer
         // Update in-header page count, change counter, schema cookie
         // (defensive — schema shape unchanged but rootpage contents
         // changed in-place).
+        $bytes = $this->bumpHeader($bytes);
+
+        // Write everything: original (with in-place rewrites) followed
+        // by appended pages. implode() does a single linear pass over
+        // the appended chunks, avoiding the O(N^2) growth of repeated
+        // string concatenation.
+        $payload = $bytes . implode('', $this->appended_pages);
+        if (file_put_contents($path, $payload) === false) {
+            throw new \RuntimeException("failed to write SQLite file: {$path}");
+        }
+    }
+
+    private function closePatch(string $_path): void
+    {
+        \assert($this->fh !== null);
+        $fh = $this->fh;
+        try {
+            // Bump header in place. The header stayed in $this->base_bytes
+            // since openForPatch slurped just the first 100 bytes.
+            $header = $this->bumpHeader($this->base_bytes);
+            if (fseek($fh, 0) !== 0) {
+                throw new \RuntimeException('failed to seek to file header');
+            }
+            if (fwrite($fh, $header) !== Format::HEADER_SIZE) {
+                throw new \RuntimeException('short write on file header');
+            }
+
+            // Pwrite each rewritten page. Pages whose pgno is in the
+            // appended range get folded into the appended tail below;
+            // those in the original region are pwritten in place.
+            foreach ($this->rewritten_pages as $pgno => $data) {
+                if ($pgno > $this->original_page_count) {
+                    // Page was appended *and* later rewritten — fold
+                    // back into appended_pages so the tail write picks
+                    // it up.
+                    $append_idx = $pgno - 1 - $this->original_page_count;
+                    $this->appended_pages[$append_idx] = $data;
+                    continue;
+                }
+                $offset = ($pgno - 1) * $this->page_size;
+                if (fseek($fh, $offset) !== 0) {
+                    throw new \RuntimeException("failed to seek to page {$pgno}");
+                }
+                if (fwrite($fh, $data) !== $this->page_size) {
+                    throw new \RuntimeException("short write on page {$pgno}");
+                }
+            }
+
+            // Write appended tail in one shot at the end of the
+            // original-region region.
+            if ($this->appended_pages !== []) {
+                $tail = implode('', $this->appended_pages);
+                $tail_offset = $this->original_page_count * $this->page_size;
+                if (fseek($fh, $tail_offset) !== 0) {
+                    throw new \RuntimeException('failed to seek to appended tail');
+                }
+                if (fwrite($fh, $tail) !== strlen($tail)) {
+                    throw new \RuntimeException('short write on appended tail');
+                }
+            }
+        } finally {
+            fclose($fh);
+            $this->fh = null;
+        }
+    }
+
+    /**
+     * Patch the in-memory header buffer with new page count, change
+     * counter, and schema cookie. Returns the patched header bytes.
+     */
+    private function bumpHeader(string $bytes): string
+    {
         $bytes = substr_replace(
             $bytes,
             pack('N', $this->page_count),
@@ -185,14 +340,6 @@ final class Writer
             Format::HDR_SCHEMA_COOKIE,
             4,
         );
-
-        // Write everything: original (with in-place rewrites) followed
-        // by appended pages. implode() does a single linear pass over
-        // the appended chunks, avoiding the O(N^2) growth of repeated
-        // string concatenation.
-        $payload = $bytes . implode('', $this->appended_pages);
-        if (file_put_contents($path, $payload) === false) {
-            throw new \RuntimeException("failed to write SQLite file: {$path}");
-        }
+        return $bytes;
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
+++ b/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
@@ -88,7 +88,7 @@ class IntegerIndexMergerInteriorChunkingTest extends BaseTestCase
             )->fetchColumn();
             unset($main);
 
-            $writer = new SortRunWriter($sort_run_path);
+            $writer = new SortRunWriter($sort_run_path, run_id: 1);
             // Strictly ascending (key, rowid) — the merger contract.
             // 8-byte-wide values keep the encoded payload in the
             // 8-byte-int branch of RecordEncoder, matching real-world
@@ -102,7 +102,6 @@ class IntegerIndexMergerInteriorChunkingTest extends BaseTestCase
             $merger = new IntegerIndexMerger(
                 $main_writer,
                 [new SortRunReader($sort_run_path)],
-                run_id: 1,
             );
             $merger->merge($rootpage);
             $main_writer->close($main_path);

--- a/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
+++ b/tests/Inspector/Output/MemoryOutput/SqliteRaw/IntegerIndexMergerInteriorChunkingTest.php
@@ -133,6 +133,114 @@ class IntegerIndexMergerInteriorChunkingTest extends BaseTestCase
     }
 
     /**
+     * Bug B regression: when a non-rightmost partition's entry count
+     * is exactly `(cells_per_leaf + 1) * k + 1` (i.e. one orphan cell
+     * past a clean leaf-cycle boundary), the tail used to fall back
+     * to "single-cell leaf with self-divider" — same cell stored in
+     * both the leaf and the parent interior page. PRAGMA
+     * integrity_check reports it as "wrong # of entries in index"
+     * and the table-side full scan double-counts the cell as a
+     * silent extra row with a duplicated rowid.
+     *
+     * The fixture builds one partition's worth of leaves directly
+     * via `extractLeavesForRange` with `is_global_rightmost = false`
+     * and an entry count chosen to land exactly on the bug's
+     * (272k+1)-shape. For `(1-int run_id, int32 key, int32 rowid)`
+     * cells the per-leaf packing is 271 cells + 1 promoted divider
+     * = 272 entries per leaf cycle, so an entry count of
+     * `272 + 1 = 273` lands on the smallest k=1 trigger.
+     *
+     * The post-fix expectation: total b-tree entries (leaf cells +
+     * promoted dividers across the returned `leaves` list) equals
+     * the input row count exactly. Pre-fix the count was off by
+     * exactly +1 because the lone tail cell appeared in both a
+     * 1-cell leaf and as the divider above it.
+     */
+    public function testNonRightmostPartitionTailDoesNotDuplicateLastCell(): void
+    {
+        // 273 entries = 1 trigger of the (272k + 1) shape. With
+        // small int32-shaped keys (run_id=1, key, rowid) the cell
+        // is 13 bytes and the per-leaf cycle is 272 entries, so 273
+        // = 1 full leaf cycle (271 in leaf + 1 promoted) + 1 tail
+        // cell. The tail-merge path under test re-absorbs that lone
+        // cell back into the previous leaf and uses it as the new
+        // divider.
+        $row_count = 273;
+
+        $base = tempnam(sys_get_temp_dir(), 'iim_partB_');
+        self::assertNotFalse($base);
+        $main_path = $base . '_main.sqlite3';
+        $sort_run_path = $base . '_run';
+
+        try {
+            $main = new \PDO("sqlite:{$main_path}");
+            $main->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $main->exec('PRAGMA page_size = 4096');
+            $main->exec('CREATE TABLE t (run_id INTEGER, k INTEGER, v INTEGER)');
+            unset($main);
+
+            $writer = new SortRunWriter($sort_run_path, run_id: 1);
+            for ($i = 1; $i <= $row_count; $i++) {
+                $writer->append($i, $i);
+            }
+            $writer->close();
+
+            $main_writer = Writer::open($main_path);
+            $merger = new IntegerIndexMerger(
+                $main_writer,
+                [new SortRunReader($sort_run_path)],
+            );
+            // is_global_rightmost = false simulates a non-rightmost
+            // partition; this is the path that triggered the bug.
+            $result = $merger->extractLeavesForRange(null, null, false);
+            $main_writer->close($main_path);
+
+            $entry_count = 0;
+            foreach ($result['leaves'] as $entry) {
+                $entry_count += $this->countLeafCells(
+                    $main_path,
+                    $entry['pgno'],
+                );
+                $entry_count += 1; // promoted divider for this leaf
+            }
+
+            self::assertNull(
+                $result['rightmost_pgno'],
+                'non-rightmost partition must not return an explicit rightmost',
+            );
+            self::assertSame(
+                $row_count,
+                $entry_count,
+                'non-rightmost tail must not duplicate the lone cell as both leaf and divider',
+            );
+        } finally {
+            @unlink($main_path);
+            @unlink($sort_run_path);
+        }
+    }
+
+    /**
+     * Count the number of cells in an index-leaf page at `$pgno`.
+     */
+    private function countLeafCells(string $path, int $pgno): int
+    {
+        $reader = Reader::open($path);
+        $page = $reader->readPage($pgno);
+        $btree_offset = $pgno === 1 ? Format::HEADER_SIZE : 0;
+        $type = ord($page[$btree_offset]);
+        if ($type !== Format::BTREE_LEAF_INDEX) {
+            throw new \RuntimeException(
+                sprintf(
+                    'expected index leaf page at pgno %d, got type 0x%02x',
+                    $pgno,
+                    $type,
+                ),
+            );
+        }
+        return (int)unpack('n', substr($page, $btree_offset + Format::PG_CELL_COUNT, 2))[1];
+    }
+
+    /**
      * Walk the index b-tree rooted at `$rootpage` and return the list
      * of every page visited (in DFS order) and the total number of
      * b-tree entries (leaf cells + interior-page divider cells).


### PR DESCRIPTION
## Summary

Follows #773. Closes the rmem→sqlite3 wall-clock gap on the format-direct ingest path by:

1. Promoting parallel CREATE INDEX (`RELI_PARALLEL_INDEX`) into the default and wiring it into `mergeShards`.
2. Re-architecting `RELI_FORMAT_DIRECT_INDEX` (the L path) so it overlaps with the C-side CREATE INDEX phase as a `ParallelIndexBuilder` sidecar, with cohort-shared `SharedPgnoCounter` page allocation.
3. Adding a per-shard partition merge for the single largest integer index — workers split the (key, rowid) stream by quantile-sampled boundaries and the orchestrator stitches the leaves into one interior tree.

The L path's net overhead vs default goes from `+2.3s → 0` over the 6 commits on a 4-core box; on 16+-core hosts the partition layer should put L net-positive vs default.

## Layered changes

Each commit is a self-contained perf step that passes `PRAGMA integrity_check = ok`. They stack:

| commit | what | bench delta |
|---|---|---|
| `414b6d75` | `RELI_PARALLEL_INDEX` default-on, wired into `mergeShards`, drop redundant `REINDEX summary*`, single main-reader open in `mergeShards`, `TableMerger` last-cell max_rowid + inline varint + bulk `unpack` of cell-pointer array | default 10.3s → 9.6s |
| `72206dc4` | `SortRunWriter` v2: workers pre-encode the leaf cell against the freshly-allocated run_id; `IntegerIndexMerger` does heap pull + memcpy only (no per-row record encoding in main); `mergeIntegerIndexes` opens main once, all 3 indexes share the writer | L cost +2.3s → +1.5s |
| `7fe6da1e` | `Writer::openForPatch` (rb+ + pwrite, no full slurp/rewrite); `SortRun` v3 parallel-array layout for bulk `unpack` | L cost +1.5s → +0.6s |
| `df336d7c` | L runs as a `ParallelIndexBuilder` sidecar via shared `SharedPgnoCounter`; `Writer::openForPatchInSession` for shared-counter pgno claims; L claims rootpage + parent inserts sqlite_master via writable_schema (no wasted `CREATE INDEX`) | L cost +0.6s → ~0 (parity ± noise) |
| `cf157ef0` | Per-index parallelism: each integer index runs in its own sub-sidecar; PIB worker cap reduced to leave CPU slots; gated by `cores >= 8` (override `RELI_L_PARALLEL`) | 8-core projection ~6.5s vs 7.0s default |
| `76bd22a1` | Per-shard partition merge for the largest integer index: `IntegerIndexMerger::extractLeavesForRange` + `assembleInteriorTree` API split, `SortRunReader::sampleKeys` for boundary sampling, `mergeOneIndexPartitioned` orchestrator | gated `RELI_L_PARTITION_COUNT=N`, intended for 16+-core hosts |

## Bench (snap.dump → sqlite3, JIT, 4-core sandbox, warm)

| mode | wall-clock |
|---|---|
| default (no L) | 9.0–9.5 s |
| L sequential (gated default) | 9.3–9.8 s |
| L parallel (`RELI_L_PARALLEL=1` force-on) | 10.2–10.7 s (over-subscribed; gated off automatically) |
| L partition=4 (`RELI_L_PARTITION_COUNT=4` force-on) | 10.9–11.3 s (over-subscribed; gated off automatically) |

The 4-core box doesn't have CPU slots for the inner-parallel modes (3 L + 4 PIB + parent + L orch ≈ 9 procs on 4 cores), so they're gated off by default. Architecture is in place; effects land automatically on 8+ / 16+-core hosts as the gates open.

Projected on 8-core: ~7.0s default, ~6.7s with L sidecar parallel.
Projected on 16-core+: ~6.0s default, ~5.5s with partition=4.

## Correctness

`PRAGMA integrity_check = ok` validated on snap.dump (~88MB output, 331K nodes / 536K edges / 117K locations / 113K attributes) under each combination:

- default
- `RELI_FORMAT_DIRECT_INDEX=1` (sequential L)
- `RELI_FORMAT_DIRECT_INDEX=1 RELI_L_PARALLEL=1` (per-index sub-sidecars)
- `RELI_FORMAT_DIRECT_INDEX=1 RELI_L_PARALLEL=1 RELI_L_PARTITION_COUNT=4` (per-shard partition for largest index)

Each integer index returns its full row count via `INDEXED BY`-pinned lookup. Existing `IntegerIndexMergerInteriorChunkingTest` continues to cover the non-partition path (the new `extractLeavesForRange` / `assembleInteriorTree` split keeps the original `merge` codepath unchanged for it). 418 unit tests (excluding `target-version` integration tests that need Docker) all green.

## Gating summary

| env var | default | what it controls |
|---|---|---|
| `RELI_PARALLEL_INDEX` | `1` (on) | `tryParallelCreateIndexes` PIB path; `=0` falls back to serial CREATE INDEX. Was opt-in pre-PR, now default-on. |
| `RELI_FORMAT_DIRECT_INDEX` | unset (off) | L path (writes integer indexes via PHP-side b-tree assembly instead of CREATE INDEX). Still opt-in. |
| `RELI_L_PARALLEL` | auto-on at `cores >= 8` | Forks one sub-sidecar per integer index. `=1` / `=0` overrides the auto-decision. |
| `RELI_L_PARTITION_COUNT` | `1` (off) | Splits the largest integer index across N forked partition workers. Manual opt-in for 16+-core hosts. |

## What's *not* in this PR

- **JIT-friendly micro-optimisations of the merger**: identified earlier (replace `array_pop` with index counter, inline varint reads in `IntegerIndexMerger::merge`, manual heap pull instead of generator-yield, `SplFixedArray` cell buffers). Each is ~tens of ms; on top of the parallelisation already in this PR they'd be hidden behind the wall-clock window the parent waits on PIB anyway. Will revisit if profile data ever shows L re-entering the critical path.
- **`PdoMemoryOutput` decomposition**: the class keeps growing (now hosts L sidecar + partition orchestration on top of the prior ingest paths). The `@todo` from #773 still applies; structural split is a non-perf change worth its own PR.
- **`ffi-zts-parallel`**: considered. Mechanical fork-→thread replacement would save ~100–170 ms of overhead (atomic counter, `pwrite` syscalls, fork startup) but doesn't unlock a fundamentally new pattern given that fork already supports the per-shard partition design via `SharedPgnoCounter` + read-only sort run inputs. Not worth the dep / debug-complexity cost vs the available win.

https://claude.ai/code/session_01WZsXSrqZWaxKFZZU1j2xPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZsXSrqZWaxKFZZU1j2xPP)_