### PR TITLE
Add depth-aware variable expansion with multiple output formats

### DIFF
--- a/src/Command/Inspector/PeekVarCommand.php
+++ b/src/Command/Inspector/PeekVarCommand.php
@@ -17,7 +17,11 @@ use Reli\Inspector\RetryingLoopProvider;
 use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettingsFromConsoleInput;
 use Reli\Inspector\Settings\TargetProcessSettings\TargetProcessSettingsFromConsoleInput;
 use Reli\Inspector\TargetProcess\TargetProcessResolver;
+use Reli\Inspector\Watch\Dump\PhpSerializeFormatter;
+use Reli\Inspector\Watch\Dump\VarDumpFormatter;
+use Reli\Inspector\Watch\Dump\VarExportFormatter;
 use Reli\Inspector\Watch\VariableReader;
+use Reli\Inspector\Watch\VariableReadOptions;
 use Reli\Inspector\Watch\VariableSpec;
 use Reli\Inspector\Watch\VariableValue;
 use Reli\Lib\Elf\Process\BinaryAnalysisCache;
@@ -80,8 +84,33 @@ final class PeekVarCommand extends ReliCommand
             'format',
             null,
             InputOption::VALUE_REQUIRED,
-            'output format: text or json (default: text)',
+            'output format: text, json, var-dump, var-export,'
+                . ' or php-serialize (default: text)',
             'text',
+        );
+        $this->addOption(
+            'max-depth',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'maximum recursion depth for var-dump / var-export /'
+                . ' php-serialize formats; -1 for unlimited (default: 10)',
+            '10',
+        );
+        $this->addOption(
+            'max-elements',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'maximum number of array elements / object properties to'
+                . ' expand at each level; -1 for unlimited (default: 100)',
+            '100',
+        );
+        $this->addOption(
+            'max-string',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'maximum string length (in bytes) before truncation;'
+                . ' -1 for unlimited (default: 200)',
+            '200',
         );
         $this->addOption(
             'no-cache',
@@ -169,6 +198,8 @@ final class PeekVarCommand extends ReliCommand
             ? (int)$repeat_ms * 1000
             : null;
 
+        $read_options = $this->buildReadOptions($input, $format);
+
         $results = [];
         do {
             try {
@@ -178,6 +209,7 @@ final class PeekVarCommand extends ReliCommand
                     $target_php_settings,
                     $eg_address,
                     $cg_address,
+                    $read_options,
                 );
             } catch (\Throwable $e) {
                 $output->writeln(
@@ -211,11 +243,99 @@ final class PeekVarCommand extends ReliCommand
         array $results,
         string $format,
     ): void {
-        if ($format === 'json') {
-            $this->outputJson($output, $specs, $results);
-            return;
+        switch ($format) {
+            case 'json':
+                $this->outputJson($output, $specs, $results);
+                return;
+            case 'var-dump':
+                $this->outputDump(
+                    $output,
+                    $specs,
+                    $results,
+                    fn (VariableValue $v) => VarDumpFormatter::format($v),
+                );
+                return;
+            case 'var-export':
+                $this->outputDump(
+                    $output,
+                    $specs,
+                    $results,
+                    fn (VariableValue $v) => VarExportFormatter::format($v),
+                );
+                return;
+            case 'php-serialize':
+                $this->outputDump(
+                    $output,
+                    $specs,
+                    $results,
+                    fn (VariableValue $v) => PhpSerializeFormatter::format($v),
+                );
+                return;
+            default:
+                $this->outputText($output, $specs, $results);
+                return;
         }
-        $this->outputText($output, $specs, $results);
+    }
+
+    /**
+     * @param list<VariableSpec> $specs
+     * @param array<string, VariableValue> $results
+     * @param \Closure(VariableValue): string $render
+     */
+    private function outputDump(
+        OutputInterface $output,
+        array $specs,
+        array $results,
+        \Closure $render,
+    ): void {
+        foreach ($specs as $spec) {
+            $var = $results[$spec->lookup_key] ?? null;
+            if ($var === null) {
+                $output->writeln($spec->lookup_key . ' = <not found>');
+                continue;
+            }
+            $output->writeln($spec->lookup_key . ' = ' . $render($var));
+        }
+    }
+
+    private function buildReadOptions(
+        InputInterface $input,
+        string $format,
+    ): VariableReadOptions {
+        $needs_recursion = in_array(
+            $format,
+            ['var-dump', 'var-export', 'php-serialize'],
+            true,
+        );
+        $depth_raw = $input->getOption('max-depth');
+        $elements_raw = $input->getOption('max-elements');
+        $string_raw = $input->getOption('max-string');
+        assert(is_string($depth_raw));
+        assert(is_string($elements_raw));
+        assert(is_string($string_raw));
+        $depth = $needs_recursion
+            ? self::parseLimit($depth_raw, 10)
+            : 0;
+        $elements = self::parseLimit($elements_raw, 100);
+        $string = self::parseLimit($string_raw, 200);
+        return new VariableReadOptions($depth, $elements, $string);
+    }
+
+    /**
+     * Parse a CLI limit option. `-1` (or `unlimited`) maps to null
+     * (no limit); anything else parses as an integer with the supplied
+     * fallback for unparseable input.
+     */
+    private static function parseLimit(string $raw, int $fallback): ?int
+    {
+        $raw = trim($raw);
+        if ($raw === 'unlimited' || $raw === '-1') {
+            return null;
+        }
+        if (!ctype_digit($raw)) {
+            return $fallback;
+        }
+        return (int)$raw;
     }
 
     /**
@@ -252,14 +372,46 @@ final class PeekVarCommand extends ReliCommand
         foreach ($specs as $spec) {
             $var = $results[$spec->lookup_key] ?? null;
             $data[$spec->lookup_key] = $var !== null
-                ? [
-                    'type' => $var->type,
-                    'value' => $var->scalar_value,
-                    'array_count' => $var->array_count,
-                ]
+                ? $this->variableValueToJson($var)
                 : null;
         }
         $output->writeln((string)json_encode($data, JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function variableValueToJson(VariableValue $var): array
+    {
+        $out = [
+            'type' => $var->type,
+            'value' => $var->scalar_value,
+            'array_count' => $var->array_count,
+        ];
+        if ($var->class_name !== null) {
+            $out['class_name'] = $var->class_name;
+        }
+        if ($var->object_id !== null) {
+            $out['object_id'] = $var->object_id;
+        }
+        if ($var->children !== null) {
+            $children = [];
+            foreach ($var->children as [$key, $child]) {
+                $children[] = [
+                    'key' => $key,
+                    'value' => $this->variableValueToJson($child),
+                ];
+            }
+            $out['children'] = $children;
+        }
+        if ($var->children_truncated) {
+            $out['children_truncated'] = true;
+        }
+        if ($var->string_truncated) {
+            $out['string_truncated'] = true;
+            $out['original_string_length'] = $var->original_string_length;
+        }
+        return $out;
     }
 
     private function formatValue(VariableValue $var): string

--- a/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
+++ b/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
@@ -18,47 +18,64 @@ use Reli\Inspector\Watch\VariableValue;
 /**
  * Renders a VariableValue tree in PHP's serialize() format.
  *
- * Compat caveats — the output is **best-effort** and may not always
- * round-trip through `unserialize()`:
+ * Reproduces serialize's DFS-order numbering so that back-edges round-trip
+ * through `unserialize()`:
  *
- *   - `serialize()` numbers every emitted entry and rewrites back-edges as
- *     `r:N;` (objects use `R:N;`). Producing those numbers correctly would
- *     require a pre-pass over the tree; we instead emit `N;` for cycles
- *     (TYPE_RECURSION). The result still parses but loses identity.
- *   - Element-truncated arrays/objects keep the header count in sync with
- *     the emitted children, so `unserialize()` accepts the prefix even
- *     though information is missing.
- *   - Strings clipped to fit max_string emit their *clipped* byte length,
- *     so the format stays syntactically valid; the original length is
- *     therefore unrecoverable from the dump.
- *   - Custom Serializable / __serialize() output cannot be reconstructed
- *     from a memory snapshot — objects always render as plain
- *     `O:len:"Class":N:{...}`.
+ *   - object cycles and *shared* (non-cyclic) object instances render as
+ *     `r:N;` pointing to the id of the first emission, mirroring PHP's
+ *     by-reference object semantics
+ *   - array cycles (only reachable through `&` aliasing in PHP) render as
+ *     `R:N;`
+ *   - if the cycle target is missing — e.g. it sat below a depth/element
+ *     budget so the reader never assigned it an id — the back-edge falls
+ *     back to `N;` (a benign placeholder that keeps the format parseable)
  *
- * Use this format when you want a compact, machine-parseable single-line
- * dump (logs, eyeball-diffing). For round-tripping back into a PHP value,
- * pull the data live with `serialize()` instead.
+ * Compat caveats — what we *can't* reconstruct from a memory snapshot:
+ *
+ *   - true `&` references on scalars: the reader resolves `IS_REFERENCE`
+ *     before we see it, so two `&$x` slots both render as their target's
+ *     value rather than the second one becoming `R:N;`
+ *   - element-truncated arrays/objects: the header count is rewritten to
+ *     match the emitted body so `unserialize()` accepts the prefix; the
+ *     elided entries are unrecoverable
+ *   - clipped strings: the byte length reflects the *clipped* size, so
+ *     the format stays syntactically valid; the original length is lost
+ *   - `Serializable` / `__serialize()` customization: custom payloads
+ *     can't be reconstructed, so objects always render as
+ *     `O:len:"Class":N:{...}` from raw properties
  */
 final class PhpSerializeFormatter
 {
+    private int $counter = 0;
+    /** @var array<int, int> address → id (objects, persistent for the whole call) */
+    private array $object_ids = [];
+    /** @var array<int, int> address → id (arrays, only valid while on the recursion path) */
+    private array $array_stack_ids = [];
+
     public static function format(VariableValue $value): string
     {
-        return self::render($value);
+        return (new self())->render($value);
     }
 
-    private static function render(VariableValue $value): string
+    private function render(VariableValue $value): string
     {
         return match ($value->type) {
-            VariableValue::TYPE_LONG => 'i:' . (string)$value->scalar_value . ';',
-            VariableValue::TYPE_DOUBLE => 'd:' . self::formatDouble($value->scalar_value) . ';',
-            VariableValue::TYPE_STRING => self::renderString((string)$value->scalar_value),
-            VariableValue::TYPE_BOOL => 'b:' . ($value->scalar_value === true ? '1' : '0') . ';',
-            VariableValue::TYPE_NULL => 'N;',
-            VariableValue::TYPE_ARRAY => self::renderArray($value),
-            VariableValue::TYPE_OBJECT => self::renderObject($value),
-            VariableValue::TYPE_RECURSION => 'N;',
-            default => 'N;',
+            VariableValue::TYPE_LONG => $this->scalarBump('i:' . (string)$value->scalar_value . ';'),
+            VariableValue::TYPE_DOUBLE => $this->scalarBump('d:' . self::formatDouble($value->scalar_value) . ';'),
+            VariableValue::TYPE_STRING => $this->scalarBump(self::renderString((string)$value->scalar_value)),
+            VariableValue::TYPE_BOOL => $this->scalarBump('b:' . ($value->scalar_value === true ? '1' : '0') . ';'),
+            VariableValue::TYPE_NULL => $this->scalarBump('N;'),
+            VariableValue::TYPE_ARRAY => $this->renderArray($value),
+            VariableValue::TYPE_OBJECT => $this->renderObject($value),
+            VariableValue::TYPE_RECURSION => $this->renderRecursion($value),
+            default => $this->scalarBump('N;'),
         };
+    }
+
+    private function scalarBump(string $emitted): string
+    {
+        $this->counter++;
+        return $emitted;
     }
 
     private static function formatDouble(mixed $v): string
@@ -82,29 +99,78 @@ final class PhpSerializeFormatter
         return 's:' . strlen($s) . ':"' . $s . '";';
     }
 
-    private static function renderArray(VariableValue $value): string
+    private function renderArray(VariableValue $value): string
     {
+        $address = $value->address;
+        if ($address !== null && isset($this->array_stack_ids[$address])) {
+            // Back-edge to an array we're still inside — R:N;.
+            // No counter bump for back-edges.
+            return 'R:' . $this->array_stack_ids[$address] . ';';
+        }
+        $this->counter++;
+        $id = $this->counter;
+        if ($address !== null) {
+            $this->array_stack_ids[$address] = $id;
+        }
         $children = $value->children ?? [];
         $body = '';
         foreach ($children as [$key, $child]) {
-            $body .= self::renderKey($key) . self::render($child);
+            // Keys don't get counted — only the value below.
+            $body .= self::renderKey($key) . $this->render($child);
+        }
+        if ($address !== null) {
+            unset($this->array_stack_ids[$address]);
         }
         return 'a:' . count($children) . ':{' . $body . '}';
     }
 
-    private static function renderObject(VariableValue $value): string
+    private function renderObject(VariableValue $value): string
     {
+        $address = $value->address;
+        if ($address !== null && isset($this->object_ids[$address])) {
+            // Object identity is preserved across siblings as well — every
+            // subsequent occurrence of the same instance is r:N;.
+            return 'r:' . $this->object_ids[$address] . ';';
+        }
+        $this->counter++;
+        $id = $this->counter;
+        if ($address !== null) {
+            $this->object_ids[$address] = $id;
+        }
         $class = $value->class_name ?? 'stdClass';
         $children = $value->children ?? [];
         $body = '';
         foreach ($children as [$key, $child]) {
-            // For object props, the key is always emitted as a string, even
-            // for numeric keys (matching serialize() behavior).
+            // Object property keys are emitted as strings even for numeric
+            // names (matches serialize() behavior). Keys themselves aren't
+            // counted; the property value below is.
             $key_str = is_int($key) ? (string)$key : $key;
-            $body .= self::renderString($key_str) . self::render($child);
+            $body .= self::renderString($key_str) . $this->render($child);
         }
         return 'O:' . strlen($class) . ':"' . $class . '":'
             . count($children) . ':{' . $body . '}';
+    }
+
+    /**
+     * The reader emits TYPE_RECURSION for back-edges it caught during
+     * traversal. We resolve which kind of back-edge it is by looking the
+     * target address up in our id tables.
+     */
+    private function renderRecursion(VariableValue $value): string
+    {
+        $address = $value->address;
+        if ($address !== null) {
+            if (isset($this->object_ids[$address])) {
+                return 'r:' . $this->object_ids[$address] . ';';
+            }
+            if (isset($this->array_stack_ids[$address])) {
+                return 'R:' . $this->array_stack_ids[$address] . ';';
+            }
+        }
+        // Address unknown to us — emit a parseable placeholder. Counter
+        // isn't bumped because PHP doesn't bump it for back-edges either,
+        // and N; here is a substitute for what would be one.
+        return 'N;';
     }
 
     private static function renderKey(int|string $key): string

--- a/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
+++ b/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use Reli\Inspector\Watch\VariableValue;
+
+/**
+ * Renders a VariableValue tree in PHP's serialize() format.
+ *
+ * Compat caveats — the output is **best-effort** and may not always
+ * round-trip through `unserialize()`:
+ *
+ *   - `serialize()` numbers every emitted entry and rewrites back-edges as
+ *     `r:N;` (objects use `R:N;`). Producing those numbers correctly would
+ *     require a pre-pass over the tree; we instead emit `N;` for cycles
+ *     (TYPE_RECURSION). The result still parses but loses identity.
+ *   - Element-truncated arrays/objects keep the header count in sync with
+ *     the emitted children, so `unserialize()` accepts the prefix even
+ *     though information is missing.
+ *   - Strings clipped to fit max_string emit their *clipped* byte length,
+ *     so the format stays syntactically valid; the original length is
+ *     therefore unrecoverable from the dump.
+ *   - Custom Serializable / __serialize() output cannot be reconstructed
+ *     from a memory snapshot — objects always render as plain
+ *     `O:len:"Class":N:{...}`.
+ *
+ * Use this format when you want a compact, machine-parseable single-line
+ * dump (logs, eyeball-diffing). For round-tripping back into a PHP value,
+ * pull the data live with `serialize()` instead.
+ */
+final class PhpSerializeFormatter
+{
+    public static function format(VariableValue $value): string
+    {
+        return self::render($value);
+    }
+
+    private static function render(VariableValue $value): string
+    {
+        return match ($value->type) {
+            VariableValue::TYPE_LONG => 'i:' . (string)$value->scalar_value . ';',
+            VariableValue::TYPE_DOUBLE => 'd:' . self::formatDouble($value->scalar_value) . ';',
+            VariableValue::TYPE_STRING => self::renderString((string)$value->scalar_value),
+            VariableValue::TYPE_BOOL => 'b:' . ($value->scalar_value === true ? '1' : '0') . ';',
+            VariableValue::TYPE_NULL => 'N;',
+            VariableValue::TYPE_ARRAY => self::renderArray($value),
+            VariableValue::TYPE_OBJECT => self::renderObject($value),
+            VariableValue::TYPE_RECURSION => 'N;',
+            default => 'N;',
+        };
+    }
+
+    private static function formatDouble(mixed $v): string
+    {
+        if (!is_int($v) && !is_float($v)) {
+            return '0';
+        }
+        if (is_float($v)) {
+            if (is_nan($v)) {
+                return 'NAN';
+            }
+            if (!is_finite($v)) {
+                return $v > 0 ? 'INF' : '-INF';
+            }
+        }
+        return (string)$v;
+    }
+
+    private static function renderString(string $s): string
+    {
+        return 's:' . strlen($s) . ':"' . $s . '";';
+    }
+
+    private static function renderArray(VariableValue $value): string
+    {
+        $children = $value->children ?? [];
+        $body = '';
+        foreach ($children as [$key, $child]) {
+            $body .= self::renderKey($key) . self::render($child);
+        }
+        return 'a:' . count($children) . ':{' . $body . '}';
+    }
+
+    private static function renderObject(VariableValue $value): string
+    {
+        $class = $value->class_name ?? 'stdClass';
+        $children = $value->children ?? [];
+        $body = '';
+        foreach ($children as [$key, $child]) {
+            // For object props, the key is always emitted as a string, even
+            // for numeric keys (matching serialize() behavior).
+            $key_str = is_int($key) ? (string)$key : $key;
+            $body .= self::renderString($key_str) . self::render($child);
+        }
+        return 'O:' . strlen($class) . ':"' . $class . '":'
+            . count($children) . ':{' . $body . '}';
+    }
+
+    private static function renderKey(int|string $key): string
+    {
+        if (is_int($key)) {
+            return 'i:' . (string)$key . ';';
+        }
+        return self::renderString($key);
+    }
+}

--- a/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
+++ b/src/Inspector/Watch/Dump/PhpSerializeFormatter.php
@@ -24,17 +24,20 @@ use Reli\Inspector\Watch\VariableValue;
  *   - object cycles and *shared* (non-cyclic) object instances render as
  *     `r:N;` pointing to the id of the first emission, mirroring PHP's
  *     by-reference object semantics
+ *   - `&`-aliased slots (the same `zend_reference` reachable from multiple
+ *     places — including scalars) render as `R:N;` for every occurrence
+ *     after the first; the first occurrence emits its target value
+ *     normally and the reference's id piggybacks on that value's id, the
+ *     same way PHP's serialize does it
  *   - array cycles (only reachable through `&` aliasing in PHP) render as
- *     `R:N;`
- *   - if the cycle target is missing — e.g. it sat below a depth/element
- *     budget so the reader never assigned it an id — the back-edge falls
- *     back to `N;` (a benign placeholder that keeps the format parseable)
+ *     `R:N;` via the same mechanism
+ *   - if the cycle / share target is missing — e.g. it sat below a depth
+ *     / element budget so the reader never assigned it an id — the
+ *     back-edge falls back to `N;` (a benign placeholder that keeps the
+ *     format parseable)
  *
  * Compat caveats — what we *can't* reconstruct from a memory snapshot:
  *
- *   - true `&` references on scalars: the reader resolves `IS_REFERENCE`
- *     before we see it, so two `&$x` slots both render as their target's
- *     value rather than the second one becoming `R:N;`
  *   - element-truncated arrays/objects: the header count is rewritten to
  *     match the emitted body so `unserialize()` accepts the prefix; the
  *     elided entries are unrecoverable
@@ -51,6 +54,8 @@ final class PhpSerializeFormatter
     private array $object_ids = [];
     /** @var array<int, int> address → id (arrays, only valid while on the recursion path) */
     private array $array_stack_ids = [];
+    /** @var array<int, int> zend_reference address → id (persistent for the whole call) */
+    private array $reference_ids = [];
 
     public static function format(VariableValue $value): string
     {
@@ -58,6 +63,31 @@ final class PhpSerializeFormatter
     }
 
     private function render(VariableValue $value): string
+    {
+        // Reference-share back-edge: a slot whose zend_reference we've
+        // already emitted under some id N. PHP serialize() does this even
+        // for scalars (`R:N;`), and it does *not* bump the counter. We
+        // never assign a separate id to the reference itself — the id
+        // belongs to the target value, and the reference's address just
+        // becomes another lookup key for the same id.
+        $ref_addr = $value->reference_address;
+        if ($ref_addr !== null && isset($this->reference_ids[$ref_addr])) {
+            return 'R:' . $this->reference_ids[$ref_addr] . ';';
+        }
+        $before_counter = $this->counter;
+        $rendered = $this->dispatch($value);
+        // First-time reference: piggyback its id on whichever id
+        // dispatch() consumed (if any). If dispatch emitted a back-edge
+        // itself — e.g. an object that was already seen — counter didn't
+        // move, and we leave reference_ids alone so a future occurrence
+        // still resolves to the underlying object's id via object_ids.
+        if ($ref_addr !== null && $this->counter > $before_counter) {
+            $this->reference_ids[$ref_addr] = $before_counter + 1;
+        }
+        return $rendered;
+    }
+
+    private function dispatch(VariableValue $value): string
     {
         return match ($value->type) {
             VariableValue::TYPE_LONG => $this->scalarBump('i:' . (string)$value->scalar_value . ';'),

--- a/src/Inspector/Watch/Dump/VarDumpFormatter.php
+++ b/src/Inspector/Watch/Dump/VarDumpFormatter.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use Reli\Inspector\Watch\VariableValue;
+
+/**
+ * Renders a VariableValue tree in PHP's var_dump() format.
+ *
+ * Mirrors the runtime output, with caveats for limits:
+ *   - depth-truncated arrays/objects show a single `...` placeholder line
+ *     after the count header, matching what `var_dump()` itself does for
+ *     nothing (var_dump has no real depth limit) but communicates "more
+ *     content elided" without breaking the {N} block shape.
+ *   - element-truncated arrays/objects append a `// ... (N more)` comment
+ *     inside the block.
+ *   - strings show the *original* byte length even when the value was
+ *     clipped to fit max_string; clipped values are followed by `"...`.
+ *
+ * Cycles render as `*RECURSION*` (matches var_dump).
+ */
+final class VarDumpFormatter
+{
+    public static function format(VariableValue $value): string
+    {
+        return self::render($value, 0);
+    }
+
+    private static function render(VariableValue $value, int $indent): string
+    {
+        return match ($value->type) {
+            VariableValue::TYPE_LONG => 'int(' . (string)$value->scalar_value . ')',
+            VariableValue::TYPE_DOUBLE => 'float(' . self::formatDouble($value->scalar_value) . ')',
+            VariableValue::TYPE_STRING => self::renderString($value),
+            VariableValue::TYPE_BOOL => 'bool(' . ($value->scalar_value === true ? 'true' : 'false') . ')',
+            VariableValue::TYPE_NULL => 'NULL',
+            VariableValue::TYPE_ARRAY => self::renderArray($value, $indent),
+            VariableValue::TYPE_OBJECT => self::renderObject($value, $indent),
+            VariableValue::TYPE_RECURSION => '*RECURSION*',
+            default => '(unknown)',
+        };
+    }
+
+    private static function formatDouble(mixed $v): string
+    {
+        if (!is_int($v) && !is_float($v)) {
+            return '0';
+        }
+        if (is_float($v) && is_finite($v) && (float)(int)$v === $v) {
+            // var_dump prints "float(1)" for 1.0, matching PHP's behavior.
+            return (string)(int)$v;
+        }
+        return (string)$v;
+    }
+
+    private static function renderString(VariableValue $value): string
+    {
+        $raw = (string)$value->scalar_value;
+        $length = $value->original_string_length ?? strlen($raw);
+        $body = '"' . $raw;
+        if ($value->string_truncated) {
+            $body .= '..."';
+        } else {
+            $body .= '"';
+        }
+        return 'string(' . $length . ') ' . $body;
+    }
+
+    private static function renderArray(VariableValue $value, int $indent): string
+    {
+        $count = $value->array_count ?? 0;
+        $header = 'array(' . $count . ') {';
+        if ($value->children === null) {
+            // Depth-limited shallow read.
+            return $header . self::eol($indent + 1) . '...'
+                . self::eol($indent) . '}';
+        }
+        return $header
+            . self::renderChildren($value, $indent, false)
+            . self::eol($indent) . '}';
+    }
+
+    private static function renderObject(VariableValue $value, int $indent): string
+    {
+        $class = $value->class_name ?? '(unknown)';
+        $id = $value->object_id ?? 0;
+        $count = $value->array_count ?? 0;
+        $header = 'object(' . $class . ')#' . $id . ' (' . $count . ') {';
+        if ($value->children === null) {
+            return $header . self::eol($indent + 1) . '...'
+                . self::eol($indent) . '}';
+        }
+        return $header
+            . self::renderChildren($value, $indent, true)
+            . self::eol($indent) . '}';
+    }
+
+    private static function renderChildren(
+        VariableValue $value,
+        int $indent,
+        bool $is_object,
+    ): string {
+        $out = '';
+        foreach ($value->children ?? [] as [$key, $child]) {
+            $out .= self::eol($indent + 1)
+                . self::renderKey($key, $is_object)
+                . self::eol($indent + 1)
+                . self::render($child, $indent + 1);
+        }
+        if ($value->children_truncated) {
+            $out .= self::eol($indent + 1) . '// ... (truncated)';
+        }
+        return $out;
+    }
+
+    private static function renderKey(int|string $key, bool $is_object): string
+    {
+        if ($is_object && is_string($key)) {
+            // Detect NUL-prefixed visibility markers from
+            // ZendObject::getPropertiesIterator.
+            if (str_starts_with($key, "\0")) {
+                $rest = substr($key, 1);
+                $sep = strpos($rest, "\0");
+                if ($sep !== false) {
+                    $owner = substr($rest, 0, $sep);
+                    $name = substr($rest, $sep + 1);
+                    if ($owner === '*') {
+                        return '["' . $name . '":protected]=>';
+                    }
+                    return '["' . $name . '":"' . $owner . '":private]=>';
+                }
+            }
+            return '["' . $key . '"]=>';
+        }
+        if (is_int($key)) {
+            return '[' . (string)$key . ']=>';
+        }
+        return '["' . $key . '"]=>';
+    }
+
+    private static function eol(int $indent): string
+    {
+        return "\n" . str_repeat('  ', $indent);
+    }
+}

--- a/src/Inspector/Watch/Dump/VarExportFormatter.php
+++ b/src/Inspector/Watch/Dump/VarExportFormatter.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use Reli\Inspector\Watch\VariableValue;
+
+/**
+ * Renders a VariableValue tree in PHP's var_export() format.
+ *
+ * Caveats vs. native var_export():
+ *   - var_export() raises a fatal error on recursive structures; we instead
+ *     emit `/* RECURSION *\/` so the dump still completes.
+ *   - Depth-truncated and element-truncated nodes emit a `/* ... *\/`
+ *     comment inside the array/object body.
+ *   - Strings clipped to fit max_string are followed by `...'` rather than
+ *     a closing single quote so the truncation is visible in the output.
+ *
+ * The output for fully-readable scalars/arrays/objects is byte-identical
+ * to what `var_export()` would emit for the same value (single-quoted
+ * strings, `array (...)` blocks, `\Class::__set_state(array(...))` for
+ * objects).
+ */
+final class VarExportFormatter
+{
+    public static function format(VariableValue $value): string
+    {
+        return self::render($value, 0);
+    }
+
+    private static function render(VariableValue $value, int $indent): string
+    {
+        return match ($value->type) {
+            VariableValue::TYPE_LONG => (string)$value->scalar_value,
+            VariableValue::TYPE_DOUBLE => self::formatDouble($value->scalar_value),
+            VariableValue::TYPE_STRING => self::renderString($value),
+            VariableValue::TYPE_BOOL => $value->scalar_value === true ? 'true' : 'false',
+            VariableValue::TYPE_NULL => 'NULL',
+            VariableValue::TYPE_ARRAY => self::renderArray($value, $indent),
+            VariableValue::TYPE_OBJECT => self::renderObject($value, $indent),
+            VariableValue::TYPE_RECURSION => '/* RECURSION */',
+            default => '/* unknown */',
+        };
+    }
+
+    private static function formatDouble(mixed $v): string
+    {
+        if (!is_int($v) && !is_float($v)) {
+            return '0.0';
+        }
+        if (is_float($v) && is_finite($v) && (float)(int)$v === $v) {
+            return (string)(int)$v . '.0';
+        }
+        return (string)$v;
+    }
+
+    private static function renderString(VariableValue $value): string
+    {
+        $raw = (string)$value->scalar_value;
+        $escaped = str_replace(
+            ['\\', '\''],
+            ['\\\\', '\\\''],
+            $raw,
+        );
+        if ($value->string_truncated) {
+            return "'" . $escaped . "...'";
+        }
+        return "'" . $escaped . "'";
+    }
+
+    private static function renderArray(VariableValue $value, int $indent): string
+    {
+        if ($value->children === null) {
+            return 'array (' . self::eol($indent + 1) . '/* ... */'
+                . self::eol($indent) . ')';
+        }
+        if ($value->children === []) {
+            return 'array (' . ($value->children_truncated
+                ? self::eol($indent + 1) . '/* ... */' . self::eol($indent)
+                : self::nbsp())
+                . ')';
+        }
+        $body = '';
+        foreach ($value->children as [$key, $child]) {
+            $body .= self::eol($indent + 1)
+                . self::renderKey($key) . ' => '
+                . self::renderChildValue($child, $indent + 1) . ',';
+        }
+        if ($value->children_truncated) {
+            $body .= self::eol($indent + 1) . '/* ... */';
+        }
+        return 'array (' . $body . self::eol($indent) . ')';
+    }
+
+    private static function renderObject(VariableValue $value, int $indent): string
+    {
+        $class = $value->class_name ?? 'stdClass';
+        $prefix = '\\' . ltrim($class, '\\') . '::__set_state(array(';
+        if ($value->children === null) {
+            return $prefix . self::eol($indent + 1) . '/* ... */'
+                . self::eol($indent) . '))';
+        }
+        if ($value->children === []) {
+            return $prefix . ($value->children_truncated
+                ? self::eol($indent + 1) . '/* ... */' . self::eol($indent)
+                : self::nbsp())
+                . '))';
+        }
+        $body = '';
+        foreach ($value->children as [$key, $child]) {
+            $body .= self::eol($indent + 1)
+                . self::renderObjectKey($key) . ' => '
+                . self::renderChildValue($child, $indent + 1) . ',';
+        }
+        if ($value->children_truncated) {
+            $body .= self::eol($indent + 1) . '/* ... */';
+        }
+        return $prefix . $body . self::eol($indent) . '))';
+    }
+
+    /**
+     * Like {@see render} but inserts a leading newline + same-level indent
+     * before non-empty arrays/objects, matching var_export()'s habit of
+     * pushing complex children onto a new line.
+     */
+    private static function renderChildValue(VariableValue $value, int $indent): string
+    {
+        $needs_break = ($value->type === VariableValue::TYPE_ARRAY
+            || $value->type === VariableValue::TYPE_OBJECT)
+            && ($value->children === null || $value->children !== []);
+        $rendered = self::render($value, $indent);
+        if ($needs_break) {
+            return self::eol($indent) . $rendered;
+        }
+        return $rendered;
+    }
+
+    private static function renderKey(int|string $key): string
+    {
+        if (is_int($key)) {
+            return (string)$key;
+        }
+        return self::quote($key);
+    }
+
+    private static function renderObjectKey(int|string $key): string
+    {
+        if (is_int($key)) {
+            return self::quote((string)$key);
+        }
+        // var_export strips visibility markers and just shows the bare name.
+        if (str_starts_with($key, "\0")) {
+            $rest = substr($key, 1);
+            $sep = strpos($rest, "\0");
+            if ($sep !== false) {
+                return self::quote(substr($rest, $sep + 1));
+            }
+        }
+        return self::quote($key);
+    }
+
+    private static function quote(string $s): string
+    {
+        $escaped = str_replace(
+            ['\\', '\''],
+            ['\\\\', '\\\''],
+            $s,
+        );
+        return "'" . $escaped . "'";
+    }
+
+    private static function nbsp(): string
+    {
+        return '';
+    }
+
+    private static function eol(int $indent): string
+    {
+        return "\n" . str_repeat('  ', $indent);
+    }
+}

--- a/src/Inspector/Watch/VariableReadOptions.php
+++ b/src/Inspector/Watch/VariableReadOptions.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch;
+
+/**
+ * Recursion / size limits for {@see VariableReader::readVariables()}.
+ *
+ * `null` on any field means "no limit" — useful for full dumps. The defaults
+ * here are the single-level shape used by inspector:trace --trace-var and
+ * inspector:watch (depth 0, no children expanded). PeekVarCommand passes its
+ * own options when the user requests a recursive output format.
+ */
+final class VariableReadOptions
+{
+    public function __construct(
+        public readonly ?int $max_depth = 0,
+        public readonly ?int $max_elements = 100,
+        public readonly ?int $max_string = 200,
+    ) {
+    }
+
+    public static function unlimited(): self
+    {
+        return new self(null, null, null);
+    }
+}

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -672,6 +672,9 @@ final class VariableReader implements VariableReaderInterface
         return $ref_pointer->address;
     }
 
+    /**
+     * @param array<int, true> $seen
+     */
     private function buildResolvedValue(
         Zval $zval,
         Dereferencer $dereferencer,
@@ -966,10 +969,8 @@ final class VariableReader implements VariableReaderInterface
                 : null;
 
             $visited_slots = [];
-            foreach (
-                $ce->properties_info->getItemIterator($dereferencer)
-                as $simple_name => $info_zval
-            ) {
+            $info_iter = $ce->properties_info->getItemIterator($dereferencer);
+            foreach ($info_iter as $simple_name => $info_zval) {
                 $info_pointer = $info_zval->value->getAsPointer(
                     \Reli\Lib\PhpInternals\Types\Zend\ZendPropertyInfo::class,
                     $zend_type_reader->sizeOf(

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -63,6 +63,7 @@ final class VariableReader implements VariableReaderInterface
         TargetPhpSettings $target_php_settings,
         int $eg_address,
         int $cg_address = 0,
+        ?VariableReadOptions $options = null,
     ): array {
         if (count($specs) === 0) {
             return [];
@@ -130,12 +131,14 @@ final class VariableReader implements VariableReaderInterface
                         $dereferencer,
                         $zend_type_reader,
                         $name,
+                        $options,
                     ) : null,
                     'local' => $eg !== null ? $this->readLocalVariable(
                         $eg,
                         $dereferencer,
                         $zend_type_reader,
                         $name,
+                        $options,
                     ) : null,
                     'static' => $eg !== null ? $this->readStaticProperty(
                         $eg,
@@ -143,6 +146,7 @@ final class VariableReader implements VariableReaderInterface
                         $zend_type_reader,
                         $name,
                         $cg_address,
+                        $options,
                     ) : null,
                     'func_static' => $eg !== null ? $this->readFuncStaticVariable(
                         $eg,
@@ -150,6 +154,7 @@ final class VariableReader implements VariableReaderInterface
                         $zend_type_reader,
                         $name,
                         $cg_address,
+                        $options,
                     ) : null,
                     default => null,
                 };
@@ -202,6 +207,7 @@ final class VariableReader implements VariableReaderInterface
         Dereferencer $dereferencer,
         ZendTypeReader $zend_type_reader,
         string $name,
+        ?VariableReadOptions $options,
     ): ?VariableValue {
         // Strip leading $ if present
         $name = str_starts_with($name, '$') ? substr($name, 1) : $name;
@@ -223,7 +229,14 @@ final class VariableReader implements VariableReaderInterface
         if ($zval === null) {
             return null;
         }
-        return $this->zvalToVariableValue($zval, $dereferencer);
+        return $this->buildValue(
+            $zval,
+            $dereferencer,
+            $zend_type_reader,
+            $options,
+            0,
+            [],
+        );
     }
 
     /**
@@ -240,6 +253,7 @@ final class VariableReader implements VariableReaderInterface
         Dereferencer $dereferencer,
         ZendTypeReader $zend_type_reader,
         string $name,
+        ?VariableReadOptions $options,
     ): ?VariableValue {
         [$func_filter, $var_part] = self::parseLocalExpression($name);
         if ($func_filter === null) {
@@ -278,9 +292,13 @@ final class VariableReader implements VariableReaderInterface
                     if ($resolved === null) {
                         return null;
                     }
-                    return $this->zvalToVariableValue(
+                    return $this->buildValue(
                         $resolved,
                         $dereferencer,
+                        $zend_type_reader,
+                        $options,
+                        0,
+                        [],
                     );
                 }
             }
@@ -358,6 +376,7 @@ final class VariableReader implements VariableReaderInterface
         ZendTypeReader $zend_type_reader,
         string $name,
         int $cg_address,
+        ?VariableReadOptions $options,
     ): ?VariableValue {
         // Parse "ClassName::$propName"
         $parts = explode('::$', $name, 2);
@@ -422,9 +441,13 @@ final class VariableReader implements VariableReaderInterface
                 if ($resolved === null) {
                     return null;
                 }
-                return $this->zvalToVariableValue(
+                return $this->buildValue(
                     $resolved,
                     $dereferencer,
+                    $zend_type_reader,
+                    $options,
+                    0,
+                    [],
                 );
             }
         }
@@ -441,6 +464,7 @@ final class VariableReader implements VariableReaderInterface
         ZendTypeReader $zend_type_reader,
         string $name,
         int $cg_address,
+        ?VariableReadOptions $options,
     ): ?VariableValue {
         // Parse "funcName()$varName" using same ()$ pattern as local
         [$func_name, $var_part] = self::parseLocalExpression($name);
@@ -510,17 +534,78 @@ final class VariableReader implements VariableReaderInterface
         if ($resolved === null) {
             return null;
         }
-        return $this->zvalToVariableValue($resolved, $dereferencer);
+        return $this->buildValue(
+            $resolved,
+            $dereferencer,
+            $zend_type_reader,
+            $options,
+            0,
+            [],
+        );
     }
 
-    private function zvalToVariableValue(
+    /**
+     * Reconstruct the NUL-mangled property name PHP uses internally for
+     * private (`\0Class\0name`) and protected (`\0*\0name`) properties.
+     *
+     * We can't read property_info->name directly because the project's
+     * RawString reader truncates at the first NUL — the value would come
+     * back empty. The unmangled simple name is available as the hash key
+     * in `properties_info`, so we mangle it back on this side using the
+     * declaring class entry for private and a fixed `*` token for
+     * protected.
+     */
+    private static function buildMangledPropertyName(
+        string $simple_name,
+        \Reli\Lib\PhpInternals\Types\Zend\ZendPropertyInfo $property_info,
+        Dereferencer $dereferencer,
+    ): string {
+        if ($property_info->isPrivate()) {
+            $owner_name = '*';
+            if ($property_info->ce !== null) {
+                try {
+                    $owner_ce = $dereferencer->deref($property_info->ce);
+                    $owner_name = $owner_ce->getClassName($dereferencer);
+                } catch (\Throwable) {
+                    // fall through with placeholder
+                }
+            }
+            return "\0" . $owner_name . "\0" . $simple_name;
+        }
+        if ($property_info->isProtected()) {
+            return "\0*\0" . $simple_name;
+        }
+        return $simple_name;
+    }
+
+    /**
+     * Convert a zval to a VariableValue tree.
+     *
+     * Recursion is bounded by $options:
+     *   - max_depth   null → unlimited; 0 → no children expansion
+     *   - max_elements null → unlimited; otherwise children list is capped
+     *   - max_string  null → unlimited; otherwise the raw string is clipped
+     *
+     * Cycle detection uses a stack of pointer addresses for arrays and
+     * objects on the current recursion path, so a shared sub-graph reached
+     * through two siblings is *not* falsely flagged — only true back-edges
+     * yield TYPE_RECURSION.
+     *
+     * @param array<int, true> $seen  pointer addresses currently on the
+     *     recursion stack (passed by value so siblings get a fresh view).
+     */
+    private function buildValue(
         Zval $zval,
         Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ?VariableReadOptions $options,
+        int $depth,
+        array $seen,
     ): VariableValue {
-        // Follow IS_INDIRECT and IS_REFERENCE
         $resolved = $this->resolveIndirectAndRef(
             $zval,
             $dereferencer,
+            $zend_type_reader,
         );
         if ($resolved === null) {
             return new VariableValue(
@@ -546,35 +631,26 @@ final class VariableReader implements VariableReaderInterface
             );
         }
         if ($zval->isString()) {
-            $str_pointer = $zval->value->str;
-            if ($str_pointer !== null) {
-                $zend_string = $dereferencer->deref($str_pointer);
-                return new VariableValue(
-                    VariableValue::TYPE_STRING,
-                    $zend_string->toString($dereferencer),
-                    null,
-                );
-            }
-            return new VariableValue(
-                VariableValue::TYPE_STRING,
-                '',
-                null,
-            );
+            return $this->buildStringValue($zval, $dereferencer, $options);
         }
         if ($zval->isArray()) {
-            $arr_pointer = $zval->value->arr;
-            if ($arr_pointer !== null) {
-                $arr = $dereferencer->deref($arr_pointer);
-                return new VariableValue(
-                    VariableValue::TYPE_ARRAY,
-                    null,
-                    $arr->nNumOfElements,
-                );
-            }
-            return new VariableValue(
-                VariableValue::TYPE_ARRAY,
-                null,
-                0,
+            return $this->buildArrayValue(
+                $zval,
+                $dereferencer,
+                $zend_type_reader,
+                $options,
+                $depth,
+                $seen,
+            );
+        }
+        if ($zval->isObject()) {
+            return $this->buildObjectValue(
+                $zval,
+                $dereferencer,
+                $zend_type_reader,
+                $options,
+                $depth,
+                $seen,
             );
         }
         if ($zval->isBool()) {
@@ -595,6 +671,295 @@ final class VariableReader implements VariableReaderInterface
             VariableValue::TYPE_UNKNOWN,
             null,
             null,
+        );
+    }
+
+    private function buildStringValue(
+        Zval $zval,
+        Dereferencer $dereferencer,
+        ?VariableReadOptions $options,
+    ): VariableValue {
+        $str_pointer = $zval->value->str;
+        if ($str_pointer === null) {
+            return new VariableValue(
+                VariableValue::TYPE_STRING,
+                '',
+                null,
+            );
+        }
+        $zend_string = $dereferencer->deref($str_pointer);
+        $raw = $zend_string->toString($dereferencer);
+        $original_length = strlen($raw);
+        $max = $options?->max_string;
+        $truncated = false;
+        if ($max !== null && $max >= 0 && $original_length > $max) {
+            $raw = substr($raw, 0, $max);
+            $truncated = true;
+        }
+        return new VariableValue(
+            VariableValue::TYPE_STRING,
+            $raw,
+            null,
+            null,
+            null,
+            null,
+            false,
+            $truncated,
+            $original_length,
+        );
+    }
+
+    /**
+     * @param array<int, true> $seen
+     */
+    private function buildArrayValue(
+        Zval $zval,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ?VariableReadOptions $options,
+        int $depth,
+        array $seen,
+    ): VariableValue {
+        $arr_pointer = $zval->value->arr;
+        if ($arr_pointer === null) {
+            return new VariableValue(
+                VariableValue::TYPE_ARRAY,
+                null,
+                0,
+            );
+        }
+        $address = $arr_pointer->address;
+        if (isset($seen[$address])) {
+            return new VariableValue(
+                VariableValue::TYPE_RECURSION,
+                null,
+                null,
+            );
+        }
+        $arr = $dereferencer->deref($arr_pointer);
+        $count = $arr->nNumOfElements;
+        $max_depth = $options?->max_depth;
+        if ($max_depth !== null && $depth >= $max_depth) {
+            return new VariableValue(
+                VariableValue::TYPE_ARRAY,
+                null,
+                $count,
+            );
+        }
+        $seen[$address] = true;
+        $children = [];
+        $max_elements = $options?->max_elements;
+        $truncated = false;
+        $i = 0;
+        foreach ($arr->getItemIterator($dereferencer) as $key => $item_zval) {
+            if ($max_elements !== null && $i >= $max_elements) {
+                $truncated = true;
+                break;
+            }
+            // Re-deref for independent CData
+            $child_zval = $dereferencer->deref($item_zval->getPointer());
+            $children[] = [
+                $key,
+                $this->buildValue(
+                    $child_zval,
+                    $dereferencer,
+                    $zend_type_reader,
+                    $options,
+                    $depth + 1,
+                    $seen,
+                ),
+            ];
+            $i++;
+        }
+        return new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            $count,
+            $children,
+            null,
+            null,
+            $truncated,
+        );
+    }
+
+    /**
+     * @param array<int, true> $seen
+     */
+    private function buildObjectValue(
+        Zval $zval,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ?VariableReadOptions $options,
+        int $depth,
+        array $seen,
+    ): VariableValue {
+        $obj_pointer = $zval->value->obj;
+        if ($obj_pointer === null) {
+            return new VariableValue(
+                VariableValue::TYPE_OBJECT,
+                null,
+                0,
+            );
+        }
+        $address = $obj_pointer->address;
+        $obj = $dereferencer->deref($obj_pointer);
+        $handle = $obj->getHandle();
+        if (isset($seen[$address])) {
+            return new VariableValue(
+                VariableValue::TYPE_RECURSION,
+                null,
+                null,
+                null,
+                null,
+                $handle,
+            );
+        }
+        $class_name = null;
+        if ($obj->ce !== null) {
+            try {
+                $ce = $dereferencer->deref($obj->ce);
+                $class_name = $ce->getClassName($dereferencer);
+            } catch (\Throwable) {
+                $class_name = null;
+            }
+        }
+        $max_depth = $options?->max_depth;
+        if ($max_depth !== null && $depth >= $max_depth) {
+            return new VariableValue(
+                VariableValue::TYPE_OBJECT,
+                null,
+                null,
+                null,
+                $class_name,
+                $handle,
+            );
+        }
+
+        $seen[$address] = true;
+        $children = [];
+        $max_elements = $options?->max_elements;
+        $truncated = false;
+        $total = 0;
+        try {
+            $is_74_plus = !$zend_type_reader->isPhpVersionLowerThan(
+                ZendTypeReader::V74,
+            );
+            [$table_offset,] = $zend_type_reader->getOffsetAndSizeOfMember(
+                ZendObject::getCTypeName(),
+                'properties_table',
+            );
+            $ce = $obj->ce !== null ? $dereferencer->deref($obj->ce) : null;
+            if ($ce === null) {
+                return new VariableValue(
+                    VariableValue::TYPE_OBJECT,
+                    null,
+                    0,
+                    [],
+                    $class_name,
+                    $handle,
+                );
+            }
+            $property_count = $ce->default_properties_count;
+            $table_size = $property_count
+                * $zend_type_reader->sizeOf(Zval::getCTypeName());
+            $properties_table_pointer = new Pointer(
+                \Reli\Lib\PhpInternals\Types\Zend\ZvalArray::class,
+                $obj->getPointer()->address + $table_offset,
+                $table_size,
+            );
+            $properties_table = $property_count > 0
+                ? $dereferencer->deref($properties_table_pointer)
+                : null;
+
+            $visited_slots = [];
+            foreach (
+                $ce->properties_info->getItemIterator($dereferencer)
+                as $simple_name => $info_zval
+            ) {
+                $info_pointer = $info_zval->value->getAsPointer(
+                    \Reli\Lib\PhpInternals\Types\Zend\ZendPropertyInfo::class,
+                    $zend_type_reader->sizeOf(
+                        \Reli\Lib\PhpInternals\Types\Zend\ZendPropertyInfo::getCTypeName()
+                    ),
+                );
+                $property_info = $dereferencer->deref($info_pointer);
+                if ($property_info->isStatic($is_74_plus)) {
+                    continue;
+                }
+                $real_offset = $property_info->offset - $table_offset;
+                $slot = (int)($real_offset / 16);
+                $visited_slots[$slot] = true;
+                if ($properties_table === null) {
+                    continue;
+                }
+                $name = self::buildMangledPropertyName(
+                    (string)$simple_name,
+                    $property_info,
+                    $dereferencer,
+                );
+                $prop_zval = $properties_table[$slot];
+                if ($prop_zval->isUndef()) {
+                    continue;
+                }
+                $total++;
+                if ($max_elements !== null && count($children) >= $max_elements) {
+                    $truncated = true;
+                    continue;
+                }
+                $child_zval = $dereferencer->deref($prop_zval->getPointer());
+                $children[] = [
+                    $name,
+                    $this->buildValue(
+                        $child_zval,
+                        $dereferencer,
+                        $zend_type_reader,
+                        $options,
+                        $depth + 1,
+                        $seen,
+                    ),
+                ];
+            }
+
+            // Trait-defined / dynamic slots not covered above
+            if ($properties_table !== null) {
+                for ($i = 0; $i < $property_count; $i++) {
+                    if (isset($visited_slots[$i])) {
+                        continue;
+                    }
+                    $prop_zval = $properties_table[$i];
+                    if ($prop_zval->isUndef()) {
+                        continue;
+                    }
+                    $total++;
+                    if ($max_elements !== null && count($children) >= $max_elements) {
+                        $truncated = true;
+                        continue;
+                    }
+                    $child_zval = $dereferencer->deref($prop_zval->getPointer());
+                    $children[] = [
+                        "property_{$i}",
+                        $this->buildValue(
+                            $child_zval,
+                            $dereferencer,
+                            $zend_type_reader,
+                            $options,
+                            $depth + 1,
+                            $seen,
+                        ),
+                    ];
+                }
+            }
+        } catch (\Throwable) {
+            // best-effort: stop iterating on read error
+        }
+        return new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            $total,
+            $children,
+            $class_name,
+            $handle,
+            $truncated,
         );
     }
 

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -602,6 +602,17 @@ final class VariableReader implements VariableReaderInterface
         int $depth,
         array $seen,
     ): VariableValue {
+        // Capture the originating zend_reference's pointer address before
+        // resolveIndirectAndRef collapses the IS_REFERENCE layer. We need
+        // it so the serialize formatter can emit R:N; for `&`-aliased
+        // slots that reach the same zend_reference (PHP gives them the
+        // same id and a back-edge for every occurrence after the first).
+        $reference_address = $this->detectReferenceAddress(
+            $zval,
+            $dereferencer,
+            $zend_type_reader,
+        );
+
         $resolved = $this->resolveIndirectAndRef(
             $zval,
             $dereferencer,
@@ -614,7 +625,60 @@ final class VariableReader implements VariableReaderInterface
                 null,
             );
         }
-        $zval = $resolved;
+        $built = $this->buildResolvedValue(
+            $resolved,
+            $dereferencer,
+            $zend_type_reader,
+            $options,
+            $depth,
+            $seen,
+        );
+        if ($reference_address !== null) {
+            return $built->withReferenceAddress($reference_address);
+        }
+        return $built;
+    }
+
+    /**
+     * Peek the zval (skipping any IS_INDIRECT layer) and return the
+     * underlying zend_reference pointer's address if the slot is a `&`-
+     * alias, otherwise null. Does not consume / modify the input.
+     */
+    private function detectReferenceAddress(
+        Zval $zval,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+    ): ?int {
+        $current = $zval;
+        if ($current->isIndirect()) {
+            try {
+                $ptr = $current->value->getAsPointer(
+                    Zval::class,
+                    $zend_type_reader->sizeOf('zval'),
+                );
+                $current = $dereferencer->deref($ptr);
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+        if (!$current->isReference()) {
+            return null;
+        }
+        $ref_pointer = $current->value->ref;
+        if ($ref_pointer === null) {
+            return null;
+        }
+        return $ref_pointer->address;
+    }
+
+    private function buildResolvedValue(
+        Zval $zval,
+        Dereferencer $dereferencer,
+        ZendTypeReader $zend_type_reader,
+        ?VariableReadOptions $options,
+        int $depth,
+        array $seen,
+    ): VariableValue {
 
         if ($zval->isLong()) {
             return new VariableValue(

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -734,6 +734,13 @@ final class VariableReader implements VariableReaderInterface
                 VariableValue::TYPE_RECURSION,
                 null,
                 null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                $address,
             );
         }
         $arr = $dereferencer->deref($arr_pointer);
@@ -744,6 +751,13 @@ final class VariableReader implements VariableReaderInterface
                 VariableValue::TYPE_ARRAY,
                 null,
                 $count,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                $address,
             );
         }
         $seen[$address] = true;
@@ -779,6 +793,9 @@ final class VariableReader implements VariableReaderInterface
             null,
             null,
             $truncated,
+            false,
+            null,
+            $address,
         );
     }
 
@@ -812,6 +829,10 @@ final class VariableReader implements VariableReaderInterface
                 null,
                 null,
                 $handle,
+                false,
+                false,
+                null,
+                $address,
             );
         }
         $class_name = null;
@@ -832,6 +853,10 @@ final class VariableReader implements VariableReaderInterface
                 null,
                 $class_name,
                 $handle,
+                false,
+                false,
+                null,
+                $address,
             );
         }
 
@@ -857,6 +882,10 @@ final class VariableReader implements VariableReaderInterface
                     [],
                     $class_name,
                     $handle,
+                    false,
+                    false,
+                    null,
+                    $address,
                 );
             }
             $property_count = $ce->default_properties_count;
@@ -960,6 +989,9 @@ final class VariableReader implements VariableReaderInterface
             $class_name,
             $handle,
             $truncated,
+            false,
+            null,
+            $address,
         );
     }
 

--- a/src/Inspector/Watch/VariableReader.php
+++ b/src/Inspector/Watch/VariableReader.php
@@ -559,8 +559,9 @@ final class VariableReader implements VariableReaderInterface
         string $simple_name,
         \Reli\Lib\PhpInternals\Types\Zend\ZendPropertyInfo $property_info,
         Dereferencer $dereferencer,
+        bool $php74_or_later,
     ): string {
-        if ($property_info->isPrivate()) {
+        if ($property_info->isPrivate($php74_or_later)) {
             $owner_name = '*';
             if ($property_info->ce !== null) {
                 try {
@@ -572,7 +573,7 @@ final class VariableReader implements VariableReaderInterface
             }
             return "\0" . $owner_name . "\0" . $simple_name;
         }
-        if ($property_info->isProtected()) {
+        if ($property_info->isProtected($php74_or_later)) {
             return "\0*\0" . $simple_name;
         }
         return $simple_name;
@@ -989,6 +990,7 @@ final class VariableReader implements VariableReaderInterface
                     (string)$simple_name,
                     $property_info,
                     $dereferencer,
+                    $is_74_plus,
                 );
                 $prop_zval = $properties_table[$slot];
                 if ($prop_zval->isUndef()) {

--- a/src/Inspector/Watch/VariableReaderInterface.php
+++ b/src/Inspector/Watch/VariableReaderInterface.php
@@ -28,6 +28,8 @@ interface VariableReaderInterface
     /**
      * @param list<VariableSpec> $specs
      * @param TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $target_php_settings
+     * @param VariableReadOptions|null $options recursion / size limits;
+     *     null preserves the legacy single-level behavior used by trace/watch.
      * @return array<string, VariableValue> keyed by `VariableSpec::$lookup_key`;
      *     specs that could not be resolved are omitted rather than being
      *     returned as a null or placeholder value.
@@ -38,5 +40,6 @@ interface VariableReaderInterface
         TargetPhpSettings $target_php_settings,
         int $eg_address,
         int $cg_address = 0,
+        ?VariableReadOptions $options = null,
     ): array;
 }

--- a/src/Inspector/Watch/VariableValue.php
+++ b/src/Inspector/Watch/VariableValue.php
@@ -46,6 +46,7 @@ final class VariableValue
         public readonly bool $children_truncated = false,
         public readonly bool $string_truncated = false,
         public readonly ?int $original_string_length = null,
+        public readonly ?int $address = null,
     ) {
     }
 }

--- a/src/Inspector/Watch/VariableValue.php
+++ b/src/Inspector/Watch/VariableValue.php
@@ -47,6 +47,30 @@ final class VariableValue
         public readonly bool $string_truncated = false,
         public readonly ?int $original_string_length = null,
         public readonly ?int $address = null,
+        public readonly ?int $reference_address = null,
     ) {
+    }
+
+    /**
+     * Return a copy with `reference_address` replaced. Used by the reader
+     * to stamp the originating zend_reference's pointer onto a value
+     * after resolveIndirectAndRef has already consumed the IS_REFERENCE
+     * layer.
+     */
+    public function withReferenceAddress(?int $reference_address): self
+    {
+        return new self(
+            $this->type,
+            $this->scalar_value,
+            $this->array_count,
+            $this->children,
+            $this->class_name,
+            $this->object_id,
+            $this->children_truncated,
+            $this->string_truncated,
+            $this->original_string_length,
+            $this->address,
+            $reference_address,
+        );
     }
 }

--- a/src/Inspector/Watch/VariableValue.php
+++ b/src/Inspector/Watch/VariableValue.php
@@ -15,6 +15,11 @@ namespace Reli\Inspector\Watch;
 
 /**
  * Represents a variable value read from a target process.
+ *
+ * Scalars use $scalar_value. Arrays and objects use $children
+ * (a list of [key, VariableValue] pairs); $array_count holds the
+ * total element count even when $children is truncated or absent
+ * (e.g. depth-limited shallow read).
  */
 final class VariableValue
 {
@@ -23,13 +28,24 @@ final class VariableValue
     public const TYPE_STRING = 'string';
     public const TYPE_BOOL = 'bool';
     public const TYPE_ARRAY = 'array';
+    public const TYPE_OBJECT = 'object';
     public const TYPE_NULL = 'null';
+    public const TYPE_RECURSION = 'recursion';
     public const TYPE_UNKNOWN = 'unknown';
 
+    /**
+     * @param list<array{0: int|string, 1: VariableValue}>|null $children
+     */
     public function __construct(
         public readonly string $type,
         public readonly int|float|string|bool|null $scalar_value,
         public readonly ?int $array_count,
+        public readonly ?array $children = null,
+        public readonly ?string $class_name = null,
+        public readonly ?int $object_id = null,
+        public readonly bool $children_truncated = false,
+        public readonly bool $string_truncated = false,
+        public readonly ?int $original_string_length = null,
     ) {
     }
 }

--- a/src/Lib/PhpInternals/Types/Zend/ZendObject.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendObject.php
@@ -89,6 +89,15 @@ final class ZendObject implements CDataDereferencable
         );
     }
 
+    /**
+     * The runtime object id PHP exposes as `#N` in `var_dump` /
+     * `spl_object_id()`. Stable for the lifetime of the object.
+     */
+    public function getHandle(): int
+    {
+        return $this->casted_cdata->casted->handle;
+    }
+
     public function getMemorySize(
         Dereferencer $dereferencer,
     ): int {

--- a/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
@@ -34,6 +34,9 @@ final class ZendPropertyInfo implements CDataDereferencable
     /** @var Pointer<ZendString> */
     public ?Pointer $doc_comment;
 
+    /** @var Pointer<ZendClassEntry>|null */
+    public ?Pointer $ce;
+
     /**
      * @param CastedCData<\FFI\PhpInternals\zend_property_info> $casted_cdata
      * @param Pointer<self> $pointer
@@ -46,6 +49,7 @@ final class ZendPropertyInfo implements CDataDereferencable
         unset($this->flags);
         unset($this->name);
         unset($this->doc_comment);
+        unset($this->ce);
     }
 
     public function __get(string $field_name): mixed
@@ -67,7 +71,34 @@ final class ZendPropertyInfo implements CDataDereferencable
                 )
                 : null
             ,
+            'ce' => $this->ce = $this->casted_cdata->casted->ce !== null
+                ? Pointer::fromCData(
+                    ZendClassEntry::class,
+                    $this->casted_cdata->casted->ce,
+                )
+                : null
+            ,
         };
+    }
+
+    /**
+     * Visibility helpers. ZEND_ACC_* low bits in zend_compile.h:
+     * public=0x01, protected=0x02, private=0x04. Stable from PHP 7.x
+     * onward.
+     */
+    public function isPublic(): bool
+    {
+        return (bool)($this->flags & 0x01);
+    }
+
+    public function isProtected(): bool
+    {
+        return (bool)($this->flags & 0x02);
+    }
+
+    public function isPrivate(): bool
+    {
+        return (bool)($this->flags & 0x04);
     }
 
     /**

--- a/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendPropertyInfo.php
@@ -82,23 +82,28 @@ final class ZendPropertyInfo implements CDataDereferencable
     }
 
     /**
-     * Visibility helpers. ZEND_ACC_* low bits in zend_compile.h:
-     * public=0x01, protected=0x02, private=0x04. Stable from PHP 7.x
-     * onward.
+     * Visibility helpers. ZEND_ACC_PUBLIC / PROTECTED / PRIVATE moved across
+     * PHP 7.4: in 7.0–7.3 they sat in the upper byte (0x100 / 0x200 / 0x400);
+     * from 7.4 onward they live in the low bits (0x01 / 0x02 / 0x04). We
+     * mirror the version handling used by {@see isStatic} so the caller's
+     * existing `$php74_or_later` plumbing flows through.
      */
-    public function isPublic(): bool
+    public function isPublic(bool $php74_or_later = true): bool
     {
-        return (bool)($this->flags & 0x01);
+        $mask = $php74_or_later ? 0x01 : 0x100;
+        return (bool)($this->flags & $mask);
     }
 
-    public function isProtected(): bool
+    public function isProtected(bool $php74_or_later = true): bool
     {
-        return (bool)($this->flags & 0x02);
+        $mask = $php74_or_later ? 0x02 : 0x200;
+        return (bool)($this->flags & $mask);
     }
 
-    public function isPrivate(): bool
+    public function isPrivate(bool $php74_or_later = true): bool
     {
-        return (bool)($this->flags & 0x04);
+        $mask = $php74_or_later ? 0x04 : 0x400;
+        return (bool)($this->flags & $mask);
     }
 
     /**

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -473,6 +473,63 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
         $this->assertStringContainsString('*RECURSION*', $display);
     }
 
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPhpSerializeCycleRoundTripsThroughUnserialize(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            class Node { public ?Node $next = null; public string $tag = "x"; }
+            $GLOBALS['n'] = new Node();
+            $GLOBALS['n']->next = $GLOBALS['n'];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$n'],
+            '--format' => 'php-serialize',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+
+        // Strip the leading "global::$n = " prefix to get just the
+        // serialize payload, then feed it back through unserialize().
+        $prefix = 'global::$n = ';
+        $start = strpos($display, $prefix);
+        $this->assertIsInt($start);
+        $payload = trim(substr($display, $start + strlen($prefix)));
+        $this->assertStringStartsWith('O:4:"Node":', $payload);
+        $this->assertStringContainsString('r:1;', $payload);
+
+        // Round-trip back through unserialize. Class Node doesn't exist
+        // in the test process, so PHP returns __PHP_Incomplete_Class —
+        // that's fine: we care that the cycle survives and the property
+        // is recoverable.
+        $revived = unserialize($payload);
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $revived);
+        $array = (array)$revived;
+        $this->assertSame('x', $array['tag']);
+        // Self-reference back through `next`: identity holds.
+        $this->assertSame($revived, $array['next']);
+    }
+
     public function testNoVarReturnsError(): void
     {
         $command = $this->createCommand();

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -530,6 +530,66 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
         $this->assertSame($revived, $array['next']);
     }
 
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPhpSerializeAmpersandShareSurvivesRoundTrip(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        // Two array slots aliased to the same scalar via `&`. After the
+        // round-trip the alias relationship must hold — writing through
+        // one slot is visible through the other. This pins the
+        // zend_reference-tracking path: the reader has to capture the
+        // ref pointer before resolveIndirectAndRef collapses it, and
+        // the formatter has to emit R:N; for the second occurrence.
+        $target_script = <<<'CODE'
+            <?php
+            $x = "hello";
+            $GLOBALS['arr'] = [&$x, &$x];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$arr'],
+            '--format' => 'php-serialize',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $prefix = 'global::$arr = ';
+        $start = strpos($display, $prefix);
+        $this->assertIsInt($start);
+        $payload = trim(substr($display, $start + strlen($prefix)));
+
+        // Native PHP serialize for [&$x, &$x] is a:2:{i:0;s:5:"hello";i:1;R:2;}
+        $this->assertSame('a:2:{i:0;s:5:"hello";i:1;R:2;}', $payload);
+
+        $revived = unserialize($payload);
+        $this->assertIsArray($revived);
+        $this->assertSame('hello', $revived[0]);
+        $revived[0] = 'modified';
+        $this->assertSame(
+            'modified',
+            $revived[1],
+            'writing to slot 0 must be visible from slot 1 — '
+                . 'the zend_reference alias is preserved',
+        );
+    }
+
     public function testNoVarReturnsError(): void
     {
         $command = $this->createCommand();

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -275,8 +275,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
         $target_script = <<<'CODE'
             <?php
             class Foo {
-                public int $pub = 1;
-                private string $priv = "secret";
+                public $pub = 1;
+                private $priv = "secret";
             }
             $GLOBALS['arr'] = ['a' => 1, 'b' => [10, 20]];
             $GLOBALS['obj'] = new Foo();
@@ -441,7 +441,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
     ): void {
         $target_script = <<<'CODE'
             <?php
-            class Node { public ?Node $next = null; }
+            class Node { public $next = null; }
             $GLOBALS['n'] = new Node();
             $GLOBALS['n']->next = $GLOBALS['n'];
             fputs(STDOUT, "ready\n");
@@ -480,7 +480,7 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
     ): void {
         $target_script = <<<'CODE'
             <?php
-            class Node { public ?Node $next = null; public string $tag = "x"; }
+            class Node { public $next = null; public $tag = "x"; }
             $GLOBALS['n'] = new Node();
             $GLOBALS['n']->next = $GLOBALS['n'];
             fputs(STDOUT, "ready\n");

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -267,6 +267,212 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
         );
     }
 
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekVarDumpFormat(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            class Foo {
+                public int $pub = 1;
+                private string $priv = "secret";
+            }
+            $GLOBALS['arr'] = ['a' => 1, 'b' => [10, 20]];
+            $GLOBALS['obj'] = new Foo();
+            $GLOBALS['s'] = "hi";
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$arr', 'global::$obj', 'global::$s'],
+            '--format' => 'var-dump',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        // Native: array(2) { ["a"]=> int(1) ["b"]=> array(2) { [0]=> int(10) [1]=> int(20) } }
+        $this->assertStringContainsString('array(2) {', $display);
+        $this->assertStringContainsString('["a"]=>', $display);
+        $this->assertStringContainsString('int(1)', $display);
+        $this->assertStringContainsString('int(10)', $display);
+        $this->assertStringContainsString('int(20)', $display);
+        $this->assertStringContainsString('object(Foo)', $display);
+        $this->assertStringContainsString('["pub"]=>', $display);
+        $this->assertStringContainsString('["priv":"Foo":private]=>', $display);
+        $this->assertStringContainsString('string(6) "secret"', $display);
+        $this->assertStringContainsString('string(2) "hi"', $display);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekVarExportFormat(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            $GLOBALS['arr'] = ['a' => 1, 'b' => [10, 20]];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$arr'],
+            '--format' => 'var-export',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $expected = var_export(['a' => 1, 'b' => [10, 20]], true);
+        $this->assertStringContainsString($expected, $display);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekPhpSerializeFormat(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            $GLOBALS['arr'] = ['a' => 1, 'b' => [10, 20]];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$arr'],
+            '--format' => 'php-serialize',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $expected = serialize(['a' => 1, 'b' => [10, 20]]);
+        $this->assertStringContainsString($expected, $display);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekVarDumpRespectsMaxDepth(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            $GLOBALS['nested'] = ['outer' => ['inner' => ['deep' => 1]]];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$nested'],
+            '--format' => 'var-dump',
+            '--max-depth' => '1',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        // Outer expanded, inner shown as `...` placeholder.
+        $this->assertStringContainsString('["outer"]=>', $display);
+        $this->assertStringContainsString('array(1) {', $display);
+        $this->assertStringNotContainsString('["deep"]=>', $display);
+        $this->assertStringContainsString('...', $display);
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testPeekVarDumpDetectsRecursion(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        $target_script = <<<'CODE'
+            <?php
+            class Node { public ?Node $next = null; }
+            $GLOBALS['n'] = new Node();
+            $GLOBALS['n']->next = $GLOBALS['n'];
+            fputs(STDOUT, "ready\n");
+            fgets(STDIN);
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $this->assertSame("ready\n", fgets($pipes[1]));
+
+        $command = $this->createCommand();
+        (new Application())->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '-p' => (string)$pid,
+            '--var' => ['global::$n'],
+            '--format' => 'var-dump',
+            '--php-version' => $php_version,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('object(Node)', $display);
+        $this->assertStringContainsString('*RECURSION*', $display);
+    }
+
     public function testNoVarReturnsError(): void
     {
         $command = $this->createCommand();

--- a/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
+++ b/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
@@ -288,6 +288,121 @@ class PhpSerializeFormatterTest extends TestCase
         );
     }
 
+    public function testScalarReferenceShareEmitsR(): void
+    {
+        // $x = "hello"; $arr = [&$x, &$x];
+        // → a:2:{i:0;s:5:"hello";i:1;R:2;}
+        // Reader stamps the same zend_reference address on both leaf
+        // VariableValues; formatter emits the second as R:2;.
+        $shared = new VariableValue(
+            VariableValue::TYPE_STRING,
+            'hello',
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            5,
+            null,
+            0xAAA,
+        );
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            2,
+            [[0, $shared], [1, $shared]],
+            null,
+            null,
+            false,
+            false,
+            null,
+            0xBEEF,
+        );
+        $this->assertSame(
+            'a:2:{i:0;s:5:"hello";i:1;R:2;}',
+            PhpSerializeFormatter::format($arr),
+        );
+    }
+
+    public function testReferenceShareLivesThroughUnserialize(): void
+    {
+        // After round-tripping through unserialize, the recovered slots
+        // are still aliased — writing to one is visible from the other.
+        // This is the property that makes the format genuinely lossless
+        // for `&`-aliasing.
+        $shared = new VariableValue(
+            VariableValue::TYPE_STRING,
+            'hello',
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            5,
+            null,
+            0xAAA,
+        );
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            2,
+            [[0, $shared], [1, $shared]],
+            null,
+            null,
+            false,
+            false,
+            null,
+            0xBEEF,
+        );
+        $revived = unserialize(PhpSerializeFormatter::format($arr));
+        $this->assertIsArray($revived);
+        $revived[0] = 'modified';
+        $this->assertSame('modified', $revived[1]);
+    }
+
+    public function testReferenceIdSurvivesIntervening(): void
+    {
+        // serialize([&$x, "world", &$x]) bumps the counter on the
+        // intervening string, so the second &$x resolves to id 2 (the
+        // first &$x's value) — not 4 — even with a non-shared sibling
+        // sitting between them.
+        $shared = new VariableValue(
+            VariableValue::TYPE_STRING,
+            'hello',
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            5,
+            null,
+            0xAAA,
+        );
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            3,
+            [
+                [0, $shared],
+                [1, $this->string('world')],
+                [2, $shared],
+            ],
+            null,
+            null,
+            false,
+            false,
+            null,
+            0xCAFE,
+        );
+        $this->assertSame(
+            'a:3:{i:0;s:5:"hello";i:1;s:5:"world";i:2;R:2;}',
+            PhpSerializeFormatter::format($arr),
+        );
+    }
+
     public function testRecursionWithUnknownAddressFallsBackToNull(): void
     {
         // The reader can drop a cycle target if the target sat below a

--- a/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
+++ b/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
@@ -109,8 +109,190 @@ class PhpSerializeFormatterTest extends TestCase
         );
     }
 
-    public function testRecursionDegradesToNull(): void
+    public function testObjectSelfCycleEmitsLowercaseR(): void
     {
+        // class Node { public ?Node $next = null; } $n = new Node;
+        // $n->next = $n; serialize($n)
+        // → O:4:"Node":1:{s:4:"next";r:1;}
+        $obj_addr = 0xDEAD;
+        $cycle = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            1,
+            [['next', new VariableValue(
+                VariableValue::TYPE_RECURSION,
+                null,
+                null,
+                null,
+                null,
+                1,
+                false,
+                false,
+                null,
+                $obj_addr,
+            )]],
+            'Node',
+            1,
+            false,
+            false,
+            null,
+            $obj_addr,
+        );
+        $this->assertSame(
+            'O:4:"Node":1:{s:4:"next";r:1;}',
+            PhpSerializeFormatter::format($cycle),
+        );
+    }
+
+    public function testSharedObjectAcrossSiblingsEmitsBackEdge(): void
+    {
+        // $o = new stdClass; $arr = [$o, $o];
+        // → a:2:{i:0;O:8:"stdClass":0:{}i:1;r:2;}
+        $shared = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            0,
+            [],
+            'stdClass',
+            1,
+            false,
+            false,
+            null,
+            0xCAFE,
+        );
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            2,
+            [[0, $shared], [1, $shared]],
+            null,
+            null,
+            false,
+            false,
+            null,
+            0xBEEF,
+        );
+        $this->assertSame(
+            'a:2:{i:0;O:8:"stdClass":0:{}i:1;r:2;}',
+            PhpSerializeFormatter::format($arr),
+        );
+    }
+
+    public function testArrayCycleEmitsUppercaseR(): void
+    {
+        // $a = []; $a[] = &$a; the cycle is the only kind of array
+        // back-edge that exists in PHP (arrays are otherwise by-value).
+        $arr_addr = 0xF00D;
+        $arr_cycle = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            1,
+            [[0, new VariableValue(
+                VariableValue::TYPE_RECURSION,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                $arr_addr,
+            )]],
+            null,
+            null,
+            false,
+            false,
+            null,
+            $arr_addr,
+        );
+        // Shorter than native (`a:1:{i:0;a:1:{i:0;R:2;}}`) because we
+        // can't see the zend_reference wrapper, but the output still
+        // round-trips through unserialize as a self-cyclic array.
+        $serialized = PhpSerializeFormatter::format($arr_cycle);
+        $this->assertSame('a:1:{i:0;R:1;}', $serialized);
+        $revived = unserialize($serialized);
+        $this->assertIsArray($revived);
+        $this->assertSame($revived, $revived[0]);
+    }
+
+    public function testObjectCycleRoundTripsThroughUnserialize(): void
+    {
+        $obj_addr = 0x1234;
+        $cycle = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            1,
+            [['self', new VariableValue(
+                VariableValue::TYPE_RECURSION,
+                null,
+                null,
+                null,
+                null,
+                1,
+                false,
+                false,
+                null,
+                $obj_addr,
+            )]],
+            'stdClass',
+            1,
+            false,
+            false,
+            null,
+            $obj_addr,
+        );
+        $revived = unserialize(PhpSerializeFormatter::format($cycle));
+        $this->assertInstanceOf(\stdClass::class, $revived);
+        $this->assertSame($revived, $revived->self);
+    }
+
+    public function testCounterAdvancesForScalarsBetweenObjects(): void
+    {
+        // serialize(['a', $o, 'b', $o]) →
+        // a:4:{i:0;s:1:"a";i:1;O:8:"stdClass":0:{}i:2;s:1:"b";i:3;r:3;}
+        // Each scalar bumps the counter, so the second $o resolves to id 3
+        // even though there are intervening strings.
+        $shared = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            0,
+            [],
+            'stdClass',
+            1,
+            false,
+            false,
+            null,
+            0x1234,
+        );
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            4,
+            [
+                [0, $this->string('a')],
+                [1, $shared],
+                [2, $this->string('b')],
+                [3, $shared],
+            ],
+            null,
+            null,
+            false,
+            false,
+            null,
+            0x5678,
+        );
+        $this->assertSame(
+            'a:4:{i:0;s:1:"a";i:1;O:8:"stdClass":0:{}i:2;s:1:"b";i:3;r:3;}',
+            PhpSerializeFormatter::format($arr),
+        );
+    }
+
+    public function testRecursionWithUnknownAddressFallsBackToNull(): void
+    {
+        // The reader can drop a cycle target if the target sat below a
+        // depth budget — no address means we can't emit r/R, so we
+        // fall back to N; (still parseable).
         $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 1, [
             [0, new VariableValue(VariableValue::TYPE_RECURSION, null, null)],
         ]);

--- a/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
+++ b/tests/Inspector/Watch/Dump/PhpSerializeFormatterTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\Watch\VariableValue;
+
+class PhpSerializeFormatterTest extends TestCase
+{
+    private function string(string $s): VariableValue
+    {
+        return new VariableValue(
+            VariableValue::TYPE_STRING,
+            $s,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            strlen($s),
+        );
+    }
+
+    public function testScalars(): void
+    {
+        $this->assertSame(
+            'i:42;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_LONG, 42, null)),
+        );
+        $this->assertSame(
+            'd:3.14;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_DOUBLE, 3.14, null)),
+        );
+        $this->assertSame(
+            's:5:"hello";',
+            PhpSerializeFormatter::format($this->string('hello')),
+        );
+        $this->assertSame(
+            'b:1;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_BOOL, true, null)),
+        );
+        $this->assertSame(
+            'b:0;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_BOOL, false, null)),
+        );
+        $this->assertSame(
+            'N;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_NULL, null, null)),
+        );
+    }
+
+    public function testNanAndInfinity(): void
+    {
+        $this->assertSame(
+            'd:NAN;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_DOUBLE, NAN, null)),
+        );
+        $this->assertSame(
+            'd:INF;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_DOUBLE, INF, null)),
+        );
+        $this->assertSame(
+            'd:-INF;',
+            PhpSerializeFormatter::format(new VariableValue(VariableValue::TYPE_DOUBLE, -INF, null)),
+        );
+    }
+
+    public function testArrayMatchesNative(): void
+    {
+        $inner = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            [0, new VariableValue(VariableValue::TYPE_LONG, 10, null)],
+            [1, new VariableValue(VariableValue::TYPE_LONG, 20, null)],
+        ]);
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            ['a', new VariableValue(VariableValue::TYPE_LONG, 1, null)],
+            ['b', $inner],
+        ]);
+        $this->assertSame(
+            serialize(['a' => 1, 'b' => [10, 20]]),
+            PhpSerializeFormatter::format($v),
+        );
+    }
+
+    public function testObjectIncludesNulPrefixedPropertyNames(): void
+    {
+        $obj = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            1,
+            [["\0Foo\0priv", $this->string('s')]],
+            'Foo',
+            1,
+        );
+        $this->assertSame(
+            'O:3:"Foo":1:{s:9:"' . "\0Foo\0priv" . '";s:1:"s";}',
+            PhpSerializeFormatter::format($obj),
+        );
+    }
+
+    public function testRecursionDegradesToNull(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 1, [
+            [0, new VariableValue(VariableValue::TYPE_RECURSION, null, null)],
+        ]);
+        $this->assertSame('a:1:{i:0;N;}', PhpSerializeFormatter::format($v));
+    }
+
+    public function testTruncatedArrayHeaderMatchesEmittedCount(): void
+    {
+        // 10 elements claimed, only 1 emitted
+        $v = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            10,
+            [[0, new VariableValue(VariableValue::TYPE_LONG, 1, null)]],
+            null,
+            null,
+            true,
+        );
+        // Header reports the emitted count (1) so unserialize() doesn't trip.
+        $this->assertSame('a:1:{i:0;i:1;}', PhpSerializeFormatter::format($v));
+    }
+}

--- a/tests/Inspector/Watch/Dump/VarDumpFormatterTest.php
+++ b/tests/Inspector/Watch/Dump/VarDumpFormatterTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\Watch\VariableValue;
+
+class VarDumpFormatterTest extends TestCase
+{
+    private function string(string $s): VariableValue
+    {
+        return new VariableValue(
+            VariableValue::TYPE_STRING,
+            $s,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            strlen($s),
+        );
+    }
+
+    public function testLong(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_LONG, 42, null);
+        $this->assertSame('int(42)', VarDumpFormatter::format($v));
+    }
+
+    public function testFloatWholeNumberDropsDecimals(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_DOUBLE, 1.0, null);
+        $this->assertSame('float(1)', VarDumpFormatter::format($v));
+    }
+
+    public function testFloatFractional(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_DOUBLE, 3.14, null);
+        $this->assertSame('float(3.14)', VarDumpFormatter::format($v));
+    }
+
+    public function testStringEmitsByteLength(): void
+    {
+        $this->assertSame('string(3) "abc"', VarDumpFormatter::format($this->string('abc')));
+    }
+
+    public function testStringTruncatedShowsOriginalLength(): void
+    {
+        $v = new VariableValue(
+            VariableValue::TYPE_STRING,
+            'abc',
+            null,
+            null,
+            null,
+            null,
+            false,
+            true,
+            10,
+        );
+        $this->assertSame('string(10) "abc..."', VarDumpFormatter::format($v));
+    }
+
+    public function testBoolTrue(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_BOOL, true, null);
+        $this->assertSame('bool(true)', VarDumpFormatter::format($v));
+    }
+
+    public function testBoolFalse(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_BOOL, false, null);
+        $this->assertSame('bool(false)', VarDumpFormatter::format($v));
+    }
+
+    public function testNull(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_NULL, null, null);
+        $this->assertSame('NULL', VarDumpFormatter::format($v));
+    }
+
+    public function testFlatArrayMatchesNative(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            ['a', new VariableValue(VariableValue::TYPE_LONG, 1, null)],
+            ['b', $this->string('x')],
+        ]);
+        ob_start();
+        var_dump(['a' => 1, 'b' => 'x']);
+        $native = rtrim((string)ob_get_clean(), "\n");
+        $this->assertSame($native, VarDumpFormatter::format($v));
+    }
+
+    public function testNestedArrayMatchesNative(): void
+    {
+        $inner = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            [0, new VariableValue(VariableValue::TYPE_LONG, 10, null)],
+            [1, new VariableValue(VariableValue::TYPE_LONG, 20, null)],
+        ]);
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            ['a', new VariableValue(VariableValue::TYPE_LONG, 1, null)],
+            ['b', $inner],
+        ]);
+        ob_start();
+        var_dump(['a' => 1, 'b' => [10, 20]]);
+        $native = rtrim((string)ob_get_clean(), "\n");
+        $this->assertSame($native, VarDumpFormatter::format($v));
+    }
+
+    public function testObjectWithVisibility(): void
+    {
+        $obj = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            2,
+            [
+                ['pub', new VariableValue(VariableValue::TYPE_LONG, 1, null)],
+                ["\0Foo\0priv", $this->string('secret')],
+            ],
+            'Foo',
+            42,
+        );
+        $expected =
+            "object(Foo)#42 (2) {\n"
+            . "  [\"pub\"]=>\n"
+            . "  int(1)\n"
+            . "  [\"priv\":\"Foo\":private]=>\n"
+            . "  string(6) \"secret\"\n"
+            . "}";
+        $this->assertSame($expected, VarDumpFormatter::format($obj));
+    }
+
+    public function testRecursionMarker(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 1, [
+            [0, new VariableValue(VariableValue::TYPE_RECURSION, null, null)],
+        ]);
+        $this->assertSame(
+            "array(1) {\n  [0]=>\n  *RECURSION*\n}",
+            VarDumpFormatter::format($v),
+        );
+    }
+
+    public function testDepthLimitedShallowArray(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 5, null);
+        $this->assertSame(
+            "array(5) {\n  ...\n}",
+            VarDumpFormatter::format($v),
+        );
+    }
+
+    public function testElementsTruncatedAddsComment(): void
+    {
+        $v = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            10,
+            [[0, new VariableValue(VariableValue::TYPE_LONG, 1, null)]],
+            null,
+            null,
+            true,
+        );
+        $this->assertStringContainsString(
+            '// ... (truncated)',
+            VarDumpFormatter::format($v),
+        );
+    }
+}

--- a/tests/Inspector/Watch/Dump/VarExportFormatterTest.php
+++ b/tests/Inspector/Watch/Dump/VarExportFormatterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Watch\Dump;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Inspector\Watch\VariableValue;
+
+class VarExportFormatterTest extends TestCase
+{
+    private function string(string $s): VariableValue
+    {
+        return new VariableValue(
+            VariableValue::TYPE_STRING,
+            $s,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            strlen($s),
+        );
+    }
+
+    public function testLong(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_LONG, 42, null);
+        $this->assertSame('42', VarExportFormatter::format($v));
+    }
+
+    public function testFloatWholeNumberKeepsZero(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_DOUBLE, 1.0, null);
+        $this->assertSame('1.0', VarExportFormatter::format($v));
+    }
+
+    public function testStringSingleQuoted(): void
+    {
+        $this->assertSame("'abc'", VarExportFormatter::format($this->string('abc')));
+    }
+
+    public function testStringEscapesSingleQuoteAndBackslash(): void
+    {
+        $this->assertSame(
+            "'a\\\\b\\'c'",
+            VarExportFormatter::format($this->string("a\\b'c")),
+        );
+    }
+
+    public function testBoolNull(): void
+    {
+        $this->assertSame(
+            'true',
+            VarExportFormatter::format(new VariableValue(VariableValue::TYPE_BOOL, true, null)),
+        );
+        $this->assertSame(
+            'NULL',
+            VarExportFormatter::format(new VariableValue(VariableValue::TYPE_NULL, null, null)),
+        );
+    }
+
+    public function testNestedArrayMatchesNative(): void
+    {
+        $inner = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            [0, new VariableValue(VariableValue::TYPE_LONG, 10, null)],
+            [1, new VariableValue(VariableValue::TYPE_LONG, 20, null)],
+        ]);
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 2, [
+            ['a', new VariableValue(VariableValue::TYPE_LONG, 1, null)],
+            ['b', $inner],
+        ]);
+        $native = var_export(['a' => 1, 'b' => [10, 20]], true);
+        $this->assertSame($native, VarExportFormatter::format($v));
+    }
+
+    public function testRecursionEmitsComment(): void
+    {
+        $v = new VariableValue(VariableValue::TYPE_ARRAY, null, 1, [
+            [0, new VariableValue(VariableValue::TYPE_RECURSION, null, null)],
+        ]);
+        $this->assertSame(
+            "array (\n  0 => /* RECURSION */,\n)",
+            VarExportFormatter::format($v),
+        );
+    }
+
+    public function testObjectAsSetState(): void
+    {
+        $obj = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            1,
+            [['x', new VariableValue(VariableValue::TYPE_LONG, 1, null)]],
+            'Foo',
+            7,
+        );
+        $this->assertSame(
+            "\\Foo::__set_state(array(\n  'x' => 1,\n))",
+            VarExportFormatter::format($obj),
+        );
+    }
+
+    public function testObjectStripsVisibilityMarker(): void
+    {
+        $obj = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            1,
+            [["\0Foo\0secret", new VariableValue(VariableValue::TYPE_LONG, 1, null)]],
+            'Foo',
+            7,
+        );
+        $this->assertStringContainsString(
+            "'secret' => 1",
+            VarExportFormatter::format($obj),
+        );
+    }
+}

--- a/tests/Inspector/Watch/VariableValueTest.php
+++ b/tests/Inspector/Watch/VariableValueTest.php
@@ -73,7 +73,40 @@ class VariableValueTest extends TestCase
         $this->assertSame('string', VariableValue::TYPE_STRING);
         $this->assertSame('bool', VariableValue::TYPE_BOOL);
         $this->assertSame('array', VariableValue::TYPE_ARRAY);
+        $this->assertSame('object', VariableValue::TYPE_OBJECT);
         $this->assertSame('null', VariableValue::TYPE_NULL);
+        $this->assertSame('recursion', VariableValue::TYPE_RECURSION);
         $this->assertSame('unknown', VariableValue::TYPE_UNKNOWN);
+    }
+
+    public function testRecursiveStructure(): void
+    {
+        $child = new VariableValue(VariableValue::TYPE_LONG, 1, null);
+        $arr = new VariableValue(
+            VariableValue::TYPE_ARRAY,
+            null,
+            1,
+            [['k', $child]],
+        );
+        $this->assertSame('array', $arr->type);
+        $this->assertSame(1, $arr->array_count);
+        $this->assertNotNull($arr->children);
+        $this->assertCount(1, $arr->children);
+        $this->assertSame('k', $arr->children[0][0]);
+        $this->assertSame($child, $arr->children[0][1]);
+    }
+
+    public function testObjectMetadata(): void
+    {
+        $obj = new VariableValue(
+            VariableValue::TYPE_OBJECT,
+            null,
+            0,
+            [],
+            'Foo\\Bar',
+            42,
+        );
+        $this->assertSame('Foo\\Bar', $obj->class_name);
+        $this->assertSame(42, $obj->object_id);
     }
 }

--- a/tools/stubs/ffi/php.php
+++ b/tools/stubs/ffi/php.php
@@ -283,6 +283,7 @@ class zend_property_info extends CData
     public int $flags;
     public ?CPointer $name;
     public ?CPointer $doc_comment;
+    public ?CPointer $ce;
 }
 
 class zend_refcounted_h extends CData


### PR DESCRIPTION
## Summary

This PR enhances the variable inspection system with configurable recursion limits and adds three new output formatters (var-dump, var-export, php-serialize) that match PHP's native output formats. The core change introduces `VariableReadOptions` to control how deeply variables are expanded during reading, enabling efficient inspection of large/recursive structures.

## Key Changes

- **Recursion-aware variable reading**: Added `VariableReadOptions` class with `max_depth`, `max_elements`, and `max_string` limits to control variable expansion during the read phase, preventing excessive memory usage on large structures.

- **Refactored `VariableReader.readVariables()`**: 
  - Now accepts optional `VariableReadOptions` parameter
  - Passes options through all variable reading methods (global, local, static, func_static)
  - Replaced `zvalToVariableValue()` with `buildValue()` that respects depth/element budgets and detects cycles

- **Cycle detection**: Implemented reference address tracking to distinguish between:
  - Object/array cycles (back-edges within the same structure)
  - Shared references (`&`-aliased slots reaching the same `zend_reference`)
  - Properly emits `TYPE_RECURSION` markers for cycle detection

- **Three new output formatters**:
  - `VarDumpFormatter`: Matches PHP's `var_dump()` output format
  - `VarExportFormatter`: Matches PHP's `var_export()` output format  
  - `PhpSerializeFormatter`: Matches PHP's `serialize()` format with proper cycle/reference handling

- **Enhanced `VariableValue`**: 
  - Added `TYPE_OBJECT` and `TYPE_RECURSION` type constants
  - Added fields for object metadata (class name, handle, properties)
  - Added reference tracking (`reference_address`) for proper serialization
  - Added truncation flags and original length tracking for strings

- **PeekVarCommand enhancements**:
  - New `--format` options: `var-dump`, `var-export`, `php-serialize`
  - New `--max-depth`, `--max-elements`, `--max-string` options to control expansion limits
  - Integrated new formatters into output pipeline

- **Property name mangling**: Added `buildMangledPropertyName()` to reconstruct PHP's internal NUL-mangled property names for private/protected properties (e.g., `\0ClassName\0propName`)

## Notable Implementation Details

- Cycle detection uses a stack of pointer addresses on the recursion path, so shared sub-graphs reached through different siblings are not falsely flagged as cycles
- Reference IDs in serialize format are assigned in DFS order to match PHP's behavior and ensure `unserialize()` compatibility
- Depth-truncated nodes emit placeholder markers (`...`) while maintaining valid output format syntax
- String truncation preserves original length in metadata for accurate `var_dump()` output
- All three formatters handle edge cases (NaN/Infinity, clipped strings, missing cycle targets) gracefully

https://claude.ai/code/session_01DDsXfwQoefVoeXzzRmPyBS