### PR TITLE
Derive heap analysis percentage from pointer-traced attribution

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/OverviewPass.php
@@ -20,9 +20,21 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class OverviewPass implements PassInterface
 {
-    /** @param array<int, array<string, mixed>> $summary */
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     * @param array<string, array{count: int, memory_usage: int}> $location_types_summary
+     *     Sum of `memory_usage` across this map is the canonical "bytes
+     *     reli attributed to PHP-level nodes via pointer-tracing": it is
+     *     built from the same node-set the rest of the report is rendered
+     *     from, so the live and offline pipelines produce the same number
+     *     for the same target. Used as the displayed Heap value so the
+     *     headline figure stops disagreeing with the per-type / per-class
+     *     totals immediately below it (see
+     *     docs/internals/memory-coverage-survey-2026-05.md G1/G2).
+     */
     public function __construct(
         private array $summary,
+        private array $location_types_summary = [],
     ) {
     }
 
@@ -52,6 +64,45 @@ final class OverviewPass implements PassInterface
         $memory_limit = (int)($flat['memory_limit'] ?? 0);
         $rss = isset($flat['rss']) ? (int)$flat['rss'] : null;
 
+        // Heap and "% analyzed" are intentionally derived from the same
+        // node-set the rest of the report is built on — i.e. SUM(memory_usage)
+        // across the per-type breakdown. That sum is what every downstream
+        // pass (TypeBreakdown, ClassRanking, RootBlame, …) is rendering
+        // already; pulling it up into the Overview makes the headline
+        // self-consistent with the body.
+        //
+        // Why not the legacy zend_mm_heap_usage / heap_memory_analyzed_percentage:
+        //   - The numerator is slot-rounded (chunk_usage + vm_stack +
+        //     compiler_arena + bin overhead) but the denominator
+        //     (memory_get_usage(false)) is not, so the ratio can exceed
+        //     100% on heaps where slot rounding outweighs unattributed
+        //     bytes (laravel, the canonical case).
+        //   - The numerator's dedup/overhead handling differs between the
+        //     live MemoryCommand path and the offline MemoryDumpReader
+        //     path, so the same target reports different Heap on the two
+        //     pipelines.
+        //
+        // Why not the bin walker total (live_small_slot_bytes + large_run_bytes):
+        //   - The bin walker is a fallback enumeration of slots reli's
+        //     pointer-tracer didn't reach, not the primary "we analyzed
+        //     this" signal. Promoting it to the denominator would make
+        //     "% analyzed" track slot rounding rather than the depth of
+        //     pointer-tracing coverage.
+        $attributed_bytes = 0;
+        foreach ($this->location_types_summary as $entry) {
+            $attributed_bytes += $entry['memory_usage'];
+        }
+
+        if ($attributed_bytes > 0 && $memory_get_usage > 0) {
+            $display_heap = $attributed_bytes;
+            $display_pct = (float)$attributed_bytes / (float)$memory_get_usage * 100.0;
+            $analyzed_source = 'pointer_trace';
+        } else {
+            $display_heap = $heap_usage;
+            $display_pct = $analyzed_pct;
+            $analyzed_source = 'summary';
+        }
+
         $summary_parts = [
             sprintf('memory_get_usage(): %s', SizeFormatter::format($memory_get_usage)),
             sprintf('memory_get_usage(true): %s', SizeFormatter::format($memory_get_real_usage)),
@@ -67,8 +118,8 @@ final class OverviewPass implements PassInterface
         }
         $summary_parts[] = sprintf(
             'Heap: %s (%.1f%% analyzed), VM stack: %s, Compiler arena: %s',
-            SizeFormatter::format($heap_usage),
-            $analyzed_pct,
+            SizeFormatter::format($display_heap),
+            $display_pct,
             SizeFormatter::format($vm_stack),
             SizeFormatter::format($compiler_arena),
         );
@@ -82,8 +133,13 @@ final class OverviewPass implements PassInterface
             'heap_usage' => $heap_usage,
             'vm_stack_total' => $vm_stack,
             'compiler_arena_total' => $compiler_arena,
-            'analyzed_percentage' => $analyzed_pct,
+            'analyzed_percentage' => $display_pct,
+            'analyzed_percentage_source' => $analyzed_source,
+            'displayed_heap_bytes' => $display_heap,
         ];
+        if ($attributed_bytes > 0) {
+            $facts['attributed_bytes'] = $attributed_bytes;
+        }
         if ($rss !== null) {
             $facts['rss'] = $rss;
         }
@@ -131,20 +187,29 @@ final class OverviewPass implements PassInterface
             }
         }
 
-        if ($analyzed_pct > 0 && $analyzed_pct < 95.0) {
-            $gap_bytes = (int)($heap_usage * (100.0 - $analyzed_pct) / 100.0);
+        if ($display_pct > 0 && $display_pct < 95.0) {
+            // gap = "bytes reli could not attribute": for the pointer-trace
+            // path that's (memory_get_usage - attributed); for the legacy
+            // summary path the historic computation was
+            // heap_usage * (100 - pct) / 100, so preserve it there.
+            if ($analyzed_source === 'pointer_trace') {
+                $gap_bytes = max(0, $memory_get_usage - $attributed_bytes);
+            } else {
+                $gap_bytes = (int)($display_heap * (100.0 - $display_pct) / 100.0);
+            }
             $findings[] = new Finding(
                 kind: 'coverage_gap',
                 severity: FindingSeverity::Warning,
                 confidence: FindingConfidence::Medium,
                 summary: sprintf(
                     'Only %.1f%% of heap analyzed — %s unaccounted',
-                    $analyzed_pct,
+                    $display_pct,
                     SizeFormatter::format($gap_bytes),
                 ),
                 facts: [
-                    'analyzed_percentage' => $analyzed_pct,
+                    'analyzed_percentage' => $display_pct,
                     'gap_bytes' => $gap_bytes,
+                    'analyzed_percentage_source' => $analyzed_source,
                 ],
                 hypothesis: 'Unaccounted memory is typically from extension-level emalloc (not PHP objects/arrays)',
                 next_checks: [

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -108,7 +108,7 @@ final class ReportGenerator
         $class_objects = $this->loadClassObjects($db, $run_id);
 
         $findings = [];
-        $findings = array_merge($findings, (new OverviewPass($summary))->analyze());
+        $findings = array_merge($findings, (new OverviewPass($summary, $location_types))->analyze());
         $findings = array_merge($findings, (new TypeBreakdownPass($location_types))->analyze());
         $findings = array_merge($findings, (new ClassRankingPass($class_objects))->analyze());
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());
@@ -342,7 +342,7 @@ final class ReportGenerator
 
         // Phase 1: Summary-based passes
         $findings = [];
-        $findings = array_merge($findings, (new OverviewPass($summary))->analyze());
+        $findings = array_merge($findings, (new OverviewPass($summary, $location_types))->analyze());
         $findings = array_merge($findings, (new TypeBreakdownPass($location_types))->analyze());
         $findings = array_merge($findings, (new ClassRankingPass($class_objects))->analyze());
         $findings = array_merge($findings, (new CompanionDetectionPass($class_objects))->analyze());

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/SummaryPassesTest.php
@@ -146,6 +146,102 @@ class SummaryPassesTest extends BaseTestCase
         $this->assertCount(0, $gaps);
     }
 
+    public function testOverviewPassDerivesHeapFromPointerTracedAttribution(): void
+    {
+        // laravel-shaped numbers from the 2026-05 coverage survey: the
+        // legacy heap_memory_analyzed_percentage tipped to 105.8% because
+        // its numerator was slot-rounded (chunk_usage + vm_stack +
+        // compiler_arena + overhead) but its denominator was
+        // memory_get_usage(false). Pulling SUM(memory_usage) up out of
+        // the per-type breakdown gives a numerator at the same
+        // granularity as memory_get_usage(false) (both are user-bytes,
+        // not slot bytes), so the Overview line is self-consistent with
+        // the per-type rows below it and stops exceeding 100%.
+        $attributed = 22_010_000;
+        $mgu = 24_000_000;
+        $pass = new OverviewPass(
+            summary: [
+                [
+                    'zend_mm_heap_total' => 26 * 1024 * 1024,
+                    'zend_mm_heap_usage' => 25_390_000,
+                    'heap_memory_analyzed_percentage' => 105.8,
+                    'memory_get_usage' => $mgu,
+                    'memory_get_real_usage' => 24 * 1024 * 1024,
+                ],
+            ],
+            location_types_summary: [
+                'ZendObjectMemoryLocation' => ['count' => 25_100, 'memory_usage' => 13_510_000],
+                'ZendStringMemoryLocation' => ['count' => 60_000, 'memory_usage' => 7_500_000],
+                'ZendArrayMemoryLocation' => ['count' => 5_000, 'memory_usage' => 1_000_000],
+            ],
+        );
+        $findings = $pass->analyze();
+
+        $overview = array_filter($findings, fn(Finding $f) => $f->kind === 'overview');
+        $f = array_values($overview)[0];
+        $this->assertSame($attributed, $f->facts['displayed_heap_bytes']);
+        $this->assertSame($attributed, $f->facts['attributed_bytes']);
+        $this->assertSame('pointer_trace', $f->facts['analyzed_percentage_source']);
+        $expected_pct = $attributed / $mgu * 100.0;
+        $this->assertEqualsWithDelta($expected_pct, $f->facts['analyzed_percentage'], 0.01);
+        $this->assertLessThan(100.0, $f->facts['analyzed_percentage']);
+        $this->assertStringNotContainsString('105.8%', $f->summary);
+        // Bin-walker enumeration must NOT bubble into the headline:
+        // it's a fallback-coverage tool, not the analysis signal.
+        $this->assertArrayNotHasKey('bin_walk_total_bytes', $f->facts);
+    }
+
+    public function testOverviewPassCoverageGapUsesMguMinusAttributedOnPointerTracePath(): void
+    {
+        // On the new pointer-trace path the gap is literally
+        // (memory_get_usage - attributed); the old derived form
+        // attributed * (100 - pct) / 100 was wrong here.
+        $pass = new OverviewPass(
+            summary: [
+                [
+                    'zend_mm_heap_usage' => 7_500_000,
+                    'heap_memory_analyzed_percentage' => 80.0,
+                    'memory_get_usage' => 10_000_000,
+                    'memory_get_real_usage' => 12 * 1024 * 1024,
+                ],
+            ],
+            location_types_summary: [
+                'ZendObjectMemoryLocation' => ['count' => 100, 'memory_usage' => 8_000_000],
+            ],
+        );
+        $findings = $pass->analyze();
+        $gaps = array_filter($findings, fn(Finding $f) => $f->kind === 'coverage_gap');
+        $this->assertCount(1, $gaps);
+        $f = array_values($gaps)[0];
+        $this->assertSame(2_000_000, $f->facts['gap_bytes']);
+        $this->assertSame('pointer_trace', $f->facts['analyzed_percentage_source']);
+    }
+
+    public function testOverviewPassFallsBackWhenLocationTypesAbsent(): void
+    {
+        // No per-type breakdown (e.g. tiny heap, or older summary
+        // shape) — fall back to the persisted summary fields rather
+        // than dividing by zero.
+        $pass = new OverviewPass(
+            summary: [
+                [
+                    'zend_mm_heap_usage' => 8388608,
+                    'heap_memory_analyzed_percentage' => 80.0,
+                    'memory_get_usage' => 8400000,
+                    'memory_get_real_usage' => 10485760,
+                ],
+            ],
+            location_types_summary: [],
+        );
+        $findings = $pass->analyze();
+
+        $overview = array_filter($findings, fn(Finding $f) => $f->kind === 'overview');
+        $f = array_values($overview)[0];
+        $this->assertSame('summary', $f->facts['analyzed_percentage_source']);
+        $this->assertSame(80.0, $f->facts['analyzed_percentage']);
+        $this->assertSame(8388608, $f->facts['displayed_heap_bytes']);
+    }
+
     // ---- TypeBreakdownPass ----
 
     public function testTypeBreakdownDetectsDominantType(): void


### PR DESCRIPTION
## Summary
This change fixes the heap analysis percentage calculation to be derived from the pointer-traced attribution data rather than the legacy `heap_memory_analyzed_percentage` field, ensuring consistency between the overview headline and per-type breakdown totals.

## Key Changes
- **OverviewPass constructor**: Added `location_types_summary` parameter containing per-type memory usage data from pointer-tracing
- **Heap and percentage calculation**: Now derives `displayed_heap_bytes` and `analyzed_percentage` from the sum of `memory_usage` across location types when available, falling back to legacy summary fields when location types are absent
- **Coverage gap calculation**: Updated to use `memory_get_usage - attributed_bytes` on the pointer-trace path (more accurate) while preserving the legacy formula for the fallback path
- **Fact tracking**: Added `analyzed_percentage_source` ('pointer_trace' or 'summary') and `attributed_bytes` to findings for transparency
- **ReportGenerator**: Updated both `generateFromDb()` and `generateFromBinary()` to pass `location_types` to OverviewPass

## Notable Implementation Details
- The pointer-trace path uses the same node-set that downstream passes (TypeBreakdown, ClassRanking, etc.) render from, ensuring the headline figure matches the body totals
- Avoids the legacy issue where slot-rounding in the numerator but not the denominator could cause percentages exceeding 100%
- Gracefully falls back to summary-based calculation when location types are unavailable (e.g., tiny heaps or older summary formats)
- Bin-walker enumeration is explicitly excluded from the headline to preserve pointer-tracing coverage as the primary analysis signal

https://claude.ai/code/session_01HkcSzRBCcJq4S9qGYANJTJ