### PR TITLE
Remove SQL fallback paths from report passes, require GraphSubstrate

### DIFF
--- a/src/Command/Inspector/MemoryCompareCommand.php
+++ b/src/Command/Inspector/MemoryCompareCommand.php
@@ -99,7 +99,9 @@ final class MemoryCompareCommand extends ReliCommand
             'full-analysis',
             null,
             InputOption::VALUE_NEGATABLE,
-            'run all analysis passes for both snapshots (default: off)',
+            'retained for compatibility (no-op as of #787 Stage A).'
+            . ' Report passes always run through GraphSubstrate;'
+            . ' the flag will be redefined or retired in Stage C of #787.',
             false,
         );
         $this->addMemoryLimitOption();

--- a/src/Command/Inspector/MemoryReportCommand.php
+++ b/src/Command/Inspector/MemoryReportCommand.php
@@ -77,7 +77,10 @@ final class MemoryReportCommand extends ReliCommand
             'full-analysis',
             null,
             InputOption::VALUE_NEGATABLE,
-            'run all analysis passes (default: on; --no-full-analysis to limit for very large snapshots)',
+            'retained for compatibility (no-op as of #787 Stage A).'
+            . ' Report passes always run through GraphSubstrate;'
+            . ' --no-full-analysis no longer skips passes. The flag'
+            . ' will be redefined or retired in Stage C of #787.',
             true,
         );
         $this->addOption(

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -32,7 +32,7 @@ final class CallStackPass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?array $frame_labels = null,
         private ?array $canonical_names = null,
     ) {
@@ -44,28 +44,6 @@ final class CallStackPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        if ($this->substrate !== null) {
-            return $this->analyzeWithSubstrate();
-        }
-        return $this->analyzeWithSql();
-    }
-
-    /**
-     * Substrate-backed path: walks the in-memory node-type index to
-     * find the (typically single) CallFramesContext node, then
-     * iterates its tree children via the CSR. Each child's tree-edge
-     * link_name is the frame number ("0", "1", ...) and the
-     * NodeLabeler resolves the child node id to "function_name:lineno"
-     * via its already-cached attribute pull.
-     *
-     * Replaces the 4-JOIN SQL query the SQL fallback uses; that one
-     * showed up at ~6% of total report runtime on big captures.
-     *
-     * @return list<Finding>
-     */
-    private function analyzeWithSubstrate(): array
-    {
-        assert($this->substrate !== null);
         $callFramesNodeId = null;
         foreach ($this->substrate->iterateNodeSizes() as $node_id => $_) {
             if ($this->substrate->getNodeType($node_id) === 'CallFramesContext') {
@@ -106,59 +84,6 @@ final class CallStackPass implements PassInterface
         }
         ksort($framesByNo);
         return $this->buildFindings(array_values($framesByNo));
-    }
-
-    /**
-     * SQL fallback: used in Phase 2 when no substrate is built.
-     *
-     * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
-     */
-    private function analyzeWithSql(): array
-    {
-        $rows = $this->db->query("
-            SELECT
-                e.link_name as frame_no,
-                fn.value as function_name,
-                ln.value as lineno
-            FROM context_edges e
-            JOIN context_nodes cn
-                ON cn.node_id = e.child_node_id
-                AND cn.type = 'CallFrameContext'
-                AND cn.run_id = {$this->run_id}
-            LEFT JOIN context_node_attributes fn
-                ON fn.node_id = e.child_node_id
-                AND fn.key = 'function_name'
-                AND fn.run_id = {$this->run_id}
-            LEFT JOIN context_node_attributes ln
-                ON ln.node_id = e.child_node_id
-                AND ln.key = 'lineno'
-                AND ln.run_id = {$this->run_id}
-            WHERE e.is_tree = 1
-                AND e.run_id = {$this->run_id}
-                AND e.parent_node_id IN (
-                    SELECT cn2.node_id
-                    FROM context_nodes cn2
-                    WHERE cn2.type = 'CallFramesContext'
-                        AND cn2.run_id = {$this->run_id}
-                )
-            ORDER BY cast(e.link_name as integer)
-        ")->fetchAll(\PDO::FETCH_ASSOC);
-
-        if ($rows === []) {
-            return [];
-        }
-
-        $frames = [];
-        foreach ($rows as $row) {
-            $fn = $row['function_name'] ?? '?';
-            $ln = $row['lineno'] ?? null;
-            $frames[] = $ln !== null
-                ? "{$fn}:{$ln}"
-                : (string)$fn;
-        }
-
-        return $this->buildFindings($frames);
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DedupCandidatePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DedupCandidatePass.php
@@ -22,7 +22,6 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 final class DedupCandidatePass implements PassInterface
 {
     private ?\PDOStatement $node_location_stmt = null;
-    private ?\PDOStatement $tree_parent_stmt = null;
 
     /**
      * @param list<array{
@@ -42,7 +41,7 @@ final class DedupCandidatePass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?array $precomputed_dedup_candidates = null,
     ) {
     }
@@ -93,38 +92,27 @@ final class DedupCandidatePass implements PassInterface
             // of the N copies" and is intrinsically bounded by the heap
             // total — no `cnt × retained` over-count, no clamp needed.
             // See T2.1 in docs/internals/memory-report-implementation-handoff.md.
-            if ($this->substrate !== null) {
-                $member_node_ids = $sample_child_node_ids
-                    ?? $this->loadDedupMemberNodeIds(
-                        $link_name,
-                        $shallow_size,
-                        $target_class,
-                        $target_location_type,
-                    );
-                if ($member_node_ids !== []) {
-                    $union_size = $this->substrate->unionReachableTreeSize($member_node_ids);
-                    if ($union_size > 0) {
-                        $total = $union_size;
-                        $size = $cnt > 0 ? (int)($union_size / $cnt) : $shallow_size;
-                    }
+            $member_node_ids = $sample_child_node_ids
+                ?? $this->loadDedupMemberNodeIds(
+                    $link_name,
+                    $shallow_size,
+                    $target_class,
+                    $target_location_type,
+                );
+            if ($member_node_ids !== []) {
+                $union_size = $this->substrate->unionReachableTreeSize($member_node_ids);
+                if ($union_size > 0) {
+                    $total = $union_size;
+                    $size = $cnt > 0 ? (int)($union_size / $cnt) : $shallow_size;
                 }
             }
 
             $sample_parent_node_id = $row['sample_parent_node_id'];
-            if ($this->substrate !== null) {
-                [
-                    'source_class' => $dedup_src,
-                    'owner_prop' => $owner_prop,
-                ] = $this->resolveDedupOwnerInfoFromSubstrate($sample_parent_node_id);
-                $dedup_tgt = $target_class ?? $this->substrate->getNodeClass($sample_child_node_id);
-            } else {
-                [
-                    'source_class' => $dedup_src,
-                    'owner_prop' => $owner_prop,
-                ] = $this->resolveDedupOwnerInfoFromSql($sample_parent_node_id);
-                $dedup_tgt = $target_class
-                    ?? $this->loadNodeLocationInfo($sample_child_node_id)['class_name'];
-            }
+            [
+                'source_class' => $dedup_src,
+                'owner_prop' => $owner_prop,
+            ] = $this->resolveDedupOwnerInfoFromSubstrate($sample_parent_node_id);
+            $dedup_tgt = $target_class ?? $this->substrate->getNodeClass($sample_child_node_id);
 
             $dedup_label = $this->buildDedupLabel(
                 $dedup_src,
@@ -333,8 +321,6 @@ final class DedupCandidatePass implements PassInterface
      */
     private function resolveDedupOwnerInfoFromSubstrate(int $parent_node_id): array
     {
-        assert($this->substrate !== null);
-
         $source_class = $this->resolveDirectSourceClassFromSubstrate($parent_node_id);
         if ($source_class !== null) {
             return [
@@ -388,79 +374,8 @@ final class DedupCandidatePass implements PassInterface
         ];
     }
 
-    /**
-     * @return array{source_class: ?string, owner_prop: ?string}
-     */
-    private function resolveDedupOwnerInfoFromSql(int $parent_node_id): array
-    {
-        $source_class = $this->resolveDirectSourceClassFromSql($parent_node_id);
-        if ($source_class !== null) {
-            return [
-                'source_class' => $source_class,
-                'owner_prop' => null,
-            ];
-        }
-
-        $array_element_info = $this->loadTreeParentInfo($parent_node_id);
-        $array_elements_node_id = $array_element_info['parent_node_id'];
-        if ($array_elements_node_id === null) {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        $array_elements_info = $this->loadTreeParentInfo($array_elements_node_id);
-        if ($array_elements_info['link_name'] !== 'array_elements') {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        $array_header_node_id = $array_elements_info['parent_node_id'];
-        if ($array_header_node_id === null) {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        $array_header_info = $this->loadTreeParentInfo($array_header_node_id);
-        $owner_prop = $array_header_info['link_name'];
-        $object_properties_node_id = $array_header_info['parent_node_id'];
-        if ($object_properties_node_id === null) {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        $object_properties_info = $this->loadTreeParentInfo($object_properties_node_id);
-        if ($object_properties_info['link_name'] !== 'object_properties') {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        $owner_node_id = $object_properties_info['parent_node_id'];
-        if ($owner_node_id === null) {
-            return [
-                'source_class' => null,
-                'owner_prop' => null,
-            ];
-        }
-
-        return [
-            'source_class' => $this->loadNodeLocationInfo($owner_node_id)['class_name'],
-            'owner_prop' => $owner_prop,
-        ];
-    }
-
     private function resolveDirectSourceClassFromSubstrate(int $parent_node_id): ?string
     {
-        assert($this->substrate !== null);
         if ($this->substrate->getTreeLinkName($parent_node_id) !== 'object_properties') {
             return null;
         }
@@ -471,53 +386,6 @@ final class DedupCandidatePass implements PassInterface
         }
 
         return $this->substrate->getNodeClass($owner_node_id);
-    }
-
-    private function resolveDirectSourceClassFromSql(int $parent_node_id): ?string
-    {
-        $parent_info = $this->loadTreeParentInfo($parent_node_id);
-        if ($parent_info['link_name'] !== 'object_properties') {
-            return null;
-        }
-
-        $owner_node_id = $parent_info['parent_node_id'];
-        if ($owner_node_id === null) {
-            return null;
-        }
-
-        return $this->loadNodeLocationInfo($owner_node_id)['class_name'];
-    }
-
-    /**
-     * @return array{parent_node_id: ?int, link_name: ?string}
-     * @psalm-suppress MixedAssignment
-     */
-    private function loadTreeParentInfo(int $child_node_id): array
-    {
-        if ($this->tree_parent_stmt === null) {
-            $this->tree_parent_stmt = $this->db->prepare(
-                "SELECT parent_node_id, link_name FROM context_edges"
-                . " WHERE run_id = ? AND child_node_id = ? AND is_tree = 1"
-                . " LIMIT 1"
-            );
-        }
-
-        $this->tree_parent_stmt->execute([$this->run_id, $child_node_id]);
-        /** @var array{parent_node_id?: int|null, link_name?: string}|false $row */
-        $row = $this->tree_parent_stmt->fetch(\PDO::FETCH_ASSOC);
-        if ($row === false) {
-            return [
-                'parent_node_id' => null,
-                'link_name' => null,
-            ];
-        }
-
-        return [
-            'parent_node_id' => array_key_exists('parent_node_id', $row)
-                ? ($row['parent_node_id'] !== null ? $row['parent_node_id'] : null)
-                : null,
-            'link_name' => $row['link_name'] ?? null,
-        ];
     }
 
     /**

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPass.php
@@ -26,7 +26,7 @@ final class DynamicPropertiesPass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
     ) {
     }
 
@@ -38,9 +38,7 @@ final class DynamicPropertiesPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        $rows = $this->substrate !== null && $this->substrate->hasTreeLinkIndex()
-            ? $this->aggregateFromSubstrate()
-            : $this->aggregateFromSql();
+        $rows = $this->aggregateFromSubstrate();
 
         $findings = [];
         foreach ($rows as $row) {
@@ -116,8 +114,6 @@ final class DynamicPropertiesPass implements PassInterface
      */
     private function aggregateFromSubstrate(): array
     {
-        assert($this->substrate !== null);
-
         /** @var array<string, array{
          *     cnt:int,
          *     header_bytes:int,
@@ -172,137 +168,6 @@ final class DynamicPropertiesPass implements PassInterface
             if ($unused_table_bytes > 0) {
                 $stats[$class_name]['objects_with_unused_capacity']++;
             }
-        }
-
-        return $this->finalizeRows($stats);
-    }
-
-    /**
-     * SQL fallback for the no-substrate code path (Phase 2 only —
-     * still used by tests and by reports run without --full-analysis).
-     *
-     * @return list<array{
-     *     class_name:string,
-     *     cnt:int,
-     *     dynamic_properties_size:int,
-     *     header_bytes:int,
-     *     used_table_bytes:int,
-     *     unused_table_bytes:int,
-     *     property_count:int,
-     *     avg_properties_per_object:float,
-     *     avg_structural_bytes_per_object:int,
-     *     objects_with_unused_capacity:int,
-     *     estimated_avoidable_bytes_if_static:int
-     * }>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
-     */
-    private function aggregateFromSql(): array
-    {
-        /** @var array<string, array{
-         *     cnt:int,
-         *     header_bytes:int,
-         *     used_table_bytes:int,
-         *     unused_table_bytes:int,
-         *     property_count:int,
-         *     objects_with_unused_capacity:int
-         * }> $stats
-         */
-        $stats = [];
-
-        $size_rows = $this->db->query("
-            SELECT
-                cnl_obj.class_name,
-                e.child_node_id AS dp_node_id,
-                COALESCE(max(cnl_dp.size), 0) AS header_bytes,
-                COALESCE(sum(CASE
-                    WHEN e_child.link_name = 'array_elements'
-                    THEN COALESCE(cnl_child.size, 0)
-                    ELSE 0
-                END), 0) AS used_table_bytes,
-                COALESCE(sum(CASE
-                    WHEN e_child.link_name = 'possible_unused_area'
-                    THEN COALESCE(cnl_child.size, 0)
-                    ELSE 0
-                END), 0) AS unused_table_bytes
-            FROM context_edges e
-            JOIN context_node_locations cnl_obj
-                ON cnl_obj.node_id = e.parent_node_id
-                AND cnl_obj.run_id = {$this->run_id}
-                AND cnl_obj.location_type = 'ZendObjectMemoryLocation'
-            LEFT JOIN context_node_locations cnl_dp
-                ON cnl_dp.node_id = e.child_node_id
-                AND cnl_dp.run_id = {$this->run_id}
-            LEFT JOIN context_edges e_child
-                ON e_child.parent_node_id = e.child_node_id
-                AND e_child.run_id = {$this->run_id}
-                AND e_child.is_tree = 1
-            LEFT JOIN context_node_locations cnl_child
-                ON cnl_child.node_id = e_child.child_node_id
-                AND cnl_child.run_id = {$this->run_id}
-            WHERE e.run_id = {$this->run_id}
-                AND e.link_name = 'dynamic_properties'
-                AND e.is_tree = 1
-                AND cnl_obj.class_name IS NOT NULL
-            GROUP BY cnl_obj.class_name, e.child_node_id
-        ")->fetchAll(\PDO::FETCH_ASSOC);
-
-        foreach ($size_rows as $row) {
-            $class_name = (string)$row['class_name'];
-            if (!isset($stats[$class_name])) {
-                $stats[$class_name] = [
-                    'cnt' => 0,
-                    'header_bytes' => 0,
-                    'used_table_bytes' => 0,
-                    'unused_table_bytes' => 0,
-                    'property_count' => 0,
-                    'objects_with_unused_capacity' => 0,
-                ];
-            }
-
-            $header_bytes = (int)$row['header_bytes'];
-            $used_table_bytes = (int)$row['used_table_bytes'];
-            $unused_table_bytes = (int)$row['unused_table_bytes'];
-
-            $stats[$class_name]['cnt']++;
-            $stats[$class_name]['header_bytes'] += $header_bytes;
-            $stats[$class_name]['used_table_bytes'] += $used_table_bytes;
-            $stats[$class_name]['unused_table_bytes'] += $unused_table_bytes;
-            if ($unused_table_bytes > 0) {
-                $stats[$class_name]['objects_with_unused_capacity']++;
-            }
-        }
-
-        $property_rows = $this->db->query("
-            SELECT
-                cnl_obj.class_name,
-                count(*) AS property_count
-            FROM context_edges e_prop
-            JOIN context_edges e_array
-                ON e_array.child_node_id = e_prop.parent_node_id
-                AND e_array.run_id = {$this->run_id}
-                AND e_array.is_tree = 1
-                AND e_array.link_name = 'array_elements'
-            JOIN context_edges e_dp
-                ON e_dp.child_node_id = e_array.parent_node_id
-                AND e_dp.run_id = {$this->run_id}
-                AND e_dp.is_tree = 1
-                AND e_dp.link_name = 'dynamic_properties'
-            JOIN context_node_locations cnl_obj
-                ON cnl_obj.node_id = e_dp.parent_node_id
-                AND cnl_obj.run_id = {$this->run_id}
-                AND cnl_obj.location_type = 'ZendObjectMemoryLocation'
-            WHERE e_prop.run_id = {$this->run_id}
-                AND e_prop.is_tree = 1
-                AND cnl_obj.class_name IS NOT NULL
-            GROUP BY cnl_obj.class_name
-        ")->fetchAll(\PDO::FETCH_ASSOC);
-
-        foreach ($property_rows as $row) {
-            $class_name = (string)$row['class_name'];
-            if (!isset($stats[$class_name])) {
-                continue;
-            }
-            $stats[$class_name]['property_count'] = (int)$row['property_count'];
         }
 
         return $this->finalizeRows($stats);

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePass.php
@@ -32,7 +32,7 @@ final class NonTreeEdgePass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?array $precomputed_edge_stats = null,
     ) {
     }
@@ -46,86 +46,6 @@ final class NonTreeEdgePass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        if ($this->substrate !== null) {
-            return $this->analyzeWithSubstrate();
-        }
-
-        return $this->analyzeWithSql();
-    }
-
-    /**
-     * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
-     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
-    private function analyzeWithSql(): array
-    {
-        $stmt = $this->db->query("
-            SELECT
-                e.link_name,
-                count(*) as ref_count,
-                count(DISTINCT e.child_node_id) as target_count,
-                round(
-                    count(*) * 1.0
-                    / max(1, count(DISTINCT e.child_node_id)),
-                    1
-                ) as avg_refs,
-                (SELECT cnl_src.class_name
-                    FROM context_edges e_pp
-                    JOIN context_node_locations cnl_src
-                        ON cnl_src.node_id = e_pp.parent_node_id
-                        AND cnl_src.run_id = {$this->run_id}
-                        AND cnl_src.location_type = 'ZendObjectMemoryLocation'
-                    WHERE e_pp.child_node_id = e.parent_node_id
-                        AND e_pp.link_name = 'object_properties'
-                        AND e_pp.run_id = {$this->run_id}
-                    LIMIT 1
-                ) as source_class,
-                (SELECT cnl_tgt.class_name
-                    FROM context_node_locations cnl_tgt
-                    WHERE cnl_tgt.node_id = e.child_node_id
-                        AND cnl_tgt.run_id = {$this->run_id}
-                        AND cnl_tgt.class_name IS NOT NULL
-                    LIMIT 1
-                ) as target_class
-            FROM context_edges e
-            WHERE e.run_id = {$this->run_id}
-                AND e.is_tree = 0
-                AND e.strength = 'strong'
-            GROUP BY e.link_name
-            HAVING count(*) > 10
-            ORDER BY count(*) DESC
-            LIMIT 20
-        ");
-
-        $findings = [];
-        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-            $finding = $this->buildSharedFinding(
-                (string)$row['link_name'],
-                (int)$row['ref_count'],
-                (int)$row['target_count'],
-                (string)($row['source_class'] ?? ''),
-                (string)($row['target_class'] ?? ''),
-            );
-            if ($finding !== null) {
-                $findings[] = $finding;
-            }
-        }
-
-        return $findings;
-    }
-
-    /**
-     * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedOperand, InvalidOperand
-     * @psalm-suppress PossiblyInvalidArgument, InvalidArgument, RiskyTruthyFalsyComparison
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
-    private function analyzeWithSubstrate(): array
-    {
-        assert($this->substrate !== null);
-
         if ($this->precomputed_edge_stats !== null) {
             $rows = $this->precomputed_edge_stats;
         } else {
@@ -247,7 +167,6 @@ final class NonTreeEdgePass implements PassInterface
 
     private function resolveDirectSourceClass(int $parent_node_id): ?string
     {
-        assert($this->substrate !== null);
         if ($this->substrate->getTreeLinkName($parent_node_id) !== 'object_properties') {
             return null;
         }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPass.php
@@ -29,7 +29,7 @@ final class PropertyScalingPass implements PassInterface
         private \PDO $db,
         private int $run_id,
         private array $class_objects_summary,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?LinkNameResolver $link_resolver = null,
     ) {
     }
@@ -65,18 +65,13 @@ final class PropertyScalingPass implements PassInterface
             return [];
         }
 
-        if ($this->substrate !== null) {
-            $props = $this->analyzeWithGraph($dominant_class);
-        } else {
-            $props = $this->analyzeWithSql($dominant_class);
-        }
+        $props = $this->analyzeWithGraph($dominant_class);
 
         if ($props === []) {
             return [];
         }
 
-        $use_retained = $this->substrate !== null
-            && $this->substrate->hasSubtreeSizes();
+        $use_retained = $this->substrate->hasSubtreeSizes();
 
         $per_instance = [];
         $shared = [];
@@ -198,7 +193,6 @@ final class PropertyScalingPass implements PassInterface
      */
     private function analyzeWithGraph(string $dominant_class): array
     {
-        assert($this->substrate !== null);
         $use_retained = $this->substrate->hasSubtreeSizes();
 
         $resolver = $this->link_resolver ?? new LinkNameResolver($this->db, $this->run_id);
@@ -300,65 +294,6 @@ final class PropertyScalingPass implements PassInterface
     }
 
     /**
-     * SQL-based analysis (Phase 2 fallback).
-     * @return list<array<string, mixed>>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, InvalidOperand
-     */
-    private function analyzeWithSql(string $dominant_class): array
-    {
-        $stmt = $this->db->query("
-            SELECT
-                e_prop.link_name,
-                count(*) as total_refs,
-                count(DISTINCT e_prop.child_node_id) as distinct_targets,
-                min(e_prop.child_node_id) as sample_child_id,
-                sum(CASE WHEN e_prop.is_tree = 1
-                    THEN COALESCE(cnl_val.size, 0) ELSE 0
-                END) as tree_size
-            FROM context_node_locations cnl_obj
-            JOIN context_edges e_to_props
-                ON e_to_props.parent_node_id = cnl_obj.node_id
-                AND e_to_props.link_name = 'object_properties'
-                AND e_to_props.run_id = {$this->run_id}
-            JOIN context_edges e_prop
-                ON e_prop.parent_node_id = e_to_props.child_node_id
-                AND e_prop.run_id = {$this->run_id}
-            LEFT JOIN context_node_locations cnl_val
-                ON cnl_val.node_id = e_prop.child_node_id
-                AND cnl_val.run_id = {$this->run_id}
-            WHERE cnl_obj.class_name = "
-            . $this->db->quote($dominant_class) . "
-                AND cnl_obj.run_id = {$this->run_id}
-            GROUP BY e_prop.link_name
-            ORDER BY tree_size DESC
-        ");
-
-        $results = [];
-        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-            $distinct = (int)$row['distinct_targets'];
-            $total_refs = (int)$row['total_refs'];
-
-            if ($distinct === 1) {
-                $scaling = 'SHARED';
-            } elseif ($distinct >= $total_refs * 0.9) {
-                $scaling = 'PER-INSTANCE';
-            } else {
-                $scaling = 'PARTIALLY SHARED';
-            }
-
-            $results[] = [
-                'property' => $row['link_name'],
-                'distinct_targets' => $distinct,
-                'total_refs' => $total_refs,
-                'size' => (int)$row['tree_size'],
-                'scaling' => $scaling,
-                'sample_child_id' => (int)$row['sample_child_id'],
-            ];
-        }
-        return $results;
-    }
-
-    /**
      * Classify sharing reason for each shared property.
      * @param list<array<string, mixed>> $shared
      * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
@@ -369,61 +304,12 @@ final class PropertyScalingPass implements PassInterface
             return;
         }
 
-        $child_ids = [];
-        foreach ($shared as $s) {
-            $child_ids[] = (int)$s['sample_child_id'];
-        }
-
-        $info = [];
-        if ($this->substrate !== null) {
-            // Substrate path: get node type directly, skip location_type
-            // (it's only used for label refinement, not critical)
-            foreach ($child_ids as $cid) {
-                $type = $this->substrate->getNodeType($cid) ?? '';
-                $info[$cid] = ['type' => $type, 'loc_type' => ''];
-            }
-        } else {
-            $placeholders = implode(',', $child_ids);
-            $stmt = $this->db->query(
-                "SELECT cn.node_id, cn.type, cnl.location_type"
-                . " FROM context_nodes cn"
-                . " LEFT JOIN context_node_locations cnl"
-                . " ON cnl.node_id = cn.node_id"
-                . " AND cnl.run_id = cn.run_id"
-                . " WHERE cn.run_id = {$this->run_id}"
-                . " AND cn.node_id IN ({$placeholders})"
-            );
-            while ($r = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-                $info[(int)$r['node_id']] = [
-                    'type' => (string)($r['type'] ?? ''),
-                    'loc_type' => (string)($r['location_type'] ?? ''),
-                ];
-            }
-        }
-
         foreach ($shared as &$s) {
             $cid = (int)$s['sample_child_id'];
-            $node_info = $info[$cid] ?? null;
-
-            if ($node_info === null) {
-                $s['share_reason'] = 'shared';
-                continue;
-            }
-
-            $type = $node_info['type'];
-            $loc = $node_info['loc_type'];
-
-            if ($type === 'PhpReferenceContext') {
-                $s['share_reason'] = 'PHP reference';
-            } elseif (str_contains($loc, 'Object')) {
-                $s['share_reason'] = 'same instance';
-            } elseif (str_contains($loc, 'Array')) {
-                $s['share_reason'] = 'array, CoW';
-            } elseif (str_contains($loc, 'String')) {
-                $s['share_reason'] = 'interned string';
-            } else {
-                $s['share_reason'] = 'shared';
-            }
+            $type = $this->substrate->getNodeType($cid) ?? '';
+            $s['share_reason'] = $type === 'PhpReferenceContext'
+                ? 'PHP reference'
+                : 'shared';
         }
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPass.php
@@ -115,7 +115,7 @@ final class StructuralDedupPass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?LinkNameResolver $link_resolver = null,
     ) {
     }
@@ -134,9 +134,7 @@ final class StructuralDedupPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        $shape_groups = $this->substrate !== null
-            ? $this->analyzeWithGraph()
-            : $this->analyzeWithSql();
+        $shape_groups = $this->analyzeWithGraph();
 
         $findings = [];
 
@@ -230,8 +228,6 @@ final class StructuralDedupPass implements PassInterface
      */
     private function analyzeWithGraph(): array
     {
-        assert($this->substrate !== null);
-
         $resolver = $this->link_resolver ?? new LinkNameResolver($this->db, $this->run_id);
 
         /** @var array<string, array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}> */
@@ -282,64 +278,6 @@ final class StructuralDedupPass implements PassInterface
             $shape_groups[$hash]['count']++;
             $shape_groups[$hash]['total_size'] += $size;
         }
-
-        return array_values($shape_groups);
-    }
-
-    /**
-     * SQL-based analysis (fallback when no substrate).
-     * @return list<array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedReturnTypeCoercion
-     * @psalm-suppress MixedArgument, MixedOperand
-     */
-    private function analyzeWithSql(): array
-    {
-        $rows = $this->db->query("
-            SELECT
-                cnl.node_id,
-                cnl.class_name,
-                cnl.size,
-                group_concat(e_prop.link_name, '|') as property_names
-            FROM context_node_locations cnl
-            JOIN context_edges e_to_obj
-                ON e_to_obj.parent_node_id = cnl.node_id
-                AND e_to_obj.link_name = 'object_properties'
-                AND e_to_obj.is_tree = 1
-                AND e_to_obj.run_id = {$this->run_id}
-            LEFT JOIN context_edges e_prop
-                ON e_prop.parent_node_id = e_to_obj.child_node_id
-                AND e_prop.is_tree = 1
-                AND e_prop.run_id = {$this->run_id}
-            WHERE cnl.location_type = 'ZendObjectMemoryLocation'
-                AND cnl.class_name IS NOT NULL
-                AND cnl.run_id = {$this->run_id}
-            GROUP BY cnl.node_id
-        ")->fetchAll(\PDO::FETCH_ASSOC);
-
-        /** @var array<string, array{class: string, size: int, props: string, count: int, total_size: int, example_id: int}> */
-        $shape_groups = [];
-        foreach ($rows as $s) {
-            $props = $s['property_names']
-                ? explode('|', $s['property_names'])
-                : [];
-            sort($props);
-            $prop_sig = implode(',', $props);
-            $hash = $s['class_name'] . '|' . $s['size'] . '|' . $prop_sig;
-
-            if (!isset($shape_groups[$hash])) {
-                $shape_groups[$hash] = [
-                    'class' => $s['class_name'],
-                    'size' => (int)$s['size'],
-                    'props' => $prop_sig,
-                    'count' => 0,
-                    'total_size' => 0,
-                    'example_id' => (int)$s['node_id'],
-                ];
-            }
-            $shape_groups[$hash]['count']++;
-            $shape_groups[$hash]['total_size'] += (int)$s['size'];
-        }
-        unset($rows);
 
         return array_values($shape_groups);
     }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopArraysPass.php
@@ -23,16 +23,13 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TopArraysPass implements PassInterface
 {
-    private ?\PDOStatement $parentStmt = null;
-    private ?\PDOStatement $nodeTypeStmt = null;
-
     /**
      * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
      */
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?array $frame_labels = null,
     ) {
     }
@@ -45,20 +42,6 @@ final class TopArraysPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        if ($this->substrate !== null) {
-            return $this->analyzeWithGraph();
-        }
-        return $this->analyzeWithSql();
-    }
-
-    /**
-     * In-memory analysis using GraphSubstrate.
-     * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess
-     */
-    private function analyzeWithGraph(): array
-    {
-        assert($this->substrate !== null);
         $array_element_nodes = $this->loadArrayElementNodes();
         $labeler = new NodeLabeler($this->db, $this->run_id, $this->frame_labels);
         $use_retained = $this->substrate->hasSubtreeSizes();
@@ -145,128 +128,6 @@ final class TopArraysPass implements PassInterface
     }
 
     /**
-     * SQL-based analysis (fallback when no substrate).
-     * @return list<Finding>
-     * @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument
-     * @psalm-suppress InvalidOperand
-     */
-    private function analyzeWithSql(): array
-    {
-        $labeler = new NodeLabeler($this->db, $this->run_id);
-
-        // Find the top 10 largest arrays first (no joins). The previous
-        // implementation joined 3 hops of context_edges before applying
-        // ORDER BY/LIMIT, computing the join for every row in v_arrays.
-        // On large captures that single query dominated the report runtime.
-        $stmt = $this->db->query("
-            SELECT
-                va.node_id,
-                va.total_size,
-                va.element_count
-            FROM v_arrays va
-            WHERE va.run_id = {$this->run_id}
-            ORDER BY va.total_size DESC
-            LIMIT 10
-        ");
-
-        $findings = [];
-        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-            $total = (int)$row['total_size'];
-            if ($total < 10240) {
-                continue;
-            }
-
-            $elements = (int)($row['element_count'] ?? 0);
-            $path = $this->buildFullPath((int)$row['node_id'], $labeler);
-
-            $findings[] = new Finding(
-                kind: 'large_array',
-                severity: $total > 1024 * 1024
-                    ? FindingSeverity::Medium
-                    : FindingSeverity::Low,
-                confidence: FindingConfidence::High,
-                summary: sprintf(
-                    '%s array, %s elements — %s',
-                    SizeFormatter::format($total),
-                    number_format($elements),
-                    $path ?: '(root)',
-                ),
-                facts: [
-                    'node_id' => (int)$row['node_id'],
-                    'table_size' => $total,
-                    'retained_size' => $total,
-                    'element_count' => $elements,
-                    'owner_path' => $path,
-                ],
-                hypothesis: 'Large array allocation;'
-                    . ' may be a cache, buffer, or accumulator',
-                next_checks: [
-                    'Check if array size is bounded',
-                    'Consider SplFixedArray for known-size collections',
-                ],
-                impact_bytes: $total,
-                evidence_node_ids: [(int)$row['node_id']],
-            );
-        }
-
-        // Sparse array detection
-        $sparse_rows = $this->db->query("
-            SELECT
-                va.node_id,
-                va.table_size,
-                va.element_count,
-                va.table_size / 32 as capacity
-            FROM v_arrays va
-            WHERE va.run_id = {$this->run_id}
-                AND va.table_size >= 32768
-                AND va.element_count > 0
-                AND va.element_count * 4 < va.table_size / 32
-            ORDER BY va.table_size DESC
-            LIMIT 5
-        ");
-
-        foreach ($sparse_rows as $sr) {
-            $s_node = (int)$sr['node_id'];
-            $s_table = (int)$sr['table_size'];
-            $s_count = (int)$sr['element_count'];
-            $s_capacity = (int)$sr['capacity'];
-            $utilization = $s_capacity > 0
-                ? $s_count / $s_capacity * 100.0
-                : 0;
-
-            $findings[] = new Finding(
-                kind: 'sparse_array',
-                severity: FindingSeverity::Medium,
-                confidence: FindingConfidence::Medium,
-                summary: sprintf(
-                    '%s table, %s/%s slots used (%.1f%%)',
-                    SizeFormatter::format($s_table),
-                    number_format($s_count),
-                    number_format($s_capacity),
-                    $utilization,
-                ),
-                facts: [
-                    'node_id' => $s_node,
-                    'table_size' => $s_table,
-                    'element_count' => $s_count,
-                    'capacity' => $s_capacity,
-                    'utilization_pct' => round($utilization, 1),
-                ],
-                hypothesis: 'Array with many empty slots — likely after'
-                    . ' mass unset() without reallocation',
-                next_checks: [
-                    'Use array_values() to repack the array',
-                    'Or rebuild with only needed elements',
-                ],
-                impact_bytes: $s_table,
-                evidence_node_ids: [$s_node],
-            );
-        }
-
-        return $findings;
-    }
-
-    /**
      * Set of every child node whose tree-edge link_name is 'array_elements'.
      *
      * Reads the substrate's in-memory tree-edge link index instead of
@@ -277,7 +138,6 @@ final class TopArraysPass implements PassInterface
      */
     private function loadArrayElementNodes(): array
     {
-        assert($this->substrate !== null);
         $set = [];
         foreach ($this->substrate->iterateTreeChildrenByLinkName('array_elements') as $child_id) {
             $set[$child_id] = true;
@@ -286,23 +146,11 @@ final class TopArraysPass implements PassInterface
     }
 
     /**
-     * Walk from node to root via tree parent edges. Reads the
-     * substrate's in-memory tree-link / parent / type indexes when
-     * available, otherwise falls back to prepared statements.
-     *
-     * @psalm-suppress MixedArrayAccess, MixedAssignment
+     * Walk from node to root via tree parent edges using the
+     * substrate's in-memory tree-link / parent / type indexes.
      */
     private function buildFullPath(int $node_id, NodeLabeler $labeler): string
     {
-        if ($this->substrate !== null && $this->substrate->hasTreeLinkIndex()) {
-            return $this->buildFullPathFromSubstrate($node_id, $labeler);
-        }
-        return $this->buildFullPathFromSql($node_id, $labeler);
-    }
-
-    private function buildFullPathFromSubstrate(int $node_id, NodeLabeler $labeler): string
-    {
-        assert($this->substrate !== null);
         $parts = [];
         $types = [];
         $cur = $node_id;
@@ -321,52 +169,6 @@ final class TopArraysPass implements PassInterface
             array_unshift($types, $this->substrate->getNodeType($cur) ?? '');
             $cur = $parent;
         }
-        return PathFormatter::toPhpSyntax($parts, $types);
-    }
-
-    /**
-     * @psalm-suppress MixedArrayAccess, MixedAssignment
-     */
-    private function buildFullPathFromSql(int $node_id, NodeLabeler $labeler): string
-    {
-        if ($this->parentStmt === null) {
-            $this->parentStmt = $this->db->prepare(
-                "SELECT parent_node_id, link_name FROM context_edges"
-                . " WHERE child_node_id = ? AND is_tree = 1"
-                . " AND run_id = {$this->run_id} LIMIT 1"
-            );
-            $this->nodeTypeStmt = $this->db->prepare(
-                "SELECT type FROM context_nodes"
-                . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
-            );
-        }
-
-        $parts = [];
-        $types = [];
-        $cur = $node_id;
-        for ($i = 0; $i < 20; $i++) {
-            $this->parentStmt->execute([$cur]);
-            $row = $this->parentStmt->fetch(\PDO::FETCH_NUM);
-            if (!$row) {
-                break;
-            }
-            if ($row[0] === null) {
-                array_unshift($parts, (string)$row[1]);
-                array_unshift($types, '');
-                break;
-            }
-            $parent = (int)$row[0];
-            $link = (string)$row[1];
-            $resolved = $labeler->resolvePathLabel($link, $cur);
-            array_unshift($parts, $resolved);
-
-            assert($this->nodeTypeStmt !== null);
-            $this->nodeTypeStmt->execute([$cur]);
-            $nt = $this->nodeTypeStmt->fetchColumn();
-            array_unshift($types, $nt !== false ? (string)$nt : '');
-            $cur = $parent;
-        }
-
         return PathFormatter::toPhpSyntax($parts, $types);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -23,9 +23,6 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\SizeFormatter;
 
 final class TopStringsPass implements PassInterface
 {
-    private ?\PDOStatement $parentStmt = null;
-    private ?\PDOStatement $nodeTypeStmt = null;
-
     /**
      * @param list<array{node_id: int, size: int, preview: string}>|null $top_strings_data Pre-computed (binary path)
      * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
@@ -35,7 +32,7 @@ final class TopStringsPass implements PassInterface
     public function __construct(
         private \PDO $db,
         private int $run_id,
-        private ?GraphSubstrate $substrate = null,
+        private GraphSubstrate $substrate,
         private ?array $top_strings_data = null,
         private ?array $frame_labels = null,
         private ?array $canonical_names = null,
@@ -132,22 +129,9 @@ final class TopStringsPass implements PassInterface
     /**
      * Walk from node to root via tree parent edges, resolved entirely
      * from the substrate's in-memory tree-link / parent / type indexes.
-     * Falls back to the old prepared-statement walk only when the
-     * substrate isn't available (Phase 2 SQL paths still use it).
-     *
-     * @psalm-suppress MixedArrayAccess, MixedAssignment
      */
     private function buildFullPath(int $node_id, NodeLabeler $labeler): string
     {
-        if ($this->substrate !== null && $this->substrate->hasTreeLinkIndex()) {
-            return $this->buildFullPathFromSubstrate($node_id, $labeler);
-        }
-        return $this->buildFullPathFromSql($node_id, $labeler);
-    }
-
-    private function buildFullPathFromSubstrate(int $node_id, NodeLabeler $labeler): string
-    {
-        assert($this->substrate !== null);
         $parts = [];
         $types = [];
         $cur = $node_id;
@@ -166,52 +150,6 @@ final class TopStringsPass implements PassInterface
             array_unshift($types, $this->substrate->getNodeType($cur) ?? '');
             $cur = $parent;
         }
-        return PathFormatter::toPhpSyntax($parts, $types);
-    }
-
-    /**
-     * @psalm-suppress MixedArrayAccess, MixedAssignment
-     */
-    private function buildFullPathFromSql(int $node_id, NodeLabeler $labeler): string
-    {
-        if ($this->parentStmt === null) {
-            $this->parentStmt = $this->db->prepare(
-                "SELECT parent_node_id, link_name FROM context_edges"
-                . " WHERE child_node_id = ? AND is_tree = 1"
-                . " AND run_id = {$this->run_id} LIMIT 1"
-            );
-            $this->nodeTypeStmt = $this->db->prepare(
-                "SELECT type FROM context_nodes"
-                . " WHERE node_id = ? AND run_id = {$this->run_id} LIMIT 1"
-            );
-        }
-
-        $parts = [];
-        $types = [];
-        $cur = $node_id;
-        for ($i = 0; $i < 20; $i++) {
-            $this->parentStmt->execute([$cur]);
-            $row = $this->parentStmt->fetch(\PDO::FETCH_NUM);
-            if (!$row) {
-                break;
-            }
-            if ($row[0] === null) {
-                array_unshift($parts, (string)$row[1]);
-                array_unshift($types, '');
-                break;
-            }
-            $parent = (int)$row[0];
-            $link = (string)$row[1];
-            $resolved = $labeler->resolvePathLabel($link, $cur);
-            array_unshift($parts, $resolved);
-
-            assert($this->nodeTypeStmt !== null);
-            $this->nodeTypeStmt->execute([$cur]);
-            $nt = $this->nodeTypeStmt->fetchColumn();
-            array_unshift($types, $nt !== false ? (string)$nt : '');
-            $cur = $parent;
-        }
-
         return PathFormatter::toPhpSyntax($parts, $types);
     }
 }

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -51,9 +51,11 @@ final class ReportGenerator
     /**
      * Generate a report from an existing SQLite database.
      *
-     * @return ReportResult
-     */
-    /**
+     * @param bool $full_analysis Retained for CLI compatibility but no
+     *   longer used: report passes now always consume the snapshot
+     *   through {@see GraphSubstrate}, so the previous "skip Phase 3,
+     *   run SQL passes" mode is gone. Stage C of the substrate
+     *   unification (issue #787) will retire or repurpose the flag.
      * @param bool|null $ffi_csr true=force on, false=force off, null=auto
      * @param int $bulk_fetch_chunk rows per chunked fetchAll inside the
      *   substrate loaders. 0 disables chunking (single fetchAll, max
@@ -72,6 +74,7 @@ final class ReportGenerator
      *   the caller). 0 disables mmap. SQLite silently caps to its
      *   compile-time SQLITE_MAX_MMAP_SIZE (typically 2 GiB - 16 KiB),
      *   so values above that are honoured up to the cap.
+     * @psalm-suppress UnusedParam $full_analysis kept for CLI compatibility
      */
     public function generateFromDb(
         \PDO $db,
@@ -90,7 +93,6 @@ final class ReportGenerator
         $this->ensureReportIndexes($db);
 
         $meta = $this->loadMeta($db, $run_id);
-        $node_count = (int)($meta['node_count'] ?? 0);
         $edge_count = (int)($meta['edge_count'] ?? 0);
 
         // Phase 1: Summary-based passes (always run)
@@ -118,38 +120,11 @@ final class ReportGenerator
         $findings = array_merge($findings, (new BinPeriodicityPass($summary))->analyze());
         $findings = array_merge($findings, (new BinShapePass($summary))->analyze());
 
-        // Phase 2: SQL-based passes (< 500K nodes, or --full-analysis)
-        $run_phase3 = $full_analysis ? $edge_count > 0 : ($edge_count > 0 && $edge_count < 500000);
-        if ($full_analysis || $node_count < 500000) {
-            // CallStackPass has a substrate-backed analyzeWithSubstrate
-            // path that's an order of magnitude cheaper than its
-            // 4-JOIN SQL fallback. Defer it to Phase 3 when the
-            // substrate is going to be built; the SQL fallback only
-            // runs on small graphs that skip Phase 3 entirely.
-            if (!$run_phase3) {
-                $findings = array_merge($findings, $this->runPass(new CallStackPass($db, $run_id)));
-            }
-            // DynamicProperties / PropertyScaling / TopArrays / TopStrings /
-            // NonTreeEdge / StructuralDedup are all "deferred to Phase 3 if
-            // graph is available" — when the substrate isn't built we run
-            // their SQL fallbacks here, otherwise the Phase 3 block below
-            // takes over and feeds them the substrate.
-            if (!$run_phase3) {
-                $findings = array_merge($findings, $this->runPass(new DynamicPropertiesPass($db, $run_id)));
-                $findings = array_merge($findings, $this->runPass(
-                    new PropertyScalingPass($db, $run_id, $class_objects)
-                ));
-                $findings = array_merge($findings, $this->runPass(new TopArraysPass($db, $run_id)));
-                $findings = array_merge($findings, $this->runPass(new TopStringsPass($db, $run_id)));
-                $findings = array_merge($findings, $this->runPass(new NonTreeEdgePass($db, $run_id)));
-                $findings = array_merge($findings, $this->runPass(
-                    new DedupCandidatePass($db, $run_id)
-                ));
-                $findings = array_merge($findings, $this->runPass(new StructuralDedupPass($db, $run_id)));
-            }
-        }
-
-        // Phase 3: Graph-based passes (< 500K edges, or --full-analysis)
+        // Phase 3: Graph-based passes. The substrate is always built when
+        // there are edges to analyse; report passes only consume the
+        // snapshot via the substrate, so the on-disk format (.db / .rmem)
+        // is just a loader selection.
+        $run_phase3 = $edge_count > 0;
         if ($run_phase3) {
             $substrate = GraphSubstrate::createFromDb($db, $run_id, $ffi_csr, $bulk_fetch_chunk);
             $meta['scc_count'] = count($substrate->getSccProfiles());
@@ -163,13 +138,10 @@ final class ReportGenerator
 
             // Shared resolver replaces the per-edge SQL N+1 that used to
             // dominate PerPropertyMemory / Ownership / StructuralDedup /
-            // PropertyScaling / NonTreeEdgePass.
-            //
-            // The substrate now carries a tree-edge link_name index built
-            // for free during loadEdgesFfi/loadEdges, so the resolver
-            // delegates to it and answers every lookup in O(1) memory —
-            // the legacy eager/lazy paths are kept as fallbacks for code
-            // paths that don't have a substrate (Phase 2 SQL passes).
+            // PropertyScaling / NonTreeEdgePass. The substrate carries a
+            // tree-edge link_name index built for free during
+            // loadEdgesFfi/loadEdges, so the resolver delegates to it
+            // and answers every lookup in O(1) memory.
             $link_resolver = new LinkNameResolver(
                 db: $db,
                 run_id: $run_id,
@@ -289,10 +261,9 @@ final class ReportGenerator
     /**
      * Generate a report from a .rmem binary file.
      *
-     * Binary input goes straight to Phase 3 substrate analysis — there
-     * is no SQL fallback for Phase 2 passes. The Phase 1 summary passes
-     * read summary/location_types/class_objects data that was serialized
-     * into the binary file's summary section.
+     * Binary input goes straight to Phase 3 substrate analysis. The
+     * Phase 1 summary passes read summary/location_types/class_objects
+     * data that was serialized into the binary file's summary section.
      *
      * @param bool|null $ffi_csr true=force on, false=force off, null=auto
      * @param int $worker_count number of parallel workers for Phase 3

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
@@ -96,32 +96,6 @@ class CallStackPassTest extends BaseTestCase
     }
 
     /**
-     * SQL fallback path (no substrate). Same fixture, same expected
-     * stack: this exercises the 4-JOIN query and the SQL frame
-     * formatting branch.
-     */
-    public function testSqlFallbackPathReturnsSameResult(): void
-    {
-        $db = $this->createDirectDb();
-        $this->seedCallStack(
-            $db,
-            [
-                ['fn' => 'main', 'line' => '1'],
-                ['fn' => 'App\\Foo::bar', 'line' => '42'],
-            ],
-        );
-
-        $pass = new CallStackPass($db, 1);
-        $findings = $pass->analyze();
-
-        $this->assertCount(1, $findings);
-        $this->assertSame(
-            ['main:1', 'App\\Foo::bar:42'],
-            $findings[0]->facts['frames'],
-        );
-    }
-
-    /**
      * Insert a CallFramesContext with one CallFrameContext child per
      * frame. Each child carries `function_name` (and optionally
      * `lineno`) attributes — the same shape NodeLabeler / the SQL

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/DedupCandidatePassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/DedupCandidatePassTest.php
@@ -37,41 +37,26 @@ class DedupCandidatePassTest extends BaseTestCase
         parent::tearDown();
     }
 
-    public function testAnalyzeWithSubstrateMatchesSqlPathForDedupFindings(): void
+    public function testAnalyzeWithSubstrateProducesDedupFinding(): void
     {
         $db = $this->createDirectDb();
         $this->seedRepresentativeScenario($db);
 
-        $sql_findings = (new DedupCandidatePass($db, 1))->analyze();
-
         $substrate = GraphSubstrate::loadFromDb($db, 1);
         $graph_findings = (new DedupCandidatePass($db, 1, $substrate))->analyze();
 
-        $dedup_sql = $this->findFinding(
-            $sql_findings,
-            'dedup_candidate',
-            'App\\Owner::$names[value]',
-        );
         $dedup_graph = $this->findFinding(
             $graph_findings,
             'dedup_candidate',
             'App\\Owner::$names[value]',
         );
 
-        $this->assertNotNull($dedup_sql);
         $this->assertNotNull($dedup_graph);
-        $this->assertSame($dedup_sql->summary, $dedup_graph->summary);
-        $this->assertSame(
-            $dedup_sql->facts['count'],
-            $dedup_graph->facts['count'],
-        );
-        $this->assertSame(60, $dedup_sql->facts['count']);
-        $sql_examples = $dedup_sql->facts['examples'] ?? null;
+        $this->assertSame(60, $dedup_graph->facts['count']);
         $graph_examples = $dedup_graph->facts['examples'] ?? null;
-        self::assertIsArray($sql_examples);
         self::assertIsArray($graph_examples);
         $this->assertSame(
-            $sql_examples['sample_value'] ?? null,
+            'same-shared-string',
             $graph_examples['sample_value'] ?? null,
         );
     }
@@ -81,7 +66,8 @@ class DedupCandidatePassTest extends BaseTestCase
         $db = $this->createDirectDb();
         $this->seedSharedSingletonScenario($db);
 
-        $findings = (new DedupCandidatePass($db, 1))->analyze();
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $findings = (new DedupCandidatePass($db, 1, $substrate))->analyze();
 
         $this->assertNull($this->findFinding(
             $findings,
@@ -102,7 +88,8 @@ class DedupCandidatePassTest extends BaseTestCase
         $db = $this->createDirectDb();
         $this->seedHeterogeneousClassScenario($db);
 
-        $findings = (new DedupCandidatePass($db, 1))->analyze();
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $findings = (new DedupCandidatePass($db, 1, $substrate))->analyze();
 
         // Without the per-class group key the SQL would have produced a
         // single bucket of count=120 mixing both classes. With the fix

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/DynamicPropertiesPassTest.php
@@ -122,34 +122,6 @@ class DynamicPropertiesPassTest extends BaseTestCase
     }
 
     /**
-     * Without a substrate the pass falls back to the raw SQL path.
-     * Same fixture, same expectation: one finding for the class above
-     * the threshold.
-     */
-    public function testSqlFallbackPathReturnsSameResult(): void
-    {
-        $db = $this->createDirectDb();
-        $this->seedDynamicProperties(
-            $db,
-            instance_count: 15,
-            header_size: 56,
-            used_table_size: 192,
-            unused_table_size: 128,
-            property_count: 4,
-        );
-
-        // No substrate argument → SQL path.
-        $pass = new DynamicPropertiesPass($db, 1);
-        $findings = $pass->analyze();
-
-        $this->assertCount(1, $findings);
-        $this->assertSame('App\\Sloppy', $findings[0]->facts['class_name']);
-        $this->assertSame(15, $findings[0]->facts['count']);
-        $this->assertSame(15 * 376, $findings[0]->facts['dynamic_properties_size']);
-        $this->assertSame(15 * 312, $findings[0]->facts['estimated_avoidable_bytes_if_static']);
-    }
-
-    /**
      * Insert N App\Sloppy instances under a synthetic root, each one
      * carrying a `dynamic_properties` array header plus its used table,
      * spare capacity region, and N property entries.

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/NonTreeEdgePassTest.php
@@ -37,30 +37,20 @@ class NonTreeEdgePassTest extends BaseTestCase
         parent::tearDown();
     }
 
-    public function testAnalyzeWithSubstrateMatchesSqlPathForSharedFindings(): void
+    public function testAnalyzeWithSubstrateProducesSharedSingletonFinding(): void
     {
         $db = $this->createDirectDb();
         $this->seedRepresentativeScenario($db);
 
-        $sql_findings = (new NonTreeEdgePass($db, 1))->analyze();
-
         $substrate = GraphSubstrate::loadFromDb($db, 1);
         $graph_findings = (new NonTreeEdgePass($db, 1, $substrate))->analyze();
 
-        $shared_sql = $this->findFinding(
-            $sql_findings,
-            'shared_singleton',
-            'App\\Owner::$service',
-        );
         $shared_graph = $this->findFinding(
             $graph_findings,
             'shared_singleton',
             'App\\Owner::$service',
         );
-        $this->assertNotNull($shared_sql);
         $this->assertNotNull($shared_graph);
-        $this->assertSame($shared_sql->summary, $shared_graph->summary);
-        $this->assertSame($shared_sql->facts, $shared_graph->facts);
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/PropertyScalingPassTest.php
@@ -44,10 +44,12 @@ class PropertyScalingPassTest extends BaseTestCase
         // each); total per_instance ≈ 204800 B. Heap clamp default = 0.
         $this->seedScalingScenario($db, 'App\\GraphNode', 200, 1024);
 
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
         $findings = (new PropertyScalingPass(
             $db,
             1,
             ['App\\GraphNode' => ['count' => 200, 'memory_usage' => 200 * 64]],
+            $substrate,
         ))->analyze();
 
         $finding = $this->findFinding($findings, 'property_scaling', 'App\\GraphNode');

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/StructuralDedupPassTest.php
@@ -42,7 +42,8 @@ class StructuralDedupPassTest extends BaseTestCase
         $db = $this->createDirectDb();
         $this->seedEmptyClassScenario($db, 'App\\Marker', 60);
 
-        $findings = (new StructuralDedupPass($db, 1))->analyze();
+        $substrate = \Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate::loadFromDb($db, 1);
+        $findings = (new StructuralDedupPass($db, 1, $substrate))->analyze();
 
         $this->assertNotNull($this->findFinding(
             $findings,
@@ -61,7 +62,8 @@ class StructuralDedupPassTest extends BaseTestCase
         $db = $this->createDirectDb();
         $this->seedEmptyClassScenario($db, $class_name, 60);
 
-        $findings = (new StructuralDedupPass($db, 1))->analyze();
+        $substrate = \Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate::loadFromDb($db, 1);
+        $findings = (new StructuralDedupPass($db, 1, $substrate))->analyze();
 
         $this->assertNull(
             $this->findFinding($findings, 'empty_object', $class_name),


### PR DESCRIPTION
## Summary

This PR removes all SQL-based fallback code paths from memory report analysis passes and makes `GraphSubstrate` a required dependency (non-nullable) for all passes. Previously, passes could operate in two modes: using an in-memory `GraphSubstrate` for efficient analysis, or falling back to direct SQL queries when the substrate wasn't available. This change consolidates all passes to exclusively use the substrate.

## Key Changes

- **Made GraphSubstrate mandatory**: Changed `?GraphSubstrate $substrate` to `GraphSubstrate $substrate` in constructor parameters across all affected passes:
  - `TopArraysPass`
  - `DedupCandidatePass`
  - `DynamicPropertiesPass`
  - `PropertyScalingPass`
  - `NonTreeEdgePass`
  - `CallStackPass`
  - `StructuralDedupPass`
  - `TopStringsPass`

- **Removed SQL fallback methods** from each pass:
  - `TopArraysPass`: Removed `analyzeWithSql()`, `buildFullPathFromSql()`, and related prepared statement caching
  - `DedupCandidatePass`: Removed `resolveDedupOwnerInfoFromSql()`, `resolveDirectSourceClassFromSql()`, `loadTreeParentInfo()`
  - `DynamicPropertiesPass`: Removed `aggregateFromSql()` method
  - `PropertyScalingPass`: Removed `analyzeWithSql()` method
  - `NonTreeEdgePass`: Removed `analyzeWithSql()` method
  - `CallStackPass`: Removed `analyzeWithSql()` method
  - `StructuralDedupPass`: Removed `analyzeWithSql()` method
  - `TopStringsPass`: Removed `buildFullPathFromSql()` and prepared statement caching

- **Simplified conditional logic**: Removed all `if ($this->substrate !== null)` checks that branched between substrate and SQL paths, keeping only the substrate-based implementations

- **Updated ReportGenerator**: Removed Phase 2 SQL-based pass execution logic; all passes now run in Phase 3 with the substrate

- **Updated tests**: Removed test cases that specifically validated SQL fallback paths (e.g., `testSqlFallbackPathReturnsSameResult()`) and consolidated test expectations

## Implementation Details

- All substrate-based analysis methods (e.g., `analyzeWithGraph()`, `aggregateFromSubstrate()`) are now the sole implementation path
- Removed instance variables used for prepared statement caching (`$parentStmt`, `$nodeTypeStmt`, `$tree_parent_stmt`, etc.)
- Removed `assert($this->substrate !== null)` statements that are no longer needed
- The `$full_analysis` parameter in `ReportGenerator::generateFromDb()` is retained for CLI compatibility but is now unused (marked with `@psalm-suppress UnusedParam`)

https://claude.ai/code/session_01BrofbBmPKSfzGrV2KsboJX