### PR TITLE
[0.12.x] fix(rmem): filter out-of-region locations from per-node size aggregation

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Comparison/BinaryComparisonDataProvider.php
@@ -15,6 +15,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Comparison;
 
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportGenerator;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportResult;
 
@@ -127,8 +128,6 @@ final class BinaryComparisonDataProvider implements ComparisonDataProvider
         $count = $this->reader->getSectionElementCount(Format::SECTION_LOCATIONS);
         $dict = $this->reader->getStringDict();
 
-        $relevant_regions = ['zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena'];
-
         $offset = 0;
         for ($i = 0; $i < $count; $i++) {
             // LocationRow layout (48 bytes):
@@ -141,8 +140,8 @@ final class BinaryComparisonDataProvider implements ComparisonDataProvider
             $region_id = unpack('V', $data, $offset + 40)[1];
             $offset += Format::LOCATION_ROW_SIZE;
 
-            $region = $dict->lookup($region_id);
-            if ($region !== null && !in_array($region, $relevant_regions, true)) {
+            // Apply the shared size-attribution region policy. See RegionFilter.
+            if (!RegionFilter::isRelevant($dict->lookup($region_id))) {
                 continue;
             }
 

--- a/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/PdoMemoryOutput.php
@@ -440,14 +440,15 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertLocationTypesSummaryFromDb(\PDO $db, int $run_id): void
     {
+        // Apply the shared size-attribution region policy. See RegionFilter.
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
+        $regionPredicate = RegionFilter::sqlPredicate('region');
         $stmt = $db->prepare("
             INSERT INTO location_types_summary (run_id, {$qi('type')}, {$qi('count')}, memory_usage)
             SELECT ?, location_type, COUNT(*), SUM(size)
             FROM context_node_locations
             WHERE run_id = ?
-              AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
-                   OR region IS NULL)
+              AND {$regionPredicate}
             GROUP BY location_type
             ORDER BY SUM(size) DESC
         ");
@@ -456,15 +457,16 @@ final class PdoMemoryOutput implements MemoryOutputInterface
 
     private function insertClassObjectsSummaryFromDb(\PDO $db, int $run_id): void
     {
+        // Apply the shared size-attribution region policy. See RegionFilter.
         $qi = fn (string $id): string => $this->driver->quoteIdentifier($id);
+        $regionPredicate = RegionFilter::sqlPredicate('region');
         $stmt = $db->prepare("
             INSERT INTO class_objects_summary (run_id, class_name, {$qi('count')}, memory_usage)
             SELECT ?, class_name, COUNT(*), SUM(size)
             FROM context_node_locations
             WHERE run_id = ?
               AND class_name IS NOT NULL
-              AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
-                   OR region IS NULL)
+              AND {$regionPredicate}
             GROUP BY class_name
             ORDER BY SUM(size) DESC
         ");

--- a/src/Inspector/Output/MemoryOutput/RegionFilter.php
+++ b/src/Inspector/Output/MemoryOutput/RegionFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Inspector\Output\MemoryOutput;
+
+/**
+ * Single source of truth for the size-attribution region policy.
+ *
+ * Memory locations carry a `region` tag assigned by
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries::classifyRegion}.
+ * Locations whose region is `'outside'` (the catch-all the classifier
+ * returns when the address sits in none of the tracked allocator
+ * regions) are typically dangling/persistent allocations whose `size`
+ * is read from arbitrary bytes — for example, a stale
+ * `php_stream_memory_data->data` walked by
+ * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job\EmitResourceJob::collectMemoryStreamData}
+ * is dereferenced as a `zend_string` whose `len` field reads as a
+ * multi-exabyte garbage value, and `getSize() = len + 24` follows.
+ *
+ * If those rows are summed into per-node sizes:
+ *   - on the FFI CSR substrate, the running total overflows
+ *     `PHP_INT_MAX`, PHP promotes the addition to `float`, and
+ *     assignment to `int $nodeSizesSum` raises
+ *     `Cannot assign float to property`;
+ *   - on the PHP-array substrate, the same overflow goes silent and
+ *     surfaces as broken multi-exabyte rows in ChokePoint and
+ *     Top Strings, while Type Breakdown — which already filters by
+ *     region — stays clean and the asymmetry confuses the report.
+ *
+ * Every surface that aggregates `size` (or surfaces raw `size` for
+ * ranking) must therefore apply the same filter:
+ *   - SQL paths use {@see self::sqlPredicate()};
+ *   - PHP paths use {@see self::isRelevant()}.
+ *
+ * `region IS NULL` is preserved on the SQL side and `null` returns
+ * `true` from {@see self::isRelevant()} so legacy rows captured before
+ * region tagging continue to flow through unchanged.
+ */
+final class RegionFilter
+{
+    /**
+     * Regions whose locations participate in size aggregation.
+     */
+    public const RELEVANT_REGIONS = [
+        'zend_mm_heap',
+        'zend_mm_huge',
+        'vm_stack',
+        'compiler_arena',
+    ];
+
+    /**
+     * True for regions that count toward per-node size sums (and for
+     * NULL — see class docblock for the legacy-row rationale).
+     */
+    public static function isRelevant(?string $region): bool
+    {
+        return $region === null
+            || in_array($region, self::RELEVANT_REGIONS, true);
+    }
+
+    /**
+     * SQL fragment matching {@see self::isRelevant()} for the given
+     * column. Drop into a `WHERE` / `AND` clause as-is; the returned
+     * string is parenthesised and contains no parameter markers (the
+     * region list is a closed set of internal identifiers, not user
+     * input).
+     */
+    public static function sqlPredicate(string $column): string
+    {
+        $quoted = array_map(
+            static fn (string $r): string => "'" . $r . "'",
+            self::RELEVANT_REGIONS,
+        );
+        $list = implode(', ', $quoted);
+        return "({$column} IN ({$list}) OR {$column} IS NULL)";
+    }
+}

--- a/src/Inspector/Output/MemoryOutput/RegionFilter.php
+++ b/src/Inspector/Output/MemoryOutput/RegionFilter.php
@@ -74,6 +74,12 @@ final class RegionFilter
      * string is parenthesised and contains no parameter markers (the
      * region list is a closed set of internal identifiers, not user
      * input).
+     *
+     * IMPORTANT: `$column` is interpolated raw — pass only trusted
+     * internal column identifiers (e.g. literals like `'region'`). Do
+     * NOT pass user-supplied input here. Every existing call site uses
+     * the fixed `'region'` literal; preserve that invariant when adding
+     * new ones.
      */
     public static function sqlPredicate(string $column): string
     {

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -29,6 +29,29 @@ use Reli\Lib\FFI\FFIHelper;
 final class BinaryReportDataProvider
 {
     /**
+     * Regions whose locations participate in size aggregation.
+     *
+     * Matches the SQL filter used by
+     * {@see \Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput::insertLocationTypesSummaryFromDb}
+     * and the inline filter in {@see self::computeLocationTypesSummary}.
+     * Locations with a non-null region outside this set are typically
+     * dangling/persistent allocations (e.g., a stale
+     * `php_stream_memory_data->data` dereferenced as a `zend_string`,
+     * walked by EmitResourceJob::collectMemoryStreamData) and must be
+     * excluded from per-node size sums; otherwise their
+     * garbage `size` inflates `node_sizes` past `PHP_INT_MAX` and the
+     * FFI CSR substrate raises "Cannot assign float to property" on
+     * `$nodeSizesSum`. A null region preserves backward compatibility
+     * with pre-region-tagging rmem files.
+     */
+    public const RELEVANT_REGIONS = [
+        'zend_mm_heap',
+        'zend_mm_huge',
+        'vm_stack',
+        'compiler_arena',
+    ];
+
+    /**
      * Find node IDs that have a specific location_type.
      *
      * Replaces: SELECT DISTINCT node_id FROM context_node_locations
@@ -105,19 +128,28 @@ final class BinaryReportDataProvider
         $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
         $locRows = $reader->castSection(Format::SECTION_LOCATIONS, 'LocationRow');
 
-        // Collect all ZendStringMemoryLocation entries
+        // Collect all ZendStringMemoryLocation entries.
+        // Apply the same region filter as computeLocationTypesSummary so
+        // that bogus 'outside'-region strings (e.g., a stale
+        // php_stream_memory_data->data dereferenced as a zend_string with
+        // garbage `len`) don't surface as multi-exabyte rows.
         /** @var list<array{node_id: int, size: int, string_value_id: int}> $candidates */
         $candidates = [];
         if ($locRows !== null) {
             for ($i = 0; $i < $count; $i++) {
                 $type = $dict->lookup($locRows[$i]->location_type_id);
-                if ($type === 'ZendStringMemoryLocation') {
-                    $candidates[] = [
-                        'node_id' => $locRows[$i]->node_id,
-                        'size' => $locRows[$i]->size,
-                        'string_value_id' => $locRows[$i]->string_value_id,
-                    ];
+                if ($type !== 'ZendStringMemoryLocation') {
+                    continue;
                 }
+                $region = $dict->lookup($locRows[$i]->region_id);
+                if ($region !== null && !in_array($region, self::RELEVANT_REGIONS, true)) {
+                    continue;
+                }
+                $candidates[] = [
+                    'node_id' => $locRows[$i]->node_id,
+                    'size' => $locRows[$i]->size,
+                    'string_value_id' => $locRows[$i]->string_value_id,
+                ];
             }
         } else {
             $data = $reader->getSectionData(Format::SECTION_LOCATIONS);
@@ -125,13 +157,19 @@ final class BinaryReportDataProvider
                 $off = $i * Format::LOCATION_ROW_SIZE;
                 $type_id = unpack('V', $data, $off + 4)[1];
                 $type = $dict->lookup($type_id);
-                if ($type === 'ZendStringMemoryLocation') {
-                    $candidates[] = [
-                        'node_id' => unpack('V', $data, $off)[1],
-                        'size' => unpack('P', $data, $off + 20)[1],
-                        'string_value_id' => unpack('V', $data, $off + 28)[1],
-                    ];
+                if ($type !== 'ZendStringMemoryLocation') {
+                    continue;
                 }
+                $region_id = unpack('V', $data, $off + 40)[1];
+                $region = $dict->lookup($region_id);
+                if ($region !== null && !in_array($region, self::RELEVANT_REGIONS, true)) {
+                    continue;
+                }
+                $candidates[] = [
+                    'node_id' => unpack('V', $data, $off)[1],
+                    'size' => unpack('P', $data, $off + 20)[1],
+                    'string_value_id' => unpack('V', $data, $off + 28)[1],
+                ];
             }
         }
 

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -18,6 +18,7 @@ use PhpCast\Cast;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\StringDict;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Lib\FFI\FFIHelper;
 
 /**
@@ -28,29 +29,6 @@ use Reli\Lib\FFI\FFIHelper;
  */
 final class BinaryReportDataProvider
 {
-    /**
-     * Regions whose locations participate in size aggregation.
-     *
-     * Matches the SQL filter used by
-     * {@see \Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput::insertLocationTypesSummaryFromDb}
-     * and the inline filter in {@see self::computeLocationTypesSummary}.
-     * Locations with a non-null region outside this set are typically
-     * dangling/persistent allocations (e.g., a stale
-     * `php_stream_memory_data->data` dereferenced as a `zend_string`,
-     * walked by EmitResourceJob::collectMemoryStreamData) and must be
-     * excluded from per-node size sums; otherwise their
-     * garbage `size` inflates `node_sizes` past `PHP_INT_MAX` and the
-     * FFI CSR substrate raises "Cannot assign float to property" on
-     * `$nodeSizesSum`. A null region preserves backward compatibility
-     * with pre-region-tagging rmem files.
-     */
-    public const RELEVANT_REGIONS = [
-        'zend_mm_heap',
-        'zend_mm_huge',
-        'vm_stack',
-        'compiler_arena',
-    ];
-
     /**
      * Find node IDs that have a specific location_type.
      *
@@ -128,11 +106,7 @@ final class BinaryReportDataProvider
         $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
         $locRows = $reader->castSection(Format::SECTION_LOCATIONS, 'LocationRow');
 
-        // Collect all ZendStringMemoryLocation entries.
-        // Apply the same region filter as computeLocationTypesSummary so
-        // that bogus 'outside'-region strings (e.g., a stale
-        // php_stream_memory_data->data dereferenced as a zend_string with
-        // garbage `len`) don't surface as multi-exabyte rows.
+        // Apply the shared size-attribution region policy. See RegionFilter.
         /** @var list<array{node_id: int, size: int, string_value_id: int}> $candidates */
         $candidates = [];
         if ($locRows !== null) {
@@ -141,8 +115,7 @@ final class BinaryReportDataProvider
                 if ($type !== 'ZendStringMemoryLocation') {
                     continue;
                 }
-                $region = $dict->lookup($locRows[$i]->region_id);
-                if ($region !== null && !in_array($region, self::RELEVANT_REGIONS, true)) {
+                if (!RegionFilter::isRelevant($dict->lookup($locRows[$i]->region_id))) {
                     continue;
                 }
                 $candidates[] = [
@@ -161,8 +134,7 @@ final class BinaryReportDataProvider
                     continue;
                 }
                 $region_id = unpack('V', $data, $off + 40)[1];
-                $region = $dict->lookup($region_id);
-                if ($region !== null && !in_array($region, self::RELEVANT_REGIONS, true)) {
+                if (!RegionFilter::isRelevant($dict->lookup($region_id))) {
                     continue;
                 }
                 $candidates[] = [

--- a/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
+++ b/src/Inspector/Output/MemoryOutput/Report/BinaryReportDataProvider.php
@@ -164,6 +164,56 @@ final class BinaryReportDataProvider
     }
 
     /**
+     * Compute location_types summary from the binary locations section.
+     *
+     * Mirrors {@see \Reli\Inspector\Output\MemoryOutput\Report\ReportGenerator::computeLocationTypesFromBinary}
+     * (which remains as a private helper on the report path). Exposed
+     * here so unit tests and other consumers can derive the same
+     * size-attribution-filtered total without going through ReportGenerator.
+     *
+     * @return array<string, array{count: int, memory_usage: int}>
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress PossiblyInvalidArrayAccess
+     */
+    public static function computeLocationTypesSummary(BinaryReader $reader): array
+    {
+        if (!$reader->hasSection(Format::SECTION_LOCATIONS)) {
+            return [];
+        }
+        $data = $reader->getSectionData(Format::SECTION_LOCATIONS);
+        $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
+        $dict = $reader->getStringDict();
+
+        /** @var array<string, array{count: int, memory_usage: int}> $result */
+        $result = [];
+        $offset = 0;
+        for ($i = 0; $i < $count; $i++) {
+            $location_type_id = unpack('V', $data, $offset + 4)[1];
+            $size = unpack('P', $data, $offset + 20)[1];
+            $region_id = unpack('V', $data, $offset + 40)[1];
+            $offset += Format::LOCATION_ROW_SIZE;
+
+            // Apply the shared size-attribution region policy. See RegionFilter.
+            if (!RegionFilter::isRelevant($dict->lookup($region_id))) {
+                continue;
+            }
+
+            $type = $dict->lookup($location_type_id);
+            if ($type === null) {
+                continue;
+            }
+            if (!isset($result[$type])) {
+                $result[$type] = ['count' => 0, 'memory_usage' => 0];
+            }
+            $result[$type]['count']++;
+            $result[$type]['memory_usage'] += $size;
+        }
+
+        uasort($result, fn (array $a, array $b): int => $b['memory_usage'] <=> $a['memory_usage']);
+        return $result;
+    }
+
+    /**
      * Compute non-tree strong edge aggregation by link_name.
      *
      * Replaces the GROUP BY link_name query in NonTreeEdgePass::analyzeWithSubstrate.

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -70,6 +70,10 @@ final class TopStringsPass implements PassInterface
                 ];
             }
         } else {
+            // Same region filter as BinaryReportDataProvider::getTopStrings:
+            // a dangling stream_memory_data->data dereferenced as a
+            // zend_string lands in 'outside' with a multi-exabyte `size`
+            // and would otherwise dominate this ranking.
             $rows = $this->db->query("
                 SELECT
                     node_id,
@@ -78,6 +82,8 @@ final class TopStringsPass implements PassInterface
                 FROM context_node_locations
                 WHERE run_id = {$this->run_id}
                     AND location_type = 'ZendStringMemoryLocation'
+                    AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
+                         OR region IS NULL)
                 ORDER BY size DESC
                 LIMIT 10
             ")->fetchAll(\PDO::FETCH_ASSOC);

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/TopStringsPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\Output\MemoryOutput\Report\Pass;
 
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Inspector\Output\MemoryOutput\Report\Finding;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingConfidence;
 use Reli\Inspector\Output\MemoryOutput\Report\FindingSeverity;
@@ -70,10 +71,8 @@ final class TopStringsPass implements PassInterface
                 ];
             }
         } else {
-            // Same region filter as BinaryReportDataProvider::getTopStrings:
-            // a dangling stream_memory_data->data dereferenced as a
-            // zend_string lands in 'outside' with a multi-exabyte `size`
-            // and would otherwise dominate this ranking.
+            // Apply the shared size-attribution region policy. See RegionFilter.
+            $regionPredicate = RegionFilter::sqlPredicate('region');
             $rows = $this->db->query("
                 SELECT
                     node_id,
@@ -82,8 +81,7 @@ final class TopStringsPass implements PassInterface
                 FROM context_node_locations
                 WHERE run_id = {$this->run_id}
                     AND location_type = 'ZendStringMemoryLocation'
-                    AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
-                         OR region IS NULL)
+                    AND {$regionPredicate}
                 ORDER BY size DESC
                 LIMIT 10
             ")->fetchAll(\PDO::FETCH_ASSOC);

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -38,6 +38,7 @@ use Reli\Inspector\Output\MemoryOutput\Report\Pass\TopStringsPass;
 use Reli\Inspector\Output\MemoryOutput\Report\Pass\TypeBreakdownPass;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\LinkCacheMode;
@@ -511,9 +512,8 @@ final class ReportGenerator
             $region_id = unpack('V', $data, $offset + 40)[1];
             $offset += Format::LOCATION_ROW_SIZE;
 
-            // Filter by region (null region also included)
-            $region = $dict->lookup($region_id);
-            if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
+            // Apply the shared size-attribution region policy. See RegionFilter.
+            if (!RegionFilter::isRelevant($dict->lookup($region_id))) {
                 continue;
             }
 
@@ -561,8 +561,8 @@ final class ReportGenerator
             if ($class_id === Format::NULL_STRING_ID) {
                 continue;
             }
-            $region = $dict->lookup($region_id);
-            if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
+            // Apply the shared size-attribution region policy. See RegionFilter.
+            if (!RegionFilter::isRelevant($dict->lookup($region_id))) {
                 continue;
             }
 

--- a/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
+++ b/src/Inspector/Output/MemoryOutput/Report/ReportGenerator.php
@@ -500,9 +500,6 @@ final class ReportGenerator
         $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
         $dict = $reader->getStringDict();
 
-        // Filter to relevant regions (same as insertLocationTypesSummaryFromDb)
-        $relevant_regions = ['zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena'];
-
         /** @var array<string, array{count: int, memory_usage: int}> $result */
         $result = [];
         $offset = 0;
@@ -516,7 +513,7 @@ final class ReportGenerator
 
             // Filter by region (null region also included)
             $region = $dict->lookup($region_id);
-            if ($region !== null && !in_array($region, $relevant_regions, true)) {
+            if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
                 continue;
             }
 
@@ -552,8 +549,6 @@ final class ReportGenerator
         $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
         $dict = $reader->getStringDict();
 
-        $relevant_regions = ['zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena'];
-
         /** @var array<string, array{count: int, memory_usage: int}> $result */
         $result = [];
         $offset = 0;
@@ -567,7 +562,7 @@ final class ReportGenerator
                 continue;
             }
             $region = $dict->lookup($region_id);
-            if ($region !== null && !in_array($region, $relevant_regions, true)) {
+            if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
                 continue;
             }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -18,7 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DerivedCacheReader;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DerivedCacheWriter;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
-use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Lib\FFI\FFIHelper;
 
 /**
@@ -346,21 +346,20 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
 
         // ---- Phase 3: Load node classes + canonical address grouping ----
         // The on-disk `node_sizes` section is intentionally NOT used here:
-        // it is a pre-summed shortcut written before region classification
-        // is reduced to the "relevant" set used by every other reporting
-        // surface (see BinaryReportDataProvider::RELEVANT_REGIONS). Pre-
-        // summed values cannot be region-filtered at read time, so a
-        // single bogus 'outside'-region entry (e.g., a stale
-        // php_stream_memory_data->data dereferenced as a zend_string with
-        // a garbage `len`, emitted by EmitResourceJob::collectMemoryStreamData)
-        // is enough to push the slot — and the running sum — past
-        // PHP_INT_MAX, at which point PHP promotes the addition to float
-        // and the `int $nodeSizesSum` property assignment raises
-        // "Cannot assign float to property". Sizes are therefore always
-        // computed below from the locations section with the same region
-        // filter Type Breakdown / location_types_summary apply, keeping
-        // every surface ($nodeSizesSum, getNodeSize, ChokePoint,
-        // Top Strings) consistent.
+        // it is a pre-summed shortcut written before the size-attribution
+        // region policy ({@see RegionFilter}) is applied, and pre-summed
+        // values cannot be region-filtered at read time. Sizes are
+        // therefore always computed below from the locations section with
+        // the shared filter, keeping every surface ($nodeSizesSum,
+        // getNodeSize, ChokePoint, Top Strings) consistent.
+        //
+        // The on-disk `node_classes` fast-path stays trusted because
+        // class_id is intern()'d only for ZendObjectMemoryLocation rows
+        // (BinaryContextTreeSink::emitNode), and ZendObject allocations
+        // never land in 'outside' — they live in zend_mm chunks. The
+        // pathological 'outside' case (a stale php_stream_memory_data->data
+        // dereferenced as a zend_string) carries class_id=NULL_STRING_ID
+        // and contributes nothing to per-node class attribution.
         if ($reader->hasSection('node_classes')) {
             $classesData = $reader->getSectionData('node_classes');
             $slotsCount = $reader->getSectionElementCount('node_classes');
@@ -451,16 +450,8 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     $region_id = unpack('V', $locData, $off + 40)[1];
                 }
 
-                // Mirror computeLocationTypesSummary: drop locations
-                // tagged with a non-null, non-relevant region (the
-                // collector classifies anything outside the four
-                // tracked allocator regions as 'outside'). Keeps the
-                // size totals from blowing past PHP_INT_MAX when a
-                // dangling pointer surfaces as a multi-exabyte zend_string.
-                $region = $dict->lookup($region_id);
-                $sizeRelevant = $region === null
-                    || in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true);
-                if ($sizeRelevant) {
+                // Apply the shared size-attribution region policy. See RegionFilter.
+                if (RegionFilter::isRelevant($dict->lookup($region_id))) {
                     if ($directMap !== null) {
                         $slot = $node_id + $directOffset;
                         $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
@@ -1529,16 +1520,13 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // properties directly via $this-> is fine — no need for the
         // by-reference aliasing dance, which Psalm can't model.
 
-        // Same region filter as rmem's loadFromBinary and
-        // PdoMemoryOutput::insertLocationTypesSummaryFromDb. Excludes
-        // dangling/persistent 'outside'-region locations whose `size`
-        // can be garbage; keeps NULL region for backward compat.
+        // Apply the shared size-attribution region policy. See RegionFilter.
+        $regionPredicate = RegionFilter::sqlPredicate('region');
         $stmt = $db->prepare(
             "SELECT node_id, sum(size) as s, min(class_name) as cls
              FROM context_node_locations
              WHERE run_id = ? AND node_id > ?
-               AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
-                    OR region IS NULL)
+               AND {$regionPredicate}
              GROUP BY node_id
              ORDER BY node_id
              LIMIT {$chunk}"

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -1529,10 +1529,16 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // properties directly via $this-> is fine — no need for the
         // by-reference aliasing dance, which Psalm can't model.
 
+        // Same region filter as rmem's loadFromBinary and
+        // PdoMemoryOutput::insertLocationTypesSummaryFromDb. Excludes
+        // dangling/persistent 'outside'-region locations whose `size`
+        // can be garbage; keeps NULL region for backward compat.
         $stmt = $db->prepare(
             "SELECT node_id, sum(size) as s, min(class_name) as cls
              FROM context_node_locations
              WHERE run_id = ? AND node_id > ?
+               AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')
+                    OR region IS NULL)
              GROUP BY node_id
              ORDER BY node_id
              LIMIT {$chunk}"

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -18,6 +18,7 @@ use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DerivedCacheReader;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DerivedCacheWriter;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
+use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
 use Reli\Lib\FFI\FFIHelper;
 
 /**
@@ -343,20 +344,28 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         unset($nodeData, $nodeRows);
 
-        // ---- Phase 3: Load node sizes + classes + canonical address grouping ----
-        // If on-disk node_sizes and node_classes sections exist, use them
-        // for sizes and classes (skipping the expensive locations scan for
-        // those two purposes). Canonical address grouping still needs
-        // the locations section.
-        $sizesLoaded = false;
-        if ($reader->hasSection('node_sizes') && $reader->hasSection('node_classes')) {
-            $sizesData = $reader->getSectionData('node_sizes');
+        // ---- Phase 3: Load node classes + canonical address grouping ----
+        // The on-disk `node_sizes` section is intentionally NOT used here:
+        // it is a pre-summed shortcut written before region classification
+        // is reduced to the "relevant" set used by every other reporting
+        // surface (see BinaryReportDataProvider::RELEVANT_REGIONS). Pre-
+        // summed values cannot be region-filtered at read time, so a
+        // single bogus 'outside'-region entry (e.g., a stale
+        // php_stream_memory_data->data dereferenced as a zend_string with
+        // a garbage `len`, emitted by EmitResourceJob::collectMemoryStreamData)
+        // is enough to push the slot — and the running sum — past
+        // PHP_INT_MAX, at which point PHP promotes the addition to float
+        // and the `int $nodeSizesSum` property assignment raises
+        // "Cannot assign float to property". Sizes are therefore always
+        // computed below from the locations section with the same region
+        // filter Type Breakdown / location_types_summary apply, keeping
+        // every surface ($nodeSizesSum, getNodeSize, ChokePoint,
+        // Top Strings) consistent.
+        if ($reader->hasSection('node_classes')) {
             $classesData = $reader->getSectionData('node_classes');
-            $slotsCount = $reader->getSectionElementCount('node_sizes');
+            $slotsCount = $reader->getSectionElementCount('node_classes');
 
-            $ffiNodeSizes = $substrate->ffiNodeSizes;
             $nodeClassIds = $substrate->nodeClassIds;
-            $substrate->nodeSizesSum = 0;
 
             for ($i = 0; $i < min($slotsCount, $nc); $i++) {
                 // node_id == i (dense), map to CSR index
@@ -369,11 +378,6 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 if ($csrIdx < 0) {
                     continue;
                 }
-
-                $size_u = unpack('P', $sizesData, $i * 8);
-                $size = $size_u[1];
-                $ffiNodeSizes[$csrIdx] = $size;
-                $substrate->nodeSizesSum += $size;
 
                 $cls_u = unpack('V', $classesData, $i * 4);
                 $cls_id = $cls_u[1];
@@ -388,12 +392,14 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     }
                 }
             }
-            $sizesLoaded = true;
         }
 
-        // Load canonical map from on-disk section if available.
+        // Load canonical map from on-disk section if available. The previous
+        // `$sizesLoaded &&` guard was a code-locality choice (group on-disk
+        // fast-paths together), not a correctness dependency; canonical_map
+        // is self-contained and orthogonal to sizes, so decouple it.
         $canonicalLoaded = false;
-        if ($sizesLoaded && $reader->hasSection('canonical_map')) {
+        if ($reader->hasSection('canonical_map')) {
             $canonData = $reader->getSectionData('canonical_map');
             $canonSlots = $reader->getSectionElementCount('canonical_map');
             for ($i = 0; $i < min($canonSlots, $nc); $i++) {
@@ -417,39 +423,44 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $canonicalLoaded = true;
         }
 
-        // If canonical was not loaded from cache, scan locations.
-        // Also needed if sizes/classes weren't loaded from on-disk sections.
+        // Scan locations for size accumulation (always) and, if
+        // canonical_map wasn't on-disk, for canonical address grouping.
         /** @var array<int, list<int>> $addr_to_nodes address → [node_id, ...] for canonical */
         $addr_to_nodes = [];
-        if (!$canonicalLoaded && $reader->hasSection(Format::SECTION_LOCATIONS)) {
+        if ($reader->hasSection(Format::SECTION_LOCATIONS)) {
             $locCount = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
             $locRows = $reader->castSection(Format::SECTION_LOCATIONS, 'LocationRow');
             $locData = $locRows === null ? $reader->getSectionData(Format::SECTION_LOCATIONS) : null;
             $ffiNodeSizes = $substrate->ffiNodeSizes;
             $nodeClassIds = $substrate->nodeClassIds;
 
-            if (!$sizesLoaded) {
-                $substrate->nodeSizesSum = 0;
-            }
+            $substrate->nodeSizesSum = 0;
             for ($i = 0; $i < $locCount; $i++) {
                 if ($locRows !== null) {
                     $node_id = $locRows[$i]->node_id;
                     $address = $locRows[$i]->address;
-                    if (!$sizesLoaded) {
-                        $class_id = $locRows[$i]->class_id;
-                        $size = $locRows[$i]->size;
-                    }
+                    $class_id = $locRows[$i]->class_id;
+                    $size = $locRows[$i]->size;
+                    $region_id = $locRows[$i]->region_id;
                 } else {
                     $off = $i * Format::LOCATION_ROW_SIZE;
                     $node_id = unpack('V', $locData, $off)[1];
                     $address = unpack('P', $locData, $off + 12)[1];
-                    if (!$sizesLoaded) {
-                        $class_id = unpack('V', $locData, $off + 8)[1];
-                        $size = unpack('P', $locData, $off + 20)[1];
-                    }
+                    $class_id = unpack('V', $locData, $off + 8)[1];
+                    $size = unpack('P', $locData, $off + 20)[1];
+                    $region_id = unpack('V', $locData, $off + 40)[1];
                 }
 
-                if (!$sizesLoaded) {
+                // Mirror computeLocationTypesSummary: drop locations
+                // tagged with a non-null, non-relevant region (the
+                // collector classifies anything outside the four
+                // tracked allocator regions as 'outside'). Keeps the
+                // size totals from blowing past PHP_INT_MAX when a
+                // dangling pointer surfaces as a multi-exabyte zend_string.
+                $region = $dict->lookup($region_id);
+                $sizeRelevant = $region === null
+                    || in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true);
+                if ($sizeRelevant) {
                     if ($directMap !== null) {
                         $slot = $node_id + $directOffset;
                         $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
@@ -457,15 +468,11 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                         $csrIdx = $phpMap[$node_id] ?? -1;
                     }
                     if ($csrIdx >= 0) {
-                        /** @psalm-suppress PossiblyUndefinedVariable */
-                        $ffiNodeSizes[$csrIdx] = $ffiNodeSizes[$csrIdx] + (int)$size;
-                        /** @psalm-suppress PossiblyUndefinedVariable */
-                        $substrate->nodeSizesSum += (int)$size;
+                        $ffiNodeSizes[$csrIdx] = $ffiNodeSizes[$csrIdx] + $size;
+                        $substrate->nodeSizesSum += $size;
 
-                        /** @psalm-suppress PossiblyUndefinedVariable */
-                        if ((int)$class_id !== Format::NULL_STRING_ID && $nodeClassIds[$csrIdx] === -1) {
-                            /** @psalm-suppress PossiblyUndefinedVariable */
-                            $className = $dict->lookup((int)$class_id);
+                        if ($class_id !== Format::NULL_STRING_ID && $nodeClassIds[$csrIdx] === -1) {
+                            $className = $dict->lookup($class_id);
                             if ($className !== null) {
                                 if (!isset($substrate->classDictReverse[$className])) {
                                     $substrate->classDictReverse[$className] = count($substrate->classDict);
@@ -477,8 +484,10 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                     }
                 }
 
-                // Canonical address grouping (was Phase 3.5)
-                if ($address !== 0) {
+                // Canonical address grouping (was Phase 3.5). Runs for all
+                // locations — even outside-region ones contribute address
+                // identity, which is independent of size attribution.
+                if (!$canonicalLoaded && $address !== 0) {
                     $addr_to_nodes[$address][] = $node_id;
                 }
             }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -644,9 +644,18 @@ class GraphSubstrate
     /** @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedPropertyTypeCoercion */
     protected function loadNodeSizes(\PDO $db, int $run_id): void
     {
+        // Same region filter rmem's loadFromBinary and
+        // PdoMemoryOutput::insertLocationTypesSummaryFromDb apply:
+        // 'outside' (and other non-relevant) regions are dangling/
+        // persistent allocations whose `size` is often garbage and must
+        // not feed per-node aggregation. Keeping NULL region preserves
+        // backward compatibility with rows captured before region tagging.
         $stmt = $db->query(
             "SELECT node_id, sum(size) as s, group_concat(DISTINCT class_name) as cls"
-            . " FROM context_node_locations WHERE run_id = {$run_id} GROUP BY node_id"
+            . " FROM context_node_locations WHERE run_id = {$run_id}"
+            . " AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')"
+            . "      OR region IS NULL)"
+            . " GROUP BY node_id"
         );
 
         while ($r = $stmt->fetch(\PDO::FETCH_NUM)) {

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -15,7 +15,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
 
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
-use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 
 class GraphSubstrate
 {
@@ -191,13 +191,8 @@ class GraphSubstrate
             }
         }
 
-        // Load locations → node_sizes + node_classes.
-        // Skip locations whose region is non-null and outside
-        // BinaryReportDataProvider::RELEVANT_REGIONS — mirroring the
-        // filter computeLocationTypesSummary applies — so that bogus
-        // 'outside'-region entries (e.g., dangling stream_memory_data
-        // strings with garbage `len`) don't inflate per-node sizes and
-        // surface as broken multi-exabyte rows in ChokePoint / Top Strings.
+        // Load locations → node_sizes + node_classes. Apply the shared
+        // size-attribution region policy. See RegionFilter.
         if ($reader->hasSection(Format::SECTION_LOCATIONS)) {
             $data = $reader->getSectionData(Format::SECTION_LOCATIONS);
             $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
@@ -213,8 +208,7 @@ class GraphSubstrate
                 /** @var array{node_id: int, location_type_id: int, class_id: int, address: int, size: int, string_value_id: int, refcount: int, type_info: int, region_id: int, bin_overhead: int} $row */
                 $offset += Format::LOCATION_ROW_SIZE;
 
-                $region = $dict->lookup($row['region_id']);
-                if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
+                if (!RegionFilter::isRelevant($dict->lookup($row['region_id']))) {
                     continue;
                 }
 
@@ -644,17 +638,12 @@ class GraphSubstrate
     /** @psalm-suppress MixedArrayAccess, MixedAssignment, MixedArgument, MixedPropertyTypeCoercion */
     protected function loadNodeSizes(\PDO $db, int $run_id): void
     {
-        // Same region filter rmem's loadFromBinary and
-        // PdoMemoryOutput::insertLocationTypesSummaryFromDb apply:
-        // 'outside' (and other non-relevant) regions are dangling/
-        // persistent allocations whose `size` is often garbage and must
-        // not feed per-node aggregation. Keeping NULL region preserves
-        // backward compatibility with rows captured before region tagging.
+        // Apply the shared size-attribution region policy. See RegionFilter.
+        $regionPredicate = RegionFilter::sqlPredicate('region');
         $stmt = $db->query(
             "SELECT node_id, sum(size) as s, group_concat(DISTINCT class_name) as cls"
             . " FROM context_node_locations WHERE run_id = {$run_id}"
-            . " AND (region IN ('zend_mm_heap', 'zend_mm_huge', 'vm_stack', 'compiler_arena')"
-            . "      OR region IS NULL)"
+            . " AND {$regionPredicate}"
             . " GROUP BY node_id"
         );
 

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -15,6 +15,7 @@ namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
 
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader as BinaryReader;
+use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
 
 class GraphSubstrate
 {
@@ -190,7 +191,13 @@ class GraphSubstrate
             }
         }
 
-        // Load locations → node_sizes + node_classes
+        // Load locations → node_sizes + node_classes.
+        // Skip locations whose region is non-null and outside
+        // BinaryReportDataProvider::RELEVANT_REGIONS — mirroring the
+        // filter computeLocationTypesSummary applies — so that bogus
+        // 'outside'-region entries (e.g., dangling stream_memory_data
+        // strings with garbage `len`) don't inflate per-node sizes and
+        // surface as broken multi-exabyte rows in ChokePoint / Top Strings.
         if ($reader->hasSection(Format::SECTION_LOCATIONS)) {
             $data = $reader->getSectionData(Format::SECTION_LOCATIONS);
             $count = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
@@ -205,6 +212,12 @@ class GraphSubstrate
                 assert(is_array($row));
                 /** @var array{node_id: int, location_type_id: int, class_id: int, address: int, size: int, string_value_id: int, refcount: int, type_info: int, region_id: int, bin_overhead: int} $row */
                 $offset += Format::LOCATION_ROW_SIZE;
+
+                $region = $dict->lookup($row['region_id']);
+                if ($region !== null && !in_array($region, BinaryReportDataProvider::RELEVANT_REGIONS, true)) {
+                    continue;
+                }
+
                 $node_id = $row['node_id'];
                 $size = $row['size'];
                 $substrate->node_sizes[$node_id] = ($substrate->node_sizes[$node_id] ?? 0) + $size;

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
@@ -15,7 +15,9 @@ namespace Reli\Inspector\Output\MemoryOutput\BinaryFormat;
 
 use PHPUnit\Framework\TestCase;
 use Reli\Inspector\Output\MemoryOutput\BinaryMemoryOutput;
+use Reli\Inspector\Output\MemoryOutput\Report\BinaryReportDataProvider;
 use Reli\Inspector\Output\MemoryOutput\Report\ReportGenerator;
+use Reli\Inspector\Output\MemoryOutput\Report\Substrate\FfiCsrGraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\BinaryContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
@@ -541,5 +543,222 @@ class BinaryFormatRoundTripTest extends TestCase
             'same-shared-string',
             $examples['sample_value'] ?? null,
         );
+    }
+
+    /**
+     * Regression for the "ChatGPT/サイズ大きすぎ" cluster of bugs:
+     *   - dangling `php_stream_memory_data->data` pointers, dereferenced by
+     *     EmitResourceJob::collectMemoryStreamData as a `zend_string`,
+     *     produce a `ZendStringMemoryLocation` whose `address` lands in
+     *     `'outside'` and whose `len + 24` is a multi-exabyte garbage value;
+     *   - on the FFI CSR path that overflows `int $nodeSizesSum` to float
+     *     and trips `Cannot assign float to property`;
+     *   - on the PHP-array path it silently propagates into ChokePoint /
+     *     Top Strings while Type Breakdown — which already filters by
+     *     region — stays clean.
+     *
+     * Every size-attribution surface must drop those rows. Build a minimal
+     * .rmem that contains exactly one such bogus 'outside' string alongside
+     * a normal in-heap object, then assert all surfaces converge.
+     */
+    public function testOutsideRegionStringIsExcludedFromAllSizeAttributionSurfaces(): void
+    {
+        $chunk_locations = new MemoryLocations();
+        // One zend_mm chunk covering 0x1000..0x10000.
+        $chunk_locations->add(new ZendMmChunkMemoryLocation(0x1000, 0x10000));
+        $huge_locations = new MemoryLocations();
+        $vm_stack_locations = new MemoryLocations();
+        $compiler_arena_locations = new MemoryLocations();
+
+        $region_boundaries = new RegionBoundaries(
+            $chunk_locations,
+            $huge_locations,
+            $vm_stack_locations,
+            $compiler_arena_locations,
+        );
+
+        $sink = new BinaryContextTreeSink($region_boundaries, batch_size: 10);
+
+        // Node 0: a normal in-heap object — region='zend_mm_heap'.
+        // Use 0-based node_ids to match what ContextAnalyzer actually emits;
+        // 1-based ids tickle an unrelated pre-existing FFI CSR slot-space
+        // off-by-one on 0.12.x that isn't what this test is here to pin.
+        $sink->emitNode(
+            node_id: 0,
+            parent_node_id: null,
+            link_name: 'root_obj',
+            type: 'ObjectContext',
+            locations: [
+                new ZendObjectMemoryLocation(
+                    address: 0x1100,
+                    size: 64,
+                    refcount: 1,
+                    type_info: 7,
+                    class_name: 'App\\GoodObject',
+                ),
+            ],
+            attributes: [],
+        );
+
+        // Node 1: a "good" string still in the heap — region='zend_mm_heap'.
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: 0,
+            link_name: 'good_string',
+            type: 'StringContext',
+            locations: [
+                new ZendStringMemoryLocation(
+                    address: 0x2000,
+                    size: 48,
+                    refcount: 1,
+                    type_info: 6,
+                    value: 'hello',
+                ),
+            ],
+            attributes: [],
+        );
+
+        // Node 2: the pathological string — address outside any tracked
+        // region (RegionBoundaries returns 'outside') with a size large
+        // enough that summing it with the two good rows actually overflows
+        // PHP_INT_MAX. The pre-fix FFI CSR loader did `$nodeSizesSum += $size`
+        // on every row regardless of region, so this row would have promoted
+        // the running sum to float and the `int $nodeSizesSum` property
+        // would have rejected the assignment with "Cannot assign float to
+        // property" — the canonical reproduction of the original report.
+        $bogus_size = PHP_INT_MAX - 100;
+        $sink->emitNode(
+            node_id: 2,
+            parent_node_id: 0,
+            link_name: 'bogus_string',
+            type: 'StringContext',
+            locations: [
+                new ZendStringMemoryLocation(
+                    address: 0xDEAD0000,
+                    size: $bogus_size,
+                    refcount: 1,
+                    type_info: 6,
+                    value: 'garbage',
+                ),
+            ],
+            attributes: [],
+        );
+
+        $binary_output = new BinaryMemoryOutput($this->rmem_path);
+        $binary_output->finalizeStreaming(
+            $sink,
+            [['zend_mm_heap_usage' => '1024', 'php_version' => '8.4.0']],
+        );
+
+        $reader = Reader::open($this->rmem_path);
+
+        // 1. FFI CSR substrate must not raise "Cannot assign float to property".
+        $ffi_substrate = FfiCsrGraphSubstrate::loadFromBinary(
+            $reader,
+            useCache: false,
+            rebuildCache: false,
+            skipScc: true,
+        );
+        // 64 (object) + 48 (good string). The bogus string is dropped.
+        $this->assertSame(112, $ffi_substrate->getNodeSizesSum());
+        $this->assertSame(64, $ffi_substrate->getNodeSize(0));
+        $this->assertSame(48, $ffi_substrate->getNodeSize(1));
+        $this->assertSame(0, $ffi_substrate->getNodeSize(2));
+
+        // 2. PHP-array substrate must agree (no silent float, same totals).
+        $php_substrate = GraphSubstrate::loadFromBinary(
+            $reader,
+            useCache: false,
+            rebuildCache: false,
+            skipScc: true,
+        );
+        $this->assertSame(112, $php_substrate->getNodeSizesSum());
+        $this->assertSame(64, $php_substrate->getNodeSize(0));
+        $this->assertSame(48, $php_substrate->getNodeSize(1));
+        $this->assertSame(0, $php_substrate->getNodeSize(2));
+
+        // 3. Top Strings must not surface the bogus row.
+        $top_strings = BinaryReportDataProvider::getTopStrings($reader, 10);
+        $node_ids = array_map(static fn (array $r): int => $r['node_id'], $top_strings);
+        $this->assertNotContains(2, $node_ids, 'bogus outside-region string leaked into Top Strings');
+        foreach ($top_strings as $row) {
+            $this->assertLessThan($bogus_size, $row['size'], 'oversized bogus row leaked into Top Strings');
+        }
+
+        // 4. Type Breakdown (computeLocationTypesSummary) and the
+        //    substrate's grand total must agree on the same filtered view.
+        $location_types = BinaryReportDataProvider::computeLocationTypesSummary($reader);
+        $type_breakdown_total = 0;
+        foreach ($location_types as $entry) {
+            $type_breakdown_total += $entry['memory_usage'];
+        }
+        $this->assertSame(
+            $ffi_substrate->getNodeSizesSum(),
+            $type_breakdown_total,
+            'Type Breakdown total disagrees with FFI substrate getNodeSizesSum()',
+        );
+        $this->assertSame(
+            $php_substrate->getNodeSizesSum(),
+            $type_breakdown_total,
+            'Type Breakdown total disagrees with PHP substrate getNodeSizesSum()',
+        );
+
+        // 5. SQL path must drop the same row. Reproduce the same fixture
+        //    in an in-memory SQLite DB and load it through the SQL
+        //    substrates — both the size sum and the per-node sizes must
+        //    match the binary path. Without RegionFilter::sqlPredicate()
+        //    in the chunked SQL loader, the substrates would disagree
+        //    with the binary path and re-introduce the SQL ↔ rmem
+        //    divergence that broke testBinaryAnalyzeReportMatchesSqlite-
+        //    ReportForKeyFindings on every target PHP version.
+        $sql = new \PDO('sqlite::memory:');
+        $sql->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $sql->exec('
+            CREATE TABLE context_nodes (
+                run_id INTEGER NOT NULL, node_id INTEGER NOT NULL,
+                type TEXT NOT NULL, canonical_node_id INTEGER,
+                PRIMARY KEY (run_id, node_id)
+            )
+        ');
+        $sql->exec('
+            CREATE TABLE context_edges (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL, parent_node_id INTEGER,
+                child_node_id INTEGER NOT NULL, link_name TEXT NOT NULL,
+                is_tree INTEGER NOT NULL, strength TEXT NOT NULL DEFAULT \'strong\'
+            )
+        ');
+        $sql->exec('
+            CREATE TABLE context_node_locations (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER NOT NULL, node_id INTEGER NOT NULL,
+                address BIGINT, size BIGINT,
+                location_type TEXT NOT NULL, class_name TEXT,
+                string_value TEXT, refcount BIGINT, type_info BIGINT,
+                region TEXT
+            )
+        ');
+        $sql->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
+            (1, 0, 'ObjectContext'),
+            (1, 1, 'StringContext'),
+            (1, 2, 'StringContext')");
+        $sql->exec("INSERT INTO context_edges (run_id, parent_node_id, child_node_id, link_name, is_tree) VALUES
+            (1, NULL, 0, 'root_obj', 1),
+            (1, 0, 1, 'good_string', 1),
+            (1, 0, 2, 'bogus_string', 1)");
+        $sql->prepare(
+            "INSERT INTO context_node_locations
+                (run_id, node_id, address, size, location_type, class_name, region)
+            VALUES
+                (1, 0, 4352,  64, 'ZendObjectMemoryLocation', 'App\\\\GoodObject', 'zend_mm_heap'),
+                (1, 1, 8192,  48, 'ZendStringMemoryLocation', NULL, 'zend_mm_heap'),
+                (1, 2, 3735879680, ?, 'ZendStringMemoryLocation', NULL, 'outside')"
+        )->execute([$bogus_size]);
+
+        $sql_php_substrate = GraphSubstrate::loadFromDb($sql, 1);
+        $this->assertSame(112, $sql_php_substrate->getNodeSizesSum());
+        $this->assertSame(64, $sql_php_substrate->getNodeSize(0));
+        $this->assertSame(48, $sql_php_substrate->getNodeSize(1));
+        $this->assertSame(0, $sql_php_substrate->getNodeSize(2));
     }
 }


### PR DESCRIPTION
## Summary

Backport of #795 onto `0.12.x`.

Same bug, same symptoms (FFI CSR path raises `Cannot assign float to property
FfiCsrGraphSubstrate::$nodeSizesSum`, ChokePoint and Top Strings surface broken
multi-exabyte rows while Type Breakdown stays clean), same fix — see #795 for the full
write-up of the root cause and the policy refactor (`RegionFilter`).

## Difference from #795

`0.12.x` does not yet have the `BinaryReportDataProvider::computeLocationTypesSummary` /
`computeClassObjectsSummary` extraction; the region filter lives inline in
`ReportGenerator::computeLocationTypesFromBinary` and `computeClassObjectsFromBinary`
private methods. To keep all call sites in lockstep on this branch:

- The new `RegionFilter` class lands as on master.
- The two `ReportGenerator` private helpers are rewired to call `RegionFilter::isRelevant()`
  instead of their own local `$relevant_regions` arrays.
- `BinaryReportDataProvider::computeLocationTypesSummary` is forward-ported as a public
  static (a small additive helper) so the regression test on the `BinaryFormat` side can
  derive the same filtered total without going through `ReportGenerator`.

So the diff is broader than #795 (touches `ReportGenerator` too), but the additional
hunks are pure mechanical const-substitution and one helper extraction.

## Regression test note

The regression test uses **0-based node_ids** because of an unrelated pre-existing FFI
CSR slot-space off-by-one on `0.12.x`: 1-based node_ids tickle a sentinel↔root cycle in
`computeSubtreeSizesFfi` that sends DFS into an unbounded stack growth loop. master
fixed that separately (see `testFfiCsrLoadFromBinarySurvivesNonZeroNodeIds` on master);
backporting that fix is out of scope for this PR. 0-based ids match what
`ContextAnalyzer` actually emits in practice and let the same regression test source
work on both branches.

## Test plan

- [x] `composer install && php vendor/bin/psalm.phar` — no errors
- [x] `php vendor/bin/phpunit --exclude-group target-version --exclude-group frankenphp --exclude-group mod_php`
      — 3258 pass, 0 failures
- [x] `php vendor/bin/phpunit --filter 'testOutsideRegion'` — passes (17 assertions
      including SQL path coverage)
- [x] `php vendor/bin/phpcs --standard=PSR12` — no new warnings
- [x] CI on the previous push: all phpunit jobs green
- [ ] Reporter to re-run `inspector:memory:report` against their `.rmem` and confirm
      crash gone + ChokePoint / Top Strings show sane numbers
