### PR TITLE
Add v3 memory dump format with module-globals map

### DIFF
--- a/docs/internals/memory-dump-inspect.md
+++ b/docs/internals/memory-dump-inspect.md
@@ -31,12 +31,14 @@ Three sections, in order: `Header`, `Memory Map`, `Regions`.
 ```
 === Header ===
   Magic:            RDUMP
-  Format Version:   2
+  Format Version:   3
   PHP Version:      v85
   PID:              23388
   EG Address:       0x55e3a43ba620
   CG Address:       0x55e3a43bade0
   RSS at dump:      31182848 bytes
+  Module Globals:
+    basic_globals:   0x55e3a43bb5a0
   Memory Map Count: 471
   Region Count:     126
 
@@ -60,11 +62,12 @@ The fixed-layout prefix of every `.rdump` file:
 | Field | Type | Meaning |
 |---|---|---|
 | `Magic` | `RDUMP\0\0\0` | Container marker; readers reject anything else. |
-| `Format Version` | uint32 | `1` for early dumps, `2` adds `RSS at dump`. The inspect command reads either; older formats print `(unavailable)` for newer fields. |
+| `Format Version` | uint32 | `1` for early dumps, `2` adds `RSS at dump`, `3` adds the `Module Globals` map. The inspect command reads any version; older formats print `(unavailable)` / `(none)` for newer fields. |
 | `PHP Version` | string | Resolved target version (`v74`, `v85`, …). Used by `inspector:memory:analyze` to pick struct layouts. |
 | `PID` | int64 | Target PID at capture time. Cosmetic only — the analyzer doesn't re-attach. |
 | `EG Address` / `CG Address` | int64 | Resolved Executor Globals / Compiler Globals addresses inside the target. The analyzer treats these as the entry points into the captured heap. |
 | `RSS at dump` | int64 | Resident bytes from `/proc/<pid>/statm` at capture time, or `(unavailable)` on format v1. |
+| `Module Globals` | map | v3 only: per-module globals addresses resolved at capture time. Currently seeded with `basic_globals` so `EmitModulesJob` can walk `BG(user_shutdown_function_names)` offline; the map is extensible so new walkers (curl/mysqlnd/...) land without another format bump. Prints `(none)` when the dumper couldn't resolve any symbol (e.g. a stripped binary). |
 | `Memory Map Count` | uint32 | Number of `/proc/<pid>/maps` entries serialised in the next section. |
 | `Region Count` | uint32 | Number of saved memory regions in the third section. |
 

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -107,6 +107,18 @@ final class MemoryDumpCommand extends ReliCommand
             $process_specifier,
             $target_php_settings_decided,
         );
+        // basic_globals is the engine's BG(...) struct. Persisting its
+        // address in the dump lets offline analysis walk the
+        // shutdown-function table; without it, objects pinned by
+        // register_shutdown_function show up as unaccounted heap.
+        // Resolution can legitimately fail (e.g. stripped binary,
+        // FrankenPHP-style static-link host that preempts the symbol);
+        // findBasicGlobals already swallows that into null, and the
+        // analyzer falls back to its existing short-circuit.
+        $bg_address = $this->php_globals_finder->findBasicGlobals(
+            $process_specifier,
+            $target_php_settings_decided,
+        );
 
         // Resolve global interned-string pointer arrays for exclude-heap
         // mode. These are plain BSS symbols (not TSRM globals), so
@@ -154,6 +166,7 @@ final class MemoryDumpCommand extends ReliCommand
             $dump_settings->include_binary,
             !$dump_settings->exclude_heap,
             $interned_string_arrays,
+            bg_address: $bg_address,
         );
 
         $output->writeln(sprintf(

--- a/src/Command/Inspector/MemoryDumpCommand.php
+++ b/src/Command/Inspector/MemoryDumpCommand.php
@@ -108,13 +108,16 @@ final class MemoryDumpCommand extends ReliCommand
             $target_php_settings_decided,
         );
         // basic_globals is the engine's BG(...) struct. Persisting its
-        // address in the dump lets offline analysis walk the
-        // shutdown-function table; without it, objects pinned by
+        // address (and the BG bytes via MemoryDumper's Phase 1
+        // interval) lets offline analysis walk the shutdown-function
+        // table; without it, objects pinned by
         // register_shutdown_function show up as unaccounted heap.
-        // Resolution can legitimately fail (e.g. stripped binary,
-        // FrankenPHP-style static-link host that preempts the symbol);
-        // findBasicGlobals already swallows that into null, and the
-        // analyzer falls back to its existing short-circuit.
+        // Resolution can legitimately fail (stripped binary,
+        // FrankenPHP-style static-link host that preempts the symbol,
+        // a cold ZTS worker with a zero tsrm_ls_cache). findBasicGlobals
+        // catches every \Throwable from findGlobals and degrades to
+        // null, and EmitModulesJob short-circuits on null — same
+        // observable behaviour as the pre-v3 baseline.
         $bg_address = $this->php_globals_finder->findBasicGlobals(
             $process_specifier,
             $target_php_settings_decided,

--- a/src/Command/Inspector/MemoryDumpInspectCommand.php
+++ b/src/Command/Inspector/MemoryDumpInspectCommand.php
@@ -78,7 +78,7 @@ final class MemoryDumpInspectCommand extends ReliCommand
             throw new \RuntimeException("invalid dump file: bad magic");
         }
         $format_version = $this->readUint32($fp);
-        if ($format_version !== 1 && $format_version !== 2) {
+        if ($format_version < 1 || $format_version > 3) {
             throw new \RuntimeException("unsupported dump format version: {$format_version}");
         }
         $php_version = $this->readString($fp);
@@ -89,6 +89,15 @@ final class MemoryDumpInspectCommand extends ReliCommand
         if ($format_version >= 2) {
             $raw = $this->readInt64($fp);
             $rss_bytes = $raw === -1 ? null : $raw;
+        }
+        /** @var array<string, int> $module_globals */
+        $module_globals = [];
+        if ($format_version >= 3) {
+            $entry_count = $this->readUint32($fp);
+            for ($i = 0; $i < $entry_count; $i++) {
+                $key = $this->readString($fp);
+                $module_globals[$key] = $this->readInt64($fp);
+            }
         }
         $memory_map_count = $this->readUint32($fp);
         $region_count = $this->readUint32($fp);
@@ -104,6 +113,18 @@ final class MemoryDumpInspectCommand extends ReliCommand
             "  RSS at dump:      "
             . ($rss_bytes === null ? '(unavailable)' : (string)$rss_bytes . ' bytes')
         );
+        if ($module_globals === []) {
+            $output->writeln('  Module Globals:   (none)');
+        } else {
+            $output->writeln('  Module Globals:');
+            foreach ($module_globals as $key => $address) {
+                $output->writeln(sprintf(
+                    '    %-16s 0x%s',
+                    $key . ':',
+                    dechex($address),
+                ));
+            }
+        }
         $output->writeln("  Memory Map Count: {$memory_map_count}");
         $output->writeln("  Region Count:     {$region_count}");
         $output->writeln('');

--- a/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
+++ b/src/Inspector/MemoryDump/MemoryDumpNormalizer.php
@@ -72,6 +72,7 @@ final class MemoryDumpNormalizer
                 $memory_areas,
                 $merged,
                 $header['rss_bytes'],
+                $header['module_globals'],
             );
             rename($temp_path, $output_path);
         } catch (\Throwable $e) {
@@ -155,6 +156,7 @@ final class MemoryDumpNormalizer
      * @param resource $fp
      * @return array{pid: int, php_version: string, eg_address: int,
      *     cg_address: int, rss_bytes: int|null,
+     *     module_globals: array<string, int>,
      *     memory_map_count: int, region_count: int}
      */
     private function readHeader($fp): array
@@ -164,7 +166,7 @@ final class MemoryDumpNormalizer
             throw new \RuntimeException('Invalid dump file: bad magic');
         }
         $version = $this->readUint32($fp);
-        if ($version !== 1 && $version !== 2) {
+        if ($version < 1 || $version > 3) {
             throw new \RuntimeException("Unsupported format version: {$version}");
         }
         $php_version = $this->readString($fp);
@@ -176,12 +178,22 @@ final class MemoryDumpNormalizer
             $raw = $this->readInt64($fp);
             $rss_bytes = $raw === -1 ? null : $raw;
         }
+        $module_globals = [];
+        if ($version >= 3) {
+            $entry_count = $this->readUint32($fp);
+            for ($i = 0; $i < $entry_count; $i++) {
+                $key = $this->readString($fp);
+                $address = $this->readInt64($fp);
+                $module_globals[$key] = $address;
+            }
+        }
         return [
             'php_version' => $php_version,
             'pid' => $pid,
             'eg_address' => $eg_address,
             'cg_address' => $cg_address,
             'rss_bytes' => $rss_bytes,
+            'module_globals' => $module_globals,
             'memory_map_count' => $this->readUint32($fp),
             'region_count' => $this->readUint32($fp),
         ];

--- a/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
+++ b/src/Inspector/MemoryDump/MemoryDumpReaderFactory.php
@@ -13,15 +13,20 @@ declare(strict_types=1);
 
 namespace Reli\Inspector\MemoryDump;
 
+use DI\Container;
 use DI\ContainerBuilder;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
 use Reli\Lib\File\PathResolver\MappedPathResolver;
 use Reli\Lib\File\PathResolver\ProcessPathResolver;
+use Reli\Lib\Log\Log;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocationsCollector;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryAttribute;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreatorInterface;
 use Reli\Lib\Process\MemoryReader\MemoryReaderInterface;
+use Reli\Lib\Process\ProcessSpecifier;
 use Reli\Inspector\MemoryDump\FastPath\FastPathReader;
 use Reli\Inspector\MemoryDump\FastPath\RegionByteProvider;
 
@@ -111,16 +116,64 @@ final class MemoryDumpReaderFactory
             }
         }
 
+        $bg_address = $this->resolveBgAddress(
+            $parsed['module_globals'],
+            $parsed['pid'],
+            $php_version,
+            $container,
+        );
+
         return new MemoryDumpReader(
             $container->get(MemoryLocationsCollector::class),
             $parsed['pid'],
             $php_version,
             $parsed['eg_address'],
             $parsed['cg_address'],
+            bg_address: $bg_address,
             rss_bytes: $parsed['rss_bytes'],
             fast_path: $fast_path,
             disable_bin_walk: $disable_bin_walk,
         );
+    }
+
+    /**
+     * Tier-1 hit wins (address came from the live process at dump time
+     * and is authoritative). Tier-1 miss falls through to PhpGlobalsFinder
+     * against the dump-backed reader; that rescues older dumps written
+     * before `basic_globals` was persisted, but only when the binary view
+     * is reachable (`--include-binary` at capture or `--dependency-root`
+     * at analyze). Finder failures silently degrade to null and
+     * EmitModulesJob short-circuits — same observable behaviour as the
+     * pre-v3 baseline.
+     *
+     * @param array<string, int> $module_globals
+     * @param value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version
+     */
+    private function resolveBgAddress(
+        array $module_globals,
+        int $pid,
+        string $php_version,
+        Container $container,
+    ): ?int {
+        if (isset($module_globals['basic_globals'])) {
+            return $module_globals['basic_globals'];
+        }
+
+        try {
+            /** @var PhpGlobalsFinder $finder */
+            $finder = $container->get(PhpGlobalsFinder::class);
+            /** @var TargetPhpSettings<value-of<\Reli\Lib\PhpInternals\ZendTypeReader::ALL_SUPPORTED_VERSIONS>> $target_settings */
+            $target_settings = new TargetPhpSettings(php_version: $php_version);
+            return $finder->findBasicGlobals(
+                new ProcessSpecifier($pid),
+                $target_settings,
+            );
+        } catch (\Throwable $e) {
+            Log::debug(
+                'tier-2 basic_globals resolve failed: ' . $e->getMessage(),
+            );
+            return null;
+        }
     }
 
     /**
@@ -134,6 +187,7 @@ final class MemoryDumpReaderFactory
      *     eg_address: int,
      *     cg_address: int,
      *     rss_bytes: int|null,
+     *     module_globals: array<string, int>,
      *     memory_areas: ProcessMemoryArea[],
      *     region_index: list<array{address: int, size: int, file_offset: int}>,
      * }
@@ -146,7 +200,7 @@ final class MemoryDumpReaderFactory
             throw new \RuntimeException("invalid dump file: bad magic");
         }
         $format_version = $this->readUint32($fp);
-        if ($format_version !== 1 && $format_version !== 2) {
+        if ($format_version < 1 || $format_version > 3) {
             throw new \RuntimeException("unsupported dump format version: {$format_version}");
         }
         $php_version = $this->readString($fp);
@@ -159,6 +213,17 @@ final class MemoryDumpReaderFactory
         if ($format_version >= 2) {
             $raw = $this->readInt64($fp);
             $rss_bytes = $raw === -1 ? null : $raw;
+        }
+        // v3 added a module-globals map after rss_bytes. v1/v2 dumps
+        // fall back to tier-2 resolution (or null) in createFromPath.
+        $module_globals = [];
+        if ($format_version >= 3) {
+            $entry_count = $this->readUint32($fp);
+            for ($i = 0; $i < $entry_count; $i++) {
+                $key = $this->readString($fp);
+                $address = $this->readInt64($fp);
+                $module_globals[$key] = $address;
+            }
         }
         $memory_map_count = $this->readUint32($fp);
         $region_count = $this->readUint32($fp);
@@ -218,6 +283,7 @@ final class MemoryDumpReaderFactory
             'eg_address' => $eg_address,
             'cg_address' => $cg_address,
             'rss_bytes' => $rss_bytes,
+            'module_globals' => $module_globals,
             'memory_areas' => $memory_areas,
             'region_index' => $region_index,
         ];

--- a/src/Inspector/MemoryDump/MemoryDumpWriter.php
+++ b/src/Inspector/MemoryDump/MemoryDumpWriter.php
@@ -18,13 +18,18 @@ use Reli\Lib\Process\MemoryMap\ProcessMemoryArea;
 final class MemoryDumpWriter
 {
     private const MAGIC = "RDUMP\0\0\0";
-    private const FORMAT_VERSION = 2;
+    private const FORMAT_VERSION = 3;
 
     /**
      * @param array<array{address: int, size: int, data: string}> $regions
      * @param ProcessMemoryArea[] $memory_areas
      * @param int|null $rss_bytes RSS in bytes captured at dump time, or
      *     null when /proc/<pid>/statm was unreadable.
+     * @param array<string, int> $module_globals Per-module globals
+     *     addresses resolved at dump time. Pre-seeded with
+     *     `basic_globals` so `EmitModulesJob` can walk the
+     *     shutdown-function table offline. New module-globals walkers
+     *     add their key without a further format bump.
      */
     public function write(
         string $output_path,
@@ -35,6 +40,7 @@ final class MemoryDumpWriter
         array $memory_areas,
         array $regions,
         ?int $rss_bytes = null,
+        array $module_globals = [],
     ): void {
         // Delegate to the streaming path so there is a single code path.
         $this->writeStreaming(
@@ -51,6 +57,7 @@ final class MemoryDumpWriter
                 }
             })(),
             $rss_bytes,
+            $module_globals,
         );
     }
 
@@ -69,6 +76,7 @@ final class MemoryDumpWriter
      * @param iterable<array{address: int, size: int, data: string}> $regions
      * @param int|null $rss_bytes RSS in bytes captured at dump time, or
      *     null when /proc/<pid>/statm was unreadable.
+     * @param array<string, int> $module_globals see write()
      * @return array{region_count: int, total_bytes: int}
      */
     public function writeStreaming(
@@ -81,6 +89,7 @@ final class MemoryDumpWriter
         int $estimated_region_count,
         iterable $regions,
         ?int $rss_bytes = null,
+        array $module_globals = [],
     ): array {
         $fp = fopen($output_path, 'wb');
         if ($fp === false) {
@@ -96,6 +105,7 @@ final class MemoryDumpWriter
                 count($memory_areas),
                 $estimated_region_count,
                 $rss_bytes,
+                $module_globals,
             );
             $this->writeMemoryMap($fp, $memory_areas);
 
@@ -131,6 +141,7 @@ final class MemoryDumpWriter
 
     /**
      * @param resource $fp
+     * @param array<string, int> $module_globals
      * @return int file offset of the region_count field, for later fix-up.
      */
     private function writeHeader(
@@ -142,6 +153,7 @@ final class MemoryDumpWriter
         int $memory_map_count,
         int $region_count,
         ?int $rss_bytes,
+        array $module_globals,
     ): int {
         $buf = self::MAGIC;
         $buf .= pack('V', self::FORMAT_VERSION);
@@ -151,6 +163,17 @@ final class MemoryDumpWriter
         $buf .= pack('P', $cg_address);
         // v2: rss_bytes (int64, signed). -1 = unavailable.
         $buf .= pack('q', $rss_bytes ?? -1);
+        // v3: module-globals map. Extensible string→address table so
+        // new walkers (basic_globals first, future curl/mysqlnd/...
+        // resource registries next) land without another format bump.
+        // EmitModulesJob short-circuits on a null bg_address, so an
+        // empty map degrades gracefully to "shutdown-function walk
+        // skipped" — same observable behaviour as v1/v2 dumps.
+        $buf .= pack('V', count($module_globals));
+        foreach ($module_globals as $key => $address) {
+            $buf .= self::packString($key);
+            $buf .= pack('P', $address);
+        }
         $buf .= pack('V', $memory_map_count);
         $region_count_offset = strlen($buf);
         $buf .= pack('V', $region_count);

--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -152,6 +152,15 @@ final class MemoryDumper
         // (include_heap=false) would otherwise skip. Capturing the
         // explicit interval here keeps EmitModulesJob's deref working
         // on every SAPI/build combination, mirroring the EG/CG pattern.
+        //
+        // Note for future module-globals walkers (curl/mysqlnd/...):
+        // adding a key to the v3 module_globals map only fixes
+        // *address resolution* offline. The corresponding struct bytes
+        // must also be reachable via the dump's captured intervals —
+        // either incidentally (e.g. in $php_rw_areas or [heap]) or by
+        // adding an explicit interval here, in the same shape as
+        // EG/CG/BG. Skip this and the analyzer will hold a non-null
+        // address that derefs to garbage.
         if ($bg_address !== null) {
             $intervals[] = [
                 'address' => $bg_address,

--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -51,6 +51,13 @@ final class MemoryDumper
      *
      * @param TargetPhpSettings<'v70'|'v71'|'v72'|'v73'|'v74'|'v80'|'v81'|'v82'|'v83'|'v84'|'v85'> $target_php_settings
      * @param list<array{address: int, count: int}> $interned_string_arrays
+     * @param ?int $bg_address `php_basic_globals` address resolved at
+     *     dump time. Persisted in the v3 header so offline analysis can
+     *     walk `BG(user_shutdown_function_names)` and attribute objects
+     *     pinned by `register_shutdown_function` under
+     *     `modules->standard->shutdown_function[N]`. Passing null
+     *     reproduces the old behaviour where the shutdown-function
+     *     subtree is silently skipped offline.
      * @param \Closure|null $on_read_complete invoked once after every remote
      *     memory region has been read into local PHP strings, before the dump
      *     file is opened for writing. The sidecar uses this hook to
@@ -70,6 +77,7 @@ final class MemoryDumper
         bool $include_heap = false,
         array $interned_string_arrays = [],
         ?\Closure $on_read_complete = null,
+        ?int $bg_address = null,
     ): MemoryDumpResult {
         $php_version = $target_php_settings->php_version;
         $zend_type_reader = $this->zend_type_reader_creator->create(
@@ -630,6 +638,12 @@ final class MemoryDumper
         }
 
         $all_areas = $memory_map->findByNameRegex('.*');
+        // Pre-seed the v3 module-globals map with basic_globals when
+        // resolved. EmitModulesJob is the only consumer today; new
+        // walkers add their key here without another format bump.
+        $module_globals = $bg_address !== null
+            ? ['basic_globals' => $bg_address]
+            : [];
         $writer = new MemoryDumpWriter();
         $writer->write(
             $output_path,
@@ -640,6 +654,7 @@ final class MemoryDumper
             $all_areas,
             $regions_data,
             $rss_bytes,
+            $module_globals,
         );
 
         $total_size = 0;

--- a/src/Inspector/MemoryDump/MemoryDumper.php
+++ b/src/Inspector/MemoryDump/MemoryDumper.php
@@ -142,6 +142,24 @@ final class MemoryDumper
                 'zend_compiler_globals',
             ),
         ];
+        // BG struct: persisting bg_address in the v3 header is only
+        // half the story; offline analysis also needs the struct's
+        // bytes to deref php_basic_globals and walk
+        // user_shutdown_function_names. On NTS that lives in the PHP
+        // binary's .data/.bss (covered by $php_rw_areas below), but on
+        // ZTS findBasicGlobals returns a TSRM-resolved per-thread
+        // address inside heap-backed TSRM storage, which minimum dumps
+        // (include_heap=false) would otherwise skip. Capturing the
+        // explicit interval here keeps EmitModulesJob's deref working
+        // on every SAPI/build combination, mirroring the EG/CG pattern.
+        if ($bg_address !== null) {
+            $intervals[] = [
+                'address' => $bg_address,
+                'size' => $zend_type_reader->sizeOf(
+                    'php_basic_globals',
+                ),
+            ];
+        }
 
         // PHP BSS segment: the anonymous writable VMA that contains EG.
         // This covers EG, CG, zend_one_char_string[256], and other PHP

--- a/src/Inspector/Sidecar/SidecarDumpHandler.php
+++ b/src/Inspector/Sidecar/SidecarDumpHandler.php
@@ -96,6 +96,13 @@ final class SidecarDumpHandler
             $process_specifier,
             $target_php_settings,
         );
+        // Persisted into the v3 dump header so offline analysis can
+        // walk BG(user_shutdown_function_names). Resolution failures
+        // already collapse to null inside findBasicGlobals.
+        $bg_address = $this->php_globals_finder->findBasicGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
 
         // Collect lightweight heap stats and RSS before stopping
         $heap_stats = $this->heap_stats_reader->read(
@@ -163,6 +170,7 @@ final class SidecarDumpHandler
                 $output_path,
                 $this->include_binary,
                 on_read_complete: $resume,
+                bg_address: $bg_address,
             );
         } finally {
             $resume();

--- a/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
+++ b/src/Lib/PhpProcessReader/PhpGlobalsFinder.php
@@ -478,7 +478,15 @@ class PhpGlobalsFinder
                 $target_php_settings,
                 'basic_globals'
             );
-        } catch (\RuntimeException) {
+        } catch (\Throwable) {
+            // findGlobals can raise MemoryReaderException,
+            // ProcessSymbolReaderException, TlsFinderException, and
+            // ElfParserException in addition to RuntimeException; this
+            // helper is the "soft" entry point and every caller
+            // (MemoryCommand / MemoryDumpCommand / CoreDumpReader /
+            // SidecarDumpHandler) treats the result as an optional
+            // address. Losing the shutdown-function walk on a stripped
+            // binary is strictly better than aborting the whole dump.
             return null;
         }
     }

--- a/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpInspectCommandTest.php
@@ -80,12 +80,13 @@ class MemoryDumpInspectCommandTest extends TestCase
 
         $display = $output->fetch();
         $this->assertStringContainsString('=== Header ===', $display);
-        $this->assertStringContainsString('Format Version:   2', $display);
+        $this->assertStringContainsString('Format Version:   3', $display);
         $this->assertStringContainsString('PHP Version:      v84', $display);
         $this->assertStringContainsString('PID:              9999', $display);
         $this->assertStringContainsString('EG Address:       0x7f0000001000', $display);
         $this->assertStringContainsString('CG Address:       0x7f0000002000', $display);
         $this->assertStringContainsString('RSS at dump:      (unavailable)', $display);
+        $this->assertStringContainsString('Module Globals:   (none)', $display);
         $this->assertStringContainsString('Memory Map Count: 0', $display);
         $this->assertStringContainsString('Region Count:     0', $display);
     }

--- a/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
+++ b/tests/Inspector/MemoryDump/DumpFileMemoryReaderTest.php
@@ -67,12 +67,22 @@ class DumpFileMemoryReaderTest extends TestCase
         $magic = fread($fp, 8);
         $this->assertSame("RDUMP\0\0\0", $magic);
         // format version (4) + php_version (4 len + body) + pid (8) +
-        // eg (8) + cg (8) + rss_bytes (8, v2) + memory_map_count (4) +
-        // region_count (4)
+        // eg (8) + cg (8) + rss_bytes (8, v2) +
+        // module_globals_count (4, v3; entries follow if non-zero) +
+        // memory_map_count (4) + region_count (4)
         fread($fp, 4);
         $len = unpack('V', fread($fp, 4))[1];
         fread($fp, $len);
-        fread($fp, 8 + 8 + 8 + 8 + 4 + 4);
+        fread($fp, 8 + 8 + 8 + 8);
+        $mg_count = unpack('V', fread($fp, 4))[1];
+        for ($i = 0; $i < $mg_count; $i++) {
+            $kl = unpack('V', fread($fp, 4))[1];
+            if ($kl > 0) {
+                fread($fp, $kl);
+            }
+            fread($fp, 8);
+        }
+        fread($fp, 4 + 4);
         // Skip the memory map entries.
         foreach ($memory_areas as $area) {
             // begin + end + file_offset strings
@@ -167,8 +177,9 @@ class DumpFileMemoryReaderTest extends TestCase
         $len = unpack('V', fread($fp, 4))[1];
         fread($fp, $len);
         // pid (8) + eg (8) + cg (8) + rss_bytes (8, v2)
+        // + module_globals_count (4, v3; empty here)
         // + memory_map_count (4) + region_count (4)
-        fread($fp, 8 + 8 + 8 + 8 + 4 + 4);
+        fread($fp, 8 + 8 + 8 + 8 + 4 + 4 + 4);
 
         $region_index = [];
         foreach ($regions as $region) {

--- a/tests/Inspector/MemoryDump/MemoryDumpReaderFactoryTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpReaderFactoryTest.php
@@ -90,4 +90,84 @@ class MemoryDumpReaderFactoryTest extends TestCase
         $this->expectExceptionMessage('invalid dump file: bad magic');
         $factory->createFromPath($this->tmp_file, []);
     }
+
+    #[Test]
+    public function testV3ModuleGlobalsRoundtrip(): void
+    {
+        $writer = new MemoryDumpWriter();
+        $writer->write(
+            $this->tmp_file,
+            1234,
+            'v84',
+            0x7f0000001000,
+            0x7f0000002000,
+            [],
+            [],
+            null,
+            ['basic_globals' => 0x7f0000003000, 'future_module_x' => 0x7f0000004000],
+        );
+
+        // Re-parse via low-level helper that mirrors the production reader.
+        $fp = fopen($this->tmp_file, 'rb');
+        $this->assertNotFalse($fp);
+        try {
+            $this->assertSame("RDUMP\0\0\0", fread($fp, 8));
+            $this->assertSame(3, unpack('Vval', fread($fp, 4))['val']);
+            // skip php_version, pid, eg, cg, rss
+            $len = unpack('Vval', fread($fp, 4))['val'];
+            fread($fp, $len);
+            fread($fp, 8 + 8 + 8 + 8);
+
+            // Module globals (v3): 2 entries, basic_globals first
+            $entry_count = unpack('Vval', fread($fp, 4))['val'];
+            $this->assertSame(2, $entry_count);
+
+            $key_len = unpack('Vval', fread($fp, 4))['val'];
+            $this->assertSame('basic_globals', fread($fp, $key_len));
+            $this->assertSame(
+                0x7f0000003000,
+                unpack('Pval', fread($fp, 8))['val'],
+            );
+
+            $key_len = unpack('Vval', fread($fp, 4))['val'];
+            $this->assertSame('future_module_x', fread($fp, $key_len));
+            $this->assertSame(
+                0x7f0000004000,
+                unpack('Pval', fread($fp, 8))['val'],
+            );
+        } finally {
+            fclose($fp);
+        }
+
+        // High-level factory path still constructs a reader.
+        $factory = new MemoryDumpReaderFactory(new ContainerBuilder());
+        $reader = $factory->createFromPath($this->tmp_file, []);
+        $this->assertInstanceOf(MemoryDumpReader::class, $reader);
+    }
+
+    /**
+     * Older dumps (v1/v2) lack the module-globals map. They must still
+     * parse — the tier-2 fallback (or null) handles the missing key.
+     */
+    #[Test]
+    public function testV2DumpStillParses(): void
+    {
+        // Hand-assemble a minimal v2 header. We can't go through the
+        // writer because it always emits v3 now; this test pins down
+        // the parser's backward-compat path.
+        $buf = "RDUMP\0\0\0";
+        $buf .= pack('V', 2);             // format version
+        $buf .= pack('V', 3) . 'v84';     // php_version
+        $buf .= pack('P', 1234);          // pid
+        $buf .= pack('P', 0x1000);        // eg
+        $buf .= pack('P', 0x2000);        // cg
+        $buf .= pack('q', -1);            // rss_bytes (unavailable)
+        $buf .= pack('V', 0);             // memory map count
+        $buf .= pack('V', 0);             // region count
+        file_put_contents($this->tmp_file, $buf);
+
+        $factory = new MemoryDumpReaderFactory(new ContainerBuilder());
+        $reader = $factory->createFromPath($this->tmp_file, []);
+        $this->assertInstanceOf(MemoryDumpReader::class, $reader);
+    }
 }

--- a/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpRoundtripTest.php
@@ -131,7 +131,7 @@ class MemoryDumpRoundtripTest extends TestCase
 
         // version
         $ver = unpack('Vval', fread($fp, 4));
-        $this->assertSame(2, $ver['val']);
+        $this->assertSame(3, $ver['val']);
 
         // php_version
         $len = unpack('Vval', fread($fp, 4))['val'];
@@ -151,6 +151,10 @@ class MemoryDumpRoundtripTest extends TestCase
         // rss_bytes (v2): caller passed default null → -1 sentinel
         $rss = unpack('qval', fread($fp, 8))['val'];
         $this->assertSame(-1, $rss);
+
+        // module globals (v3): default empty
+        $mg_count = unpack('Vval', fread($fp, 4))['val'];
+        $this->assertSame(0, $mg_count);
 
         // counts
         $map_count = unpack('Vval', fread($fp, 4))['val'];
@@ -186,8 +190,8 @@ class MemoryDumpRoundtripTest extends TestCase
         $file_size = filesize($this->tmp_file);
         // File should be at least 2MB (chunk data) + header
         $this->assertGreaterThan(2 * 1024 * 1024, $file_size);
-        // But not much more than 2MB
-        $this->assertLessThan(2 * 1024 * 1024 + 1024, $file_size);
+        // But not much more than 2MB (header + small module_globals map)
+        $this->assertLessThan(2 * 1024 * 1024 + 2048, $file_size);
     }
 
     #[Test]

--- a/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumpWriterTest.php
@@ -96,7 +96,7 @@ class MemoryDumpWriterTest extends TestCase
 
         // Format version
         $result = unpack('Vval', fread($fp, 4));
-        $this->assertSame(2, $result['val']);
+        $this->assertSame(3, $result['val']);
 
         // PHP version
         $len = unpack('Vval', fread($fp, 4))['val'];
@@ -118,6 +118,10 @@ class MemoryDumpWriterTest extends TestCase
         // RSS bytes (v2)
         $rss_bytes = unpack('Pval', fread($fp, 8))['val'];
         $this->assertSame(107798528, $rss_bytes);
+
+        // Module globals (v3): empty map when caller passed default
+        $module_globals_count = unpack('Vval', fread($fp, 4))['val'];
+        $this->assertSame(0, $module_globals_count);
 
         // Memory map count
         $memory_map_count = unpack('Vval', fread($fp, 4))['val'];

--- a/tests/Inspector/MemoryDump/MemoryDumperTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumperTest.php
@@ -96,6 +96,7 @@ class MemoryDumperTest extends BaseTestCase
 
         $eg = $globals_finder->findExecutorGlobals($process, $settings);
         $cg = $globals_finder->findCompilerGlobals($process, $settings);
+        $bg = $globals_finder->findBasicGlobals($process, $settings);
 
         $dumper = new MemoryDumper(
             $memory_reader,
@@ -119,6 +120,7 @@ class MemoryDumperTest extends BaseTestCase
             $eg,
             $cg,
             $output_path,
+            bg_address: $bg,
         );
 
         $this->assertFileExists($result->output_path);
@@ -129,8 +131,90 @@ class MemoryDumperTest extends BaseTestCase
             'Dump should contain at least 512K of data',
         );
 
+        // Regression: when bg_address is resolved, both the v3 header
+        // *and* the bytes themselves must land in the dump so
+        // EmitModulesJob can deref php_basic_globals offline. The
+        // failure mode this guards against is silent: the analyzer
+        // would see a non-null address, deref garbage, and skip the
+        // shutdown-function walk for reasons unrelated to v3 parsing.
+        if ($bg !== null) {
+            $factory = new MemoryDumpReaderFactory(new \DI\ContainerBuilder());
+            $parsed = self::reflectParse($factory, $output_path);
+            $this->assertArrayHasKey(
+                'basic_globals',
+                $parsed['module_globals'],
+                'v3 header must carry bg_address when resolved',
+            );
+            $this->assertSame($bg, $parsed['module_globals']['basic_globals']);
+
+            $bg_size = (new ZendTypeReaderCreator())
+                ->create($php_version)
+                ->sizeOf('php_basic_globals');
+            $covered = false;
+            foreach ($parsed['region_index'] as $region) {
+                $end = $region['address'] + $region['size'];
+                if (
+                    $bg >= $region['address']
+                    && ($bg + $bg_size) <= $end
+                ) {
+                    $covered = true;
+                    break;
+                }
+            }
+            $this->assertTrue(
+                $covered,
+                'php_basic_globals interval must land in a captured region',
+            );
+        }
+
         // Clean up
         unlink($output_path);
+    }
+
+    /**
+     * MemoryDumpReaderFactory::parse() is private; reach it via
+     * reflection so the regression assertion above can inspect the
+     * dump's region index without re-implementing the parser.
+     *
+     * @return array{
+     *     pid: int,
+     *     php_version: string,
+     *     eg_address: int,
+     *     cg_address: int,
+     *     rss_bytes: int|null,
+     *     module_globals: array<string, int>,
+     *     memory_areas: list<\Reli\Lib\Process\MemoryMap\ProcessMemoryArea>,
+     *     region_index: list<array{address: int, size: int, file_offset: int}>,
+     * }
+     */
+    private static function reflectParse(
+        MemoryDumpReaderFactory $factory,
+        string $path,
+    ): array {
+        $fp = fopen($path, 'rb');
+        if ($fp === false) {
+            throw new \RuntimeException("failed to open: {$path}");
+        }
+        try {
+            $rc = new \ReflectionClass(MemoryDumpReaderFactory::class);
+            $method = $rc->getMethod('parse');
+            $method->setAccessible(true);
+            /** @var array{
+             *     pid: int,
+             *     php_version: string,
+             *     eg_address: int,
+             *     cg_address: int,
+             *     rss_bytes: int|null,
+             *     module_globals: array<string, int>,
+             *     memory_areas: list<\Reli\Lib\Process\MemoryMap\ProcessMemoryArea>,
+             *     region_index: list<array{address: int, size: int, file_offset: int}>,
+             * } $parsed
+             */
+            $parsed = $method->invoke($factory, $fp);
+            return $parsed;
+        } finally {
+            fclose($fp);
+        }
     }
 
     private function createGlobalsFinder(


### PR DESCRIPTION
## Summary

Extends the memory dump format from v2 to v3 to persist module-globals addresses (starting with `basic_globals`) at dump time. This enables offline analysis to walk the shutdown-function table and attribute objects pinned by `register_shutdown_function`, fixing the bug documented in `docs/internals/bug-dump-analyze-missing-bg-address.md` (originally surfaced while investigating laravel-snappy #536).

## Key Changes

- **Format bump to v3**: Added a string→address map in the dump header after `rss_bytes`. The map is extensible so future module-globals walkers (curl, mysqlnd resource registries, etc.) can add their keys without another format bump.

- **BG bytes capture**: when `basic_globals` is resolved, `MemoryDumper` also captures the `php_basic_globals` struct bytes explicitly via a Phase-1 interval, mirroring the existing EG/CG handling. This matters especially for ZTS / minimum dumps (`include_heap=false`) where `findBasicGlobals` returns a TSRM-resolved per-thread address inside heap-backed TSRM storage that would not otherwise be covered by any captured interval. Without this, the v3 header would carry a non-null `bg_address` whose target bytes are absent from the dump, and `EmitModulesJob`'s `deref(php_basic_globals)` would land on garbage.

- **Backward compatibility**: v1/v2 dumps continue to parse. Missing `basic_globals` in older dumps triggers a tier-2 fallback that uses `PhpGlobalsFinder` against the dump-backed reader (rescues older dumps when the binary view is reachable via `--include-binary` or `--dependency-root`). Finder failures silently degrade to null, reproducing the pre-v3 behavior where the shutdown-function subtree is skipped.

- **Capture-time resolution**: `MemoryDumpCommand` and `SidecarDumpHandler` now call `PhpGlobalsFinder::findBasicGlobals()` at dump time and pass the result to `MemoryDumper::dump()` via a new `bg_address` parameter. The dumper pre-seeds the v3 module-globals map with `basic_globals` when resolved.

- **`findBasicGlobals` exception catch widened**: `findGlobals` can raise `MemoryReaderException`, `ProcessSymbolReaderException`, `TlsFinderException`, and `ElfParserException` in addition to `RuntimeException`. The "swallow to null" helper now catches `\Throwable` so the comment and runtime behaviour agree, matching the tier-2 fallback in `MemoryDumpReaderFactory::resolveBgAddress`. Every caller already treats the result as `?int`.

- **Writer and reader updates**:
  - `MemoryDumpWriter` bumped to `FORMAT_VERSION = 3` and accepts a `module_globals` array parameter
  - `MemoryDumpReaderFactory` parses the v3 module-globals map and resolves `basic_globals` via tier-1 (dump header) or tier-2 (PhpGlobalsFinder) lookup
  - `MemoryDumpNormalizer` and `MemoryDumpInspectCommand` updated to handle v3 parsing
  - `DumpFileMemoryReader` adjusted to skip the v3 module-globals entries when seeking to region data

- **Inspect command**: now displays the module-globals map in the header output, showing each key and its address in hex.

- **Tests**: added roundtrip tests for v3 format and backward-compat tests for v2 dumps. Updated existing tests to account for the new header structure. The target-version `MemoryDumperTest` now also asserts, when `bg_address` resolves, that (a) the v3 header carries it and (b) the `php_basic_globals` interval lands inside a captured region — pinning down the bytes-capture half of the fix that the v3-roundtrip tests alone cannot.

## Implementation Details

- The module-globals map uses a simple format: `uint32` entry count, then for each entry: string key (length-prefixed) and `int64` address.
- `MemoryDumpReader` constructor gains a `bg_address` parameter (nullable) to support the resolved address.
- Tier-2 resolution in `resolveBgAddress()` catches all exceptions and logs them at debug level, ensuring dump analysis degrades gracefully when binary introspection fails.

## Adding a new module-globals walker later

Adding `curl_globals` / `mysqlnd_globals` / etc. is **not** purely a `module_globals[key]` addition. Two responsibilities live in the dumper:

1. **Address persistence** — add a `findXxxGlobals` call in the capture-time dump path (`MemoryDumpCommand` / `SidecarDumpHandler`) and pre-seed the v3 header map. Resolution failures should keep degrading to a missing key (tier-2 fallback handles older dumps).
2. **Bytes capture** — ensure the corresponding globals struct bytes land in the dump. On NTS the struct is usually incidentally covered by `$php_rw_areas` (binary `.data`/`.bss`), but on ZTS / TSRM the address resolves into per-thread heap-backed storage that minimum dumps skip. In those cases add an explicit Phase-1 interval next to EG/CG/BG. Skip this and the analyzer holds an address that derefs to garbage — same failure shape as if the address were absent, but harder to diagnose.

`MemoryDumper` carries an inline comment to this effect so the responsibility is visible at the code site, not only in the PR description.

https://claude.ai/code/session_01KqePP44k2fHpu3XNRdTaDX