### PR TITLE
fix(collector): drop stream-data zend_string rows when the dereferenced `len` is implausible

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -40,6 +40,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLoc
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringSlotTailMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContext;
+use Reli\Lib\Process\MemoryLocation;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
@@ -48,6 +49,21 @@ use Reli\Lib\Process\Pointer\Pointer;
  */
 final class EmitResourceJob implements CollectorJob
 {
+    /**
+     * Upper bound on `zend_string.len` for strings reached via stream
+     * abstract data (php_stream_memory_data->data,
+     * php_stdio_data->temp_name). Anything past this is treated as a
+     * dangling pointer landing on garbage rather than a real string —
+     * see {@see self::tryEmitStreamString()}.
+     *
+     * The bound is generous on purpose: real allocations sit well under
+     * 1 GiB even for large in-memory buffers, while every pathological
+     * shape reli has actually seen (multi-exabyte `len` from a stale
+     * php_stream_memory_data->data) lands many orders of magnitude
+     * above it.
+     */
+    private const MAX_PLAUSIBLE_STREAM_STRING_LEN = 1 << 30;
+
     /** @param Pointer<ZendResource> $pointer */
     public function __construct(
         private Pointer $pointer,
@@ -233,40 +249,12 @@ final class EmitResourceJob implements CollectorJob
         $resource_context->addLocation($abstract_location);
         $extra_addresses[] = $abstract_address;
 
-        $data_address = $mem_data->data;
-        if ($data_address === 0) {
-            return;
-        }
-
-        $string_pointer = new Pointer(
-            ZendString::class,
-            $data_address,
-            $ctx->zend_type_reader->sizeOf('zend_string'),
+        $this->tryEmitStreamString(
+            $mem_data->data,
+            'stream_memory_data',
+            $ctx,
+            $resource_context,
         );
-
-        // Collect the string inline (same as EmitStringJob but adds to resource context)
-        if (!$ctx->memory_locations->has($data_address)) {
-            $str = $ctx->dereferencer->deref($string_pointer);
-            $memory_location = ZendStringMemoryLocation::fromZendString($str, $ctx->dereferencer);
-            $ctx->memory_locations->add($memory_location);
-            $slot_tail = ZendStringSlotTailMemoryLocation::tryFromStringInChunks(
-                $memory_location,
-                $ctx->chunk_memory_locations,
-            );
-            if ($slot_tail !== null) {
-                $ctx->memory_locations->add($slot_tail);
-            }
-            $string_context = $ctx->context_pools->string_context_pool->getContextForLocation(
-                $memory_location,
-                $slot_tail,
-            );
-            $resource_context->add('stream_memory_data', $string_context);
-        } else {
-            $cached = $ctx->context_pools->string_context_pool->getContextByAddress($data_address);
-            if ($cached !== null) {
-                $resource_context->add('stream_memory_data', $cached);
-            }
-        }
     }
 
     /** @param list<int> $extra_addresses */
@@ -364,39 +352,91 @@ final class EmitResourceJob implements CollectorJob
 
         $resource_context->stream_fd = $stdio_data->fd;
 
-        $temp_name_address = $stdio_data->temp_name;
-        if ($temp_name_address === 0) {
+        $this->tryEmitStreamString(
+            $stdio_data->temp_name,
+            'stream_temp_name',
+            $ctx,
+            $resource_context,
+        );
+    }
+
+    /**
+     * Treat `$address` as a `zend_string *` reachable through a stream's
+     * abstract data and emit a {@see ZendStringMemoryLocation} for it
+     * under `$context_key`. Bails out silently when:
+     *   - the pointer is null;
+     *   - the address sits outside any tracked zend_mm chunk (persistent
+     *     allocations live there too, but they are region='outside' and
+     *     we would only end up dropping them again at report time — see
+     *     {@see \Reli\Inspector\Output\MemoryOutput\RegionFilter});
+     *   - the dereferenced `len` exceeds {@see self::MAX_PLAUSIBLE_STREAM_STRING_LEN}
+     *     (the sentinel for "address sits in a chunk slot but the slot
+     *     was recycled and now holds garbage"; see commit history for
+     *     the stale `php_stream_memory_data->data` failure mode).
+     *
+     * The cached path mirrors the previous inline block: if the
+     * address has already been visited, just reattach the existing
+     * string context to the resource.
+     *
+     * @param non-empty-string $context_key
+     */
+    private function tryEmitStreamString(
+        int $address,
+        string $context_key,
+        CollectorContext $ctx,
+        ResourceContext $resource_context,
+    ): void {
+        if ($address === 0) {
             return;
         }
 
-        $string_pointer = new Pointer(
-            ZendString::class,
-            $temp_name_address,
-            $ctx->zend_type_reader->sizeOf('zend_string'),
-        );
-
-        if (!$ctx->memory_locations->has($temp_name_address)) {
-            $str = $ctx->dereferencer->deref($string_pointer);
-            $memory_location = ZendStringMemoryLocation::fromZendString($str, $ctx->dereferencer);
-            $ctx->memory_locations->add($memory_location);
-            $slot_tail = ZendStringSlotTailMemoryLocation::tryFromStringInChunks(
-                $memory_location,
-                $ctx->chunk_memory_locations,
-            );
-            if ($slot_tail !== null) {
-                $ctx->memory_locations->add($slot_tail);
-            }
-            $string_context = $ctx->context_pools->string_context_pool->getContextForLocation(
-                $memory_location,
-                $slot_tail,
-            );
-            $resource_context->add('stream_temp_name', $string_context);
-        } else {
-            $cached = $ctx->context_pools->string_context_pool->getContextByAddress($temp_name_address);
+        if ($ctx->memory_locations->has($address)) {
+            $cached = $ctx->context_pools->string_context_pool->getContextByAddress($address);
             if ($cached !== null) {
-                $resource_context->add('stream_temp_name', $cached);
+                $resource_context->add($context_key, $cached);
             }
+            return;
         }
+
+        // Outside-zend_mm addresses are either persistent allocations
+        // (which would be filtered as region='outside' downstream
+        // anyway) or dangling/freed memory; either way we don't want
+        // to deref blindly. The 1-byte probe is enough — `contains`
+        // checks chunk membership by address, not size.
+        if (
+            $ctx->chunk_memory_locations === null
+            || !$ctx->chunk_memory_locations->contains(new MemoryLocation($address, 1))
+        ) {
+            return;
+        }
+
+        $str = $ctx->dereferencer->deref(new Pointer(
+            ZendString::class,
+            $address,
+            $ctx->zend_type_reader->sizeOf('zend_string'),
+        ));
+
+        // Slot recycled into garbage: `len` reads as a multi-exabyte
+        // value. Skip rather than emit a bogus row that downstream
+        // size aggregation has to filter out.
+        if ($str->len < 0 || $str->len > self::MAX_PLAUSIBLE_STREAM_STRING_LEN) {
+            return;
+        }
+
+        $memory_location = ZendStringMemoryLocation::fromZendString($str, $ctx->dereferencer);
+        $ctx->memory_locations->add($memory_location);
+        $slot_tail = ZendStringSlotTailMemoryLocation::tryFromStringInChunks(
+            $memory_location,
+            $ctx->chunk_memory_locations,
+        );
+        if ($slot_tail !== null) {
+            $ctx->memory_locations->add($slot_tail);
+        }
+        $string_context = $ctx->context_pools->string_context_pool->getContextForLocation(
+            $memory_location,
+            $slot_tail,
+        );
+        $resource_context->add($context_key, $string_context);
     }
 
     /** @param list<int> $extra_addresses */

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -375,20 +375,23 @@ final class EmitResourceJob implements CollectorJob
      * surface as a `MemoryReaderException` from `deref` and are caught
      * by the outer `tryCollectStreamData` try/catch, which lets the
      * resource walk continue without the stream child. We deliberately
-     * do NOT pre-screen by chunk membership: persistent stream buffers
-     * and legitimate-but-not-zend-mm allocations on some PHP versions
-     * can still have a sane `len`, and rejecting them silently masked
-     * a real `php://memory` link in
-     * `MemoryLocationsCollectorTest::testStreamResourceTracking` on the
-     * PHP 8.0 target.
+     * do NOT pre-screen by chunk membership: huge-allocated or
+     * persistent stream buffers can legitimately sit outside
+     * `chunk_memory_locations`, and a chunk-membership precheck would
+     * drop them along with the genuinely wild ones. The outer try/catch
+     * is the safer floor here.
      *
      * Note that this guard is a heuristic, not a hard guarantee. A
      * raw-byte buffer or recycled slot that happens to land on a
      * `len` value below {@see self::MAX_PLAUSIBLE_STREAM_STRING_LEN}
      * will still slip through and produce a `region='outside'` row
-     * downstream. The defensive read-side filter introduced in #795
-     * ({@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}) is
-     * still relied on as a safety net for that case.
+     * downstream — including, in practice, the PHP 7.0..8.0 case where
+     * reli's `php_stream_memory_data` declaration mismatches the
+     * upstream raw-buffer layout (see the v80 skip in
+     * `MemoryLocationsCollectorTest::testStreamResourceTracking` for the
+     * full trail). The read-side filter introduced in #795
+     * ({@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}) is the
+     * safety net for that case.
      *
      * The cached path mirrors the previous inline block: if the
      * address has already been visited, just reattach the existing

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -374,16 +374,21 @@ final class EmitResourceJob implements CollectorJob
      * Truly wild pointers (e.g. addresses outside any mapped page)
      * surface as a `MemoryReaderException` from `deref` and are caught
      * by the outer `tryCollectStreamData` try/catch, which lets the
-     * resource walk continue without the stream child. We don't
-     * pre-screen by chunk membership: persistent stream buffers and
-     * legitimate-but-not-zend-mm allocations on some PHP versions can
-     * still have a sane `len`, and rejecting them silently masked a
-     * real `php://memory` link in `MemoryLocationsCollectorTest::testStreamResourceTracking`
-     * on the PHP 8.0 target. The size-attribution side of the bug is
-     * already handled at write time by
-     * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\BinaryContextTreeSink::emitNode()}
-     * (which gates per-node accumulators on `RegionFilter::isRelevant`)
-     * and at read time by {@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}.
+     * resource walk continue without the stream child. We deliberately
+     * do NOT pre-screen by chunk membership: persistent stream buffers
+     * and legitimate-but-not-zend-mm allocations on some PHP versions
+     * can still have a sane `len`, and rejecting them silently masked
+     * a real `php://memory` link in
+     * `MemoryLocationsCollectorTest::testStreamResourceTracking` on the
+     * PHP 8.0 target.
+     *
+     * Note that this guard is a heuristic, not a hard guarantee. A
+     * raw-byte buffer or recycled slot that happens to land on a
+     * `len` value below {@see self::MAX_PLAUSIBLE_STREAM_STRING_LEN}
+     * will still slip through and produce a `region='outside'` row
+     * downstream. The defensive read-side filter introduced in #795
+     * ({@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}) is
+     * still relied on as a safety net for that case.
      *
      * The cached path mirrors the previous inline block: if the
      * address has already been visited, just reattach the existing

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php
@@ -40,7 +40,6 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLoc
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringSlotTailMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ResourceContext;
-use Reli\Lib\Process\MemoryLocation;
 use Reli\Lib\Process\Pointer\Pointer;
 
 /**
@@ -365,14 +364,26 @@ final class EmitResourceJob implements CollectorJob
      * abstract data and emit a {@see ZendStringMemoryLocation} for it
      * under `$context_key`. Bails out silently when:
      *   - the pointer is null;
-     *   - the address sits outside any tracked zend_mm chunk (persistent
-     *     allocations live there too, but they are region='outside' and
-     *     we would only end up dropping them again at report time — see
-     *     {@see \Reli\Inspector\Output\MemoryOutput\RegionFilter});
-     *   - the dereferenced `len` exceeds {@see self::MAX_PLAUSIBLE_STREAM_STRING_LEN}
-     *     (the sentinel for "address sits in a chunk slot but the slot
-     *     was recycled and now holds garbage"; see commit history for
-     *     the stale `php_stream_memory_data->data` failure mode).
+     *   - the dereferenced `len` exceeds
+     *     {@see self::MAX_PLAUSIBLE_STREAM_STRING_LEN}
+     *     (the sentinel for "the slot was recycled and now holds
+     *     garbage"; see commit history for the stale
+     *     `php_stream_memory_data->data` failure mode that this guard
+     *     exists for).
+     *
+     * Truly wild pointers (e.g. addresses outside any mapped page)
+     * surface as a `MemoryReaderException` from `deref` and are caught
+     * by the outer `tryCollectStreamData` try/catch, which lets the
+     * resource walk continue without the stream child. We don't
+     * pre-screen by chunk membership: persistent stream buffers and
+     * legitimate-but-not-zend-mm allocations on some PHP versions can
+     * still have a sane `len`, and rejecting them silently masked a
+     * real `php://memory` link in `MemoryLocationsCollectorTest::testStreamResourceTracking`
+     * on the PHP 8.0 target. The size-attribution side of the bug is
+     * already handled at write time by
+     * {@see \Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\BinaryContextTreeSink::emitNode()}
+     * (which gates per-node accumulators on `RegionFilter::isRelevant`)
+     * and at read time by {@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}.
      *
      * The cached path mirrors the previous inline block: if the
      * address has already been visited, just reattach the existing
@@ -395,18 +406,6 @@ final class EmitResourceJob implements CollectorJob
             if ($cached !== null) {
                 $resource_context->add($context_key, $cached);
             }
-            return;
-        }
-
-        // Outside-zend_mm addresses are either persistent allocations
-        // (which would be filtered as region='outside' downstream
-        // anyway) or dangling/freed memory; either way we don't want
-        // to deref blindly. The 1-byte probe is enough — `contains`
-        // checks chunk membership by address, not size.
-        if (
-            $ctx->chunk_memory_locations === null
-            || !$ctx->chunk_memory_locations->contains(new MemoryLocation($address, 1))
-        ) {
             return;
         }
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2884,10 +2884,25 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertTrue($found_memory, 'Should find a php://memory stream (label=MEMORY)');
         $this->assertTrue($found_temp, 'Should find a php://temp stream (label=TEMP)');
         $this->assertTrue($found_stdio, 'Should find a STDIO stream');
-        $this->assertTrue(
-            $found_memory_data_link,
-            'Should find stream_memory_data link for MEMORY or TEMP stream'
-        );
+        // PHP 8.0 changed `php_stream_memory_data` later: from 7.0..8.0
+        // the struct is `{ char *data; size_t fpos; size_t fsize; size_t
+        // smax; int mode; }` (raw byte buffer) and from 8.1 onwards it
+        // is `{ zend_string *data; size_t fpos; int mode; }`. Reli's
+        // PhpStreamMemoryData / v80.h declarations only model the 8.1+
+        // shape; on 8.0 the `data` field is treated as a `zend_string *`
+        // and the deref reads raw stream content as `gc.refcount` /
+        // `len`, producing a multi-exabyte garbage `len`. The collector
+        // (EmitResourceJob::tryEmitStreamString) drops those rows on
+        // sight rather than write a bogus 'outside'-region location, so
+        // the `stream_memory_data` link is genuinely absent on 8.0 — the
+        // assertion only fires on the versions where the layout matches
+        // reli's view.
+        if ($php_version !== ZendTypeReader::V80) {
+            $this->assertTrue(
+                $found_memory_data_link,
+                'Should find stream_memory_data link for MEMORY or TEMP stream'
+            );
+        }
     }
 
     /**

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2885,25 +2885,30 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertTrue($found_temp, 'Should find a php://temp stream (label=TEMP)');
         $this->assertTrue($found_stdio, 'Should find a STDIO stream');
         // PHP 8.1 changed `php_stream_memory_data`: from 7.0..8.0 the
-        // struct is `{ char *data; size_t fpos; size_t fsize; size_t
-        // smax; int mode; }` (raw byte buffer) and from 8.1 onwards it
-        // is `{ zend_string *data; size_t fpos; int mode; }`. Reli's
-        // PhpStreamMemoryData / v80.h declarations only model the 8.1+
-        // shape; on 8.0 the `data` field is treated as a `zend_string *`
-        // and the deref reads raw stream content as `gc.refcount` /
-        // `len`, producing a multi-exabyte garbage `len`. The collector
+        // upstream struct is `{ char *data; size_t fpos; size_t fsize;
+        // size_t smax; int mode; }` (raw byte buffer) and from 8.1
+        // onwards it is `{ zend_string *data; size_t fpos; int mode; }`.
+        // Reli's PhpStreamMemoryData class and every reli header
+        // (v70.h..v80.h) declare the 8.1+ shape, so on every old PHP
+        // version the `data` field is treated as a `zend_string *` and
+        // the deref reads raw stream content as `gc.refcount` / `len`,
+        // producing a multi-exabyte garbage `len`. The collector
         // (EmitResourceJob::tryEmitStreamString) drops those rows on
         // sight rather than write a bogus 'outside'-region location, so
-        // the `stream_memory_data` link is genuinely absent on 8.0 — the
-        // assertion only fires on the versions where the layout matches
-        // reli's view.
+        // the `stream_memory_data` link is genuinely absent there.
         //
-        // TODO: model the v70..v80 raw-buffer layout and emit a
+        // The skip below only checks V80 because this test runs through
+        // `provideFromV80` (V80, V81, …) — v70..v79 are never exercised
+        // here, so we don't need to spell them out. v81+ matches reli's
+        // declaration and produces a real link.
+        //
+        // TODO: model the v70..v80 raw-buffer layout in
+        // PhpStreamMemoryData / the v7x.h + v80.h headers and emit a
         // dedicated `PhpStreamMemoryRawBufferMemoryLocation` so the
         // stream-memory body is tracked on those PHP versions too.
-        // Tracking the v70..v80 layout fix as a follow-up rather than
-        // adding it to this PR keeps the collector guard small and
-        // focused on the original report.
+        // Tracking the layout fix as a follow-up rather than folding it
+        // into this PR keeps the collector guard small and focused on
+        // the original report.
         if ($php_version !== ZendTypeReader::V80) {
             $this->assertTrue(
                 $found_memory_data_link,

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -2884,8 +2884,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         $this->assertTrue($found_memory, 'Should find a php://memory stream (label=MEMORY)');
         $this->assertTrue($found_temp, 'Should find a php://temp stream (label=TEMP)');
         $this->assertTrue($found_stdio, 'Should find a STDIO stream');
-        // PHP 8.0 changed `php_stream_memory_data` later: from 7.0..8.0
-        // the struct is `{ char *data; size_t fpos; size_t fsize; size_t
+        // PHP 8.1 changed `php_stream_memory_data`: from 7.0..8.0 the
+        // struct is `{ char *data; size_t fpos; size_t fsize; size_t
         // smax; int mode; }` (raw byte buffer) and from 8.1 onwards it
         // is `{ zend_string *data; size_t fpos; int mode; }`. Reli's
         // PhpStreamMemoryData / v80.h declarations only model the 8.1+
@@ -2897,6 +2897,13 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         // the `stream_memory_data` link is genuinely absent on 8.0 — the
         // assertion only fires on the versions where the layout matches
         // reli's view.
+        //
+        // TODO: model the v70..v80 raw-buffer layout and emit a
+        // dedicated `PhpStreamMemoryRawBufferMemoryLocation` so the
+        // stream-memory body is tracked on those PHP versions too.
+        // Tracking the v70..v80 layout fix as a follow-up rather than
+        // adding it to this PR keeps the collector guard small and
+        // focused on the original report.
         if ($php_version !== ZendTypeReader::V80) {
             $this->assertTrue(
                 $found_memory_data_link,


### PR DESCRIPTION
## Summary

Follow-up to #795 — the read-side fix introduced there filters bogus `'outside'`-region
rows out of every report surface, but they are still written to the rmem file in the
first place. The collector deref of `php_stream_memory_data->data` (and the analogous
`php_stdio_data->temp_name`) treats the field as `zend_string *` and proceeds without
inspecting the result, so a stale / persistent / recycled-slot pointer ends up emitting
a `ZendStringMemoryLocation` whose `getSize() = len + 24` is a multi-exabyte garbage
value. This PR tightens the collector so it drops the most egregious of those rows at
emit time, and consolidates the two call sites into a shared helper.

## Root cause

`EmitResourceJob::collectMemoryStreamData()` (and `collectStdioStreamData()`) walks the
stream's abstract data and dereferences whatever the `data` / `temp_name` field happens
to point at as a `zend_string`. When the underlying allocation is dangling, persistent,
or — on PHP 7.0..8.0 — actually a `char *` raw buffer (see "Known limitation" below),
the dereferenced `len` reads as a multi-exabyte garbage value, the
`getSize() = len + 24` row is written to the locations section with
`region='outside'`, and every downstream reader has to filter it back out.

## What this PR changes

Extract `EmitResourceJob::tryEmitStreamString()` and route both call sites through it.
The helper:

1. Returns early if `$address === 0`.
2. Reuses the cached string context via `string_context_pool->getContextByAddress()`
   when the address has already been visited.
3. After deref, drops the row silently when `$str->len` is negative or exceeds
   `MAX_PLAUSIBLE_STREAM_STRING_LEN = 1 GiB` — the sentinel for "the slot was recycled
   and now holds garbage" (the canonical failure mode behind the original report).

Note that step (3) is a **heuristic**, not a hard guarantee: a raw-byte buffer or
recycled slot that happens to land on a `len` value below the threshold will still slip
through and produce an `'outside'`-region row downstream. #795's read-side
`RegionFilter` is the safety net for that case and stays in place.

The chunk-membership precheck the first revision of this PR carried (`chunk_memory_locations->contains(...)`)
was dropped because huge-allocated or persistent stream buffers can legitimately sit
outside `chunk_memory_locations`, and a chunk-membership precheck would drop them along
with truly wild pointers. The outer `tryCollectStreamData` try/catch already swallows
`MemoryReaderException` for genuinely invalid pointers, so deref safety is unaffected.

## Known limitation (follow-up)

`MemoryLocationsCollectorTest::testStreamResourceTracking` now conditionally skips the
`stream_memory_data` link assertion on PHP 8.0 because reli's `PhpStreamMemoryData` /
every reli header from `v70.h` through `v80.h` carry the 8.1+ struct shape
(`{ zend_string *data; size_t fpos; int mode; }`) even though PHP 7.0..8.0 has the
older `{ char *data; size_t fpos; size_t fsize; size_t smax; int mode; }`. On those
versions the deref reads raw stream content as `gc.refcount` / `len` and
`tryEmitStreamString()` correctly drops the bogus row — so the link is genuinely
absent. The skip below only spells out `V80` because this test runs through
`provideFromV80` (V80, V81, …); v70..v79 are never exercised here, and V81+ matches
reli's declaration so the link surfaces as expected.

Properly modelling the v70..v80 raw-buffer layout (probably by emitting a dedicated
`PhpStreamMemoryRawBufferMemoryLocation`) is a separate follow-up; this PR's intent is
to stop the garbage row from being written, not to extend stream-content coverage on
old PHP.

## Test plan

- [x] `composer install && php vendor/bin/psalm.phar` — no errors
- [x] `php vendor/bin/phpunit --exclude-group target-version --exclude-group frankenphp --exclude-group mod_php`
      — 3487 pass, 0 failures
- [x] `RELI_TEST_PHP_TARGETS=v80 php vendor/bin/phpunit --group target-version --filter 'testStreamResourceTracking'`
      — passes locally
- [x] `php vendor/bin/phpcs --standard=PSR12 src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitResourceJob.php tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php`
      — no warnings
- [x] CI: 49/49 green on the previous push
- [ ] Reporter to re-run `inspector:memory:report` against their `.rmem` (regenerated
      with the patched collector) and confirm the multi-exabyte-`len`-driven
      `region='outside'` rows that the rest of the stack used to filter out are no
      longer in the locations section
