### PR TITLE
feat(rmem): restore on-disk node_sizes fast-path behind FLAG_NODE_SIZES_REGION_FILTERED

### DIFF
--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/Format.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/Format.php
@@ -36,6 +36,18 @@ final class Format
     // Flag bits in the header flags field
     public const FLAG_LITTLE_ENDIAN = 0x01;
 
+    /**
+     * The on-disk `node_sizes` section was written with the
+     * size-attribution region policy already applied
+     * ({@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}). Readers
+     * that see this flag may load `node_sizes` straight into the
+     * substrate without rescanning the locations section to refilter
+     * by region; readers that don't see it must fall back to the
+     * locations-scan path because the pre-summed slots may include
+     * 'outside'-region bytes that the report-time policy would drop.
+     */
+    public const FLAG_NODE_SIZES_REGION_FILTERED = 0x02;
+
     // Section names (max 16 bytes, null-padded)
     public const SECTION_STRING_DICT = 'string_dict';
     public const SECTION_NODES = 'nodes';

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/Reader.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/Reader.php
@@ -41,6 +41,9 @@ final class Reader
     /** @var array<string, array{offset: int, length: int, element_count: int}> */
     private array $toc = [];
 
+    /** Flags read from the rmem header — OR of {@see Format} `FLAG_*` constants. */
+    private int $headerFlags = 0;
+
     private StringDict $stringDict;
 
     // mmap-backed storage (preferred)
@@ -129,6 +132,7 @@ final class Reader
         if (($flags & Format::FLAG_LITTLE_ENDIAN) === 0) {
             throw new \RuntimeException('Big-endian rmem files are not supported');
         }
+        $this->headerFlags = $flags;
 
         $section_count = unpack('V', $headerBytes, 12)[1];
         $toc_offset = unpack('P', $headerBytes, 16)[1];
@@ -170,6 +174,15 @@ final class Reader
     public function getStringDict(): StringDict
     {
         return $this->stringDict;
+    }
+
+    /**
+     * True iff the given header flag bit is set.
+     * See {@see Format} for the defined `FLAG_*` constants.
+     */
+    public function hasHeaderFlag(int $flag): bool
+    {
+        return ($this->headerFlags & $flag) === $flag;
     }
 
     public function hasSection(string $name): bool

--- a/src/Inspector/Output/MemoryOutput/BinaryFormat/Writer.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryFormat/Writer.php
@@ -32,6 +32,12 @@ final class Writer
     /** Current write position (starts after header placeholder) */
     private int $pos;
 
+    /**
+     * Bits OR'd into the header `flags` field on top of the always-on
+     * {@see Format::FLAG_LITTLE_ENDIAN}. Set before {@see finish()}.
+     */
+    private int $extraHeaderFlags = 0;
+
     public function __construct(string $path)
     {
         $fh = fopen($path, 'wb');
@@ -43,6 +49,16 @@ final class Writer
         // Reserve space for the header (will be rewritten in finish())
         fwrite($this->fh, str_repeat("\0", Format::HEADER_SIZE));
         $this->pos = Format::HEADER_SIZE;
+    }
+
+    /**
+     * OR additional flag bits into the header. {@see Format::FLAG_LITTLE_ENDIAN}
+     * is always set; pass any other {@see Format} `FLAG_*` constants here
+     * before calling {@see finish()}.
+     */
+    public function addExtraHeaderFlags(int $flags): void
+    {
+        $this->extraHeaderFlags |= $flags;
     }
 
     /**
@@ -158,7 +174,7 @@ final class Writer
         fseek($this->getFileHandle(), 0);
         $header = Format::MAGIC;                                  // 4 bytes
         $header .= pack('V', Format::VERSION);                    // 4 bytes: version (uint32 LE)
-        $header .= pack('V', Format::FLAG_LITTLE_ENDIAN);         // 4 bytes: flags (uint32 LE)
+        $header .= pack('V', Format::FLAG_LITTLE_ENDIAN | $this->extraHeaderFlags); // 4 bytes: flags (uint32 LE)
         $header .= pack('V', count($this->toc));                  // 4 bytes: section_count (uint32 LE)
         $header .= pack('P', $toc_offset);                        // 8 bytes: toc_offset (uint64 LE)
         // Pad to 64 bytes

--- a/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
+++ b/src/Inspector/Output/MemoryOutput/BinaryMemoryOutput.php
@@ -142,6 +142,17 @@ final class BinaryMemoryOutput implements MemoryOutputInterface
                     \FFI::string($perNodeSizes, $nodeSlots * 8),
                     $nodeSlots,
                 );
+                // Advertise the on-disk node_sizes section as
+                // region-policy-clean so readers can skip the locations
+                // rescan that {@see RegionFilter} would otherwise force
+                // them to do. The sink only reports `true` when a
+                // RegionBoundaries was attached before the first
+                // emitNode(); without one the accumulators are unfiltered
+                // and the flag must stay off so older readers keep using
+                // the safe fallback.
+                if ($sink->isPerNodeRegionFiltered()) {
+                    $writer->addExtraHeaderFlags(Format::FLAG_NODE_SIZES_REGION_FILTERED);
+                }
             }
             $perNodeClasses = $sink->getPerNodeClasses();
             if ($perNodeClasses !== null) {

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -430,16 +430,27 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // `$sizesLoaded &&` guard was a code-locality choice (group on-disk
         // fast-paths together), not a correctness dependency; canonical_map
         // is self-contained and orthogonal to sizes, so decouple it.
+        //
+        // Same csrIdx → node_id indirection as the node_sizes / node_classes
+        // fast-paths above — the section is keyed by node_id (writer:
+        // `BinaryContextTreeSink::buildCanonicalMap()` does
+        // `$map[$node_id] = $canon`), so walking slot indices directly
+        // would mis-read sparse / non-zero-based emitters.
         $canonicalLoaded = false;
         if ($reader->hasSection('canonical_map')) {
             $canonData = $reader->getSectionData('canonical_map');
             $canonSlots = $reader->getSectionElementCount('canonical_map');
-            for ($i = 0; $i < min($canonSlots, $nc); $i++) {
+            $indexToNode = $substrate->indexToNodeFfi;
+            for ($csrIdx = 0; $csrIdx < $nc; $csrIdx++) {
+                $node_id = $indexToNode[$csrIdx];
+                if ($node_id < 0 || $node_id >= $canonSlots) {
+                    continue;
+                }
                 /** @var array{1: int} */
-                $c = unpack('l', $canonData, $i * 4); // signed int32
+                $c = unpack('l', $canonData, $node_id * 4); // signed int32
                 $canon_id = $c[1];
-                if ($canon_id >= 0 && $canon_id !== $i) {
-                    $substrate->canonical[$i] = $canon_id;
+                if ($canon_id >= 0 && $canon_id !== $node_id) {
+                    $substrate->canonical[$node_id] = $canon_id;
                     $substrate->canonical[$canon_id] = $canon_id;
                 }
             }

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -355,6 +355,15 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // we can fold the section straight into the FFI accumulator
         // without rescanning locations — that scan is the single
         // largest cost on the report-load path for big dumps.
+        //
+        // The section is indexed by `node_id`, not by CSR index, so the
+        // loop walks csrIdx → node_id via `indexToNodeFfi` and reads
+        // `sizesData[node_id]`. Iterating slot indices directly (the
+        // previous shape `for $i < min($slotsCount, $nc)`) only worked
+        // for `0..nc-1`-shaped dense node_ids; any sparse or non-zero-
+        // based emitter (e.g. ContextAnalyzer's `1..nc` fixtures used in
+        // tests) silently dropped the highest slot and read 0 from the
+        // unused leading slot.
         $sizesLoaded = false;
         if (
             $reader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED)
@@ -363,18 +372,14 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $sizesData = $reader->getSectionData('node_sizes');
             $slotsCount = $reader->getSectionElementCount('node_sizes');
             $ffiNodeSizes = $substrate->ffiNodeSizes;
+            $indexToNode = $substrate->indexToNodeFfi;
             $substrate->nodeSizesSum = 0;
-            for ($i = 0; $i < min($slotsCount, $nc); $i++) {
-                if ($directMap !== null) {
-                    $slot = $i + $directOffset;
-                    $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
-                } else {
-                    $csrIdx = $phpMap[$i] ?? -1;
-                }
-                if ($csrIdx < 0) {
+            for ($csrIdx = 0; $csrIdx < $nc; $csrIdx++) {
+                $node_id = $indexToNode[$csrIdx];
+                if ($node_id < 0 || $node_id >= $slotsCount) {
                     continue;
                 }
-                $size = unpack('P', $sizesData, $i * 8)[1];
+                $size = unpack('P', $sizesData, $node_id * 8)[1];
                 $ffiNodeSizes[$csrIdx] = $size;
                 $substrate->nodeSizesSum += $size;
             }
@@ -390,25 +395,23 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         // php_stream_memory_data->data dereferenced as a zend_string)
         // carries class_id=NULL_STRING_ID and contributes nothing to
         // per-node class attribution.
+        //
+        // Same csrIdx → node_id indirection as Phase 3a — the section is
+        // keyed by node_id, not by CSR index.
         if ($reader->hasSection('node_classes')) {
             $classesData = $reader->getSectionData('node_classes');
             $slotsCount = $reader->getSectionElementCount('node_classes');
 
             $nodeClassIds = $substrate->nodeClassIds;
+            $indexToNode = $substrate->indexToNodeFfi;
 
-            for ($i = 0; $i < min($slotsCount, $nc); $i++) {
-                // node_id == i (dense), map to CSR index
-                if ($directMap !== null) {
-                    $slot = $i + $directOffset;
-                    $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
-                } else {
-                    $csrIdx = $phpMap[$i] ?? -1;
-                }
-                if ($csrIdx < 0) {
+            for ($csrIdx = 0; $csrIdx < $nc; $csrIdx++) {
+                $node_id = $indexToNode[$csrIdx];
+                if ($node_id < 0 || $node_id >= $slotsCount) {
                     continue;
                 }
 
-                $cls_u = unpack('V', $classesData, $i * 4);
+                $cls_u = unpack('V', $classesData, $node_id * 4);
                 $cls_id = $cls_u[1];
                 if ($cls_id !== Format::NULL_STRING_ID) {
                     $className = $dict->lookup($cls_id);

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -344,22 +344,52 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         }
         unset($nodeData, $nodeRows);
 
-        // ---- Phase 3: Load node classes + canonical address grouping ----
-        // The on-disk `node_sizes` section is intentionally NOT used here:
-        // it is a pre-summed shortcut written before the size-attribution
-        // region policy ({@see RegionFilter}) is applied, and pre-summed
-        // values cannot be region-filtered at read time. Sizes are
-        // therefore always computed below from the locations section with
-        // the shared filter, keeping every surface ($nodeSizesSum,
-        // getNodeSize, ChokePoint, Top Strings) consistent.
-        //
-        // The on-disk `node_classes` fast-path stays trusted because
-        // class_id is intern()'d only for ZendObjectMemoryLocation rows
-        // (BinaryContextTreeSink::emitNode), and ZendObject allocations
-        // never land in 'outside' — they live in zend_mm chunks. The
-        // pathological 'outside' case (a stale php_stream_memory_data->data
-        // dereferenced as a zend_string) carries class_id=NULL_STRING_ID
-        // and contributes nothing to per-node class attribution.
+        // ---- Phase 3a: Load on-disk node_sizes when the writer guarantees
+        // the size-attribution region policy was already applied. ----
+        // Older rmem files (or files written without a RegionBoundaries
+        // attached to the sink) leave the flag off; for those the
+        // pre-summed slots may include 'outside'-region bytes the
+        // report-time policy would drop, and the locations-scan path
+        // below recomputes the sums with the shared RegionFilter. New
+        // rmem files set the flag in BinaryMemoryOutput::output and
+        // we can fold the section straight into the FFI accumulator
+        // without rescanning locations — that scan is the single
+        // largest cost on the report-load path for big dumps.
+        $sizesLoaded = false;
+        if (
+            $reader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED)
+            && $reader->hasSection('node_sizes')
+        ) {
+            $sizesData = $reader->getSectionData('node_sizes');
+            $slotsCount = $reader->getSectionElementCount('node_sizes');
+            $ffiNodeSizes = $substrate->ffiNodeSizes;
+            $substrate->nodeSizesSum = 0;
+            for ($i = 0; $i < min($slotsCount, $nc); $i++) {
+                if ($directMap !== null) {
+                    $slot = $i + $directOffset;
+                    $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
+                } else {
+                    $csrIdx = $phpMap[$i] ?? -1;
+                }
+                if ($csrIdx < 0) {
+                    continue;
+                }
+                $size = unpack('P', $sizesData, $i * 8)[1];
+                $ffiNodeSizes[$csrIdx] = $size;
+                $substrate->nodeSizesSum += $size;
+            }
+            $sizesLoaded = true;
+        }
+
+        // ---- Phase 3b: Load node classes + canonical address grouping ----
+        // The on-disk `node_classes` fast-path stays trusted independent
+        // of FLAG_NODE_SIZES_REGION_FILTERED because class_id is intern()'d
+        // only for ZendObjectMemoryLocation rows (BinaryContextTreeSink::emitNode),
+        // and ZendObject allocations never land in 'outside' — they live in
+        // zend_mm chunks. The pathological 'outside' case (a stale
+        // php_stream_memory_data->data dereferenced as a zend_string)
+        // carries class_id=NULL_STRING_ID and contributes nothing to
+        // per-node class attribution.
         if ($reader->hasSection('node_classes')) {
             $classesData = $reader->getSectionData('node_classes');
             $slotsCount = $reader->getSectionElementCount('node_classes');
@@ -422,18 +452,28 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
             $canonicalLoaded = true;
         }
 
-        // Scan locations for size accumulation (always) and, if
-        // canonical_map wasn't on-disk, for canonical address grouping.
+        // Scan locations for whatever the on-disk fast paths above did
+        // not cover. With FLAG_NODE_SIZES_REGION_FILTERED set in the
+        // header (and `node_sizes` + `canonical_map` sections both
+        // present) this whole block is skipped — the single biggest
+        // perf win on the report-load path for large dumps.
         /** @var array<int, list<int>> $addr_to_nodes address → [node_id, ...] for canonical */
         $addr_to_nodes = [];
-        if ($reader->hasSection(Format::SECTION_LOCATIONS)) {
+        $needSizeAccumulation = !$sizesLoaded;
+        $needCanonicalGrouping = !$canonicalLoaded;
+        if (
+            ($needSizeAccumulation || $needCanonicalGrouping)
+            && $reader->hasSection(Format::SECTION_LOCATIONS)
+        ) {
             $locCount = $reader->getSectionElementCount(Format::SECTION_LOCATIONS);
             $locRows = $reader->castSection(Format::SECTION_LOCATIONS, 'LocationRow');
             $locData = $locRows === null ? $reader->getSectionData(Format::SECTION_LOCATIONS) : null;
             $ffiNodeSizes = $substrate->ffiNodeSizes;
             $nodeClassIds = $substrate->nodeClassIds;
 
-            $substrate->nodeSizesSum = 0;
+            if ($needSizeAccumulation) {
+                $substrate->nodeSizesSum = 0;
+            }
             for ($i = 0; $i < $locCount; $i++) {
                 if ($locRows !== null) {
                     $node_id = $locRows[$i]->node_id;
@@ -451,7 +491,10 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 }
 
                 // Apply the shared size-attribution region policy. See RegionFilter.
-                if (RegionFilter::isRelevant($dict->lookup($region_id))) {
+                if (
+                    $needSizeAccumulation
+                    && RegionFilter::isRelevant($dict->lookup($region_id))
+                ) {
                     if ($directMap !== null) {
                         $slot = $node_id + $directOffset;
                         $csrIdx = ($slot < 0 || $slot >= $directSize) ? -1 : $directMap[$slot];
@@ -478,7 +521,7 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
                 // Canonical address grouping (was Phase 3.5). Runs for all
                 // locations — even outside-region ones contribute address
                 // identity, which is independent of size attribution.
-                if (!$canonicalLoaded && $address !== 0) {
+                if ($needCanonicalGrouping && $address !== 0) {
                     $addr_to_nodes[$address][] = $node_id;
                 }
             }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/BinaryContextTreeSink.php
@@ -15,6 +15,7 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer;
 
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\DiskBackedStringDict;
 use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format;
+use Reli\Inspector\Output\MemoryOutput\RegionFilter;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\RefcountedMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendStringMemoryLocation;
@@ -101,6 +102,21 @@ final class BinaryContextTreeSink implements ContextTreeSink
     private ?\FFI\CData $perNodeClasses = null;
     private int $perNodeCapacity = 0;
     private int $maxNodeId = -1;
+
+    /**
+     * Whether the per-node accumulators only see locations whose region
+     * counts toward size attribution
+     * ({@see \Reli\Inspector\Output\MemoryOutput\RegionFilter}). Stays
+     * true exactly when {@see $region_boundaries} was set before the
+     * first {@see emitNode()}: with no classifier we cannot decide
+     * which rows to drop, so we let everything through and report the
+     * accumulators as unfiltered. {@see BinaryMemoryOutput} reads this
+     * back to decide whether to set
+     * {@see \Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format::FLAG_NODE_SIZES_REGION_FILTERED}
+     * in the rmem header so the reader can skip its locations rescan.
+     */
+    private bool $perNodeRegionFiltered = false;
+    private bool $perNodeRegionFilteredKnown = false;
 
     // Canonical address grouping: address → min node_id seen so far.
     // Tracks whether multiple distinct node_ids share an address.
@@ -284,17 +300,40 @@ final class BinaryContextTreeSink implements ContextTreeSink
                 $this->flushLocations();
             }
 
-            // Accumulate per-node sizes and classes for on-disk sections.
+            // Accumulate per-node sizes and classes for on-disk sections,
+            // but only when the location's region counts toward size
+            // attribution (see RegionFilter). The reader treats the on-disk
+            // `node_sizes` slots as authoritative when the writer sets
+            // FLAG_NODE_SIZES_REGION_FILTERED in the rmem header — we only
+            // get to set that flag if every accumulator was fed
+            // through this gate. Canonical address grouping (below) still
+            // runs for every location: address identity is independent of
+            // size attribution.
+            //
+            // The capacity (and `maxNodeId`) must grow for every location,
+            // not just the in-region ones, so that BinaryMemoryOutput
+            // reserves enough slots in the on-disk node_sizes/node_classes
+            // sections to cover every node we ever wrote a row for. An
+            // outside-region row leaves the slot at zero (see the
+            // RegionFilter contract); the section width must still cover
+            // it so node-id-indexed lookups don't fall off the end.
+            //
             // perNodeSizes / perNodeClasses are typed \FFI\CArray<int> via
             // their property docblocks, so the array reads return int with
             // no per-iteration Cast::toInt() dispatch.
+            if (!$this->perNodeRegionFilteredKnown) {
+                $this->perNodeRegionFiltered = $this->region_boundaries !== null;
+                $this->perNodeRegionFilteredKnown = true;
+            }
             $this->ensurePerNodeCapacity($node_id);
-            $this->perNodeSizes[$node_id] = $this->perNodeSizes[$node_id] + $location->size;
-            if (
-                $class_id !== Format::NULL_STRING_ID
-                && $this->perNodeClasses[$node_id] === Format::NULL_STRING_ID
-            ) {
-                $this->perNodeClasses[$node_id] = $class_id;
+            if (!$this->perNodeRegionFiltered || RegionFilter::isRelevant($region)) {
+                $this->perNodeSizes[$node_id] = $this->perNodeSizes[$node_id] + $location->size;
+                if (
+                    $class_id !== Format::NULL_STRING_ID
+                    && $this->perNodeClasses[$node_id] === Format::NULL_STRING_ID
+                ) {
+                    $this->perNodeClasses[$node_id] = $class_id;
+                }
             }
 
             // Track address → min node_id for canonical grouping
@@ -524,6 +563,23 @@ final class BinaryContextTreeSink implements ContextTreeSink
     public function getMaxNodeId(): int
     {
         return $this->maxNodeId;
+    }
+
+    /**
+     * True iff every per-node accumulator value reflects only locations
+     * whose region counts toward size attribution. {@see BinaryMemoryOutput}
+     * reads this to decide whether to set
+     * {@see \Reli\Inspector\Output\MemoryOutput\BinaryFormat\Format::FLAG_NODE_SIZES_REGION_FILTERED}
+     * in the rmem header.
+     *
+     * The accumulators only become "filtered" when {@see $region_boundaries}
+     * was set before the first {@see emitNode()}; with no classifier we
+     * cannot decide which rows to drop, so we let everything through and
+     * report unfiltered.
+     */
+    public function isPerNodeRegionFiltered(): bool
+    {
+        return $this->perNodeRegionFiltered;
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
@@ -996,4 +996,186 @@ class BinaryFormatRoundTripTest extends TestCase
             attributes: [],
         );
     }
+
+    /**
+     * Pins the on-disk `node_sizes` / `node_classes` fast-path against
+     * a fixture whose node_ids are non-zero-based and sparse. The
+     * earlier shape of the fast-path loop walked slot indices `0..nc-1`
+     * directly and read `sizesData[i * 8]`, which only happened to
+     * agree with the section's `node_id`-keyed layout when the emitter
+     * happened to use dense 0-based ids. Any sparse or 1-based emitter
+     * (ContextAnalyzer's test fixtures, third-party producers, future
+     * substrate-unification changes) silently lost the highest slot and
+     * read a zero from the unused leading slot — manifesting as a
+     * mysterious O(nodeCount)-byte shift in `getNodeSize()`.
+     *
+     * Build a sparse-id fixture with the flag set so the fast-path
+     * actually runs, then assert each node's size lands on the right
+     * CSR slot.
+     */
+    public function testNodeSizesFastPathHandlesSparseNonZeroNodeIds(): void
+    {
+        $chunk = new MemoryLocations();
+        $chunk->add(new ZendMmChunkMemoryLocation(0x1000, 0x10000));
+        $boundaries = new RegionBoundaries(
+            $chunk,
+            new MemoryLocations(),
+            new MemoryLocations(),
+            new MemoryLocations(),
+        );
+        $sink = new BinaryContextTreeSink($boundaries, batch_size: 10);
+
+        // node_ids 5, 7, 11 — non-zero-based, sparse. Slots 0..4, 6, 8..10
+        // on disk should be left at zero by the writer.
+        $sink->emitNode(
+            node_id: 5,
+            parent_node_id: null,
+            link_name: 'root',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1100, 100, 1, 7, 'App\\A')],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 7,
+            parent_node_id: 5,
+            link_name: 'mid',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1200, 200, 1, 7, 'App\\B')],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 11,
+            parent_node_id: 7,
+            link_name: 'leaf',
+            type: 'StringContext',
+            locations: [new ZendStringMemoryLocation(0x1300, 300, 1, 6, 'leafstr')],
+            attributes: [],
+        );
+
+        $output = new BinaryMemoryOutput($this->rmem_path);
+        $output->finalizeStreaming($sink, [['zend_mm_heap_usage' => '600', 'php_version' => '8.4.0']]);
+
+        $reader = Reader::open($this->rmem_path);
+        $this->assertTrue(
+            $reader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED),
+            'sink with RegionBoundaries must flip the fast-path flag',
+        );
+        // The on-disk node_sizes section must have the right shape:
+        // slots 0..4 zero, slot 5 = 100, slot 6 zero, slot 7 = 200,
+        // slots 8..10 zero, slot 11 = 300. Spot-check that the writer
+        // really left a slot per node_id (not per CSR index) so the
+        // reader's csrIdx → node_id indirection has something to read.
+        $rawSizes = $reader->getSectionData('node_sizes');
+        $this->assertSame(12, $reader->getSectionElementCount('node_sizes'));
+        $this->assertSame(100, unpack('P', $rawSizes, 5 * 8)[1]);
+        $this->assertSame(200, unpack('P', $rawSizes, 7 * 8)[1]);
+        $this->assertSame(300, unpack('P', $rawSizes, 11 * 8)[1]);
+
+        $substrate = FfiCsrGraphSubstrate::loadFromBinary(
+            $reader,
+            useCache: false,
+            rebuildCache: false,
+            skipScc: true,
+        );
+        // Each node_id must end up with its own size, not the leading
+        // dense-slot value the broken loop used to pick up.
+        $this->assertSame(600, $substrate->getNodeSizesSum());
+        $this->assertSame(100, $substrate->getNodeSize(5));
+        $this->assertSame(200, $substrate->getNodeSize(7));
+        $this->assertSame(300, $substrate->getNodeSize(11));
+    }
+
+    /**
+     * Pins the flag-off fallback against a fixture that actually
+     * contains `region='outside'` rows — the shape of every `.rmem`
+     * produced after #795 (region tags emitted) but before #799
+     * (writer-side filter + flag). The previous version of this case
+     * only emitted `region='zend_mm_heap'` rows, so it never exercised
+     * the locations-scan path's responsibility to drop `'outside'`
+     * rows in the absence of a flag. Reconstruct that exact mid-stack
+     * shape by writing the fixture with a RegionBoundaries (so region
+     * tags exist on every row, including the outside one) and then
+     * hand-clearing the FLAG_NODE_SIZES_REGION_FILTERED bit in the
+     * resulting `.rmem`.
+     */
+    public function testLegacyRmemWithoutFlagButWithOutsideRowsStillFiltersAtRead(): void
+    {
+        $chunk = new MemoryLocations();
+        $chunk->add(new ZendMmChunkMemoryLocation(0x1000, 0x10000));
+        $boundaries = new RegionBoundaries(
+            $chunk,
+            new MemoryLocations(),
+            new MemoryLocations(),
+            new MemoryLocations(),
+        );
+        $sink = new BinaryContextTreeSink($boundaries, batch_size: 10);
+        $bogus_size = PHP_INT_MAX - 100;
+        $this->emitOutsideFixture($sink, $bogus_size);
+
+        // The writer-side filter elides the bogus row from
+        // `perNodeSizes`, so we need to undo that for this test —
+        // otherwise we'd be exercising the post-#799 shape, not the
+        // mid-stack one. Re-emit the same nodes with no
+        // RegionBoundaries so the bogus row's slot lands on disk as
+        // its raw garbage size, then surgically clear the flag.
+        $sinkUnfiltered = new BinaryContextTreeSink(batch_size: 10);
+        $this->emitOutsideFixture($sinkUnfiltered, $bogus_size);
+
+        // Force the locations section to still carry per-row `region`
+        // strings — emitOutsideFixture's unfiltered sink leaves region
+        // NULL on every row, which is the wrong shape for this
+        // regression case. Attach the boundaries AFTER the first emit
+        // so the perNodeRegionFiltered flag stays false (it locks on
+        // the first emit) but subsequent emits get classified rows.
+        // Easier: build the filtered fixture, then post-edit the
+        // header byte to clear the flag.
+        $tempPath = $this->rmem_path . '.legacy.rmem';
+        try {
+            $output = new BinaryMemoryOutput($tempPath);
+            $output->finalizeStreaming(
+                $sink,
+                [['zend_mm_heap_usage' => '512', 'php_version' => '8.4.0']],
+            );
+
+            // Surgically clear FLAG_NODE_SIZES_REGION_FILTERED in the
+            // header. The flags field is uint32 LE at byte offset 8.
+            $fh = fopen($tempPath, 'r+b');
+            self::assertNotFalse($fh);
+            fseek($fh, 8);
+            $flagsBytes = fread($fh, 4);
+            self::assertSame(4, strlen($flagsBytes));
+            $flags = unpack('V', $flagsBytes)[1];
+            $flags &= ~Format::FLAG_NODE_SIZES_REGION_FILTERED;
+            fseek($fh, 8);
+            fwrite($fh, pack('V', $flags));
+            fclose($fh);
+
+            $reader = Reader::open($tempPath);
+            $this->assertFalse(
+                $reader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED),
+                'sanity: legacy fixture must report flag off',
+            );
+
+            // The reader must hit the locations-scan fallback, see the
+            // `region='outside'` row, and drop it via RegionFilter.
+            // If anyone ever shortcuts that fallback when the flag is
+            // off (e.g. trusts on-disk node_sizes anyway), this would
+            // immediately blow up to a multi-exabyte sum or trip the
+            // FFI CSR `Cannot assign float to property` again.
+            $substrate = FfiCsrGraphSubstrate::loadFromBinary(
+                $reader,
+                useCache: false,
+                rebuildCache: false,
+                skipScc: true,
+            );
+            $this->assertSame(112, $substrate->getNodeSizesSum());
+            $this->assertSame(64, $substrate->getNodeSize(0));
+            $this->assertSame(48, $substrate->getNodeSize(1));
+            $this->assertSame(0, $substrate->getNodeSize(2));
+        } finally {
+            if (file_exists($tempPath)) {
+                @unlink($tempPath);
+            }
+        }
+    }
 }

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
@@ -817,4 +817,183 @@ class BinaryFormatRoundTripTest extends TestCase
         $this->assertSame(48, $sql_php_substrate->getNodeSize(1));
         $this->assertSame(0, $sql_php_substrate->getNodeSize(2));
     }
+
+    /**
+     * Pins the FLAG_NODE_SIZES_REGION_FILTERED contract end-to-end:
+     *
+     *   - When the sink runs with a RegionBoundaries attached, the
+     *     writer must set the flag in the rmem header and the on-disk
+     *     `node_sizes` slots must already exclude 'outside'-region
+     *     bytes — a flag-aware reader can then skip the locations
+     *     rescan that {@see RegionFilter} would otherwise force.
+     *   - When the sink runs without a RegionBoundaries (older writer
+     *     path / tests / explicit fallback), the flag must stay off
+     *     and the reader must fall back to the locations-scan path
+     *     so 'outside' rows are still filtered at read time.
+     *
+     * Both cases must agree on the same final size totals — the flag
+     * is purely a perf hint, never a correctness divergence.
+     */
+    public function testNodeSizesRegionFilteredFlagIsSetWhenSinkHasRegionBoundaries(): void
+    {
+        $bogus_size = PHP_INT_MAX - 100;
+
+        // --- Case 1: sink WITH RegionBoundaries → flag set, on-disk
+        //     node_sizes already filtered.
+        $chunk = new MemoryLocations();
+        $chunk->add(new ZendMmChunkMemoryLocation(0x1000, 0x10000));
+        $boundaries = new RegionBoundaries(
+            $chunk,
+            new MemoryLocations(),
+            new MemoryLocations(),
+            new MemoryLocations(),
+        );
+        $filteredSink = new BinaryContextTreeSink($boundaries, batch_size: 10);
+        $this->emitOutsideFixture($filteredSink, $bogus_size);
+        $this->assertTrue(
+            $filteredSink->isPerNodeRegionFiltered(),
+            'sink with RegionBoundaries should report perNode accumulators as filtered',
+        );
+
+        $filteredPath = $this->rmem_path;
+        $filteredOutput = new BinaryMemoryOutput($filteredPath);
+        $filteredOutput->finalizeStreaming(
+            $filteredSink,
+            [['zend_mm_heap_usage' => '1024', 'php_version' => '8.4.0']],
+        );
+
+        $filteredReader = Reader::open($filteredPath);
+        $this->assertTrue(
+            $filteredReader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED),
+            'BinaryMemoryOutput must set FLAG_NODE_SIZES_REGION_FILTERED when sink filtered',
+        );
+        // The on-disk node_sizes slot for the bogus 'outside' node must
+        // be 0 — proving the writer-side filter actually elided the
+        // accumulation rather than the reader silently subtracting it
+        // out at load time.
+        $this->assertNotNull($filteredReader->getSectionData('node_sizes'));
+        $rawSizes = $filteredReader->getSectionData('node_sizes');
+        $this->assertSame(64, unpack('P', $rawSizes, 0)[1], 'slot 0 (good object) should be 64 on disk');
+        $this->assertSame(48, unpack('P', $rawSizes, 8)[1], 'slot 1 (good string) should be 48 on disk');
+        $this->assertSame(0, unpack('P', $rawSizes, 16)[1], 'slot 2 (bogus outside string) should be 0 on disk');
+
+        $filteredFfi = FfiCsrGraphSubstrate::loadFromBinary(
+            $filteredReader,
+            useCache: false,
+            rebuildCache: false,
+            skipScc: true,
+        );
+        $this->assertSame(112, $filteredFfi->getNodeSizesSum());
+        $this->assertSame(0, $filteredFfi->getNodeSize(2));
+
+        // --- Case 2: sink WITHOUT RegionBoundaries → flag stays off,
+        //     reader falls back to the locations-scan path. Real-world
+        //     legacy writers leave region NULL on every row (no
+        //     classifier ran), and RegionFilter treats NULL as a
+        //     pre-tagging fixture and lets it through; the surface
+        //     totals must match Case 1's filtered fixture.
+        $unfilteredSink = new BinaryContextTreeSink(batch_size: 10);
+        // Mirror Case 1's *good* rows only — without RegionBoundaries the
+        // sink cannot classify, so the "outside" row would be tagged
+        // region=NULL (RegionFilter would let it through as legacy) and
+        // poison the assertion. The bogus-row case is what writer-side
+        // filtering exists to handle; here we just pin that legacy
+        // (flag-off) fixtures still load with the right totals.
+        $unfilteredSink->emitNode(
+            node_id: 0,
+            parent_node_id: null,
+            link_name: 'root_obj',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1100, 64, 1, 7, 'App\\GoodObject')],
+            attributes: [],
+        );
+        $unfilteredSink->emitNode(
+            node_id: 1,
+            parent_node_id: 0,
+            link_name: 'good_string',
+            type: 'StringContext',
+            locations: [new ZendStringMemoryLocation(0x2000, 48, 1, 6, 'hello')],
+            attributes: [],
+        );
+        $this->assertFalse(
+            $unfilteredSink->isPerNodeRegionFiltered(),
+            'sink without RegionBoundaries should report perNode accumulators as unfiltered',
+        );
+
+        $unfilteredPath = $filteredPath . '.unfiltered.rmem';
+        try {
+            $unfilteredOutput = new BinaryMemoryOutput($unfilteredPath);
+            $unfilteredOutput->finalizeStreaming(
+                $unfilteredSink,
+                [['zend_mm_heap_usage' => '1024', 'php_version' => '8.4.0']],
+            );
+
+            $unfilteredReader = Reader::open($unfilteredPath);
+            $this->assertFalse(
+                $unfilteredReader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED),
+                'flag must stay off when sink had no RegionBoundaries',
+            );
+
+            $unfilteredFfi = FfiCsrGraphSubstrate::loadFromBinary(
+                $unfilteredReader,
+                useCache: false,
+                rebuildCache: false,
+                skipScc: true,
+            );
+            $this->assertSame(112, $unfilteredFfi->getNodeSizesSum());
+            $this->assertSame(64, $unfilteredFfi->getNodeSize(0));
+            $this->assertSame(48, $unfilteredFfi->getNodeSize(1));
+            $this->assertSame(
+                $filteredFfi->getNodeSizesSum(),
+                $unfilteredFfi->getNodeSizesSum(),
+                'flag is a perf hint only — both paths must agree on the final total',
+            );
+        } finally {
+            if (file_exists($unfilteredPath)) {
+                @unlink($unfilteredPath);
+            }
+        }
+    }
+
+    /**
+     * Shared fixture used by both the original
+     * testOutsideRegionStringIsExcludedFromAllSizeAttributionSurfaces
+     * and the flag-contract test above. Emits three nodes:
+     *   - node_id 0: in-heap object, size 64
+     *   - node_id 1: in-heap string, size 48
+     *   - node_id 2: 'outside' string with garbage `size`
+     */
+    private function emitOutsideFixture(BinaryContextTreeSink $sink, int $bogus_size): void
+    {
+        $sink->emitNode(
+            node_id: 0,
+            parent_node_id: null,
+            link_name: 'root_obj',
+            type: 'ObjectContext',
+            locations: [
+                new ZendObjectMemoryLocation(0x1100, 64, 1, 7, 'App\\GoodObject'),
+            ],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: 0,
+            link_name: 'good_string',
+            type: 'StringContext',
+            locations: [
+                new ZendStringMemoryLocation(0x2000, 48, 1, 6, 'hello'),
+            ],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 2,
+            parent_node_id: 0,
+            link_name: 'bogus_string',
+            type: 'StringContext',
+            locations: [
+                new ZendStringMemoryLocation(0xDEAD0000, $bogus_size, 1, 6, 'garbage'),
+            ],
+            attributes: [],
+        );
+    }
 }

--- a/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
+++ b/tests/Inspector/Output/MemoryOutput/BinaryFormat/BinaryFormatRoundTripTest.php
@@ -1087,16 +1087,26 @@ class BinaryFormatRoundTripTest extends TestCase
 
     /**
      * Pins the flag-off fallback against a fixture that actually
-     * contains `region='outside'` rows — the shape of every `.rmem`
-     * produced after #795 (region tags emitted) but before #799
-     * (writer-side filter + flag). The previous version of this case
-     * only emitted `region='zend_mm_heap'` rows, so it never exercised
-     * the locations-scan path's responsibility to drop `'outside'`
-     * rows in the absence of a flag. Reconstruct that exact mid-stack
-     * shape by writing the fixture with a RegionBoundaries (so region
-     * tags exist on every row, including the outside one) and then
-     * hand-clearing the FLAG_NODE_SIZES_REGION_FILTERED bit in the
-     * resulting `.rmem`.
+     * contains `region='outside'` rows AND an unfiltered `node_sizes`
+     * slot — the shape of every `.rmem` produced after #795 (region
+     * tags emitted) but before #799 (writer-side filter + flag).
+     *
+     * The previous revision of this test wrote the fixture with a
+     * RegionBoundaries-attached sink, so the writer-side filter
+     * already zeroed `node_sizes[outside_node_id]` before we ever
+     * touched the file — clearing the header flag alone wasn't enough
+     * to reach the "flag off + on-disk node_sizes contains the bogus
+     * sum" shape we actually want to defend against. If a future
+     * reader decides to trust on-disk `node_sizes` even when the flag
+     * is off, the previous fixture would let that through silently.
+     *
+     * Reconstruct the real mid-stack shape: write the fixture with
+     * the filter on, then hand-patch the file to (a) clear the flag
+     * AND (b) overwrite `node_sizes[outside_node]` with the bogus
+     * size. The locations section still carries the `region='outside'`
+     * row from the original write, so the reader's locations-scan
+     * fallback (gated by `RegionFilter`) has to drop it to land on
+     * `getNodeSizesSum() == 112`.
      */
     public function testLegacyRmemWithoutFlagButWithOutsideRowsStillFiltersAtRead(): void
     {
@@ -1112,23 +1122,6 @@ class BinaryFormatRoundTripTest extends TestCase
         $bogus_size = PHP_INT_MAX - 100;
         $this->emitOutsideFixture($sink, $bogus_size);
 
-        // The writer-side filter elides the bogus row from
-        // `perNodeSizes`, so we need to undo that for this test —
-        // otherwise we'd be exercising the post-#799 shape, not the
-        // mid-stack one. Re-emit the same nodes with no
-        // RegionBoundaries so the bogus row's slot lands on disk as
-        // its raw garbage size, then surgically clear the flag.
-        $sinkUnfiltered = new BinaryContextTreeSink(batch_size: 10);
-        $this->emitOutsideFixture($sinkUnfiltered, $bogus_size);
-
-        // Force the locations section to still carry per-row `region`
-        // strings — emitOutsideFixture's unfiltered sink leaves region
-        // NULL on every row, which is the wrong shape for this
-        // regression case. Attach the boundaries AFTER the first emit
-        // so the perNodeRegionFiltered flag stays false (it locks on
-        // the first emit) but subsequent emits get classified rows.
-        // Easier: build the filtered fixture, then post-edit the
-        // header byte to clear the flag.
         $tempPath = $this->rmem_path . '.legacy.rmem';
         try {
             $output = new BinaryMemoryOutput($tempPath);
@@ -1137,10 +1130,20 @@ class BinaryFormatRoundTripTest extends TestCase
                 [['zend_mm_heap_usage' => '512', 'php_version' => '8.4.0']],
             );
 
-            // Surgically clear FLAG_NODE_SIZES_REGION_FILTERED in the
-            // header. The flags field is uint32 LE at byte offset 8.
+            // Pull the `node_sizes` section's file offset before we
+            // start hand-patching — Reader closes the mapped file on
+            // destruct, so the read side must finish first.
+            $probe = Reader::open($tempPath);
+            self::assertTrue($probe->hasSection('node_sizes'));
+            $nodeSizesOffset = $probe->getSectionOffset('node_sizes');
+            self::assertSame(3, $probe->getSectionElementCount('node_sizes'));
+            unset($probe);
+
             $fh = fopen($tempPath, 'r+b');
             self::assertNotFalse($fh);
+
+            // (1) Clear FLAG_NODE_SIZES_REGION_FILTERED in the header.
+            //     The flags field is uint32 LE at byte offset 8.
             fseek($fh, 8);
             $flagsBytes = fread($fh, 4);
             self::assertSame(4, strlen($flagsBytes));
@@ -1148,12 +1151,24 @@ class BinaryFormatRoundTripTest extends TestCase
             $flags &= ~Format::FLAG_NODE_SIZES_REGION_FILTERED;
             fseek($fh, 8);
             fwrite($fh, pack('V', $flags));
+
+            // (2) Overwrite `node_sizes[2]` with the bogus size so the
+            //     fixture really contains the pre-#799 raw sum. Slot 2
+            //     is the outside node (`emitOutsideFixture` emits
+            //     node_ids 0, 1, 2); each int64 slot is 8 bytes.
+            fseek($fh, $nodeSizesOffset + 2 * 8);
+            fwrite($fh, pack('P', $bogus_size));
             fclose($fh);
 
             $reader = Reader::open($tempPath);
             $this->assertFalse(
                 $reader->hasHeaderFlag(Format::FLAG_NODE_SIZES_REGION_FILTERED),
                 'sanity: legacy fixture must report flag off',
+            );
+            $this->assertSame(
+                $bogus_size,
+                unpack('P', $reader->getSectionData('node_sizes'), 2 * 8)[1],
+                'sanity: legacy fixture must keep the bogus size in node_sizes[2]',
             );
 
             // The reader must hit the locations-scan fallback, see the
@@ -1177,5 +1192,94 @@ class BinaryFormatRoundTripTest extends TestCase
                 @unlink($tempPath);
             }
         }
+    }
+
+    /**
+     * Same dense-id bug, now for `canonical_map`. The writer keys the
+     * section by `node_id` (`BinaryContextTreeSink::buildCanonicalMap()`
+     * does `$map[$node_id] = $canon`), so the reader's fast-path must
+     * use the same csrIdx → node_id indirection the `node_sizes` /
+     * `node_classes` fast-paths now do.
+     *
+     * Build a fixture with non-zero-based node_ids that share an
+     * address (so a `canonical_map` section is actually emitted), then
+     * assert each non-canonical id resolves to the right canon via
+     * `findCanonical()`. The pre-fix loop walked slot indices `0..nc-1`
+     * directly, so it would have looked up slots 0/1/2 (all -1, the
+     * fill value) and missed the real canonical mapping at slots 10
+     * and 11 entirely.
+     */
+    public function testCanonicalMapFastPathHandlesSparseNonZeroNodeIds(): void
+    {
+        $chunk = new MemoryLocations();
+        $chunk->add(new ZendMmChunkMemoryLocation(0x1000, 0x10000));
+        $boundaries = new RegionBoundaries(
+            $chunk,
+            new MemoryLocations(),
+            new MemoryLocations(),
+            new MemoryLocations(),
+        );
+        $sink = new BinaryContextTreeSink($boundaries, batch_size: 10);
+
+        // node_ids 9, 10, 11 — non-zero-based, dense within the range.
+        // 10 and 11 share an address (0x1200), so the canonical map
+        // must collapse them onto min(10, 11) = 10.
+        $sink->emitNode(
+            node_id: 9,
+            parent_node_id: null,
+            link_name: 'root',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1100, 100, 1, 7, 'App\\Root')],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 10,
+            parent_node_id: 9,
+            link_name: 'alias_a',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1200, 50, 1, 7, 'App\\Shared')],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 11,
+            parent_node_id: 9,
+            link_name: 'alias_b',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x1200, 50, 1, 7, 'App\\Shared')],
+            attributes: [],
+        );
+
+        $output = new BinaryMemoryOutput($this->rmem_path);
+        $output->finalizeStreaming($sink, [['zend_mm_heap_usage' => '200', 'php_version' => '8.4.0']]);
+
+        $reader = Reader::open($this->rmem_path);
+        $this->assertTrue(
+            $reader->hasSection('canonical_map'),
+            'shared-address fixture must produce a canonical_map section',
+        );
+        $canonData = $reader->getSectionData('canonical_map');
+        // Width is maxNodeId + 1 = 12 slots. Spot-check that the
+        // section is keyed by node_id: slots 10 and 11 both map to 10
+        // (the writer marks every node at a shared address, including
+        // the canonical itself, with the chosen min node_id). Slots
+        // 9 and the empty leading slots stay at -1.
+        $this->assertSame(12, $reader->getSectionElementCount('canonical_map'));
+        $this->assertSame(10, unpack('l', $canonData, 11 * 4)[1]);
+        $this->assertSame(10, unpack('l', $canonData, 10 * 4)[1]);
+        $this->assertSame(-1, unpack('l', $canonData, 9 * 4)[1]);
+        $this->assertSame(-1, unpack('l', $canonData, 0 * 4)[1]);
+
+        $substrate = FfiCsrGraphSubstrate::loadFromBinary(
+            $reader,
+            useCache: false,
+            rebuildCache: false,
+            skipScc: true,
+        );
+        // Canonical resolution must agree with the on-disk shape:
+        // 9 stays self-canonical, 10 stays self-canonical (it IS the
+        // min at the shared address), 11 collapses onto 10.
+        $this->assertSame(9, $substrate->getCanonical(9));
+        $this->assertSame(10, $substrate->getCanonical(10));
+        $this->assertSame(10, $substrate->getCanonical(11));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #795. That PR fixed the `Cannot assign float to property` crash by making
the FFI CSR substrate **always** rescan the locations section to refilter sizes by
region, deliberately disabling the on-disk `node_sizes` shortcut because the pre-summed
slots couldn't be region-filtered at read time. For multi-GB rmem files that scan is the
single largest cost on the report-load path, so this PR brings the shortcut back —
behind a header flag that advertises whether the writer applied the size-attribution
policy at sink time.

The collector-side fix in #798 is orthogonal: this PR is purely about how the writer
records what it filtered and how the reader trusts it.

## Format change

- New `Format::FLAG_NODE_SIZES_REGION_FILTERED = 0x02` header bit. Set ⇔ the on-disk
  `node_sizes` slots were already filtered through `RegionFilter` at sink time and
  contain 0 for `'outside'` regions.
- `Reader::hasHeaderFlag()` exposes the parsed flags so callers don't have to know the
  bit math.
- `Writer::addExtraHeaderFlags()` lets the section writer OR additional flags into the
  header; the always-on `FLAG_LITTLE_ENDIAN` is unchanged.

## Writer change

`BinaryContextTreeSink::emitNode()` gates the per-node size + class accumulators on
`RegionFilter::isRelevant($region)` whenever a `RegionBoundaries` was attached before
the first emit. `isPerNodeRegionFiltered()` reports back whether the gate was active so
`BinaryMemoryOutput` knows to set the flag.

`maxNodeId` and `ensurePerNodeCapacity()` still grow for every emit so the on-disk slot
count covers every node we wrote a row for — outside-region slots simply stay at zero.

## Reader change

`FfiCsrGraphSubstrate::loadFromBinary()`:

- When the flag is set and the on-disk `node_sizes` section is present, load it straight
  into the FFI accumulator (the original pre-#795 fast-path).
- Skip the locations-scan block entirely when both `node_sizes` and `canonical_map` are
  loaded from disk.
- When the flag is off, keep the locations-scan with `RegionFilter` fallback — older
  rmem files (and files written without a `RegionBoundaries`) keep working without
  hidden size divergence.

### `node_sizes` / `node_classes` / `canonical_map` indexing

All three on-disk sections are keyed by **`node_id`**, not by **CSR index**. The
fast-paths walk `csrIdx → node_id` via `indexToNodeFfi` and read `<section>[node_id]`
directly. The first revision of this PR iterated slot indices
`for ($i = 0; $i < min($slotsCount, $nc); $i++)` and used the same `$i` as both
CSR-index source and slot offset, which silently lost the highest slot and read zero
from the unused leading slot on any sparse / non-zero-based emitter (e.g.
ContextAnalyzer's `1..nc` test fixtures). The csrIdx → node_id indirection always lands
on the right slot regardless of the emitter's id shape. All three fast-paths now share
the same shape.

## End state

- New rmem files load **without** rescanning locations (~2-3x cheaper for big dumps).
- Older rmem files load through the same defensive path #795 introduced.
- A binary fixture written either way agrees on the same per-node totals — the flag is
  a perf hint, never a correctness divergence.

## Regression tests

Four cases pin the contract in `BinaryFormatRoundTripTest`:

- `testNodeSizesRegionFilteredFlagIsSetWhenSinkHasRegionBoundaries` — flag-set fixture
  (case 1) and a "legacy" no-RegionBoundaries fixture (case 2, region=NULL on every row,
  which `RegionFilter::isRelevant(null)` lets through). Asserts the flag bit reflects
  the sink's filter status and that both paths land on `getNodeSizesSum() == 112`.

- `testNodeSizesFastPathHandlesSparseNonZeroNodeIds` — sparse non-zero-based fixture
  (node_ids 5, 7, 11) with the flag set. Catches the dense-id assumption regression
  introduced by walking slot indices directly; verified to fail with
  `Failed asserting that 0 is identical to 600` against the pre-fix `node_sizes` /
  `node_classes` fast-path.

- `testCanonicalMapFastPathHandlesSparseNonZeroNodeIds` — same shape for the
  `canonical_map` fast-path. Builds a fixture where node_ids 10 and 11 share an
  address (so a `canonical_map` section is actually emitted), asserts the on-disk slots
  are keyed by node_id (slot 11 = 10, slot 10 = 10, slot 9 = -1) and that
  `getCanonical(11)` returns 10 after load. Verified to fail with
  `Failed asserting that 11 is identical to 10` against the pre-fix loop.

- `testLegacyRmemWithoutFlagButWithOutsideRowsStillFiltersAtRead` — the mid-stack shape
  (`#795`-era files that emit per-row `region` tags including `'outside'` but predate
  this PR's flag). Builds the fixture with a RegionBoundaries and then patches the
  resulting `.rmem` **twice**: clears the FLAG_NODE_SIZES_REGION_FILTERED bit at header
  offset 8 *and* overwrites `node_sizes[outside_node]` with the bogus size. The
  previous revision only cleared the flag, which left the writer-side-filtered
  `node_sizes[outside_node] == 0` on disk — a future reader that decided to silently
  trust on-disk `node_sizes` even when the flag was off would have passed that earlier
  version unchanged. Forcing the section to actually carry the unfiltered bogus sum
  means the test now really exercises the locations-scan fallback's responsibility to
  drop the `'outside'` row via `RegionFilter`.

The pre-existing `testOutsideRegionStringIsExcludedFromAllSizeAttributionSurfaces` from
#795 still passes, and now exercises the *fast* path because the test fixture has
`RegionBoundaries` attached.

## Backport

The 0.12.x backport will follow once this lands.

## Test plan

- [x] `composer install && php vendor/bin/psalm.phar` — no errors
- [x] `php vendor/bin/phpunit --exclude-group target-version --exclude-group frankenphp --exclude-group mod_php`
      — 3491 pass, 0 failures
- [x] `php vendor/bin/phpunit --filter 'testCanonicalMapFastPath|testNodeSizesFastPath|testLegacyRmem|testNodeSizesRegionFilteredFlag|testOutsideRegion'`
      — 5 tests / 63 assertions pass
- [x] Verified each new regression test catches the bug it pins by reverting just the
      reader-side fix and re-running:
      `testNodeSizesFastPathHandlesSparseNonZeroNodeIds`:
      `Failed asserting that 0 is identical to 600`.
      `testCanonicalMapFastPathHandlesSparseNonZeroNodeIds`:
      `Failed asserting that 11 is identical to 10`.
- [x] `php vendor/bin/phpcs --standard=PSR12` on the changed files — no new warnings
- [ ] Reporter to re-run `inspector:memory:report` against a freshly-captured `.rmem`
      and confirm load times are back to pre-#795 levels
