### PR TITLE
fix(memory-analyze): recover memory_limit call stack after vm_stack extension

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
@@ -135,7 +135,15 @@ final class ZendVmStack implements CDataDereferencable
         return $stack;
     }
 
-    public function materializeAsPointerArray(
+    /**
+     * Materialize the arbitrary byte range
+     * `[$base_address, $top_address)` of this arena's storage as a
+     * `PointerArray`. The caller is responsible for picking a range
+     * that actually lies inside the arena — this method does no
+     * cross-checking against `$this->top` / `$this->end` and only
+     * clamps negative sizes to zero.
+     */
+    public function materializeRangeAsPointerArray(
         Dereferencer $dereferencer,
         int $base_address,
         int $top_address,

--- a/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendVmStack.php
@@ -137,13 +137,14 @@ final class ZendVmStack implements CDataDereferencable
 
     public function materializeAsPointerArray(
         Dereferencer $dereferencer,
-        int $end_address,
+        int $base_address,
+        int $top_address,
     ): PointerArray {
-        assert($this->top !== null);
+        $size = max(0, $top_address - $base_address);
         $pointer = new Pointer(
             PointerArray::class,
-            $this->top->address,
-            $end_address - $this->top->address,
+            $base_address,
+            $size,
         );
         return $dereferencer->deref($pointer);
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -689,7 +689,15 @@ final class MemoryLocationsCollector
             } else {
                 $hwm = $struct_top;
             }
-            $materialized_vm_stack = $vm_stack->materializeAsPointerArray(
+            // Belt-and-braces: clamp to the arena's allocation
+            // boundary so a corrupted dump (or a state we haven't
+            // anticipated) can't ask us to materialize a multi-GB
+            // pointer array.
+            $arena_end = $vm_stack->end?->address;
+            if ($arena_end !== null) {
+                $hwm = min($hwm, $arena_end);
+            }
+            $materialized_vm_stack = $vm_stack->materializeRangeAsPointerArray(
                 $ctx->dereferencer,
                 $arena_base,
                 $hwm,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -23,6 +23,7 @@ use Reli\Lib\PhpInternals\Types\Zend\ZendCompilerGlobals;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecuteData;
 use Reli\Lib\PhpInternals\Types\Zend\ZendExecutorGlobals;
 use Reli\Lib\PhpInternals\Types\Zend\ZendMmChunk;
+use Reli\Lib\PhpInternals\Types\Zend\ZendVmStack;
 use Reli\Lib\PhpInternals\ZendTypeReader;
 use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult;
@@ -663,20 +664,35 @@ final class MemoryLocationsCollector
             return;
         }
 
+        $vm_stack_struct_size = $ctx->zend_type_reader->sizeOf(ZendVmStack::getCTypeName());
         $first_stack = true;
         foreach ($last_vm_stack->iterateStackChain($ctx->dereferencer) as $vm_stack) {
-            if ($first_stack) {
-                $first_stack = false;
-                $stack_end_address = $eg->vm_stack_top->address;
-            } else {
-                if (is_null($vm_stack->end)) {
+            // _zend_vm_stack::top is initialised to the arena base when the arena is
+            // created and is later bumped UP to the high-water mark when a new arena
+            // is allocated on top of this one (zend_vm_stack_extend saves the live
+            // EG(vm_stack_top) into the outgoing arena's struct->top). After the
+            // memory_limit fatal, EG(vm_stack_top) gets unwound back to the shutdown
+            // handler's frame, which can sit LOWER than struct->top in the same
+            // arena. Either of struct->top or EG(vm_stack_top) can be the higher one,
+            // so take the max and always scan from the arena's base.
+            $struct_top = $vm_stack->top?->address;
+            if (is_null($struct_top)) {
+                if (!$first_stack) {
                     break;
                 }
-                $stack_end_address = $vm_stack->end->address;
+                $struct_top = 0;
+            }
+            $arena_base = $vm_stack->pointer->address + $vm_stack_struct_size;
+            if ($first_stack) {
+                $first_stack = false;
+                $hwm = max($struct_top, $eg->vm_stack_top->address);
+            } else {
+                $hwm = $struct_top;
             }
             $materialized_vm_stack = $vm_stack->materializeAsPointerArray(
                 $ctx->dereferencer,
-                $stack_end_address
+                $arena_base,
+                $hwm,
             );
             foreach ($materialized_vm_stack->getReverseIteratorAsInt() as $key => $value) {
                 if ($value !== $op_array_address) {
@@ -695,10 +711,20 @@ final class MemoryLocationsCollector
                         $ctx->dereferencer,
                         $max_challenge_depth,
                     );
-                    if ($root_vm_stack->top->address !== $root_execute_data_candidate->getPointer()->address) {
+                    // A true chain root has prev_execute_data == NULL. getRootFrame()
+                    // may also return early when max_depth is reached, in which case
+                    // the returned frame still has a non-null prev — that's a false
+                    // candidate. Originally this was checked indirectly by comparing
+                    // the candidate root's address against root_vm_stack->top, but
+                    // _zend_vm_stack::top gets bumped to the high-water-mark when a
+                    // new arena is allocated above this one, so that comparison only
+                    // works for the unextended single-arena case.
+                    $reached_true_root = is_null($root_execute_data_candidate->prev_execute_data);
+                    $legacy_top_match = $root_vm_stack->top->address === $root_execute_data_candidate->getPointer()->address;
+                    if (!$reached_true_root && !$legacy_top_match) {
                         continue;
                     }
-                    Log::debug('root candidate frame found', ['frame_address' => $root_vm_stack->top->address]);
+                    Log::debug('root candidate frame found', ['frame_address' => $root_execute_data_candidate->getPointer()->address]);
 
                     // Emit call_frames_context as root node
                     $call_frames_context = new CallFramesContext();

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -1179,6 +1179,190 @@ class MemoryLocationsCollectorTest extends BaseTestCase
         }
     }
 
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testMemoryLimitViolationAcrossExtendedVmStack(string $php_version, string $docker_image_name)
+    {
+        // Regression test: when the VM stack has been extended (a new arena was
+        // allocated on top of an older one mid-execution), the older arena's
+        // _zend_vm_stack::top field is bumped from its initial value (= arena
+        // base) to the high-water mark at extension time. The historical scan
+        // logic assumed struct->top stayed at the base and computed the scan
+        // range as [struct->top, eg->vm_stack_top], which produced a negative
+        // size in this scenario and aborted the call-frame recovery. This test
+        // forces an extension by recursing deeply with light-weight frames
+        // before allocating until memory_limit fires, then verifies that the
+        // recovered chain still contains the recursive function frames.
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        // 6000-deep recursion is enough to spill out of the initial 256 KB
+        // vm_stack arena (each frame is ~112 B) and trigger at least one
+        // zend_vm_stack_extend before the heap OOM at the bottom of the stack.
+        $target_script =
+            <<<'CODE'
+            <?php
+            ini_set('memory_limit', '4M');
+            register_shutdown_function(function () {
+                $error = error_get_last();
+                if (is_null($error)) {
+                    return;
+                }
+                if (strpos($error['message'], 'Allowed memory size of') !== 0) {
+                    return;
+                }
+                fputs(STDOUT, json_encode($error) . "\n");
+                fgets(STDIN);
+            });
+            function deep($n) {
+                if ($n > 0) {
+                    deep($n - 1);
+                    return;
+                }
+                $arr = [];
+                while (true) {
+                    $arr[] = str_repeat('x', 1024);
+                }
+            }
+            deep(6000);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        $error_message = '';
+        $error_json = '';
+        while (($line = fgets($pipes[1])) !== false) {
+            if ($error_message === '' && str_starts_with($line, 'Fatal error: Allowed memory size of')) {
+                $error_message = $line;
+            } elseif ($error_message !== '' && str_starts_with($line, '{')) {
+                $error_json = $line;
+                break;
+            }
+        }
+        $this->assertStringStartsWith(
+            'Fatal error: Allowed memory size of',
+            $error_message
+        );
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+            new ProcExeReadlinkResolver(),
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
+        );
+        $error = json_decode($error_json, true);
+        $sink = new ArrayContextTreeSink();
+        $collected_memories = $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            new MemoryLimitErrorDetails(
+                $error['file'],
+                $error['line'],
+                -1, // unlimited challenge depth — chain is intentionally deep
+            ),
+            null,
+            $sink,
+        );
+        $this->assertGreaterThan(0, $collected_memories->memory_get_usage_size);
+        $contexts = $sink->getResult();
+        $call_frames = $contexts['memory_limit_call_frames']
+            ?? $contexts['call_frames']
+            ?? [];
+        $deep_frames = [];
+        foreach ($call_frames as $k => $v) {
+            if (is_array($v) && ($v['function_name'] ?? '') === 'deep') {
+                $deep_frames[] = $v;
+            }
+        }
+        // 6000 calls + the deepest frame inside while(true) is far more than
+        // anything the unextended-arena case could produce, so finding e.g.
+        // >=100 deep() frames confirms the chain walk survived the extension.
+        $this->assertGreaterThanOrEqual(
+            100,
+            count($deep_frames),
+            'Should recover many deep() frames across the extended vm_stack chain'
+        );
+    }
+
     public static function provideFromV71()
     {
         yield from TargetPhpVmProvider::from(ZendTypeReader::V71);


### PR DESCRIPTION
## What

`inspector:memory:analyze --memory-limit-error-file=… --memory-limit-error-line=…` (the call-stack recovery hack added in #384) fails on dumps captured against deeply-recursive workloads with

```
PHP Fatal error:  Uncaught FFI\ParserException: Negative array index at line 1
in src/Lib/FFI/FFIHelper.php on line 59
```

emitted from `ZendVmStack::materializeAsPointerArray()` → `FFI::new('char[$size]')` when `$size` is negative. When this path bails out, no `memory_limit_call_frames` context is emitted and the user loses the OOM-time call stack that was the whole point of feeding `--memory-limit-error-*`.

## Root cause

`collectRealCallStackOnMemoryLimitViolation` linearly scans each `_zend_vm_stack` arena in the chain for a slot that holds the user's `op_array` address, then walks `prev_execute_data` from the matching candidate to verify the chain reaches the root. The scan range was

- current arena: `[vm_stack->top, eg->vm_stack_top]`
- older arenas: `[vm_stack->top, vm_stack->end]`

on the implicit assumption that `_zend_vm_stack::top` stays at its initial value (= arena base, set by `zend_vm_stack_new_page`). That holds only while the request fits in the very first 256 KB vm_stack arena. As soon as `zend_vm_stack_extend` allocates a new arena on top of an older one it saves the live `EG(vm_stack_top)` into the outgoing arena's `top` field — `struct->top` becomes the high-water mark, not the base. After the `memory_limit` fatal, `EG(vm_stack_top)` is additionally unwound back toward the shutdown handler's frame, which can sit *lower* than `struct->top` in the same arena. `end - top` then goes negative and FFI rejects the `char[$size]` allocation.

The chain-root verification fails for the same reason: it compared `root_execute_data_candidate->getPointer()->address` against `root_vm_stack->top->address`, which only happened to match in the unextended-single-arena case (where `struct->top` was still pointing at the arena base where the first frame got placed).

The bug surfaces on real-world workloads — e.g. `wayfinder:generate` traversing a Mpdf-using controller via Surveyor's recursive type resolver pushes through several 256 KB arenas before OOMing inside `nikic/php-parser`'s lexer.

## Fix

1. `ZendVmStack::materializeAsPointerArray()` is replaced by `materializeRangeAsPointerArray()`. It takes an explicit `(base_address, top_address)` pair and clamps `size = max(0, top - base)`, so out-of-order inputs degrade to an empty scan rather than crashing. The rename also reflects that the caller now picks an arbitrary range — the old name implied the method used the stack's own `top` field as the implicit base.
2. `MemoryLocationsCollector::collectRealCallStackOnMemoryLimitViolation` computes the arena base as `vm_stack->pointer + sizeOf('struct _zend_vm_stack')` and uses `max(struct->top, eg->vm_stack_top)` for the current arena's scan upper bound (`struct->top` alone for older arenas). That covers both the live-frames region and the historical high-water region — either of which can hold the op_array slot we're after. The chosen upper bound is then clamped to `vm_stack->end` as a belt-and-braces safety net so a corrupted or unexpected state can't ask us to materialize a multi-GB pointer array.
3. The chain-root check is relaxed to `prev_execute_data === NULL`, which is the proper invariant of "we walked all the way back to the chain root". The historical `root_vm_stack->top == root_candidate->address` match is kept as an OR-fallback, so behaviour on the unextended-single-arena case is unchanged.

## Test

`testMemoryLimitViolationAcrossExtendedVmStack` forces an extension by recursing 6000 deep with light-weight frames before OOMing on the heap, then asserts the chain walk recovers many `deep()` frames. The test fails on `0.13.x` (0 frames recovered, the bug aborts collection) and passes after the fix.

The three pre-existing `testMemoryLimitViolation*` cases also pass after the fix — they happen to exercise only the unextended-single-arena path, which is why the bug went unnoticed until now.

```
$ RELI_TEST_PHP_TARGETS=v84 php vendor/bin/phpunit --filter 'testMemoryLimitViolation' --group target-version
Tests: 4, Assertions: 20
```

`psalm` clean on both modified source files.

## Context

Surfaced while dogfooding reli on https://github.com/laravel/wayfinder/issues/264 — `wayfinder:generate` OOMs inside `nikic/php-parser` because Surveyor's `Reflector::methodReturnType` recurses into vendored mPDF source (a 27,498-line single file) with no cross-file memoization. The recovered call stack from the fixed `--memory-limit-error-*` path is what makes that diagnosis actionable from a sidecar dump.

## Follow-ups in this branch

After initial review:

- The arena upper bound is now clamped to `vm_stack->end` (defensive cap so we never ask FFI for a multi-GB range when state is unexpected).
- `materializeAsPointerArray()` was renamed to `materializeRangeAsPointerArray()` with a docblock making the contract explicit — the caller picks an arbitrary range and is responsible for in-arena bounds; the method only clamps negative sizes.