### PR TITLE
feat(memory-report): surface recovered memory_limit call stack in Overview

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatter.php
@@ -117,7 +117,9 @@ final class TextReportFormatter implements ReportFormatterInterface
             foreach ($overview as $finding) {
                 if ($finding->kind === 'call_stack' && $finding->hypothesis !== '') {
                     $lines[] = '';
-                    $lines[] = '  Call Stack at capture:';
+                    /** @var string $header */
+                    $header = $finding->facts['header'] ?? 'Call Stack at capture:';
+                    $lines[] = '  ' . $header;
                     foreach (explode("\n", $finding->hypothesis) as $frame) {
                         $lines[] = '    ' . $frame;
                     }

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -32,9 +32,34 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
  * the at-capture stack is just the shutdown handler that woke reli,
  * so we surface the recovered stack as the primary one and tuck the
  * at-capture one underneath.
+ *
+ * The root link names `call_frames` and `memory_limit_call_frames`
+ * are the API contract between the collector and this pass. They
+ * are emitted on the collector side by
+ * `Collector\Job\EmitCallFramesJob` (`call_frames`) and
+ * `MemoryLocationsCollector::collectRealCallStackOnMemoryLimitViolation`
+ * (`memory_limit_call_frames`). Renaming either side requires
+ * renaming both.
  */
 final class CallStackPass implements PassInterface
 {
+    /**
+     * `facts['stack_kind']` discriminator carried on every
+     * `call_stack` Finding this pass emits. Lets JSON / TUI
+     * consumers branch on the semantic kind without grepping the
+     * presentation `header` text.
+     */
+    public const STACK_KIND_MEMORY_LIMIT = 'memory_limit';
+    public const STACK_KIND_CAPTURE = 'capture';
+    public const STACK_KIND_CAPTURE_SHUTDOWN = 'capture_shutdown';
+
+    private const ROOT_NAME_MEMORY_LIMIT = 'memory_limit_call_frames';
+    private const ROOT_NAME_CAPTURE = 'call_frames';
+
+    private const HEADER_MEMORY_LIMIT = 'Call Stack at memory_limit:';
+    private const HEADER_CAPTURE_SHUTDOWN = 'Captured inside shutdown handler:';
+    private const HEADER_CAPTURE = 'Call Stack at capture:';
+
     /**
      * @param array<int, string>|null $frame_labels Pre-loaded frame labels (binary path)
      * @param array<int, string>|null $canonical_names Pre-loaded class/
@@ -62,9 +87,9 @@ final class CallStackPass implements PassInterface
                 continue;
             }
             $name = $this->substrate->getTreeLinkName($root_id);
-            if ($name === 'memory_limit_call_frames') {
+            if ($name === self::ROOT_NAME_MEMORY_LIMIT) {
                 $oom_root = $root_id;
-            } elseif ($name === 'call_frames') {
+            } elseif ($name === self::ROOT_NAME_CAPTURE) {
                 $capture_root = $root_id;
             }
         }
@@ -81,7 +106,8 @@ final class CallStackPass implements PassInterface
             $finding = $this->buildFinding(
                 $oom_root,
                 $labeler,
-                'Call Stack at memory_limit:',
+                self::HEADER_MEMORY_LIMIT,
+                self::STACK_KIND_MEMORY_LIMIT,
             );
             if ($finding !== null) {
                 $findings[] = $finding;
@@ -91,14 +117,19 @@ final class CallStackPass implements PassInterface
             // When the OOM-time stack is available, the at-capture
             // stack is just the shutdown handler that signalled the
             // sidecar. Keep it for diagnostic completeness but mark
-            // the header so the formatter can render it as a sub-block.
-            $header = $oom_root !== null
-                ? 'Captured inside shutdown handler:'
-                : 'Call Stack at capture:';
+            // it so the formatter can render it as a sub-block.
+            if ($oom_root !== null) {
+                $header = self::HEADER_CAPTURE_SHUTDOWN;
+                $stack_kind = self::STACK_KIND_CAPTURE_SHUTDOWN;
+            } else {
+                $header = self::HEADER_CAPTURE;
+                $stack_kind = self::STACK_KIND_CAPTURE;
+            }
             $finding = $this->buildFinding(
                 $capture_root,
                 $labeler,
                 $header,
+                $stack_kind,
             );
             if ($finding !== null) {
                 $findings[] = $finding;
@@ -112,6 +143,7 @@ final class CallStackPass implements PassInterface
         int $root_id,
         NodeLabeler $labeler,
         string $header,
+        string $stack_kind,
     ): ?Finding {
         $framesByNo = [];
         foreach ($this->substrate->getChildren($root_id) as $child_id) {
@@ -150,6 +182,7 @@ final class CallStackPass implements PassInterface
             facts: [
                 'frames' => $frames,
                 'depth' => count($frames),
+                'stack_kind' => $stack_kind,
                 'header' => $header,
             ],
             hypothesis: implode("\n", $lines),

--- a/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/CallStackPass.php
@@ -20,7 +20,18 @@ use Reli\Inspector\Output\MemoryOutput\Report\Substrate\GraphSubstrate;
 use Reli\Inspector\Output\MemoryOutput\Report\Substrate\NodeLabeler;
 
 /**
- * Shows the call stack at the time of snapshot capture.
+ * Surfaces the call stack(s) in Overview.
+ *
+ * Most snapshots have a single `call_frames` root — the program's
+ * stack at the moment reli read EG(current_execute_data). When the
+ * snapshot was captured via the sidecar on `memory_limit` and the
+ * `--memory-limit-error-*` traceback hack succeeded, a second
+ * `memory_limit_call_frames` root is also present, carrying the real
+ * pre-fatal stack (recovered by linearly scanning the VM stack for
+ * the op_array referenced by the user's file:line). In that case
+ * the at-capture stack is just the shutdown handler that woke reli,
+ * so we surface the recovered stack as the primary one and tuck the
+ * at-capture one underneath.
  */
 final class CallStackPass implements PassInterface
 {
@@ -44,15 +55,18 @@ final class CallStackPass implements PassInterface
     #[\Override]
     public function analyze(): array
     {
-        $callFramesNodeId = null;
-        foreach ($this->substrate->iterateNodeSizes() as $node_id => $_) {
-            if ($this->substrate->getNodeType($node_id) === 'CallFramesContext') {
-                $callFramesNodeId = $node_id;
-                break;
+        $oom_root = null;
+        $capture_root = null;
+        foreach ($this->substrate->getRoots() as $root_id) {
+            if ($this->substrate->getNodeType($root_id) !== 'CallFramesContext') {
+                continue;
             }
-        }
-        if ($callFramesNodeId === null) {
-            return [];
+            $name = $this->substrate->getTreeLinkName($root_id);
+            if ($name === 'memory_limit_call_frames') {
+                $oom_root = $root_id;
+            } elseif ($name === 'call_frames') {
+                $capture_root = $root_id;
+            }
         }
 
         $labeler = new NodeLabeler(
@@ -61,8 +75,46 @@ final class CallStackPass implements PassInterface
             $this->frame_labels,
             $this->canonical_names,
         );
+
+        $findings = [];
+        if ($oom_root !== null) {
+            $finding = $this->buildFinding(
+                $oom_root,
+                $labeler,
+                'Call Stack at memory_limit:',
+            );
+            if ($finding !== null) {
+                $findings[] = $finding;
+            }
+        }
+        if ($capture_root !== null) {
+            // When the OOM-time stack is available, the at-capture
+            // stack is just the shutdown handler that signalled the
+            // sidecar. Keep it for diagnostic completeness but mark
+            // the header so the formatter can render it as a sub-block.
+            $header = $oom_root !== null
+                ? 'Captured inside shutdown handler:'
+                : 'Call Stack at capture:';
+            $finding = $this->buildFinding(
+                $capture_root,
+                $labeler,
+                $header,
+            );
+            if ($finding !== null) {
+                $findings[] = $finding;
+            }
+        }
+
+        return $findings;
+    }
+
+    private function buildFinding(
+        int $root_id,
+        NodeLabeler $labeler,
+        string $header,
+    ): ?Finding {
         $framesByNo = [];
-        foreach ($this->substrate->getChildren($callFramesNodeId) as $child_id) {
+        foreach ($this->substrate->getChildren($root_id) as $child_id) {
             $link_name = $this->substrate->getTreeLinkName($child_id) ?? '?';
             // Call Stack is the one rendering site that benefits from
             // the line-number suffix ("paused at line N of fn"); every
@@ -80,35 +132,27 @@ final class CallStackPass implements PassInterface
             $framesByNo[(int)$link_name] = $label;
         }
         if ($framesByNo === []) {
-            return [];
+            return null;
         }
         ksort($framesByNo);
-        return $this->buildFindings(array_values($framesByNo));
-    }
+        $frames = array_values($framesByNo);
 
-    /**
-     * @param  list<string> $frames frame labels in call order
-     * @return list<Finding>
-     */
-    private function buildFindings(array $frames): array
-    {
         $lines = [];
         foreach ($frames as $i => $frame) {
             $lines[] = "#{$i} {$frame}";
         }
 
-        return [
-            new Finding(
-                kind: 'call_stack',
-                severity: FindingSeverity::Info,
-                confidence: FindingConfidence::High,
-                summary: 'Call stack: ' . implode(' -> ', $frames),
-                facts: [
-                    'frames' => $frames,
-                    'depth' => count($frames),
-                ],
-                hypothesis: implode("\n", $lines),
-            ),
-        ];
+        return new Finding(
+            kind: 'call_stack',
+            severity: FindingSeverity::Info,
+            confidence: FindingConfidence::High,
+            summary: 'Call stack: ' . implode(' -> ', $frames),
+            facts: [
+                'frames' => $frames,
+                'depth' => count($frames),
+                'header' => $header,
+            ],
+            hypothesis: implode("\n", $lines),
+        );
     }
 }

--- a/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php
@@ -47,6 +47,103 @@ class TextReportFormatterTest extends BaseTestCase
         $this->assertStringContainsString('Heap: 42.00 MB (99.5% analyzed)', $output);
     }
 
+    /**
+     * Golden-ish: with both a `memory_limit` and a
+     * `capture_shutdown` call-stack Finding present (as
+     * `CallStackPass` emits when the `--memory-limit-error-*`
+     * traceback succeeded on a sidecar dump), the Overview should
+     * render the OOM-time stack first under
+     * "Call Stack at memory_limit:" and the shutdown-handler chain
+     * second under "Captured inside shutdown handler:".
+     */
+    public function testFormatShowsMemoryLimitAndCaptureShutdownStacksInOrder(): void
+    {
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'call_stack',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'Call stack: App\\Bottom::oom:99 -> <main>:3',
+                facts: [
+                    'frames' => ['App\\Bottom::oom:99', '<main>:3'],
+                    'depth' => 2,
+                    'stack_kind' => 'memory_limit',
+                    'header' => 'Call Stack at memory_limit:',
+                ],
+                hypothesis: "#0 App\\Bottom::oom:99\n#1 <main>:3",
+            ),
+            new Finding(
+                kind: 'call_stack',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'Call stack: Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114',
+                facts: [
+                    'frames' => ['Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114'],
+                    'depth' => 1,
+                    'stack_kind' => 'capture_shutdown',
+                    'header' => 'Captured inside shutdown handler:',
+                ],
+                hypothesis: '#0 Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114',
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        $this->assertStringContainsString('=== Overview ===', $output);
+        $this->assertStringContainsString('Call Stack at memory_limit:', $output);
+        $this->assertStringContainsString('    #0 App\\Bottom::oom:99', $output);
+        $this->assertStringContainsString('    #1 <main>:3', $output);
+        $this->assertStringContainsString('Captured inside shutdown handler:', $output);
+        $this->assertStringContainsString(
+            '    #0 Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114',
+            $output,
+        );
+
+        // Order: memory_limit block must precede the shutdown-handler
+        // sub-block so the formatter renders the recovered pre-fatal
+        // stack first.
+        $oom_pos = strpos($output, 'Call Stack at memory_limit:');
+        $capture_pos = strpos($output, 'Captured inside shutdown handler:');
+        $this->assertNotFalse($oom_pos);
+        $this->assertNotFalse($capture_pos);
+        $this->assertLessThan(
+            $capture_pos,
+            $oom_pos,
+            'memory_limit stack must render before the shutdown-handler sub-block',
+        );
+    }
+
+    /**
+     * Plain capture (no memory_limit traceback) still renders the
+     * historical "Call Stack at capture:" header — i.e. the default
+     * code path when no `facts['header']` is set or when the pass
+     * emits a `capture` stack_kind.
+     */
+    public function testFormatShowsCallStackAtCaptureForPlainCapture(): void
+    {
+        $result = new ReportResult([], [
+            new Finding(
+                kind: 'call_stack',
+                severity: FindingSeverity::Info,
+                confidence: FindingConfidence::High,
+                summary: 'Call stack: main:1',
+                facts: [
+                    'frames' => ['main:1'],
+                    'depth' => 1,
+                    'stack_kind' => 'capture',
+                    'header' => 'Call Stack at capture:',
+                ],
+                hypothesis: '#0 main:1',
+            ),
+        ]);
+        $formatter = new TextReportFormatter();
+        $output = $formatter->format($result);
+
+        $this->assertStringContainsString('Call Stack at capture:', $output);
+        $this->assertStringNotContainsString('Call Stack at memory_limit:', $output);
+        $this->assertStringNotContainsString('Captured inside shutdown handler:', $output);
+    }
+
     public function testFormatShowsActionableFindings(): void
     {
         $result = new ReportResult([], [

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
@@ -69,6 +69,10 @@ class CallStackPassTest extends BaseTestCase
             $finding->facts['frames'],
         );
         $this->assertSame('Call Stack at capture:', $finding->facts['header']);
+        $this->assertSame(
+            CallStackPass::STACK_KIND_CAPTURE,
+            $finding->facts['stack_kind'],
+        );
         $this->assertStringContainsString('main:1', $finding->summary);
     }
 
@@ -112,10 +116,18 @@ class CallStackPassTest extends BaseTestCase
         $this->assertCount(2, $findings, 'both call-stack findings should be emitted');
         $this->assertSame('Call Stack at memory_limit:', $findings[0]->facts['header']);
         $this->assertSame(
+            CallStackPass::STACK_KIND_MEMORY_LIMIT,
+            $findings[0]->facts['stack_kind'],
+        );
+        $this->assertSame(
             ['App\\Bottom::oom:99', 'App\\Middle::call:17', '<main>:3'],
             $findings[0]->facts['frames'],
         );
         $this->assertSame('Captured inside shutdown handler:', $findings[1]->facts['header']);
+        $this->assertSame(
+            CallStackPass::STACK_KIND_CAPTURE_SHUTDOWN,
+            $findings[1]->facts['stack_kind'],
+        );
         $this->assertSame(
             ['Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114'],
             $findings[1]->facts['frames'],
@@ -145,6 +157,10 @@ class CallStackPassTest extends BaseTestCase
 
         $this->assertCount(1, $findings);
         $this->assertSame('Call Stack at memory_limit:', $findings[0]->facts['header']);
+        $this->assertSame(
+            CallStackPass::STACK_KIND_MEMORY_LIMIT,
+            $findings[0]->facts['stack_kind'],
+        );
     }
 
     /**

--- a/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php
@@ -34,21 +34,25 @@ class CallStackPassTest extends BaseTestCase
     }
 
     /**
-     * Three call frames under a CallFramesContext: the substrate path
-     * should resolve each "frame_no" link to its function/lineno label
-     * via NodeLabeler and emit one call_stack finding with all three
-     * frames in order.
+     * Three call frames under a `call_frames` root: the substrate
+     * path should resolve each "frame_no" link to its function/lineno
+     * label via NodeLabeler and emit one call_stack finding with all
+     * three frames in order, carrying the default "Call Stack at
+     * capture:" header for the formatter.
      */
     public function testReportsCallStackFromSubstrate(): void
     {
         $db = $this->createDirectDb();
-        $this->seedCallStack(
+        $this->seedCallFramesRoot(
             $db,
-            [
+            root_node_id: 1,
+            link_name: 'call_frames',
+            frames: [
                 ['fn' => 'main', 'line' => '1'],
                 ['fn' => 'App\\Foo::bar', 'line' => '42'],
                 ['fn' => 'App\\Foo::baz', 'line' => '99'],
             ],
+            first_frame_id: 100,
         );
 
         $substrate = GraphSubstrate::loadFromDb($db, 1);
@@ -64,17 +68,91 @@ class CallStackPassTest extends BaseTestCase
             ['main:1', 'App\\Foo::bar:42', 'App\\Foo::baz:99'],
             $finding->facts['frames'],
         );
+        $this->assertSame('Call Stack at capture:', $finding->facts['header']);
         $this->assertStringContainsString('main:1', $finding->summary);
     }
 
     /**
-     * No CallFramesContext at all → empty result. Mirrors the early
-     * exit in analyzeWithSubstrate.
+     * When the memory_limit traceback succeeded, the graph has both
+     * a `memory_limit_call_frames` root (the recovered pre-fatal
+     * stack) and a `call_frames` root (the shutdown handler that
+     * woke the sidecar). The pass should emit both findings — OOM
+     * first as the primary "Call Stack at memory_limit:" block,
+     * then the at-capture one labelled as "Captured inside shutdown
+     * handler:" so the formatter renders it as a sub-block.
+     */
+    public function testSurfacesMemoryLimitStackAheadOfShutdownHandlerStack(): void
+    {
+        $db = $this->createDirectDb();
+        $this->seedCallFramesRoot(
+            $db,
+            root_node_id: 1,
+            link_name: 'memory_limit_call_frames',
+            frames: [
+                ['fn' => 'App\\Bottom::oom', 'line' => '99'],
+                ['fn' => 'App\\Middle::call', 'line' => '17'],
+                ['fn' => '<main>', 'line' => '3'],
+            ],
+            first_frame_id: 100,
+        );
+        $this->seedCallFramesRoot(
+            $db,
+            root_node_id: 2,
+            link_name: 'call_frames',
+            frames: [
+                ['fn' => 'Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}', 'line' => '114'],
+            ],
+            first_frame_id: 200,
+        );
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $pass = new CallStackPass($db, 1, $substrate);
+        $findings = $pass->analyze();
+
+        $this->assertCount(2, $findings, 'both call-stack findings should be emitted');
+        $this->assertSame('Call Stack at memory_limit:', $findings[0]->facts['header']);
+        $this->assertSame(
+            ['App\\Bottom::oom:99', 'App\\Middle::call:17', '<main>:3'],
+            $findings[0]->facts['frames'],
+        );
+        $this->assertSame('Captured inside shutdown handler:', $findings[1]->facts['header']);
+        $this->assertSame(
+            ['Reli\\Sidecar\\Client\\MemoryLimitHandler::{closure}:114'],
+            $findings[1]->facts['frames'],
+        );
+    }
+
+    /**
+     * When only `memory_limit_call_frames` is present (unusual but
+     * possible if the at-capture stack was never emitted), the pass
+     * should still surface it as the primary "Call Stack at
+     * memory_limit:" finding rather than falling back to nothing.
+     */
+    public function testSurfacesMemoryLimitStackWhenNoCaptureStack(): void
+    {
+        $db = $this->createDirectDb();
+        $this->seedCallFramesRoot(
+            $db,
+            root_node_id: 1,
+            link_name: 'memory_limit_call_frames',
+            frames: [['fn' => '<main>', 'line' => '1']],
+            first_frame_id: 100,
+        );
+
+        $substrate = GraphSubstrate::loadFromDb($db, 1);
+        $pass = new CallStackPass($db, 1, $substrate);
+        $findings = $pass->analyze();
+
+        $this->assertCount(1, $findings);
+        $this->assertSame('Call Stack at memory_limit:', $findings[0]->facts['header']);
+    }
+
+    /**
+     * No CallFramesContext at all → empty result.
      */
     public function testReturnsEmptyWhenNoCallFramesContext(): void
     {
         $db = $this->createDirectDb();
-        // Single object node, no call frames anywhere.
         $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
             (1, 1, 'RootContext'),
             (1, 2, 'ObjectContext')
@@ -96,34 +174,36 @@ class CallStackPassTest extends BaseTestCase
     }
 
     /**
-     * Insert a CallFramesContext with one CallFrameContext child per
-     * frame. Each child carries `function_name` (and optionally
-     * `lineno`) attributes — the same shape NodeLabeler / the SQL
-     * pass query expect.
+     * Insert a CallFramesContext root with one CallFrameContext
+     * child per frame. Each child carries `function_name` (and
+     * optionally `lineno`) attributes — the same shape NodeLabeler
+     * expects.
      *
      * @param list<array{fn:string, line?:string}> $frames
      */
-    private function seedCallStack(\PDO $db, array $frames): void
-    {
+    private function seedCallFramesRoot(
+        \PDO $db,
+        int $root_node_id,
+        string $link_name,
+        array $frames,
+        int $first_frame_id,
+    ): void {
         $db->exec("INSERT INTO context_nodes (run_id, node_id, type) VALUES
-            (1, 1, 'RootContext'),
-            (1, 2, 'CallFramesContext')
+            (1, {$root_node_id}, 'CallFramesContext')
         ");
         // CallFramesContext needs a location row so the substrate's
-        // node_sizes index includes it (the substrate path iterates
-        // node_sizes when scanning for the CallFramesContext node).
+        // node_sizes index includes it.
         $db->exec("INSERT INTO context_node_locations
             (run_id, node_id, address, size, location_type, class_name) VALUES
-            (1, 2, 1000, 0, 'ZendVmStackMemoryLocation', NULL)
+            (1, {$root_node_id}, {$root_node_id}000, 0, 'ZendVmStackMemoryLocation', NULL)
         ");
         $db->exec("INSERT INTO context_edges
             (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
-            (1, NULL, 1, 'call_frames_root', 1, 'strong'),
-            (1, 1, 2, 'call_frames', 1, 'strong')
+            (1, NULL, {$root_node_id}, '{$link_name}', 1, 'strong')
         ");
 
-        $next_id = 100;
-        $next_addr = 0x10000;
+        $next_id = $first_frame_id;
+        $next_addr = $first_frame_id * 0x100;
         foreach ($frames as $i => $frame) {
             $node_id = $next_id++;
             $addr = $next_addr++;
@@ -136,7 +216,7 @@ class CallStackPassTest extends BaseTestCase
             ");
             $db->exec("INSERT INTO context_edges
                 (run_id, parent_node_id, child_node_id, link_name, is_tree, strength) VALUES
-                (1, 2, {$node_id}, '{$i}', 1, 'strong')
+                (1, {$root_node_id}, {$node_id}, '{$i}', 1, 'strong')
             ");
 
             $fn = $frame['fn'];


### PR DESCRIPTION
## What

`inspector:memory:report`'s Overview now surfaces the recovered pre-fatal call stack as the primary `Call Stack at memory_limit:` block whenever the `--memory-limit-error-*` traceback succeeded, with the shutdown-handler chain shown underneath as a `Captured inside shutdown handler:` sub-block. Snapshots taken outside of a memory_limit context are unchanged — they keep showing `Call Stack at capture:`.

## Why

The Overview's `Call Stack at capture:` block is built from `EG(current_execute_data)` — what the PHP VM currently thinks the stack is. When the snapshot was triggered via the sidecar's `MemoryLimitHandler::register()`, that's just the bundled handler closure blocked on the request socket to reli — the messenger, not the program state we want.

The real pre-fatal stack is recovered separately by the `--memory-limit-error-*` op_array-scan-and-traceback hack (originally #384) and emitted into the context graph as a `memory_limit_call_frames` root. It already surfaces in Findings as a retainer-tree branch, but the Overview never picked it up because `CallStackPass` looked for *"the first `CallFramesContext` anywhere via `iterateNodeSizes`"* (which lands on the at-capture root), and `TextReportFormatter` hard-coded the `Call Stack at capture:` header. The result for sidecar+`memory_limit` was the boring messenger up top and the interesting recovered stack buried in Findings, with no visible link between them.

## Change

```diff
 === Overview ===
   Captured: 2026-…
   memory_get_usage(): … | … | memory_limit: … | …

-  Call Stack at capture:
-    #0 fgets:-1
-    #1 Reli\Sidecar\Client\SidecarClient::send:147
-    #2 Reli\Sidecar\Client\SidecarClient::requestDump:99
-    #3 Reli\Sidecar\Client\MemoryLimitHandler::{closure}…:114
+  Call Stack at memory_limit:
+    #0 deep_oom:7
+    #1 deep_oom:9
+    ...
+    #N <main>:13
+
+  Captured inside shutdown handler:
+    #0 fgets:-1
+    #1 Reli\Sidecar\Client\SidecarClient::send:147
+    #2 Reli\Sidecar\Client\SidecarClient::requestDump:99
+    #3 Reli\Sidecar\Client\MemoryLimitHandler::{closure}…:114
```

- `CallStackPass` now identifies `CallFramesContext` **roots** explicitly by link name (`memory_limit_call_frames` and `call_frames`) and emits findings in priority order — OOM-time first when present, at-capture second.
- Every `call_stack` Finding now carries a structured `facts['stack_kind']` discriminator (`memory_limit` / `capture` / `capture_shutdown`, exposed as `CallStackPass::STACK_KIND_*` constants) alongside the presentation `facts['header']`. JSON / TUI consumers can branch on the semantic kind without grepping the header text.
- `TextReportFormatter` reads the header from `facts['header']` instead of hard-coding it. Existing behaviour for non-memory-limit captures (`Call Stack at capture:`) is preserved as the default header.
- The two root link names (`memory_limit_call_frames` / `call_frames`) are documented in the `CallStackPass` class docblock as the contract between the collector (`EmitCallFramesJob` / `MemoryLocationsCollector::collectRealCallStackOnMemoryLimitViolation`) and this pass; renaming either side requires renaming both.

## Side effect

The previous `iterateNodeSizes`-based scan would also accept any non-root `CallFramesContext` — including the ones embedded under Generator / Fiber context trees — and could pick the wrong stack on snapshots that contained those. Looking at roots only resolves that as a side benefit.

## Historical note

Back in 0.9.x–0.11.x (pre-#556), the JSON output chained the recovered frames *underneath* the shutdown handler stack as one continuous chain, which made the relationship obvious to anyone reading the output. The structural split happened when the multi-pass `inspector:memory:report` engine landed in #556 (0.12.0) — the recovered stack became one generic graph root alongside everything else, and the Overview lost its old logical link to it. This PR restores that link at the rendering layer without giving up the per-pass graph architecture.

## Tests

`tests/Inspector/Output/MemoryOutput/Report/Pass/CallStackPassTest.php` — updated the existing capture-only case to assert both `facts['header']` and `facts['stack_kind']`, and added:

- `testSurfacesMemoryLimitStackAheadOfShutdownHandlerStack` — both roots seeded, asserts OOM-first ordering and the two distinct header / stack_kind values.
- `testSurfacesMemoryLimitStackWhenNoCaptureStack` — `memory_limit_call_frames` only, asserts the OOM stack is still surfaced with the `memory_limit` stack_kind rather than falling silent.

`tests/Inspector/Output/MemoryOutput/Report/Formatter/TextReportFormatterTest.php` — two new golden-ish formatter cases:

- `testFormatShowsMemoryLimitAndCaptureShutdownStacksInOrder` — feeds the two-Finding shape `CallStackPass` emits on a memory_limit sidecar dump through `TextReportFormatter` and asserts the `Call Stack at memory_limit:` block renders ahead of `Captured inside shutdown handler:` with the expected `#N` frame lines under each.
- `testFormatShowsCallStackAtCaptureForPlainCapture` — pins the plain-capture path so the historical `Call Stack at capture:` header isn't regressed by future header-routing changes.

Broader report-package test run (`tests/Inspector/Output/MemoryOutput/Report`) — 263 tests, 782 assertions, all pass. `psalm` clean on the touched files.

## Relation to #801

Independent of, but motivated by, #801 (`fix(memory-analyze): recover the memory_limit call stack after vm_stack extension`). Once #801 is in, the recovered stack actually exists for the kinds of real-world deep-recursion OOMs that hit `zend_vm_stack_extend` — so the presentation gap is worth closing on top.

## Follow-ups in this branch

After initial review:

- Lifted root-link names (`memory_limit_call_frames` / `call_frames`) and the three presentation headers into named constants on `CallStackPass`; the docblock now describes the collector contract explicitly.
- Added a structured `facts['stack_kind']` field (`STACK_KIND_MEMORY_LIMIT` / `STACK_KIND_CAPTURE` / `STACK_KIND_CAPTURE_SHUTDOWN`) so JSON consumers can read the semantic discriminator without grepping the presentation header.
- Added the two `TextReportFormatter` test cases above so the change is covered all the way through to the rendered text.