### PR TITLE
Filter zero-size scaffolding nodes from iterateNodeSizes()

### DIFF
--- a/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Pass/BlameAllocationPass.php
@@ -69,11 +69,10 @@ final class BlameAllocationPass implements PassInterface
         // Track which canonicals have been blamed to avoid double-counting
         $blamed_canonicals = [];
 
+        // `iterateNodeSizes()` is guaranteed to skip zero-size
+        // scaffolding nodes, so the previous `if ($size === 0)` guard
+        // is no longer needed here.
         foreach ($this->substrate->iterateNodeSizes() as $node => $size) {
-            if ($size === 0) {
-                continue;
-            }
-
             // Skip non-canonical duplicates to avoid double-counting
             $canon = $this->substrate->getCanonical($node);
             if (isset($blamed_canonicals[$canon])) {

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrate.php
@@ -1461,12 +1461,21 @@ final class FfiCsrGraphSubstrate extends GraphSubstrate
         return $this->nodeSizesSum;
     }
 
-    /** @return iterable<int, int> node_id => size */
+    /**
+     * See {@see GraphSubstrate::iterateNodeSizes()} for the contract —
+     * zero-size scaffolding slots are filtered here to match the
+     * PHP-array variant.
+     *
+     * @return iterable<int, int> node_id => size
+     */
     #[\Override]
     public function iterateNodeSizes(): iterable
     {
         for ($i = 0; $i < $this->nodeCount; $i++) {
-            yield $this->indexToNodeFfi[$i] => $this->ffiNodeSizes[$i];
+            $size = $this->ffiNodeSizes[$i];
+            if ($size > 0) {
+                yield $this->indexToNodeFfi[$i] => $size;
+            }
         }
     }
 

--- a/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
+++ b/src/Inspector/Output/MemoryOutput/Report/Substrate/GraphSubstrate.php
@@ -922,10 +922,38 @@ class GraphSubstrate
         return array_sum($this->node_sizes);
     }
 
-    /** @return iterable<int, int> node_id => size */
+    /**
+     * Yield (node_id, size) for every node that carries a non-zero
+     * attributed shallow size — i.e. an actual heap allocation. Skips
+     * scaffolding nodes the collector emits to anchor synthetic roots
+     * like `global_variables` / `interned_strings`: they exist in the
+     * graph (with children + edges + subtree size), but they aren't
+     * real allocations, so passes that ask "iterate the heap's nodes"
+     * shouldn't see them.
+     *
+     * On the PHP-array `.db` loader this filter is essentially a no-op
+     * because `loadNodeSizes` only queries `context_node_locations` —
+     * scaffolding nodes have no row there. The FFI variant enumerates
+     * from `context_nodes` first (it needs every CSR slot for graph
+     * walks), so its `ffiNodeSizes` does include zero-size scaffolding
+     * slots; filtering here keeps both substrate paths' output to
+     * `TopArraysPass` / `RmemModel::getTypeRanking` etc. byte-for-byte
+     * aligned instead of leaving the two paths to drift on whether
+     * `global_variables` shows up as a `large_array` with `table: 0 B`.
+     *
+     * Callers that need every CSR-known node (zero-size or not) should
+     * walk `getRoots()` + `getStrongChildren()` instead, which is the
+     * traversal the substrate is actually designed for.
+     *
+     * @return iterable<int, int> node_id => size
+     */
     public function iterateNodeSizes(): iterable
     {
-        return $this->node_sizes;
+        foreach ($this->node_sizes as $node_id => $size) {
+            if ($size > 0) {
+                yield $node_id => $size;
+            }
+        }
     }
 
     /** @return iterable<int, int> node_id => subtree_size */

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
@@ -63,6 +63,54 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
         $this->assertTrue($found128);
     }
 
+    public function testIterateNodeSizesSkipsZeroSizeScaffoldingForBothVariants(): void
+    {
+        // The `top` context has no locations — it's the collector's
+        // anchor for the synthetic root. Pre-fix, the PHP-array
+        // substrate's `loadNodeSizes` excluded it (no row in
+        // context_node_locations) while the FFI substrate's
+        // `loadNodeSizesFfi` enumerated `context_nodes` first and gave
+        // it a zero-size CSR slot. The drift surfaced as
+        // `TopArraysPass` emitting "global_variables 86 KB retained,
+        // table: 0 B" findings only on the FFI / .rmem path.
+        //
+        // After the fix both `iterateNodeSizes()` impls filter
+        // `size > 0`, so the two substrates yield the same set on the
+        // same input.
+        $leaf = $this->createMockContext('leaf', [], [
+            new ZendObjectMemoryLocation(0x2000, 128, 1, 7, 'App\\Leaf'),
+        ]);
+        // Intermediate scaffolding node with no locations — same shape
+        // as the real synthetic roots the collector emits for
+        // `global_variables` / `interned_strings`.
+        $scaffold = $this->createMockContext('scaffold', ['inner' => $leaf], []);
+        $top = $this->createMockContext('top', ['root' => $scaffold], []);
+        $this->buildDb($top);
+
+        $db = $this->openDb();
+        $phpArraySizes = iterator_to_array(
+            GraphSubstrate::loadFromDb($db, 1)->iterateNodeSizes(),
+        );
+        $ffiSizes = iterator_to_array(
+            FfiCsrGraphSubstrate::loadFromDb($db, 1)->iterateNodeSizes(),
+        );
+
+        ksort($phpArraySizes);
+        ksort($ffiSizes);
+        $this->assertSame(
+            $phpArraySizes,
+            $ffiSizes,
+            'iterateNodeSizes() must agree across substrate variants',
+        );
+        foreach ($ffiSizes as $node_id => $size) {
+            $this->assertGreaterThan(
+                0,
+                $size,
+                "node {$node_id} has size 0 — scaffolding leaked into iterateNodeSizes()",
+            );
+        }
+    }
+
     public function testSubtreeSizesComputed(): void
     {
         $child = $this->createMockContext('child', [], [

--- a/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
+++ b/tests/Inspector/Output/MemoryOutput/Report/Substrate/FfiCsrGraphSubstrateTest.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace Reli\Inspector\Output\MemoryOutput\Report\Substrate;
 
 use Reli\BaseTestCase;
+use Reli\Inspector\Output\MemoryOutput\BinaryFormat\Reader;
+use Reli\Inspector\Output\MemoryOutput\BinaryMemoryOutput;
 use Reli\Inspector\Output\MemoryOutput\MemoryAnalysisResult;
 use Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver;
 use Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\BinaryContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendObjectMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
@@ -25,6 +28,7 @@ use Reli\Lib\Process\MemoryLocation;
 class FfiCsrGraphSubstrateTest extends BaseTestCase
 {
     private string $db_path;
+    private string $rmem_path;
 
     protected function setUp(): void
     {
@@ -33,11 +37,13 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
             $this->markTestSkipped('FFI extension not available');
         }
         $this->db_path = tempnam(sys_get_temp_dir(), 'reli_ffi_csr_test_') . '.db';
+        $this->rmem_path = tempnam(sys_get_temp_dir(), 'reli_ffi_csr_test_') . '.rmem';
     }
 
     protected function tearDown(): void
     {
         @unlink($this->db_path);
+        @unlink($this->rmem_path);
         parent::tearDown();
     }
 
@@ -109,6 +115,65 @@ class FfiCsrGraphSubstrateTest extends BaseTestCase
                 "node {$node_id} has size 0 — scaffolding leaked into iterateNodeSizes()",
             );
         }
+    }
+
+    public function testIterateNodeSizesSkipsZeroSizeScaffoldingOnRmemPath(): void
+    {
+        // Companion to the loadFromDb test above: the bug originally
+        // surfaced on `.rmem` reports (the FFI substrate is the default
+        // for binary input), so cover that path end-to-end too — build
+        // a fixture via BinaryContextTreeSink + BinaryMemoryOutput, then
+        // load through `FfiCsrGraphSubstrate::loadFromBinary` and confirm
+        // the same zero-size-scaffolding filter applies.
+        $sink = new BinaryContextTreeSink(batch_size: 8);
+        // Synthetic-root-shape scaffolding: a parent context whose own
+        // `locations` array is empty (no context_node_locations row would
+        // exist on the .db side; the FFI binary loader allocates a CSR
+        // slot for it regardless because subsequent edges target it).
+        $sink->emitNode(
+            node_id: 1,
+            parent_node_id: null,
+            link_name: 'root',
+            type: 'RootContext',
+            locations: [],
+            attributes: [],
+        );
+        $sink->emitNode(
+            node_id: 2,
+            parent_node_id: 1,
+            link_name: 'scaffold',
+            type: 'ScaffoldContext',
+            locations: [],
+            attributes: [],
+        );
+        // Real allocation under the scaffolding — this is the only node
+        // that should appear in `iterateNodeSizes()`.
+        $sink->emitNode(
+            node_id: 3,
+            parent_node_id: 2,
+            link_name: 'leaf',
+            type: 'ObjectContext',
+            locations: [new ZendObjectMemoryLocation(0x2000, 128, 1, 7, 'App\\Leaf')],
+            attributes: [],
+        );
+        $binary_output = new BinaryMemoryOutput($this->rmem_path);
+        $binary_output->finalizeStreaming($sink, [
+            ['zend_mm_heap_usage' => '128'],
+        ]);
+
+        $reader = Reader::open($this->rmem_path);
+        $substrate = FfiCsrGraphSubstrate::loadFromBinary($reader);
+
+        $sizes = iterator_to_array($substrate->iterateNodeSizes());
+        foreach ($sizes as $node_id => $size) {
+            $this->assertGreaterThan(
+                0,
+                $size,
+                "node {$node_id} has size 0 — scaffolding leaked into iterateNodeSizes() on .rmem path",
+            );
+        }
+        // The only positive-size node is the leaf allocation.
+        $this->assertSame([3 => 128], $sizes);
     }
 
     public function testSubtreeSizesComputed(): void


### PR DESCRIPTION
## Summary

Fixes a substrate divergence where the FFI CSR graph substrate and PHP-array substrate were yielding different node sets from `iterateNodeSizes()`. The FFI variant was including zero-size scaffolding nodes (synthetic roots like `global_variables` and `interned_strings`) while the PHP-array variant excluded them, causing downstream passes like `TopArraysPass` to emit different findings on the two paths.

## Changes

- **GraphSubstrate.php**: Modified `iterateNodeSizes()` to filter out nodes with `size <= 0`, ensuring only actual heap allocations are yielded. Added comprehensive documentation explaining the contract and why scaffolding nodes must be excluded.

- **FfiCsrGraphSubstrate.php**: Updated `iterateNodeSizes()` to match the filtering behavior by checking `size > 0` before yielding, with a cross-reference to the base class documentation.

- **BlameAllocationPass.php**: Removed the now-redundant `if ($size === 0) continue;` guard since `iterateNodeSizes()` is now guaranteed to skip zero-size nodes.

- **FfiCsrGraphSubstrateTest.php**: Added `testIterateNodeSizesSkipsZeroSizeScaffoldingForBothVariants()` test that verifies both substrate variants produce identical output when processing a graph with scaffolding nodes, ensuring the two paths remain byte-for-byte aligned.

## Implementation Details

The fix recognizes that scaffolding nodes exist in the graph structure (with children, edges, and subtree sizes) but represent synthetic anchors rather than real allocations. Callers needing every CSR-known node should traverse via `getRoots()` + `getStrongChildren()` instead. This filtering is essentially a no-op for the PHP-array path (which only queries `context_node_locations` and never includes scaffolding rows) but necessary for the FFI path (which enumerates from `context_nodes` and must include every CSR slot for graph walks).

https://claude.ai/code/session_01BrofbBmPKSfzGrV2KsboJX