### PR TITLE
docs: add ext-rdump section to memory dump documentation

### DIFF
--- a/docs/memory/memory-dump.md
+++ b/docs/memory/memory-dump.md
@@ -99,6 +99,26 @@ php ./reli inspector:memory:analyze snapshot.rdump \
     -r /path/to/target/root
 ```
 
+## Capturing from inside the process (ext-rdump)
+
+`inspector:memory:dump` attaches from the *outside* via `ptrace` /
+`process_vm_readv`. The [ext-rdump](https://github.com/reliforp/ext-rdump)
+extension writes the same dump from *inside* the target, either with a single
+call or automatically when `memory_limit` is exceeded:
+
+```php
+<?php
+rdump_dump('/tmp/app.rdump');          // snapshot of the current process
+// rdump_dump('/tmp/app.rdump', true); // full: embed read-only segments too
+```
+
+```ini
+; php.ini: dump automatically when memory_limit is exceeded
+rdump.oom_dump=/tmp/oom-%p.rdump
+```
+
+Use it when `ptrace` is unavailable.
+
 ## Comparison with `gcore`
 
 | | `inspector:memory:dump` | `gcore` |


### PR DESCRIPTION
## Summary

Add documentation for the ext-rdump extension as an alternative method for capturing memory dumps from inside the target process, complementing the existing `inspector:memory:dump` command that uses ptrace.

## Changes

- Added new "Capturing from inside the process (ext-rdump)" section to `docs/memory/memory-dump.md`
- Documented the `rdump_dump()` function for manual snapshot capture
- Documented the `rdump.oom_dump` php.ini directive for automatic dumps on memory limit exceeded
- Included usage examples for both manual and automatic dump modes
- Added note about when to use ext-rdump (when ptrace is unavailable)

## Details

The new section explains that ext-rdump provides an alternative to the external ptrace-based approach by writing dumps from within the target process itself. This is useful in environments where ptrace is restricted or unavailable. The documentation includes practical examples showing both the programmatic API and the automatic OOM dump configuration.

https://claude.ai/code/session_01YEZT2YCmBzLyDL24ejjSTL