### PR TITLE
fix(memory-report): reach suspended generators/fibers, closures, foreach iterables

### DIFF
--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV70.php
@@ -21,4 +21,13 @@ final class PhpInternalsConstantsV70 extends VersionAwareConstants
     public const int ZEND_CALL_CODE = (1 << 24);
 
     public const int ZEND_CALL_TOP = (1 << 25);
+
+    // 7.0 packs call_info with ZEND_CALL_INFO_SHIFT 24: ZEND_CALL_CLOSURE
+    // (1 << 5) lands at bit 29. ZEND_CALL_HAS_SYMBOL_TABLE did not exist yet
+    // (added in 7.1) and named params are 8.0+, so both are pinned to 0.
+    public const int ZEND_CALL_CLOSURE = (1 << 29);
+
+    public const int ZEND_CALL_HAS_SYMBOL_TABLE = 0;
+
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = 0;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV71.php
@@ -17,4 +17,11 @@ final class PhpInternalsConstantsV71 extends VersionAwareConstants
 {
     public const int ZEND_ACC_CLOSURE = 0x100000;
     public const int ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
+
+    // 7.1-7.3: ZEND_CALL_INFO_SHIFT 16 with the pre-7.4 bit numbering, so
+    // ZEND_CALL_CLOSURE (1 << 5) lands at bit 21 (it moved to bit 22 in 7.4).
+    // HAS_SYMBOL_TABLE (bit 20) matches the base; named params are 8.0+.
+    public const int ZEND_CALL_CLOSURE = (1 << 21);
+
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = 0;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV72.php
@@ -17,4 +17,10 @@ final class PhpInternalsConstantsV72 extends VersionAwareConstants
 {
     public const int ZEND_ACC_CLOSURE = 0x100000;
     public const int ZEND_ACC_HAS_RETURN_TYPE = 0x40000000;
+
+    // 7.1-7.3: ZEND_CALL_CLOSURE (1 << 5) at bit 21 (moved to 22 in 7.4);
+    // HAS_SYMBOL_TABLE (bit 20) matches the base; named params are 8.0+.
+    public const int ZEND_CALL_CLOSURE = (1 << 21);
+
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = 0;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV73.php
@@ -17,4 +17,10 @@ final class PhpInternalsConstantsV73 extends VersionAwareConstants
 {
     public const int ZEND_ACC_CLOSURE = (1 << 20);
     public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 30);
+
+    // 7.1-7.3: ZEND_CALL_CLOSURE (1 << 5) at bit 21 (moved to 22 in 7.4);
+    // HAS_SYMBOL_TABLE (bit 20) matches the base; named params are 8.0+.
+    public const int ZEND_CALL_CLOSURE = (1 << 21);
+
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = 0;
 }

--- a/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
+++ b/src/Lib/PhpInternals/Constants/PhpInternalsConstantsV74.php
@@ -17,4 +17,9 @@ final class PhpInternalsConstantsV74 extends VersionAwareConstants
 {
     public const int ZEND_ACC_CLOSURE = (1 << 20);
     public const int ZEND_ACC_HAS_RETURN_TYPE = (1 << 13);
+
+    // 7.4 already uses the modern call_info numbering (ZEND_CALL_CLOSURE at
+    // bit 22, HAS_SYMBOL_TABLE at bit 20, both inherited), but named params
+    // are still 8.0+, so HAS_EXTRA_NAMED_PARAMS is pinned to 0.
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = 0;
 }

--- a/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
+++ b/src/Lib/PhpInternals/Constants/VersionAwareConstants.php
@@ -32,6 +32,29 @@ abstract class VersionAwareConstants
     /** @var int */
     public const int ZEND_CALL_GENERATOR = (1 << 24);
 
+    /*
+     * Effective (post-ZEND_CALL_INFO_SHIFT) call_info bits as stored in
+     * `execute_data->This.u1.type_info`. These are the PHP 7.4+ values; the
+     * high bits moved across versions (7.0 used ZEND_CALL_INFO_SHIFT 24, not
+     * 16, and the call_info bit numbers were renumbered at 7.4), so the
+     * 7.0-7.3 differences live in the per-version subclasses.
+     */
+
+    /** @var int */
+    public const int ZEND_CALL_HAS_SYMBOL_TABLE = (1 << 20);
+
+    /** @var int */
+    public const int ZEND_CALL_CLOSURE = (1 << 22);
+
+    /**
+     * Named arguments are a PHP 8.0 feature; the flag does not exist before
+     * 8.0, so every pre-8.0 subclass pins this to 0 (so `& flag` never
+     * matches a 7.x call_info bit that happens to share the position).
+     *
+     * @var int
+     */
+    public const int ZEND_CALL_HAS_EXTRA_NAMED_PARAMS = (1 << 27);
+
     /** @param value-of<ZendTypeReader::ALL_SUPPORTED_VERSIONS> $php_version */
     public static function getConstantsOfVersion(string $php_version): self
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -247,6 +247,16 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
     }
 
     /**
+     * Whether this frame is a closure invocation (ZEND_CALL_CLOSURE, set in
+     * This.u1.type_info). When set, the closure object is recoverable from
+     * the frame's `func` pointer even though no IS_OBJECT zval references it.
+     */
+    public function isClosureCall(): bool
+    {
+        return (bool)($this->This->u1->type_info & (1 << 22));
+    }
+
+    /**
      * Return the closure-object address backing this frame's func, or null if
      * the frame isn't a closure call. ZEND_CALL_CLOSURE (= 1 << 22) is set in
      * `This.u1.type_info` for closure invocations; the closure object pointer
@@ -262,8 +272,7 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         if ($this->func === null) {
             return null;
         }
-        $ZEND_CALL_CLOSURE = 1 << 22;
-        if (($this->This->u1->type_info & $ZEND_CALL_CLOSURE) === 0) {
+        if (!$this->isClosureCall()) {
             return null;
         }
         [$func_offset_in_closure, ] = $zend_type_reader->getOffsetAndSizeOfMember(

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -236,29 +236,42 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         ;
     }
 
-    public function hasSymbolTable(): bool
+    public function hasSymbolTable(ZendTypeReader $zend_type_reader): bool
     {
-        return (bool)($this->This->u1->type_info & (1 << 20));
+        return (bool)(
+            $this->This->u1->type_info
+            & (int)$zend_type_reader->constants::ZEND_CALL_HAS_SYMBOL_TABLE
+        );
     }
 
-    public function hasExtraNamedParams(): bool
+    public function hasExtraNamedParams(ZendTypeReader $zend_type_reader): bool
     {
-        return (bool)($this->This->u1->type_info & (1 << 27));
+        return (bool)(
+            $this->This->u1->type_info
+            & (int)$zend_type_reader->constants::ZEND_CALL_HAS_EXTRA_NAMED_PARAMS
+        );
     }
 
     /**
      * Whether this frame is a closure invocation (ZEND_CALL_CLOSURE, set in
      * This.u1.type_info). When set, the closure object is recoverable from
      * the frame's `func` pointer even though no IS_OBJECT zval references it.
+     *
+     * The bit position is version-dependent (effective bit 29 on 7.0, 21 on
+     * 7.1-7.3, 22 on 7.4+), so the value comes from VersionAwareConstants
+     * rather than a literal.
      */
-    public function isClosureCall(): bool
+    public function isClosureCall(ZendTypeReader $zend_type_reader): bool
     {
-        return (bool)($this->This->u1->type_info & (1 << 22));
+        return (bool)(
+            $this->This->u1->type_info
+            & (int)$zend_type_reader->constants::ZEND_CALL_CLOSURE
+        );
     }
 
     /**
      * Return the closure-object address backing this frame's func, or null if
-     * the frame isn't a closure call. ZEND_CALL_CLOSURE (= 1 << 22) is set in
+     * the frame isn't a closure call. ZEND_CALL_CLOSURE is set in
      * `This.u1.type_info` for closure invocations; the closure object pointer
      * can be recovered via the `ZEND_CLOSURE_OBJECT(func)` macro
      * (= `func - offsetof(zend_closure, func)`), which is how PHP itself keeps
@@ -272,7 +285,7 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         if ($this->func === null) {
             return null;
         }
-        if (!$this->isClosureCall()) {
+        if (!$this->isClosureCall($zend_type_reader)) {
             return null;
         }
         [$func_offset_in_closure, ] = $zend_type_reader->getOffsetAndSizeOfMember(

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -246,6 +246,37 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         return (bool)($this->This->u1->type_info & (1 << 27));
     }
 
+    /**
+     * Return the closure-object address backing this frame's func, or null if
+     * the frame isn't a closure call. ZEND_CALL_CLOSURE (= 1 << 22) is set in
+     * `This.u1.type_info` for closure invocations; the closure object pointer
+     * can be recovered via the `ZEND_CLOSURE_OBJECT(func)` macro
+     * (= `func - offsetof(zend_closure, func)`), which is how PHP itself keeps
+     * the closure alive across the call frame (and across Generator suspension
+     * — the captured frame retains its `ZEND_CALL_CLOSURE` flag, so the
+     * closure's refcount stays bumped without any IS_OBJECT zval reference
+     * being held).
+     */
+    public function getClosureObjectAddress(ZendTypeReader $zend_type_reader): ?int
+    {
+        if ($this->func === null) {
+            return null;
+        }
+        $ZEND_CALL_CLOSURE = 1 << 22;
+        if (($this->This->u1->type_info & $ZEND_CALL_CLOSURE) === 0) {
+            return null;
+        }
+        [$func_offset_in_closure, ] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_closure',
+            'func',
+        );
+        $closure_addr = $this->func->address - $func_offset_in_closure;
+        if ($closure_addr <= 0) {
+            return null;
+        }
+        return $closure_addr;
+    }
+
     public function isInternalCall(Dereferencer $dereferencer): bool
     {
         if (is_null($this->func)) {

--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -238,10 +238,16 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
 
     public function hasSymbolTable(ZendTypeReader $zend_type_reader): bool
     {
-        return (bool)(
-            $this->This->u1->type_info
-            & (int)$zend_type_reader->constants::ZEND_CALL_HAS_SYMBOL_TABLE
-        );
+        $flag = (int)$zend_type_reader->constants::ZEND_CALL_HAS_SYMBOL_TABLE;
+        if ($flag === 0) {
+            // Before 7.1 there was no ZEND_CALL_HAS_SYMBOL_TABLE flag; the
+            // engine treated a non-NULL `execute_data->symbol_table` as the
+            // indicator (the slot was not yet reused from EG(symtable_cache),
+            // which is exactly why the flag was added in 7.1). So on those
+            // versions fall back to the pointer itself.
+            return $this->symbol_table !== null;
+        }
+        return (bool)($this->This->u1->type_info & $flag);
     }
 
     public function hasExtraNamedParams(ZendTypeReader $zend_type_reader): bool

--- a/src/Lib/PhpInternals/Types/Zend/ZendGenerator.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendGenerator.php
@@ -131,14 +131,20 @@ class ZendGenerator implements PointedTypeResolverAware
         $out = [];
         for ($slot = 0; $slot < 4; $slot++) {
             $ptr_raw = $this->casted_cdata->raw;
-            $ptr = unpack(
+            $unpacked = unpack(
                 'Pv',
                 FFI::string(
                     $ptr_raw,
                     $node_offset + ($slot + 1) * 8,
                 ),
                 $node_offset + $slot * 8,
-            )['v'];
+            );
+            if ($unpacked === false) {
+                continue;
+            }
+            // unpack('P', …) yields an int; cast silences Psalm's Mixed
+            // without a per-element Cast::toInt dispatch in this small loop.
+            $ptr = (int)$unpacked['v'];
             if ($ptr !== 0) {
                 $out[] = $ptr;
             }

--- a/src/Lib/PhpInternals/Types/Zend/ZendGenerator.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendGenerator.php
@@ -95,6 +95,57 @@ class ZendGenerator implements PointedTypeResolverAware
         };
     }
 
+    /**
+     * Raw zend_generator* pointers stored inside the `node` field. PHP uses
+     * these to wire `yield from` chains together: `parent` points back up the
+     * chain, `child`/`leaf` point down to the currently-executing sub-generator,
+     * and the union at offsets 16/24 holds either `leaves.first`/`leaves.last`
+     * (both Generator*) or `children.ht` (HashTable*) depending on whether
+     * this node has multiple children. These references are NOT zval-shaped
+     * — the engine bumps refcount on the pointed-to generator directly — so
+     * an IS_OBJECT-zval-only scan misses them and any sub-generator only
+     * reached via this chain ends up looking orphan even when its parent
+     * generator is a walker-reachable Coroutine.
+     *
+     * @return list<int> non-zero pointer values (filtered)
+     */
+    public function getNodeRawGeneratorPointers(ZendTypeReader $zend_type_reader): array
+    {
+        [$node_offset, $node_size] = $zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_generator',
+            'node',
+        );
+        if ($node_size < 32) {
+            return [];
+        }
+        // The node struct (32 bytes) holds four 8-byte slots:
+        //   +0  parent       (zend_generator*)
+        //   +8  leaf/child   (zend_generator*)  -- union
+        //   +16 first/ht     (zend_generator* | HashTable*)
+        //   +24 last         (zend_generator*) (only when leaves variant)
+        // We can't tell from the on-disk struct which union arm is active,
+        // so we treat all four slots as candidate pointers and let the
+        // downstream emit job validate the target — non-generator addresses
+        // dispatch to a regular EmitObjectJob which fails-soft on bad
+        // pointers via the job runner's catch.
+        $out = [];
+        for ($slot = 0; $slot < 4; $slot++) {
+            $ptr_raw = $this->casted_cdata->raw;
+            $ptr = unpack(
+                'Pv',
+                FFI::string(
+                    $ptr_raw,
+                    $node_offset + ($slot + 1) * 8,
+                ),
+                $node_offset + $slot * 8,
+            )['v'];
+            if ($ptr !== 0) {
+                $out[] = $ptr;
+            }
+        }
+        return $out;
+    }
+
     #[\Override]
     public static function getCTypeName(): string
     {

--- a/src/Lib/PhpInternals/Types/Zend/ZendObjectsStore.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendObjectsStore.php
@@ -52,7 +52,17 @@ final class ZendObjectsStore
                 ? new Pointer(
                     PointerArray::class,
                     FFIHelper::castPointerToInt($this->cdata->casted->object_buckets),
-                    $this->cdata->casted->size * 8,
+                    // Cover only slots [0..top): slots [top..size) are
+                    // untouched (handle never assigned), so the dump's
+                    // pagemap-residency filter excludes those pages and a
+                    // full-capacity deref fails with
+                    // MemoryAddressNotInDumpException. The job runner then
+                    // silently swallows the exception, EmitObjectsStoreJob
+                    // never pushes the iterator, and every object that
+                    // is only reachable through the iter path (typical
+                    // leak shape: live in objects_store but unreachable
+                    // from globals/locals/etc.) becomes orphan.
+                    $this->cdata->casted->top * 8,
                 )
                 : null
             ,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -46,7 +46,10 @@ final class EmitCallFrameJob implements CollectorJob
         // Push jobs for child elements (reverse order for DFS)
 
         // Extra named params
-        if ($this->execute_data->hasExtraNamedParams() and !is_null($this->execute_data->extra_named_params)) {
+        if (
+            $this->execute_data->hasExtraNamedParams($ctx->zend_type_reader)
+            and !is_null($this->execute_data->extra_named_params)
+        ) {
             $queue->push(new EmitArrayJob(
                 $this->execute_data->extra_named_params,
                 $parent,
@@ -55,7 +58,10 @@ final class EmitCallFrameJob implements CollectorJob
         }
 
         // Symbol table
-        if ($this->execute_data->hasSymbolTable() and !is_null($this->execute_data->symbol_table)) {
+        if (
+            $this->execute_data->hasSymbolTable($ctx->zend_type_reader)
+            and !is_null($this->execute_data->symbol_table)
+        ) {
             $queue->push(new EmitArrayJob(
                 $this->execute_data->symbol_table,
                 $parent,
@@ -191,7 +197,10 @@ final class EmitCallFrameJob implements CollectorJob
         $parent = $frame_node_id >= 0 ? $frame_node_id : null;
 
         // Extra named params
-        if ($execute_data->hasExtraNamedParams() and !is_null($execute_data->extra_named_params)) {
+        if (
+            $execute_data->hasExtraNamedParams($ctx->zend_type_reader)
+            and !is_null($execute_data->extra_named_params)
+        ) {
             $queue->push(new EmitArrayJob(
                 $execute_data->extra_named_params,
                 $parent,
@@ -200,7 +209,10 @@ final class EmitCallFrameJob implements CollectorJob
         }
 
         // Symbol table
-        if ($execute_data->hasSymbolTable() and !is_null($execute_data->symbol_table)) {
+        if (
+            $execute_data->hasSymbolTable($ctx->zend_type_reader)
+            and !is_null($execute_data->symbol_table)
+        ) {
             $queue->push(new EmitArrayJob(
                 $execute_data->symbol_table,
                 $parent,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -125,9 +125,7 @@ final class EmitCallFrameJob implements CollectorJob
             }
         }
 
-        $call_frame_context = new CallFrameContext($function_name, $lineno, $filename);
-
-        // Track memory location
+        // Track memory location for the frame header + variable table area.
         try {
             $variable_table_pointer = $execute_data->getVariableTablePointer($ctx->dereferencer);
             $frame_end = $variable_table_pointer->address + $variable_table_pointer->size;
@@ -135,35 +133,94 @@ final class EmitCallFrameJob implements CollectorJob
         } catch (\Throwable) {
             $frame_size = $execute_data->getPointer()->size;
         }
-        $ctx->memory_locations->add(
-            new CallFrameHeaderMemoryLocation(
-                $execute_data->getPointer()->address,
-                $frame_size,
-            ),
+        $header_memory_location = new CallFrameHeaderMemoryLocation(
+            $execute_data->getPointer()->address,
+            $frame_size,
         );
+        $ctx->memory_locations->add($header_memory_location);
 
-        return $call_frame_context;
+        return new CallFrameContext(
+            $function_name,
+            $lineno,
+            $filename,
+            $header_memory_location,
+        );
     }
 
     /**
      * Collect a call frame inline (non-job, for use inside generators/fibers).
-     * This does NOT push child jobs - it collects everything synchronously.
-     * Used when the call frame is inside a generator/fiber context where
-     * the variable values need to be resolved inline (they're part of the
-     * generator/fiber's own allocation).
+     *
+     * Emits the call frame context immediately (so we have its node_id) and
+     * pushes the same child jobs that {@see self::execute()} would push for
+     * an active frame: extra_named_params, symbol_table, local variables, $this.
+     *
+     * This is what catches the locals of suspended Generator/Fiber frames —
+     * critical for Phpactor-style workloads where in-flight Amp Coroutines
+     * hold parser/reflection working-set memory (token arrays, etc.) in their
+     * frame locals, none of which is reachable through any other PHP root.
      */
     public static function collectCallFrameInline(
         ZendExecuteData $execute_data,
         CollectorContext $ctx,
+        JobQueue $queue,
+        ?int $parent_node_id,
+        string $link_name,
     ): CallFrameContext {
         $call_frame_context = self::collectCallFrameHeader($execute_data, $ctx);
 
-        // For inline collection (generators/fibers), we skip collecting
-        // $this, local variables, symbol_table, and extra_named_params
-        // because they would require recursive zval resolution.
-        // The original code did collect these, but the iterative design
-        // handles them through the job queue when the generator/fiber
-        // object's properties are processed.
+        $frame_node_id = $ctx->emitNode($call_frame_context, $parent_node_id, $link_name);
+        $parent = $frame_node_id >= 0 ? $frame_node_id : null;
+
+        // Extra named params
+        if ($execute_data->hasExtraNamedParams() and !is_null($execute_data->extra_named_params)) {
+            $queue->push(new EmitArrayJob(
+                $execute_data->extra_named_params,
+                $parent,
+                'extra_named_params',
+            ));
+        }
+
+        // Symbol table
+        if ($execute_data->hasSymbolTable() and !is_null($execute_data->symbol_table)) {
+            $queue->push(new EmitArrayJob(
+                $execute_data->symbol_table,
+                $parent,
+                'symbol_table',
+            ));
+        }
+
+        // Local variables — emit the variable table node, then push iterator job
+        $local_variables_iterator = $execute_data->getVariables(
+            $ctx->dereferencer,
+            $ctx->zend_type_reader,
+        );
+        $has_variables = false;
+        foreach ($local_variables_iterator as $_name => $_value) {
+            $has_variables = true;
+            break;
+        }
+        if ($has_variables) {
+            $variable_table_context = new \Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\CallFrameVariableTableContext();
+            $var_table_node_id = $ctx->emitNode(
+                $variable_table_context,
+                $parent,
+                'local_variables',
+            );
+            $var_parent = $var_table_node_id >= 0 ? $var_table_node_id : $parent;
+            $queue->push(new CallFrameVariableIteratorJob(
+                $execute_data,
+                $var_parent,
+            ));
+        }
+
+        // $this
+        if ($execute_data->hasThis()) {
+            $queue->push(new ResolveZvalJob(
+                $execute_data->This,
+                $parent,
+                'this',
+            ));
+        }
 
         return $call_frame_context;
     }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -95,6 +95,25 @@ final class EmitCallFrameJob implements CollectorJob
                 'this',
             ));
         }
+
+        // Closure-object back-reference (see collectCallFrameInline for the
+        // detailed why; mirrored here so active frames are covered too).
+        $closure_addr = $this->execute_data->getClosureObjectAddress($ctx->zend_type_reader);
+        if ($closure_addr !== null) {
+            try {
+                $closure_pointer = new \Reli\Lib\Process\Pointer\Pointer(
+                    \Reli\Lib\PhpInternals\Types\Zend\ZendObject::class,
+                    $closure_addr,
+                    $ctx->zend_type_reader->sizeOf('zend_object'),
+                );
+                $queue->push(new EmitObjectJob(
+                    $closure_pointer,
+                    $parent,
+                    'closure',
+                ));
+            } catch (\Throwable) {
+            }
+        }
     }
 
     /**
@@ -220,6 +239,33 @@ final class EmitCallFrameJob implements CollectorJob
                 $parent,
                 'this',
             ));
+        }
+
+        // Closure-object back-reference: a closure-invocation frame carries
+        // the ZEND_CALL_CLOSURE flag in This.u1.type_info, and PHP recovers
+        // the closure object pointer from the func pointer via the
+        // ZEND_CLOSURE_OBJECT(func) macro. This is how PHP keeps the closure
+        // alive across the call frame *and* across Generator/Fiber suspension
+        // — the captured frame retains the flag and refcount=1 is maintained
+        // without any IS_OBJECT zval ever referencing the closure. Without
+        // this synthetic edge the closure body of every Amp\call() Coroutine
+        // (and similar suspended-closure patterns) appears as "no in-heap
+        // incoming refs" / orphan from objects_store.
+        $closure_addr = $execute_data->getClosureObjectAddress($ctx->zend_type_reader);
+        if ($closure_addr !== null) {
+            try {
+                $closure_pointer = new \Reli\Lib\Process\Pointer\Pointer(
+                    \Reli\Lib\PhpInternals\Types\Zend\ZendObject::class,
+                    $closure_addr,
+                    $ctx->zend_type_reader->sizeOf('zend_object'),
+                );
+                $queue->push(new EmitObjectJob(
+                    $closure_pointer,
+                    $parent,
+                    'closure',
+                ));
+            } catch (\Throwable) {
+            }
         }
 
         return $call_frame_context;

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitFiberJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitFiberJob.php
@@ -53,18 +53,30 @@ final class EmitFiberJob implements CollectorJob
     {
         $fiber_context = new FiberContext();
 
+        // Emit the fiber context first so its node_id is available for
+        // anchoring the call frames and their locals.
+        $fiber_node_id = $ctx->emitNode($fiber_context, $this->object_node_id, 'fiber');
+        $fiber_parent = $fiber_node_id >= 0 ? $fiber_node_id : null;
+
         try {
             if ($this->zend_fiber->execute_data !== null) {
                 $execute_data = $ctx->dereferencer->deref($this->zend_fiber->execute_data);
                 $call_frames_context = new CallFramesContext();
+                $call_frames_node_id = $ctx->emitNode(
+                    $call_frames_context,
+                    $fiber_parent,
+                    'call_frames',
+                );
+                $cf_parent = $call_frames_node_id >= 0 ? $call_frames_node_id : $fiber_parent;
                 foreach ($execute_data->iterateStackChain($ctx->dereferencer) as $key => $frame) {
-                    $call_frame_context = EmitCallFrameJob::collectCallFrameInline(
+                    EmitCallFrameJob::collectCallFrameInline(
                         $frame,
                         $ctx,
+                        $queue,
+                        $cf_parent,
+                        (string)$key,
                     );
-                    $call_frames_context->add((string)$key, $call_frame_context);
                 }
-                $fiber_context->add('call_frames', $call_frames_context);
             }
         } catch (\Throwable) {
         }
@@ -93,7 +105,7 @@ final class EmitFiberJob implements CollectorJob
         } catch (\Throwable) {
         }
 
-        $ctx->emitNode($fiber_context, $this->object_node_id, 'fiber');
+        // Fiber context already emitted at the top of execute(); avoid double-emit.
     }
 
     private function scanFiberCStackForVmStack(CollectorContext $ctx): void

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
@@ -77,6 +77,32 @@ final class EmitGeneratorJob implements CollectorJob
         } catch (\Throwable) {
         }
 
+        // Push jobs to walk the `node` field's raw zend_generator* pointers.
+        // These wire `yield from` chains together with refcount management
+        // done in C (not via zval), so without an explicit emit here every
+        // sub-generator that's only reachable through such a chain ends up
+        // tree-owned by objects_store iter despite the parent generator being
+        // walker-reachable. EmitObjectJob is fail-soft for bad pointers
+        // (caught by the job runner) and dispatches to EmitGeneratorJob
+        // recursively when the target's class is Generator.
+        try {
+            foreach ($this->zend_generator->getNodeRawGeneratorPointers($ctx->zend_type_reader)
+                as $idx => $node_gen_ptr
+            ) {
+                $node_pointer = new \Reli\Lib\Process\Pointer\Pointer(
+                    ZendObject::class,
+                    $node_gen_ptr,
+                    $ctx->zend_type_reader->sizeOf('zend_object'),
+                );
+                $queue->push(new EmitObjectJob(
+                    $node_pointer,
+                    $parent,
+                    'node[' . $idx . ']',
+                ));
+            }
+        } catch (\Throwable) {
+        }
+
         // Push jobs for value, key, retval (in reverse order for DFS)
         try {
             $queue->push(new ResolveZvalJob($this->zend_generator->retval, $parent, 'retval'));

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
@@ -48,7 +48,13 @@ final class EmitGeneratorJob implements CollectorJob
     {
         $generator_context = new GeneratorContext();
 
-        // Collect call frames
+        // Emit the generator context first so we have a node_id to attach
+        // call frames (and their locals) under.
+        $generator_node_id = $ctx->emitNode($generator_context, $this->object_node_id, 'generator');
+        $parent = $generator_node_id >= 0 ? $generator_node_id : null;
+
+        // Collect call frames — emit each inline so its locals walking jobs
+        // can be queued with the correct parent.
         try {
             if (
                 $this->zend_generator->execute_data !== null
@@ -56,21 +62,20 @@ final class EmitGeneratorJob implements CollectorJob
             ) {
                 $execute_data = $ctx->dereferencer->deref($this->zend_generator->execute_data);
                 $call_frames_context = new CallFramesContext();
+                $call_frames_node_id = $ctx->emitNode($call_frames_context, $parent, 'call_frames');
+                $cf_parent = $call_frames_node_id >= 0 ? $call_frames_node_id : $parent;
                 foreach ($execute_data->iterateStackChain($ctx->dereferencer) as $key => $frame) {
-                    $call_frame_context = EmitCallFrameJob::collectCallFrameInline(
+                    EmitCallFrameJob::collectCallFrameInline(
                         $frame,
                         $ctx,
+                        $queue,
+                        $cf_parent,
+                        (string)$key,
                     );
-                    $call_frames_context->add((string)$key, $call_frame_context);
                 }
-                $generator_context->add('call_frames', $call_frames_context);
             }
         } catch (\Throwable) {
         }
-
-        // Emit the generator context
-        $generator_node_id = $ctx->emitNode($generator_context, $this->object_node_id, 'generator');
-        $parent = $generator_node_id >= 0 ? $generator_node_id : null;
 
         // Push jobs for value, key, retval (in reverse order for DFS)
         try {

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitGeneratorJob.php
@@ -86,9 +86,10 @@ final class EmitGeneratorJob implements CollectorJob
         // (caught by the job runner) and dispatches to EmitGeneratorJob
         // recursively when the target's class is Generator.
         try {
-            foreach ($this->zend_generator->getNodeRawGeneratorPointers($ctx->zend_type_reader)
-                as $idx => $node_gen_ptr
-            ) {
+            $node_gen_ptrs = $this->zend_generator->getNodeRawGeneratorPointers(
+                $ctx->zend_type_reader,
+            );
+            foreach ($node_gen_ptrs as $idx => $node_gen_ptr) {
                 $node_pointer = new \Reli\Lib\Process\Pointer\Pointer(
                     ZendObject::class,
                     $node_gen_ptr,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitInternalIteratorJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitInternalIteratorJob.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
+
+use Reli\Lib\PhpInternals\Types\Zend\ZendObject;
+use Reli\Lib\PhpInternals\Types\Zend\Zval;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\CollectorJob;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
+use Reli\Lib\Process\Pointer\Pointer;
+
+/**
+ * Walks a `__iterator_wrapper` instance's `data` zval at the
+ * `zend_object_iterator` layout offset, exposing the wrapped iterable
+ * (typically a Generator from `foreach (gen() as ...)`).
+ *
+ * The wrapper has zero PHP-declared properties — the wrapped iterable
+ * lives only in the C-level `zend_object_iterator.data` slot — so a
+ * generic object walker would never see it.
+ */
+final class EmitInternalIteratorJob implements CollectorJob
+{
+    public function __construct(
+        private ZendObject $object,
+        private ?int $object_node_id,
+        CollectorContext $ctx,
+    ) {
+    }
+
+    #[\Override]
+    public function execute(CollectorContext $ctx, JobQueue $queue): void
+    {
+        // zend_object_iterator layout:
+        //   offset 0..55  std (zend_object base, 56B)
+        //   offset 56..71 data (zval, 16B)  <-- wrapped iterable
+        //   offset 72..79 funcs (function table ptr, ignored)
+        //   offset 80..87 index (long, ignored)
+        [$data_offset, $data_size] = $ctx->zend_type_reader->getOffsetAndSizeOfMember(
+            'zend_object_iterator',
+            'data',
+        );
+
+        $object_address = $this->object->getPointer()->address;
+        $data_pointer = new Pointer(
+            Zval::class,
+            $object_address + $data_offset,
+            $data_size,
+        );
+
+        try {
+            $data_zval = $ctx->dereferencer->deref($data_pointer);
+        } catch (\Throwable) {
+            return;
+        }
+
+        $queue->push(new ResolveZvalJob(
+            $data_zval,
+            $this->object_node_id,
+            'data',
+        ));
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitObjectJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitObjectJob.php
@@ -131,6 +131,7 @@ final class EmitObjectJob implements CollectorJob
             || $class_name === \PDOStatement::class
             || $class_name === 'SimpleXMLElement'
             || $class_name === 'SimpleXMLIterator'
+            || $class_name === '__iterator_wrapper'
         ) {
             $object = $ctx->dereferencer->deref($this->pointer);
             $this->processObject($object, $ctx, $queue);
@@ -491,6 +492,30 @@ final class EmitObjectJob implements CollectorJob
         if ($class_name === 'Generator') {
             try {
                 $queue->push(new EmitGeneratorJob(
+                    $object,
+                    $object_node_id,
+                    $ctx,
+                ));
+            } catch (\Throwable) {
+            }
+        }
+
+        // PHP 8.x's `foreach` over a class that exposes
+        // Z_OBJ_HT->get_iterator (Generator, internal Traversables that don't
+        // implement Iterator directly, etc.) creates a `__iterator_wrapper`
+        // PHP-visible instance whose layout is exactly `zend_object_iterator`:
+        // a zend_object std (56B) followed by a zval `data` at offset 56
+        // holding the wrapped iterable, then funcs (8B) and index (8B).
+        // That `data` zval is stored OUTSIDE the standard properties_table —
+        // the wrapper has 0 declared properties — so a generic object walker
+        // never sees the wrapped Generator / Iterator. Without this special
+        // case every parser-internal `foreach (gen() as $x) yield $x;` style
+        // pipeline (extremely common in Amp coroutine code, e.g. Phpactor)
+        // leaves the inner Generator and everything its frame locals hold
+        // visible only via objects_store iter.
+        if ($class_name === '__iterator_wrapper') {
+            try {
+                $queue->push(new EmitInternalIteratorJob(
                     $object,
                     $object_node_id,
                     $ctx,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/CallFrameContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
 
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\CallFrameHeaderMemoryLocation;
+
 final class CallFrameContext implements ReferenceContext
 {
     use ReferenceContextDefault;
@@ -21,6 +23,7 @@ final class CallFrameContext implements ReferenceContext
         public string $function_name,
         public int $lineno,
         public readonly ?string $filename = null,
+        public ?CallFrameHeaderMemoryLocation $header_memory_location = null,
     ) {
     }
 
@@ -33,6 +36,15 @@ final class CallFrameContext implements ReferenceContext
     public function getLocalVariable(string $variable_name): ReferenceContext|int|null
     {
         return $this->getLocalVariables()?->getVariable($variable_name) ?? null;
+    }
+
+    #[\Override]
+    public function getLocations(): iterable
+    {
+        if ($this->header_memory_location !== null) {
+            return [$this->header_memory_location];
+        }
+        return [];
     }
 
     #[\Override]

--- a/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataClosureTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataClosureTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+
+class ZendExecuteDataClosureTest extends TestCase
+{
+    private const ZEND_CALL_CLOSURE = 1 << 22;
+
+    /** Build a zend_execute_data whose This.u1.type_info holds $call_info. */
+    private function makeExecuteData(ZendTypeReader $reader, int $call_info): ZendExecuteData
+    {
+        $size = $reader->sizeOf('zend_execute_data');
+        [$this_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'This');
+        // This is a zval; its u1.type_info is the 4 bytes after the 8-byte value.
+        $type_info_offset = $this_offset + 8;
+        $raw = \FFI::cdef()->new("unsigned char[{$size}]");
+        $packed = pack('V', $call_info);
+        for ($b = 0; $b < 4; $b++) {
+            $raw[$type_info_offset + $b] = \ord($packed[$b]);
+        }
+        $casted = $reader->readAs('zend_execute_data', $raw);
+        return ZendExecuteData::fromCastedCDataWithResolver(
+            $casted,
+            new Pointer(ZendExecuteData::class, 0x1000, $size),
+            new VersionedPointedTypeResolver(ZendTypeReader::V82),
+        );
+    }
+
+    public function testIsClosureCallWhenFlagSet(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+        // flag set alongside unrelated call-info bits — still a closure call.
+        $execute_data = $this->makeExecuteData($reader, self::ZEND_CALL_CLOSURE | (1 << 20));
+        $this->assertTrue($execute_data->isClosureCall());
+    }
+
+    public function testNotClosureCallWhenFlagClear(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+        // neighbouring bits set, but not ZEND_CALL_CLOSURE.
+        $execute_data = $this->makeExecuteData($reader, (1 << 21) | (1 << 23));
+        $this->assertFalse($execute_data->isClosureCall());
+    }
+}

--- a/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataClosureTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataClosureTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Reli\Lib\PhpInternals\Types\Zend;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
 use Reli\Lib\PhpInternals\ZendTypeReader;
@@ -20,10 +21,13 @@ use Reli\Lib\Process\Pointer\Pointer;
 
 class ZendExecuteDataClosureTest extends TestCase
 {
-    private const ZEND_CALL_CLOSURE = 1 << 22;
-
-    /** Build a zend_execute_data whose This.u1.type_info holds $call_info. */
-    private function makeExecuteData(ZendTypeReader $reader, int $call_info): ZendExecuteData
+    /**
+     * Build a zend_execute_data whose This.u1.type_info holds $call_info.
+     *
+     * The caller owns $reader: the casted CData is a view into its FFI scope,
+     * so the reader must outlive every field access on the returned object.
+     */
+    private function makeExecuteData(ZendTypeReader $reader, string $version, int $call_info): ZendExecuteData
     {
         $size = $reader->sizeOf('zend_execute_data');
         [$this_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'This');
@@ -38,7 +42,7 @@ class ZendExecuteDataClosureTest extends TestCase
         return ZendExecuteData::fromCastedCDataWithResolver(
             $casted,
             new Pointer(ZendExecuteData::class, 0x1000, $size),
-            new VersionedPointedTypeResolver(ZendTypeReader::V82),
+            new VersionedPointedTypeResolver($version),
         );
     }
 
@@ -46,15 +50,52 @@ class ZendExecuteDataClosureTest extends TestCase
     {
         $reader = new ZendTypeReader(ZendTypeReader::V82);
         // flag set alongside unrelated call-info bits — still a closure call.
-        $execute_data = $this->makeExecuteData($reader, self::ZEND_CALL_CLOSURE | (1 << 20));
-        $this->assertTrue($execute_data->isClosureCall());
+        $execute_data = $this->makeExecuteData($reader, ZendTypeReader::V82, (1 << 22) | (1 << 20));
+        $this->assertTrue($execute_data->isClosureCall($reader));
     }
 
     public function testNotClosureCallWhenFlagClear(): void
     {
         $reader = new ZendTypeReader(ZendTypeReader::V82);
         // neighbouring bits set, but not ZEND_CALL_CLOSURE.
-        $execute_data = $this->makeExecuteData($reader, (1 << 21) | (1 << 23));
-        $this->assertFalse($execute_data->isClosureCall());
+        $execute_data = $this->makeExecuteData($reader, ZendTypeReader::V82, (1 << 21) | (1 << 23));
+        $this->assertFalse($execute_data->isClosureCall($reader));
+    }
+
+    /**
+     * The effective ZEND_CALL_CLOSURE bit moved across PHP versions
+     * (ZEND_CALL_INFO_SHIFT 24 on 7.0, the pre-7.4 bit numbering on 7.1-7.3,
+     * the modern numbering on 7.4+). isClosureCall() must honour the
+     * version-specific position, not a single literal.
+     *
+     * @return iterable<string, array{string, int}>
+     */
+    public static function closureBitProvider(): iterable
+    {
+        yield '7.0 (shift 24, bit 5 -> 29)' => [ZendTypeReader::V70, 1 << 29];
+        yield '7.2 (shift 16, bit 5 -> 21)' => [ZendTypeReader::V72, 1 << 21];
+        yield '7.3 (shift 16, bit 5 -> 21)' => [ZendTypeReader::V73, 1 << 21];
+        yield '7.4 (renumbered, bit 6 -> 22)' => [ZendTypeReader::V74, 1 << 22];
+        yield '8.2 (bit 6 -> 22)' => [ZendTypeReader::V82, 1 << 22];
+    }
+
+    #[DataProvider('closureBitProvider')]
+    public function testClosureBitPositionIsVersionAware(string $version, int $closure_bit): void
+    {
+        $reader = new ZendTypeReader($version);
+
+        $closure_frame = $this->makeExecuteData($reader, $version, $closure_bit);
+        $this->assertTrue(
+            $closure_frame->isClosureCall($reader),
+            "the version-specific closure bit must register on {$version}",
+        );
+
+        // The closure bit of a *different* version must not be mistaken for a
+        // closure call under this version's layout.
+        $non_closure_frame = $this->makeExecuteData($reader, $version, $closure_bit << 1);
+        $this->assertFalse(
+            $non_closure_frame->isClosureCall($reader),
+            "a neighbouring bit must not register as a closure call on {$version}",
+        );
     }
 }

--- a/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataSymbolTableTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataSymbolTableTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+
+class ZendExecuteDataSymbolTableTest extends TestCase
+{
+    private const ZEND_CALL_HAS_SYMBOL_TABLE = 1 << 20; // 7.4+/8.x effective bit
+
+    /**
+     * Build a zend_execute_data with the given This.u1.type_info call_info and
+     * symbol_table pointer poked into a zeroed buffer.
+     *
+     * The caller owns $reader: the casted CData is a view into its FFI scope.
+     */
+    private function makeExecuteData(
+        ZendTypeReader $reader,
+        string $version,
+        int $call_info,
+        int $symbol_table_ptr,
+    ): ZendExecuteData {
+        $size = $reader->sizeOf('zend_execute_data');
+        [$this_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'This');
+        [$st_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'symbol_table');
+        $raw = \FFI::cdef()->new("unsigned char[{$size}]");
+
+        // This.u1.type_info: the 4 bytes after the 8-byte zval value.
+        $type_info = pack('V', $call_info);
+        for ($b = 0; $b < 4; $b++) {
+            $raw[$this_offset + 8 + $b] = \ord($type_info[$b]);
+        }
+        // symbol_table pointer (8 bytes).
+        $st = pack('P', $symbol_table_ptr);
+        for ($b = 0; $b < 8; $b++) {
+            $raw[$st_offset + $b] = \ord($st[$b]);
+        }
+
+        $casted = $reader->readAs('zend_execute_data', $raw);
+        return ZendExecuteData::fromCastedCDataWithResolver(
+            $casted,
+            new Pointer(ZendExecuteData::class, 0x1000, $size),
+            new VersionedPointedTypeResolver($version),
+        );
+    }
+
+    public function testFlagVersionUsesTypeInfoBitNotPointer(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+
+        // flag set -> true regardless of the (here null) pointer
+        $with_flag = $this->makeExecuteData($reader, ZendTypeReader::V82, self::ZEND_CALL_HAS_SYMBOL_TABLE, 0);
+        $this->assertTrue($with_flag->hasSymbolTable($reader));
+
+        // A non-null symbol_table pointer WITHOUT the flag must NOT count on
+        // 7.1+: the slot is reused from EG(symtable_cache), which is the whole
+        // reason the flag exists.
+        $stale_pointer = $this->makeExecuteData($reader, ZendTypeReader::V82, 0, 0x7f0000001000);
+        $this->assertFalse($stale_pointer->hasSymbolTable($reader));
+    }
+
+    public function testPre71FallsBackToSymbolTablePointer(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V70);
+
+        // 7.0 has no flag; a non-null symbol_table pointer is the indicator.
+        $with_pointer = $this->makeExecuteData($reader, ZendTypeReader::V70, 0, 0x7f0000001000);
+        $this->assertTrue($with_pointer->hasSymbolTable($reader));
+
+        // No symbol table -> null pointer -> false.
+        $without = $this->makeExecuteData($reader, ZendTypeReader::V70, 0, 0);
+        $this->assertFalse($without->hasSymbolTable($reader));
+    }
+}

--- a/tests/Lib/PhpInternals/Types/Zend/ZendGeneratorTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendGeneratorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use PHPUnit\Framework\TestCase;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Pointer;
+
+class ZendGeneratorTest extends TestCase
+{
+    /**
+     * Build a zend_generator backed by a zeroed buffer, then poke the four
+     * 8-byte node slots so getNodeRawGeneratorPointers() can be exercised
+     * without a live process.
+     */
+    private function makeGenerator(ZendTypeReader $reader, array $node_slots): ZendGenerator
+    {
+        $size = $reader->sizeOf('zend_generator');
+        [$node_offset] = $reader->getOffsetAndSizeOfMember('zend_generator', 'node');
+        $raw = \FFI::cdef()->new("unsigned char[{$size}]");
+        foreach ($node_slots as $slot => $value) {
+            $packed = pack('P', $value);
+            for ($b = 0; $b < 8; $b++) {
+                $raw[$node_offset + $slot * 8 + $b] = \ord($packed[$b]);
+            }
+        }
+        $casted = $reader->readAs('zend_generator', $raw);
+        return new ZendGenerator(
+            $casted,
+            new Pointer(ZendGenerator::class, 0x1000, $size),
+        );
+    }
+
+    public function testExtractsNonZeroNodePointers(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+        $generator = $this->makeGenerator($reader, [
+            0 => 0x7f0000001000,
+            1 => 0x7f0000002000,
+            2 => 0x7f0000003000,
+            3 => 0x7f0000004000,
+        ]);
+
+        $this->assertSame(
+            [0x7f0000001000, 0x7f0000002000, 0x7f0000003000, 0x7f0000004000],
+            $generator->getNodeRawGeneratorPointers($reader),
+        );
+    }
+
+    public function testFiltersZeroNodeSlots(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+        // Only parent (slot 0) and the leaves.first slot (2) are set; the
+        // child/leaf and last slots are NULL and must be dropped.
+        $generator = $this->makeGenerator($reader, [
+            0 => 0x7f0000001000,
+            1 => 0,
+            2 => 0x7f0000003000,
+            3 => 0,
+        ]);
+
+        $this->assertSame(
+            [0x7f0000001000, 0x7f0000003000],
+            $generator->getNodeRawGeneratorPointers($reader),
+        );
+    }
+
+    public function testReturnsEmptyWhenAllNodeSlotsZero(): void
+    {
+        $reader = new ZendTypeReader(ZendTypeReader::V82);
+        $generator = $this->makeGenerator($reader, []);
+
+        $this->assertSame([], $generator->getNodeRawGeneratorPointers($reader));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
@@ -100,11 +100,13 @@ class GeneratorClosureReachabilityIntegrationTest extends BaseTestCase
         //     execution, so its frame carries ZEND_CALL_CLOSURE.
         $target_script = <<<'CODE'
             <?php
+            // Untyped properties on purpose: typed properties are 7.4+ and
+            // this target also runs on 7.0-7.3.
             class ReliGenLeafMarker {
-                public string $tag = 'gen-leaf';
+                public $tag = 'gen-leaf';
             }
             class ReliClosureMarker {
-                public string $tag = 'closure-captured';
+                public $tag = 'closure-captured';
             }
 
             function reli_child_gen(): \Generator {

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use Reli\Lib\PhpProcessReader\MainExecutable\ProcExeReadlinkResolver;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Reli\BaseTestCase;
+use Reli\Inspector\Settings\TargetPhpSettings\TargetPhpSettings;
+use Reli\Lib\ByteStream\IntegerByteSequence\LittleEndianReader;
+use Reli\Lib\Elf\Parser\Elf64Parser;
+use Reli\Lib\Elf\Process\LinkMapLoader;
+use Reli\Lib\Elf\Process\PerBinarySymbolCacheRetriever;
+use Reli\Lib\Elf\Process\ProcessModuleSymbolReaderCreator;
+use Reli\Lib\Elf\Process\BinaryAnalysisCache;
+use Reli\Lib\Elf\SymbolResolver\Elf64SymbolResolverCreator;
+use Reli\Lib\File\CatFileReader;
+use Reli\Lib\File\PathResolver\ContainerAwarePathResolver;
+use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpGlobalsFinder;
+use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
+use Reli\Lib\PhpProcessReader\TsrmGlobalsResolver;
+use Reli\Lib\Elf\Process\BinaryFingerprintCreator;
+use Reli\Lib\PhpProcessReader\PhpSymbolReaderCreator;
+use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
+use Reli\Lib\Process\MemoryMap\ProcessMemoryMapCreator;
+use Reli\Lib\Process\MemoryReader\MemoryReader;
+use Reli\Lib\Process\ProcessSpecifier;
+use Reli\TargetPhpVmProvider;
+
+/**
+ * End-to-end coverage for the "walker reachability" fixes: against a real PHP
+ * process that parks objects behind a suspended `yield from` chain and an
+ * executing closure frame, the memory walker must actually reach those objects
+ * and wire the structural edges (sub-generator `node[]` links, the closure
+ * object edge) rather than leaving them to the objects_store fallback.
+ *
+ * The unit tests (ZendGeneratorTest / ZendExecuteDataClosureTest) pin the
+ * byte-level extraction; this test proves the whole pipeline extracts the
+ * information from a live target.
+ */
+#[Group('target-version')]
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class GeneratorClosureReachabilityIntegrationTest extends BaseTestCase
+{
+    /** @var resource|null */
+    private $child = null;
+
+    private string $memory_limit_backup;
+
+    public function setUp(): void
+    {
+        $this->child = null;
+        $this->memory_limit_backup = ini_get('memory_limit');
+        ini_set('memory_limit', '1G');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('memory_limit', $this->memory_limit_backup);
+        if (!is_null($this->child)) {
+            $child_status = proc_get_status($this->child);
+            if (is_array($child_status)) {
+                if ($child_status['running']) {
+                    posix_kill($child_status['pid'], SIGKILL);
+                }
+            }
+            $this->child = null;
+        }
+    }
+
+    #[DataProviderExternal(TargetPhpVmProvider::class, 'allSupported')]
+    public function testReachesGeneratorAndClosureHeldObjects(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+
+        // The marker objects below are reachable ONLY through the paths the
+        // reachability fixes restore:
+        //   - ReliGenLeafMarker:    a local of the child generator's suspended
+        //     frame, itself reached only via the parent's `yield from` node[].
+        //   - ReliClosureMarker:    captured by a closure that is parked mid
+        //     execution, so its frame carries ZEND_CALL_CLOSURE.
+        $target_script = <<<'CODE'
+            <?php
+            class ReliGenLeafMarker {
+                public string $tag = 'gen-leaf';
+            }
+            class ReliClosureMarker {
+                public string $tag = 'closure-captured';
+            }
+
+            function reli_child_gen(): \Generator {
+                $leaf = new ReliGenLeafMarker();
+                yield 1;
+                // keep $leaf live across the suspension point
+                echo $leaf->tag;
+            }
+            function reli_parent_gen(): \Generator {
+                yield from reli_child_gen();
+            }
+
+            // Suspend the parent inside `yield from`: the child generator runs
+            // to its first yield and is now referenced only via parent->node.
+            $parent = reli_parent_gen();
+            $parent->current();
+
+            // Park a closure mid-execution so its frame is on the call stack
+            // with ZEND_CALL_CLOSURE set when reli attaches.
+            $closure_marker = new ReliClosureMarker();
+            $cl = function () use ($closure_marker) {
+                fputs(STDOUT, "ready\n");
+                fgets(STDIN);
+                return $closure_marker;
+            };
+            $cl();
+            CODE;
+
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes,
+        );
+        $s = fgets($pipes[1]);
+        $this->assertSame("ready\n", $s);
+
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+            new ProcExeReadlinkResolver(),
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $process_specifier = new ProcessSpecifier($pid);
+        $target_php_settings = new TargetPhpSettings(php_version: $php_version);
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            $process_specifier,
+            $target_php_settings,
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder,
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
+        );
+        $tmp_path = tempnam(sys_get_temp_dir(), 'reli_test_genclosure_') . '.sqlite3';
+        $driver = new \Reli\Inspector\Output\MemoryOutput\PdoDriver\SqliteDriver($tmp_path);
+        $pdo_output = new \Reli\Inspector\Output\MemoryOutput\PdoMemoryOutput($driver);
+        [$sink, $run_id, $db] = $pdo_output->createStreamingSink();
+
+        $memory_locations_collector->collectAll(
+            $process_specifier,
+            $target_php_settings,
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+        $sink->flush();
+
+        // --- the marker objects must be reached at all ---
+        $this->assertSame(
+            1,
+            $this->countClass($db, $run_id, 'ReliGenLeafMarker'),
+            'object held only by a suspended `yield from` child frame must be reached',
+        );
+        $this->assertSame(
+            1,
+            $this->countClass($db, $run_id, 'ReliClosureMarker'),
+            'object captured by a parked closure frame must be reached',
+        );
+
+        // --- the structural edges the fixes synthesize must exist ---
+        // `node[N]` edges come only from EmitGeneratorJob walking the raw
+        // zend_generator* pointers of a `yield from` chain.
+        $this->assertGreaterThan(
+            0,
+            $this->countEdgeLinkLike($db, $run_id, 'node[%'),
+            '`yield from` sub-generator node[] edge must be wired',
+        );
+
+        // The leaf marker must hang under a generator context (i.e. it was
+        // reached through the generator walk, not merely swept up by the
+        // objects_store fallback). `node_id IN (locations of class Generator)`
+        // proves the leaf's owning frame is inside a generator subtree.
+        $generator_node_count = (int)$db->query(
+            "SELECT COUNT(*) FROM context_node_locations"
+            . " WHERE run_id = {$run_id} AND class_name = 'Generator'"
+        )->fetchColumn();
+        $this->assertGreaterThanOrEqual(
+            2,
+            $generator_node_count,
+            'both the parent and the yield-from child generator must be reached',
+        );
+
+        $db = null;
+        @unlink($tmp_path);
+    }
+
+    private function countClass(\PDO $db, int $run_id, string $class_name): int
+    {
+        /** @psalm-suppress MixedAssignment */
+        $count = $db->query(
+            "SELECT COUNT(DISTINCT address) FROM context_node_locations"
+            . " WHERE run_id = {$run_id}"
+            . " AND class_name = " . $db->quote($class_name)
+        )->fetchColumn();
+        return (int)$count;
+    }
+
+    private function countEdgeLinkLike(\PDO $db, int $run_id, string $link_pattern): int
+    {
+        /** @psalm-suppress MixedAssignment */
+        $count = $db->query(
+            "SELECT COUNT(*) FROM context_edges"
+            . " WHERE run_id = {$run_id}"
+            . " AND link_name LIKE " . $db->quote($link_pattern)
+        )->fetchColumn();
+        return (int)$count;
+    }
+}


### PR DESCRIPTION
A set of object-graph reachability fixes so the memory walker reaches structures it previously missed:

- **Suspended Generator/Fiber frame locals** — walk the frozen call frame's locals so objects pinned only by a suspended generator/fiber are reached.
- **objects_store deref scope** — scope the objects_store deref to the touched range (avoids over-reading).
- **Closure-object edge** — synthesize the closure→object edge from `ZEND_CALL_CLOSURE` frames.
- **`zend_generator->node`** — follow the raw generator pointers in the node.
- **`__iterator_wrapper.data`** — walk the wrapper's data zval to reach foreach-held iterables.

Independent of the phar / open-files attribution work; split into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)