### PR TITLE
feat(memory-report): collector attribution infra (address_map auto-register + MallocBuffer location)

### DIFF
--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ContextAnalyzer/ContextAnalyzer.php
@@ -41,6 +41,26 @@ final class ContextAnalyzer
 {
     private int $node_id = 0;
 
+    /** @var (\Closure(int, ReferenceContext): void)|null */
+    private ?\Closure $on_node_assigned = null;
+
+    /**
+     * Register a callback fired the first time a node_id is assigned to a
+     * Context (i.e. when {@see analyzeContext} promotes a "reserved" or
+     * fresh Context to a fully-emitted one). The callback receives the
+     * node_id and the Context itself, and is the natural seam for keeping
+     * an external address→node_id map in sync with the analyzer's own
+     * traversal — Context already carries its primary locations via
+     * `getLocations()`, so callers no longer have to remember to write
+     * an address_map entry by hand at every emission site.
+     *
+     * @param \Closure(int, ReferenceContext): void $on_node_assigned
+     */
+    public function setOnNodeAssigned(\Closure $on_node_assigned): void
+    {
+        $this->on_node_assigned = $on_node_assigned;
+    }
+
     /**
      * The $memo parameter is the legacy WeakMap-based emit state.
      * Production callers (CollectorContext) pass null and the
@@ -178,6 +198,9 @@ final class ContextAnalyzer
             $current_node_id = $this->node_id++;
         }
         $linked_context->setMemoNodeId($current_node_id);
+        if ($this->on_node_assigned !== null) {
+            ($this->on_node_assigned)($current_node_id, $linked_context);
+        }
         if ($memo !== null) {
             $memo[$linked_context] = $current_node_id;
         }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MallocBufferMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/MallocBufferMemoryLocation.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+/**
+ * Generic LocationRow for an opaque char*-style buffer of a known
+ * length. Used for fields that aren't a zend_string but still
+ * allocate `len`-bytes of zend_mm-managed memory — e.g.
+ * `phar_archive_data.signature`, the various `char *` paths in
+ * phar's module globals, etc. The buffer's `tag` is recorded as the
+ * MemoryLocation's debug/source label so it shows up distinctly in
+ * the report's per-type breakdown.
+ */
+final class MallocBufferMemoryLocation extends MemoryLocation
+{
+    public function __construct(
+        int $address,
+        int $size,
+        /** Free-form label identifying which subsystem owns this
+         *  allocation, e.g. `phar.signature`. Surfaces in reports. */
+        public readonly string $tag,
+    ) {
+        parent::__construct($address, $size);
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -47,6 +47,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\Lexbor\LexborScanRangeFinder;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\Lexbor\LexborStateScanner;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\LexborStateContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ModulesContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\ReferenceContext;
 use Reli\Lib\PhpProcessReader\PhpTsrmLsCacheFinder;
 use Reli\Lib\PhpProcessReader\PhpZendMemoryManagerChunkFinder;
 use Reli\Lib\Process\MemoryMap\ProcessMemoryMap;
@@ -323,6 +324,24 @@ final class MemoryLocationsCollector
             $vm_stack_memory_locations,
             $chunk_memory_locations,
             $fast_path,
+        );
+
+        // Auto-register every emitted Context's attached locations into the
+        // address_map. The manual `address_map[$addr] = $node_id` writes
+        // scattered across Jobs only cover the primary "registerable" address
+        // each Job knows about — sub-allocations that hang off the same
+        // Context (op_array header/body, object handlers, …) used to slip
+        // through and confuse downstream reachability checks (e.g. the bin
+        // walker's `reachable_count` stat). Existing explicit writes are
+        // left in place so addresses that aren't on the Context (aliases
+        // like the input pointer when it differs from the object's true
+        // slot) keep their mapping.
+        $analyzer->setOnNodeAssigned(
+            static function (int $node_id, ReferenceContext $context) use ($ctx): void {
+                foreach ($context->getLocations() as $location) {
+                    $ctx->address_map[$location->address] = $node_id;
+                }
+            }
         );
 
         // Create the job queue


### PR DESCRIPTION
Shared base for the open-files and ext/phar attribution PRs (each stacks on this):

- **auto-register Context locations into address_map on emit** — so the bin walker's reach detection sees every emitted location.
- **generic `MallocBufferMemoryLocation`** — a char*-style buffer of known length with a free-form `tag` label, for allocations that aren't a zend_string but still occupy zend_mm memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)