### PR TITLE
test: stabilize the container "ready" handshake against leading noise

### DIFF
--- a/tests/Command/Inspector/MemoryCompareCommandIntegrationTest.php
+++ b/tests/Command/Inspector/MemoryCompareCommandIntegrationTest.php
@@ -104,8 +104,8 @@ class MemoryCompareCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
         $this->children[] = $child;
-        $ready = fgets($pipes[1]);
-        $this->assertSame("ready\n", $ready);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
         $this->snapshotTrace('target_ready pid=' . $pid, $docker_image_name);
 
         // Dump

--- a/tests/Command/Inspector/MemoryDumpCommandTest.php
+++ b/tests/Command/Inspector/MemoryDumpCommandTest.php
@@ -99,8 +99,8 @@ class MemoryDumpCommandTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $ready = fgets($pipes[1]);
-        $this->assertSame("ready\n", $ready);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         return [$this->child, $pid, $pipes];
     }

--- a/tests/Command/Inspector/MemoryReportCommandIntegrationTest.php
+++ b/tests/Command/Inspector/MemoryReportCommandIntegrationTest.php
@@ -126,8 +126,8 @@ class MemoryReportCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $ready = fgets($pipes[1]);
-        $this->assertSame("ready\n", $ready);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         return [$this->child, $pid, $pipes];
     }
@@ -166,8 +166,8 @@ class MemoryReportCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $ready = fgets($pipes[1]);
-        $this->assertSame("ready\n", $ready);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         return [$this->child, $pid, $pipes];
     }

--- a/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/PeekVarCommandIntegrationTest.php
@@ -75,8 +75,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         $app = new Application();
@@ -144,8 +144,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         $app = new Application();
@@ -185,8 +185,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         $app = new Application();
@@ -227,8 +227,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         $app = new Application();
@@ -291,7 +291,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -337,7 +338,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -374,7 +376,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -411,7 +414,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -454,7 +458,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -493,7 +498,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);
@@ -555,7 +561,8 @@ class PeekVarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $this->assertSame("ready\n", fgets($pipes[1]));
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $command = $this->createCommand();
         (new Application())->addCommand($command);

--- a/tests/Command/Inspector/SidecarCommandIntegrationTest.php
+++ b/tests/Command/Inspector/SidecarCommandIntegrationTest.php
@@ -96,8 +96,8 @@ class SidecarCommandIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $ready = fgets($pipes[1]);
-        $this->assertSame("ready\n", $ready);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         return [$this->child, $pid, $pipes];
     }

--- a/tests/Command/Inspector/WatchCommandIntegrationTest.php
+++ b/tests/Command/Inspector/WatchCommandIntegrationTest.php
@@ -83,8 +83,8 @@ class WatchCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         // Build the DI container and get command
         $container_builder = new \DI\ContainerBuilder();
@@ -150,8 +150,8 @@ class WatchCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $container_builder = new \DI\ContainerBuilder();
         $container_builder->addDefinitions(
@@ -210,8 +210,8 @@ class WatchCommandIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         // Run reli as a subprocess (not CommandTester) because
         // daemon mode uses Amphp EventLoop + async futures that

--- a/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
+++ b/tests/Inspector/CoreDumpReader/CoreDumpReaderIntegrationTest.php
@@ -102,8 +102,8 @@ class CoreDumpReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         // Take coredump via gcore (non-destructive)
         $this->core_file = $this->takeCoreDump($pid);
@@ -225,8 +225,8 @@ class CoreDumpReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $this->core_file = $this->takeCoreDump($pid);
         $this->assertFileExists($this->core_file);

--- a/tests/Inspector/MemoryDump/MemoryDumperTest.php
+++ b/tests/Inspector/MemoryDump/MemoryDumperTest.php
@@ -84,8 +84,8 @@ class MemoryDumperTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $globals_finder = $this->createGlobalsFinder(
             $memory_reader,

--- a/tests/Inspector/Watch/HeapStatsReaderTest.php
+++ b/tests/Inspector/Watch/HeapStatsReaderTest.php
@@ -83,8 +83,8 @@ class HeapStatsReaderTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
 

--- a/tests/Inspector/Watch/VariableReaderIntegrationTest.php
+++ b/tests/Inspector/Watch/VariableReaderIntegrationTest.php
@@ -92,8 +92,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -249,8 +249,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -335,8 +335,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -453,8 +453,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -555,8 +555,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -651,8 +651,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -1222,8 +1222,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(
@@ -1337,8 +1337,8 @@ class VariableReaderIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $process_specifier = new ProcessSpecifier($pid);
         $target_php_settings = new TargetPhpSettings(

--- a/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/FrankenPhpNativeTraceCollectorTest.php
@@ -95,8 +95,8 @@ class FrankenPhpNativeTraceCollectorTest extends BaseTestCase
             $pipes
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
 

--- a/tests/Lib/Dwarf/NativeTraceCollectorTest.php
+++ b/tests/Lib/Dwarf/NativeTraceCollectorTest.php
@@ -100,8 +100,8 @@ class NativeTraceCollectorTest extends BaseTestCase
             $pipes
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
 

--- a/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/CallTraceReaderTest.php
@@ -90,8 +90,8 @@ class CallTraceReaderTest extends BaseTestCase
             $pipes
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(

--- a/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
+++ b/tests/Lib/PhpProcessReader/CallTraceReader/FrankenPhpCallTraceReaderTest.php
@@ -92,8 +92,8 @@ class FrankenPhpCallTraceReaderTest extends BaseTestCase
             $pipes
         );
 
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
         $child_status = proc_get_status($this->child);
         $this->assertSame(true, $child_status['running']);
 

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/GeneratorClosureReachabilityIntegrationTest.php
@@ -141,8 +141,8 @@ class GeneratorClosureReachabilityIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -137,8 +137,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -376,8 +376,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -550,8 +550,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -707,8 +707,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -1563,8 +1563,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -1856,8 +1856,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2034,8 +2034,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2171,8 +2171,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2325,8 +2325,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2480,8 +2480,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2672,8 +2672,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -2923,8 +2923,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -3156,8 +3156,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -3460,8 +3460,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         $php_symbol_reader_creator = new PhpSymbolReaderCreator(
             new ProcessModuleSymbolReaderCreator(
@@ -3668,8 +3668,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         [$db, $run_id, $tmp_path] = $this->collectStreamingDb(
             $pid,
@@ -3753,8 +3753,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         [$db, $run_id, $tmp_path] = $this->collectStreamingDb(
             $pid,
@@ -3831,8 +3831,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
             $target_script,
             $pipes
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("a\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
 
         [$db, $run_id, $tmp_path] = $this->collectStreamingDb(
             $pid,

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/OpenFilesSourceAttributionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/OpenFilesSourceAttributionIntegrationTest.php
@@ -119,8 +119,8 @@ class OpenFilesSourceAttributionIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMemoryCollectionIntegrationTest.php
@@ -105,8 +105,8 @@ class PdoMemoryCollectionIntegrationTest extends BaseTestCase
             $target_script,
             $pipes,
         );
-        $s = fgets($pipes[1]);
-        $this->assertSame("ready\n", $s);
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        $this->assertTrue($ready, "child did not print 'ready'. Got: " . var_export($seen, true));
 
         $memory_reader = new MemoryReader();
         $type_reader_creator = new ZendTypeReaderCreator();

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/PdoMysqlMemoryCollectionIntegrationTest.php
@@ -238,12 +238,18 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
             $pipes,
         );
 
-        $pid_written = fgets($pipes[1]);
-        $this->assertSame("pid written\n", $pid_written);
+        [$pid_written, $pid_seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'pid written');
+        $this->assertTrue(
+            $pid_written,
+            "child did not print 'pid written'. Got: " . var_export($pid_seen, true),
+        );
         $pid = (int)file_get_contents($pid_file);
 
-        $s = fgets($pipes[1]);
-        if ($s !== "ready\n") {
+        // Tolerate any leading noise (mysqlnd / MySQL-init chatter, startup
+        // warnings) before the readiness marker instead of demanding it be
+        // the very next line — that strict check was the flaky failure.
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'ready');
+        if (!$ready) {
             $stderr = stream_get_contents($pipes[2]);
             // Kill child and clean up before failing
             $child_status = proc_get_status($this->child);
@@ -252,7 +258,7 @@ class PdoMysqlMemoryCollectionIntegrationTest extends BaseTestCase
             }
             $this->child = null;
             $this->fail(
-                "PHP script did not output 'ready'. Got: " . var_export($s, true)
+                "PHP script did not output 'ready'. Got: " . var_export($seen, true)
                 . "\nStderr: " . $stderr
             );
         }

--- a/tests/TargetPhpVmProvider.php
+++ b/tests/TargetPhpVmProvider.php
@@ -133,6 +133,47 @@ class TargetPhpVmProvider
         return self::from(ZendTypeReader::V74);
     }
 
+    /**
+     * Read a child's stdout pipe until a line equal to $marker appears,
+     * tolerating any leading noise (blank lines, startup warnings, mysqlnd /
+     * init-restart chatter), and return [matched, everything-read].
+     *
+     * The strict `fgets() === "$marker\n"` handshake used to fail flakily the
+     * moment a single stray line slipped in before the marker. Reads
+     * non-blocking against a deadline so a target that parks on fgets(STDIN)
+     * without ever printing the marker fails fast instead of blocking forever
+     * (the pipe never reaches EOF while the child is alive).
+     *
+     * @param resource $pipe
+     * @return array{bool, string} [whether the marker line was seen, the raw text read]
+     */
+    public static function waitForMarkerLine($pipe, string $marker = 'ready', float $timeout_seconds = 30.0): array
+    {
+        stream_set_blocking($pipe, false);
+        $seen = '';
+        $matched = false;
+        $deadline = microtime(true) + $timeout_seconds;
+        while (microtime(true) < $deadline) {
+            $line = fgets($pipe);
+            if ($line === false) {
+                if (feof($pipe)) {
+                    break;
+                }
+                usleep(10000);
+                continue;
+            }
+            $seen .= $line;
+            if (rtrim($line, "\r\n") === $marker) {
+                $matched = true;
+                break;
+            }
+        }
+        // Restore blocking mode so any later raw fgets() on this pipe behaves
+        // as the callers expect.
+        stream_set_blocking($pipe, true);
+        return [$matched, $seen];
+    }
+
     public static function runScriptViaContainer(
         string $docker_image_name,
         string $script,
@@ -179,8 +220,8 @@ class TargetPhpVmProvider
                 '/tmp/reli-test' => '/tmp/reli-test',
             ],
         );
-        $pid_written_message = fgets($pipes[1]);
-        assert($pid_written_message === "pid written\n");
+        [$pid_written, $seen] = self::waitForMarkerLine($pipes[1], 'pid written');
+        assert($pid_written, "child did not print 'pid written'. Got: " . var_export($seen, true));
         $pid = (int)file_get_contents($pid_file);
         return [$proc_handle, $pid];
     }
@@ -224,8 +265,8 @@ class TargetPhpVmProvider
                 '/tmp/reli-test' => '/tmp/reli-test',
             ],
         );
-        $pid_written_message = fgets($pipes[1]);
-        assert($pid_written_message === "pid written\n");
+        [$pid_written, $seen] = self::waitForMarkerLine($pipes[1], 'pid written');
+        assert($pid_written, "child did not print 'pid written'. Got: " . var_export($seen, true));
         $pid = (int)file_get_contents($pid_file);
         return [$proc_handle, $pid];
     }


### PR DESCRIPTION
## Problem

Integration tests spawn a PHP target in a container and synchronise on a marker line (`ready` / `a` / `pid written`) with a strict `fgets() === "marker\n"`. A single stray line before the marker — a startup warning, mysqlnd / MySQL-init chatter, etc. — makes that read return the wrong line and the test fails flakily, e.g.:

```
PdoMysqlMemoryCollectionIntegrationTest::testCollectPdoMysqlMysqlndBuffers@v71
PHP script did not output 'ready'. Got: '\n'
```

## Fix

Add `TargetPhpVmProvider::waitForMarkerLine()`:
- reads **non-blocking against a deadline**, skipping any noise up to the marker line;
- **restores blocking mode** before returning, so later raw `fgets()` on the same pipe behaves as callers expect;
- a target that parks on `fgets(STDIN)` without ever printing the marker **fails fast on the deadline** instead of being mistaken for success or blocking forever (the pipe never reaches EOF while the child is alive).

Migrate every strict marker handshake to it — the two internal `pid written` reads in the helper plus the call sites across the integration suite. The opcache flows already had their own noise-skipping reader (`readOpcacheReadySignal`) and are left as-is.

## Verification

- `php -l` + phpcs clean on all touched files.
- End-to-end locally: `PdoMemoryCollectionIntegrationTest` (marker `ready`, via `runScriptViaContainer`) and `CallTraceReaderTest` (marker `a`) pass on a real `php:8.4-cli`.
- No dangling `$var` left behind by the removed `$s = fgets(...)` assignments.

Tests-only; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)