### PR TITLE
Track VM stack arenas and improve call frame size accounting

### DIFF
--- a/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
+++ b/src/Lib/PhpInternals/Types/Zend/ZendExecuteData.php
@@ -427,7 +427,14 @@ final class ZendExecuteData implements LazyDereferencable, PointedTypeResolverAw
         $tmp_num = $func->op_array->T;
         $arg_num = $func->op_array->num_args;
         $real_arg_num = $this->This->u2->num_args;
-        $extra_arg_num = $real_arg_num - $arg_num;
+        // PHP always allocates a CV slot for each *declared* parameter
+        // even when the caller passed fewer (the missing args are
+        // filled in with their default values), so extra args is the
+        // overflow PAST the declared count — never negative. The old
+        // unclamped `real - arg` undercounted variable_table_size on
+        // any frame whose call site omitted optional args, which
+        // surfaced as an inter-frame gap in VM stack accounting.
+        $extra_arg_num = max(0, $real_arg_num - $arg_num);
         return $compiled_variables_num + $tmp_num + $extra_arg_num;
     }
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/CollectorContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/CollectorContext.php
@@ -33,6 +33,18 @@ final class CollectorContext
     /** Tracks the function context matching a memory limit error location */
     public ?UserFunctionDefinitionContext $memory_limit_error_function_context = null;
 
+    /**
+     * Address-range lookup for VM stack arenas, used by EmitCallFrameJob
+     * to attach a weak `vm_stack_arena` edge from each frame to the
+     * arena it physically resides in. Populated by collectAll() before
+     * any EmitCallFrameJob runs; sorted by `begin` so a linear scan
+     * is fine for the (tens to a few hundred) arenas a typical
+     * process keeps live.
+     *
+     * @var list<array{int, int, int}> list of [arena_begin, arena_end, arena_node_id]
+     */
+    public array $vm_stack_arena_lookup = [];
+
     public function __construct(
         public Dereferencer $dereferencer,
         public ZendTypeReader $zend_type_reader,

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -32,13 +32,18 @@ final class EmitCallFrameJob implements CollectorJob
         private ZendExecuteData $execute_data,
         private ?int $parent_node_id,
         private string $link_name,
+        private ?int $successor_frame_address = null,
     ) {
     }
 
     #[\Override]
     public function execute(CollectorContext $ctx, JobQueue $queue): void
     {
-        $call_frame_context = self::collectCallFrameHeader($this->execute_data, $ctx);
+        $call_frame_context = self::collectCallFrameHeader(
+            $this->execute_data,
+            $ctx,
+            $this->successor_frame_address,
+        );
 
         // Emit the call frame
         $frame_node_id = $ctx->emitNode($call_frame_context, $this->parent_node_id, $this->link_name);
@@ -150,6 +155,7 @@ final class EmitCallFrameJob implements CollectorJob
     public static function collectCallFrameHeader(
         ZendExecuteData $execute_data,
         CollectorContext $ctx,
+        ?int $successor_frame_address = null,
     ): CallFrameContext {
         $function_name = $execute_data->getFullyQualifiedFunctionName(
             $ctx->dereferencer,
@@ -172,15 +178,34 @@ final class EmitCallFrameJob implements CollectorJob
         }
 
         // Track memory location for the frame header + variable table area.
+        $frame_addr = $execute_data->getPointer()->address;
         try {
             $variable_table_pointer = $execute_data->getVariableTablePointer($ctx->dereferencer);
             $frame_end = $variable_table_pointer->address + $variable_table_pointer->size;
-            $frame_size = $frame_end - $execute_data->getPointer()->address;
+            $frame_size = $frame_end - $frame_addr;
         } catch (\Throwable) {
             $frame_size = $execute_data->getPointer()->size;
         }
+        // If the caller passed the address of the frame this one called
+        // (its successor on the VM stack, immediately above it in
+        // address order), use the gap to cover any allocation PHP
+        // performed past `last_var + T` — most notably the extra
+        // zvals named-arg `SEND_*` opcodes push per named argument,
+        // which are invisible to `zend_vm_calc_used_stack`'s reading
+        // of `op_array.T`. Only honor the successor when it sits
+        // ABOVE this frame's reli-computed end AND within a sane
+        // window (capped at sizeof(zend_vm_stack) bytes so a stale
+        // hint that lands in a different arena can't blow the
+        // accounting up).
+        if (
+            $successor_frame_address !== null
+            && $successor_frame_address > $frame_addr + $frame_size
+            && $successor_frame_address - ($frame_addr + $frame_size) < 4096
+        ) {
+            $frame_size = $successor_frame_address - $frame_addr;
+        }
         $header_memory_location = new CallFrameHeaderMemoryLocation(
-            $execute_data->getPointer()->address,
+            $frame_addr,
             $frame_size,
         );
         $ctx->memory_locations->add($header_memory_location);

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -20,6 +20,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\JobQueue;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\CallFrameHeaderMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\CallFrameContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\CallFrameVariableTableContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\EdgeStrength;
 
 /**
  * Emit a single call frame node and push jobs for local variables and $this.
@@ -42,6 +43,26 @@ final class EmitCallFrameJob implements CollectorJob
         // Emit the call frame
         $frame_node_id = $ctx->emitNode($call_frame_context, $this->parent_node_id, $this->link_name);
         $parent = $frame_node_id >= 0 ? $frame_node_id : null;
+
+        // Weak (non-tree) edge from this frame to the VM stack arena
+        // it lives in. The arena tree is emitted up-front by
+        // MemoryLocationsCollector::collectAll() so the lookup table
+        // is already populated by the time any EmitCallFrameJob runs
+        // (including the post-loop memory_limit_call_frames recovery).
+        if ($frame_node_id >= 0 && $ctx->vm_stack_arena_lookup !== []) {
+            $frame_addr = $this->execute_data->getPointer()->address;
+            foreach ($ctx->vm_stack_arena_lookup as [$arena_begin, $arena_end, $arena_node_id]) {
+                if ($frame_addr >= $arena_begin && $frame_addr < $arena_end) {
+                    $ctx->sink->emitReference(
+                        $arena_node_id,
+                        $frame_node_id,
+                        'vm_stack_arena',
+                        EdgeStrength::Weak,
+                    );
+                    break;
+                }
+            }
+        }
 
         // Push jobs for child elements (reverse order for DFS)
 

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJob.php
@@ -193,14 +193,21 @@ final class EmitCallFrameJob implements CollectorJob
         // zvals named-arg `SEND_*` opcodes push per named argument,
         // which are invisible to `zend_vm_calc_used_stack`'s reading
         // of `op_array.T`. Only honor the successor when it sits
-        // ABOVE this frame's reli-computed end AND within a sane
-        // window (capped at sizeof(zend_vm_stack) bytes so a stale
-        // hint that lands in a different arena can't blow the
-        // accounting up).
+        // ABOVE this frame's reli-computed end AND inside the same
+        // arena as this frame: $ctx->vm_stack_arena_lookup is already
+        // populated by collectAll() before any EmitCallFrameJob runs,
+        // so a same-arena check rules out hints that walk into a
+        // neighbouring arena (or into garbage from a corrupted
+        // dump) without leaving any false-negative window for the
+        // legitimate gap.
         if (
             $successor_frame_address !== null
             && $successor_frame_address > $frame_addr + $frame_size
-            && $successor_frame_address - ($frame_addr + $frame_size) < 4096
+            && self::sameArena(
+                $ctx->vm_stack_arena_lookup,
+                $frame_addr,
+                $successor_frame_address,
+            )
         ) {
             $frame_size = $successor_frame_address - $frame_addr;
         }
@@ -216,6 +223,41 @@ final class EmitCallFrameJob implements CollectorJob
             $filename,
             $header_memory_location,
         );
+    }
+
+    /**
+     * Return true when both addresses fall inside the same VM stack
+     * arena according to the lookup table built up-front by
+     * `MemoryLocationsCollector::collectAll()`. When the table is
+     * empty (e.g. no VM stack reachable from EG) the check is a
+     * no-op and returns false; callers should fall back to the
+     * formula-derived size in that case.
+     *
+     * `@internal` — public only for direct unit-test coverage of the
+     * arena gating; production callers should reach the gate through
+     * {@see collectCallFrameHeader()}.
+     *
+     * @param list<array{int, int, int}> $arena_lookup
+     *     Sorted (by begin) list of [arena_begin, arena_end, node_id]
+     *     triples; the node_id is unused here.
+     */
+    public static function sameArena(
+        array $arena_lookup,
+        int $a,
+        int $b,
+    ): bool {
+        foreach ($arena_lookup as [$arena_begin, $arena_end, $_]) {
+            if ($a >= $arena_begin && $a < $arena_end) {
+                return $b >= $arena_begin && $b < $arena_end;
+            }
+            // The lookup table is sorted by arena_begin, so once we
+            // pass an arena that starts above $a, no later arena can
+            // contain $a either.
+            if ($arena_begin > $a) {
+                return false;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFramesJob.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFramesJob.php
@@ -46,16 +46,28 @@ final class EmitCallFramesJob implements CollectorJob
 
         $execute_data = $ctx->dereferencer->deref($this->eg->current_execute_data);
 
-        // Collect all frames as a list, then push them as jobs
+        // Collect all frames as a list, then push them as jobs.
+        // iterateStackChain yields leaf first, then its callers down to
+        // <main> — so $frames[0] is the innermost frame and
+        // $frames[N-1] is the root.
         $frames = [];
         foreach ($execute_data->iterateStackChain($ctx->dereferencer) as $key => $frame) {
             $frames[] = [(string)$key, $frame];
         }
 
-        // Push in reverse order for DFS (first frame processed first)
+        // Each non-leaf frame's true allocated size is
+        // `successor.address - this.address` where `successor` is the
+        // frame it called (= the previous index in the chain order =
+        // higher VM stack address). The leaf has no successor in the
+        // chain; for the active live arena its allocation ends at
+        // EG(vm_stack_top), so use that.
+        $leaf_successor = $this->eg->vm_stack_top?->address;
         for ($i = count($frames) - 1; $i >= 0; $i--) {
             [$key, $frame] = $frames[$i];
-            $queue->push(new EmitCallFrameJob($frame, $parent, $key));
+            $successor = $i === 0
+                ? $leaf_successor
+                : $frames[$i - 1][1]->getPointer()->address;
+            $queue->push(new EmitCallFrameJob($frame, $parent, $key, $successor));
         }
     }
 }

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/UnusedVmStackMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/UnusedVmStackMemoryLocation.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+/**
+ * The unused tail of a VM stack arena — the bytes between the arena's
+ * current `top` and `end`. The arena was emalloc'd as a whole 256 KB
+ * (or whatever ZEND_VM_STACK_PAGE_SIZE evaluates to) block, but only
+ * the `arena_base .. top` range is occupied by frames; the rest is
+ * reserved allocator space that no zend_execute_data owns.
+ *
+ * Sized so that
+ *   Σ CallFrameHeaderMemoryLocation + Σ UnusedVmStackMemoryLocation
+ *   = Σ arena_size
+ * across all live VM stack arenas, with no overlap between any pair
+ * of locations.
+ */
+final class UnusedVmStackMemoryLocation extends MemoryLocation
+{
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/VmStackArenaHeaderMemoryLocation.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocation/VmStackArenaHeaderMemoryLocation.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation;
+
+use Reli\Lib\Process\MemoryLocation;
+
+/**
+ * The `_zend_vm_stack` struct header at the start of every VM stack
+ * arena. Sized at runtime via
+ * `ZendTypeReader::sizeOf('struct _zend_vm_stack')` so any future
+ * field changes track automatically.
+ *
+ * With this location attached, an arena's 256 KB partitions as
+ *   ArenaHeader (struct) + Σ CallFrameHeader + UnusedVmStack
+ * with no overlap.
+ */
+final class VmStackArenaHeaderMemoryLocation extends MemoryLocation
+{
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -912,11 +912,33 @@ final class MemoryLocationsCollector
                         $frames[] = [(string)$frame_no, $execute_data];
                     }
 
-                    // Create a local job queue and push in reverse order for DFS
+                    // Create a local job queue and push in reverse order
+                    // for DFS. The recovered chain is leaf-first
+                    // (frames[0] = innermost, frames[N-1] = root), so each
+                    // frame's "successor" (= what it called, sitting at
+                    // a higher VM stack address) is `frames[i-1]`. The
+                    // leaf has no successor here — we can't recover the
+                    // true post-recovery top so leave it null and fall
+                    // back to the formula-based size. The candidate
+                    // frame in this branch is the one whose op_array
+                    // matched the OOM file/line, which is typically
+                    // deep inside a hot loop, so the leaf undercount
+                    // (if the call to it used named args) stays small
+                    // relative to the chain total.
                     $recovery_queue = new Collector\JobQueue();
                     for ($i = count($frames) - 1; $i >= 0; $i--) {
                         [$frame_key, $frame] = $frames[$i];
-                        $recovery_queue->push(new Collector\Job\EmitCallFrameJob($frame, $parent, $frame_key));
+                        $successor = $i === 0
+                            ? null
+                            : $frames[$i - 1][1]->getPointer()->address;
+                        $recovery_queue->push(
+                            new Collector\Job\EmitCallFrameJob(
+                                $frame,
+                                $parent,
+                                $frame_key,
+                                $successor,
+                            ),
+                        );
                     }
 
                     // Run the recovery queue

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -29,12 +29,15 @@ use Reli\Lib\PhpInternals\ZendTypeReaderCreator;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\UnusedVmStackMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\VmStackMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArenaMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendMmChunkMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendMmHugeListMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\CallFramesContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\UserFunctionDefinitionContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\VmStackArenaContext;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext\VmStackContext;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextAnalyzer;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\ContextAnalyzer\ContextTreeSink;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\RegionAnalyzer\RegionBoundaries;
@@ -272,12 +275,15 @@ final class MemoryLocationsCollector
         $eg = $dereferencer->deref($eg_pointer);
 
         $vm_stack_memory_locations = new MemoryLocations();
+        /** @var list<ZendVmStack> $vm_stack_arenas */
+        $vm_stack_arenas = [];
         if (!is_null($eg->vm_stack)) {
             $vm_stack_curent = $dereferencer->deref($eg->vm_stack);
             foreach ($vm_stack_curent->iterateStackChain($dereferencer) as $vm_stack) {
                 $vm_stack_memory_locations->add(
                     VmStackMemoryLocation::fromZendVmStack($vm_stack),
                 );
+                $vm_stack_arenas[] = $vm_stack;
             }
         }
 
@@ -345,6 +351,87 @@ final class MemoryLocationsCollector
                 }
             }
         );
+
+        // Emit the vm_stack root branch up-front so subsequent
+        // EmitCallFrameJob runs (both the live call_frames chain and
+        // the post-loop memory_limit_call_frames recovery) can attach
+        // a weak `vm_stack_arena` edge from each frame to the arena
+        // it lives in. Per-arena slack (`end - top`) goes onto
+        // VmStackArenaContext as an UnusedVmStackMemoryLocation, so
+        // Σ CallFrameHeaderMemoryLocation + Σ UnusedVmStackMemoryLocation
+        // covers each arena exactly once — no double counting in
+        // heap usage / "% analyzed".
+        if (count($vm_stack_arenas) > 0) {
+            $vm_stack_context = new VmStackContext();
+            $vm_stack_root_id = $ctx->emitNode($vm_stack_context, null, 'vm_stack');
+            $vm_stack_parent = $vm_stack_root_id >= 0 ? $vm_stack_root_id : null;
+            $first_arena = true;
+            foreach ($vm_stack_arenas as $arena_idx => $vm_stack) {
+                $begin = $vm_stack->getPointer()->address;
+                $end = $vm_stack->end?->address ?? $begin;
+                // `_zend_vm_stack::top` is initialised to the arena
+                // base when the arena is created and is only bumped
+                // when a NEW arena is allocated on top of this one
+                // (zend_vm_stack_extend saves the live
+                // EG(vm_stack_top) into the outgoing arena's
+                // struct->top). For inactive arenas down the prev
+                // chain that gives the true high-water mark; for the
+                // ACTIVE arena (the head, first in iteration)
+                // struct->top is still the arena base and the live
+                // cursor lives in EG(vm_stack_top). Mirroring the
+                // convention from
+                // {@see collectRealCallStackOnMemoryLimitViolation()},
+                // take the max so slack on the active arena reflects
+                // PHP's view (`end - eg->vm_stack_top`) instead of
+                // mis-attributing every live frame as slack.
+                $struct_top = $vm_stack->top?->address ?? $begin;
+                if ($first_arena) {
+                    $first_arena = false;
+                    $hwm = max(
+                        $struct_top,
+                        $eg->vm_stack_top?->address ?? $struct_top,
+                    );
+                } else {
+                    $hwm = $struct_top;
+                }
+                // Defensive clamp: if a corrupted dump hands us a
+                // hwm past the arena's own end, treat the whole
+                // arena as fully used. Sub-base hwm collapses slack
+                // to the full arena, which is the right answer for
+                // a freshly-created arena that's seen no frames.
+                $hwm = max($begin, min($hwm, $end));
+                $size = $end - $begin;
+                $slack = $end - $hwm;
+                $arena_context = new VmStackArenaContext(
+                    $begin,
+                    $size,
+                    $size - $slack,
+                    $slack,
+                );
+                if ($slack > 0) {
+                    $arena_context->addLocation(
+                        new UnusedVmStackMemoryLocation($hwm, $slack),
+                    );
+                }
+                $arena_node_id = $ctx->emitNode(
+                    $arena_context,
+                    $vm_stack_parent,
+                    (string)$arena_idx,
+                );
+                if ($arena_node_id >= 0) {
+                    $ctx->vm_stack_arena_lookup[] = [$begin, $end, $arena_node_id];
+                }
+            }
+            // Sort by begin address — the lookup in EmitCallFrameJob
+            // currently scans linearly (a few hundred arenas at most
+            // for a typical process), but a sorted list lets us
+            // upgrade to binary search later without re-touching the
+            // emit side.
+            usort(
+                $ctx->vm_stack_arena_lookup,
+                static fn (array $a, array $b): int => $a[0] <=> $b[0],
+            );
+        }
 
         // Create the job queue
         $queue = new Collector\JobQueue();

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -363,7 +363,7 @@ final class MemoryLocationsCollector
         // covers each arena exactly once — no double counting in
         // heap usage / "% analyzed".
         if (count($vm_stack_arenas) > 0) {
-            $vm_stack_context = new VmStackContext();
+            $vm_stack_context = new VmStackContext(count($vm_stack_arenas));
             $vm_stack_root_id = $ctx->emitNode($vm_stack_context, null, 'vm_stack');
             $vm_stack_parent = $vm_stack_root_id >= 0 ? $vm_stack_root_id : null;
             // sizeof(struct _zend_vm_stack) — pulled from the type

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollector.php
@@ -30,6 +30,7 @@ use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\BinWalkResult;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\BinWalk\ZendMmBinWalker;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\MemoryLocations;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\UnusedVmStackMemoryLocation;
+use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\VmStackArenaHeaderMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\VmStackMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendArenaMemoryLocation;
 use Reli\Lib\PhpProcessReader\PhpMemoryReader\MemoryLocation\ZendMmChunkMemoryLocation;
@@ -365,6 +366,19 @@ final class MemoryLocationsCollector
             $vm_stack_context = new VmStackContext();
             $vm_stack_root_id = $ctx->emitNode($vm_stack_context, null, 'vm_stack');
             $vm_stack_parent = $vm_stack_root_id >= 0 ? $vm_stack_root_id : null;
+            // sizeof(struct _zend_vm_stack) — pulled from the type
+            // reader so future field changes track automatically.
+            // Mirrors the same usage inside
+            // collectRealCallStackOnMemoryLimitViolation() below
+            // and EmitFiberJob.
+            $vm_stack_struct_size = $zend_type_reader->sizeOf(ZendVmStack::getCTypeName());
+            // Frames are pushed at a 16-byte (zval-sized) boundary
+            // beyond the struct header, so a 24-byte struct leaves
+            // an 8-byte alignment gap before the first frame. The
+            // header MemoryLocation covers the struct + that gap
+            // so the arena partitions cleanly into header / frames
+            // / slack with nothing dangling.
+            $arena_header_size = (intdiv($vm_stack_struct_size + 15, 16)) * 16;
             $first_arena = true;
             foreach ($vm_stack_arenas as $arena_idx => $vm_stack) {
                 $begin = $vm_stack->getPointer()->address;
@@ -408,6 +422,19 @@ final class MemoryLocationsCollector
                     $size - $slack,
                     $slack,
                 );
+                // The arena's struct header sits at the very start
+                // of the allocation. Attaching it as its own
+                // MemoryLocation closes the otherwise-unattributed
+                // `Σ struct_size` gap between the per-frame +
+                // per-arena-slack partition and the raw arena size.
+                if ($arena_header_size > 0) {
+                    $arena_context->addLocation(
+                        new VmStackArenaHeaderMemoryLocation(
+                            $begin,
+                            $arena_header_size,
+                        ),
+                    );
+                }
                 if ($slack > 0) {
                     $arena_context->addLocation(
                         new UnusedVmStackMemoryLocation($hwm, $slack),

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackArenaContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackArenaContext.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+/**
+ * One `_zend_vm_stack` arena (an emalloc'd block of
+ * ZEND_VM_STACK_PAGE_SIZE bytes that holds zero or more
+ * zend_execute_data frames).
+ *
+ * Frames live in the {@see CallFramesContext} branch — each frame
+ * gets a CallFrameHeaderMemoryLocation sized to the bytes that
+ * specific frame occupies. The arena itself carries only the
+ * leftover slack (`UnusedVmStackMemoryLocation`, sized
+ * `end - top`), so per-frame and per-arena sizes partition the
+ * arena cleanly with no double counting.
+ *
+ * The link from a frame to its arena is a weak edge labelled
+ * `vm_stack_arena`, emitted by EmitCallFrameJob once the arena
+ * tree is in place.
+ */
+final class VmStackArenaContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+
+    public function __construct(
+        public readonly int $address,
+        public readonly int $size,
+        public readonly int $used,
+        public readonly int $slack,
+    ) {
+    }
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        return [
+            'address' => $this->address,
+            'size' => $this->size,
+            'used' => $this->used,
+            'slack' => $this->slack,
+        ];
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContext.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+/**
+ * Root branch holding the linked list of VM stack arenas
+ * (`_zend_vm_stack` chain reachable from `EG(vm_stack)`).
+ *
+ * Each child is a {@see VmStackArenaContext}. Frames in `call_frames`
+ * / `memory_limit_call_frames` carry a weak (non-tree) edge into the
+ * arena they physically reside in.
+ */
+final class VmStackContext implements ReferenceContext
+{
+    use ReferenceContextDefault;
+
+    #[\Override]
+    public function getContexts(): iterable
+    {
+        return [
+            '#count' => count($this->referencing_contexts),
+        ];
+    }
+}

--- a/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContext.php
+++ b/src/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContext.php
@@ -20,16 +20,28 @@ namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
  * Each child is a {@see VmStackArenaContext}. Frames in `call_frames`
  * / `memory_limit_call_frames` carry a weak (non-tree) edge into the
  * arena they physically reside in.
+ *
+ * The `arena_count` is passed in by the collector rather than read
+ * from `$referencing_contexts`: the children are wired up via
+ * `$ctx->emitNode($arena_context, $vm_stack_parent, ...)` instead of
+ * `$vm_stack_context->add(...)`, so the trait-backed slot stays
+ * empty and a `count($this->referencing_contexts)` here would always
+ * read zero.
  */
 final class VmStackContext implements ReferenceContext
 {
     use ReferenceContextDefault;
 
+    public function __construct(
+        public readonly int $arena_count = 0,
+    ) {
+    }
+
     #[\Override]
     public function getContexts(): iterable
     {
         return [
-            '#count' => count($this->referencing_contexts),
+            '#count' => $this->arena_count,
         ];
     }
 }

--- a/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataGetTotalVariablesNumTest.php
+++ b/tests/Lib/PhpInternals/Types/Zend/ZendExecuteDataGetTotalVariablesNumTest.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpInternals\Types\Zend;
+
+use FFI;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Reli\Lib\PhpInternals\VersionedPointedTypeResolver;
+use Reli\Lib\PhpInternals\ZendTypeReader;
+use Reli\Lib\Process\Pointer\Dereferencer;
+use Reli\Lib\Process\Pointer\Pointer;
+
+/**
+ * Covers {@see ZendExecuteData::getTotalVariablesNum()}.
+ *
+ * The historical formula `last_var + T + (real_arg_num - arg_num)`
+ * went negative whenever a call site omitted optional arguments — a
+ * function declared `f($a, $b = null)` called as `f(1)` would report
+ * `last_var + T - 1`, undercounting the variable table size by one
+ * zval for every missing declared parameter. PHP's own
+ * `zend_vm_calc_used_stack` clamps the extra term via
+ * `MIN(arg_num, num_args)`, so the corrected formula here uses
+ * `max(0, real_arg_num - arg_num)`. The cases below pin that
+ * behaviour:
+ *
+ *   - normal call (real == declared)
+ *   - call passing MORE args than declared (e.g. variadic)
+ *   - call passing FEWER args than declared (optional args omitted)
+ *   - internal function (formula bypassed; returns This.u2.num_args)
+ *   - null `func` (returns 0)
+ */
+class ZendExecuteDataGetTotalVariablesNumTest extends TestCase
+{
+    private const PHP_VERSION = ZendTypeReader::V84;
+    /** Pretend address for the synthetic function pointer. */
+    private const FAKE_FUNC_PTR_ADDR = 0x10000;
+
+    /**
+     * Build a `zend_execute_data` whose `func` points at our synthetic
+     * address and whose `This.u2.num_args` equals the given count. The
+     * returned object is paired with the dereferencer that resolves
+     * `func` to a synthetic ZendFunction with the requested op_array
+     * fields.
+     *
+     * @return array{ZendExecuteData, Dereferencer}
+     */
+    private function makePair(
+        ZendTypeReader $reader,
+        int $real_arg_num,
+        ?int $func_type,
+        ?int $func_last_var = null,
+        ?int $func_T = null,
+        ?int $func_num_args = null,
+    ): array {
+        $size = $reader->sizeOf('zend_execute_data');
+        [$this_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'This');
+        [$func_offset] = $reader->getOffsetAndSizeOfMember('zend_execute_data', 'func');
+
+        $raw = FFI::cdef()->new("unsigned char[{$size}]");
+
+        // This is a zval (16 B): value (8) + u1 (4) + u2 (4). num_args lives in u2.
+        $u2 = pack('V', $real_arg_num);
+        for ($b = 0; $b < 4; $b++) {
+            $raw[$this_offset + 12 + $b] = ord($u2[$b]);
+        }
+
+        // func is a pointer (8 B).
+        $func_ptr_bytes = ($func_type !== null)
+            ? pack('P', self::FAKE_FUNC_PTR_ADDR)
+            : pack('P', 0);
+        for ($b = 0; $b < 8; $b++) {
+            $raw[$func_offset + $b] = ord($func_ptr_bytes[$b]);
+        }
+
+        $casted = $reader->readAs('zend_execute_data', $raw);
+        $execute_data = ZendExecuteData::fromCastedCDataWithResolver(
+            $casted,
+            new Pointer(ZendExecuteData::class, 0x1000, $size),
+            new VersionedPointedTypeResolver(self::PHP_VERSION),
+        );
+
+        $dereferencer = $func_type === null
+            ? $this->createStub(Dereferencer::class)
+            : $this->stubDereferencerReturning(
+                $this->makeFunction(
+                    $reader,
+                    $func_type,
+                    $func_last_var ?? 0,
+                    $func_T ?? 0,
+                    $func_num_args ?? 0,
+                ),
+            );
+
+        return [$execute_data, $dereferencer];
+    }
+
+    private function stubDereferencerReturning(ZendFunction $function): Dereferencer
+    {
+        $stub = $this->createStub(Dereferencer::class);
+        $stub->method('deref')->willReturn($function);
+        return $stub;
+    }
+
+    private function makeFunction(
+        ZendTypeReader $reader,
+        int $type,
+        int $last_var,
+        int $T,
+        int $num_args,
+    ): ZendFunction {
+        $size = $reader->sizeOf('zend_function');
+        $raw = FFI::cdef()->new("unsigned char[{$size}]");
+
+        // type lives at offset 0 of zend_function (common header byte).
+        $raw[0] = $type;
+
+        // op_array fields. Use the union's `op_array` member offset 0
+        // since zend_function is a union — op_array starts at the same
+        // base address as the union itself; its inner fields are
+        // located via the offset-of-member lookup on `zend_op_array`.
+        [$last_var_off] = $reader->getOffsetAndSizeOfMember('zend_op_array', 'last_var');
+        [$T_off] = $reader->getOffsetAndSizeOfMember('zend_op_array', 'T');
+        [$num_args_off] = $reader->getOffsetAndSizeOfMember('zend_op_array', 'num_args');
+
+        $writeU32 = static function (int $offset, int $value) use ($raw): void {
+            $bytes = pack('V', $value);
+            for ($b = 0; $b < 4; $b++) {
+                $raw[$offset + $b] = ord($bytes[$b]);
+            }
+        };
+        $writeU32($last_var_off, $last_var);
+        $writeU32($T_off, $T);
+        $writeU32($num_args_off, $num_args);
+
+        $casted = $reader->readAs('zend_function', $raw);
+        return new ZendFunction(
+            $casted,
+            new Pointer(ZendFunction::class, self::FAKE_FUNC_PTR_ADDR, $size),
+        );
+    }
+
+    public function testReturnsZeroWhenFuncIsNull(): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair($reader, real_arg_num: 3, func_type: null);
+
+        $this->assertSame(0, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+
+    public function testInternalFunctionReturnsRealArgNum(): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair(
+            $reader,
+            real_arg_num: 4,
+            func_type: ZendFunction::ZEND_INTERNAL_FUNCTION,
+        );
+
+        // Internal calls skip the formula and just report what the
+        // caller pushed.
+        $this->assertSame(4, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+
+    public function testUserFunctionWithExactArgs(): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair(
+            $reader,
+            real_arg_num: 2,
+            func_type: ZendFunction::ZEND_USER_FUNCTION,
+            func_last_var: 5,
+            func_T: 3,
+            func_num_args: 2,
+        );
+
+        // real == declared: extra is 0; total = last_var + T.
+        $this->assertSame(5 + 3, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+
+    public function testUserFunctionWithMoreArgsThanDeclared(): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair(
+            $reader,
+            real_arg_num: 5,
+            func_type: ZendFunction::ZEND_USER_FUNCTION,
+            func_last_var: 3,
+            func_T: 2,
+            func_num_args: 3,
+        );
+
+        // real > declared: extra = real - declared = 2; total = 3 + 2 + 2.
+        $this->assertSame(3 + 2 + 2, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+
+    /**
+     * The bug this guards against: the historical formula went
+     * negative on optional-arg-omission and undercounted the variable
+     * table, surfacing as inter-frame gaps in VM stack accounting.
+     */
+    public function testUserFunctionWithFewerArgsThanDeclaredDoesNotShrink(): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair(
+            $reader,
+            real_arg_num: 1,
+            func_type: ZendFunction::ZEND_USER_FUNCTION,
+            func_last_var: 5,
+            func_T: 4,
+            func_num_args: 5,
+        );
+
+        // real < declared: extra clamps to 0; total stays at
+        // last_var + T regardless of how many optional args were
+        // omitted. The pre-fix formula returned 5 + 4 + (1 - 5) = 5.
+        $this->assertSame(5 + 4, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+
+    /**
+     * @return iterable<string, array{int, int, int, int, int}>
+     *     [real_arg_num, last_var, T, num_args, expected]
+     */
+    public static function variantsProvider(): iterable
+    {
+        // Single optional omission: f($a, $b = null) called as f(1).
+        yield 'single optional omitted'         => [1, 2, 1, 2, 3];
+        // Multiple optionals omitted: f($a, $b = null, $c = null, $d = null) as f(1).
+        yield 'many optionals omitted'          => [1, 4, 2, 4, 6];
+        // Exact match.
+        yield 'exact match'                     => [3, 3, 5, 3, 8];
+        // Extra positional / variadic overflow.
+        yield 'one extra arg'                   => [4, 3, 2, 3, 6];
+        // No CVs at all (no params, no locals): still includes T.
+        yield 'no CVs at all, only T'           => [0, 0, 1, 0, 1];
+        // Caller passes args to a no-arg function (rare; e.g. dispatch trampoline).
+        yield 'overflow on no-arg declaration'  => [3, 0, 0, 0, 3];
+    }
+
+    #[DataProvider('variantsProvider')]
+    public function testFormulaVariants(int $real, int $last_var, int $T, int $num_args, int $expected): void
+    {
+        $reader = new ZendTypeReader(self::PHP_VERSION);
+        [$execute_data, $dereferencer] = $this->makePair(
+            $reader,
+            real_arg_num: $real,
+            func_type: ZendFunction::ZEND_USER_FUNCTION,
+            func_last_var: $last_var,
+            func_T: $T,
+            func_num_args: $num_args,
+        );
+
+        $this->assertSame($expected, $execute_data->getTotalVariablesNum($dereferencer));
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJobSameArenaTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/Collector/Job/EmitCallFrameJobSameArenaTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\Collector\Job;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the arena gating used by
+ * {@see EmitCallFrameJob::collectCallFrameHeader()} when sizing a
+ * frame from its successor's address. The gating must reject any
+ * successor that lands outside the frame's own arena — a 4096 B
+ * window alone would not catch the case where two arenas happen to
+ * sit adjacently in address space.
+ */
+class EmitCallFrameJobSameArenaTest extends TestCase
+{
+    /**
+     * Build a lookup table of (arena_begin, arena_end, node_id)
+     * triples, sorted by begin.
+     *
+     * @param list<array{int, int}> $arenas pairs of [begin, size]
+     * @return list<array{int, int, int}>
+     */
+    private function lookup(array $arenas): array
+    {
+        $rows = [];
+        $id = 1;
+        foreach ($arenas as [$begin, $size]) {
+            $rows[] = [$begin, $begin + $size, $id++];
+        }
+        usort($rows, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+        return $rows;
+    }
+
+    public function testEmptyLookupNeverMatches(): void
+    {
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena([], 0x1000, 0x1100),
+        );
+    }
+
+    public function testBothInSameArenaIsTrue(): void
+    {
+        $lookup = $this->lookup([
+            [0x1000, 0x200],
+            [0x2000, 0x200],
+        ]);
+
+        $this->assertTrue(
+            EmitCallFrameJob::sameArena($lookup, 0x1050, 0x1100),
+        );
+        $this->assertTrue(
+            EmitCallFrameJob::sameArena($lookup, 0x2010, 0x2150),
+        );
+    }
+
+    public function testCrossArenaIsFalseEvenWhenAdjacent(): void
+    {
+        // Two arenas sitting immediately next to each other: the
+        // successor sits 16 bytes (= one zval) into the next arena.
+        // The 4096 B window alone would accept this; the same-arena
+        // gate must reject it.
+        $lookup = $this->lookup([
+            [0x1000, 0x100],
+            [0x1100, 0x100],
+        ]);
+
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena($lookup, 0x10f0, 0x1110),
+        );
+    }
+
+    public function testAddressBelowAllArenasIsFalse(): void
+    {
+        $lookup = $this->lookup([
+            [0x2000, 0x100],
+        ]);
+
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena($lookup, 0x1000, 0x1100),
+        );
+    }
+
+    public function testAddressAboveAllArenasIsFalse(): void
+    {
+        $lookup = $this->lookup([
+            [0x1000, 0x100],
+        ]);
+
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena($lookup, 0x9000, 0x9100),
+        );
+    }
+
+    public function testFrameInsideButSuccessorInsideADifferentArenaIsFalse(): void
+    {
+        $lookup = $this->lookup([
+            [0x1000, 0x100],
+            [0x5000, 0x100],
+        ]);
+
+        // Frame sits inside the first arena; successor sits inside
+        // the second. Same-arena gate must reject this even though
+        // both addresses are inside *some* tracked arena.
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena($lookup, 0x1050, 0x5050),
+        );
+    }
+
+    public function testSuccessorAtExclusiveEndBoundaryIsFalse(): void
+    {
+        // The end address is exclusive ([begin, end)).
+        $lookup = $this->lookup([
+            [0x1000, 0x100],
+        ]);
+
+        $this->assertFalse(
+            EmitCallFrameJob::sameArena($lookup, 0x1080, 0x1100),
+        );
+    }
+
+    public function testFrameAtBeginAndSuccessorJustInsideIsTrue(): void
+    {
+        $lookup = $this->lookup([
+            [0x1000, 0x100],
+        ]);
+
+        $this->assertTrue(
+            EmitCallFrameJob::sameArena($lookup, 0x1000, 0x10ff),
+        );
+    }
+}

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -4056,4 +4056,255 @@ class MemoryLocationsCollectorTest extends BaseTestCase
 
         return null;
     }
+
+    /**
+     * Pins the `vm_stack` root branch shape added in PR #821:
+     *
+     *   - root → `vm_stack` (VmStackContext) with `#count` set to the
+     *     number of live arenas;
+     *   - each arena child carries a VmStackArenaHeaderMemoryLocation
+     *     for the struct + alignment-padded prefix;
+     *   - any arena with bytes between EG(vm_stack_top) and arena.end
+     *     carries an UnusedVmStackMemoryLocation for that tail;
+     *   - every emitted CallFrameContext in `call_frames` carries a
+     *     weak `vm_stack_arena` edge into one of the arena nodes.
+     *
+     * The target script intentionally exercises a NAMED-ARG call so
+     * the per-frame size from successor-address sizing actually kicks
+     * in (positional calls would happen to produce a clean partition
+     * even without it).
+     */
+    #[DataProvider('provideFromV80')]
+    public function testVmStackRootBranchAndArenaWeakEdges(
+        string $php_version,
+        string $docker_image_name,
+    ): void {
+        if ($php_version === 'skip') {
+            $this->markTestSkipped('No matching PHP versions for this target set');
+        }
+        $memory_reader = new MemoryReader();
+        $type_reader_creator = new ZendTypeReaderCreator();
+
+        $target_script =
+            <<<'CODE'
+            <?php
+            function consume(int $a, ?int $b = null, ?int $c = null): void {
+                fputs(STDOUT, "a\n");
+                fgets(STDIN);
+            }
+            // Named-arg call so successor-address sizing is exercised:
+            // PHP pushes one extra zval per named arg past last_var + T.
+            consume(a: 1, b: 2);
+            CODE
+        ;
+        $pipes = [];
+        [$this->child, $pid] = TargetPhpVmProvider::runScriptViaContainer(
+            $docker_image_name,
+            $target_script,
+            $pipes
+        );
+        [$ready, $seen] = TargetPhpVmProvider::waitForMarkerLine($pipes[1], 'a');
+        $this->assertTrue($ready, "child did not print 'a'. Got: " . var_export($seen, true));
+
+        $php_symbol_reader_creator = new PhpSymbolReaderCreator(
+            new ProcessModuleSymbolReaderCreator(
+                new Elf64SymbolResolverCreator(
+                    new CatFileReader(),
+                    new Elf64Parser(
+                        new LittleEndianReader()
+                    )
+                ),
+                $memory_reader,
+                new PerBinarySymbolCacheRetriever(),
+                new LittleEndianReader(),
+                new LinkMapLoader(
+                    $memory_reader,
+                    new LittleEndianReader()
+                ),
+                new ContainerAwarePathResolver(),
+                $binary_analysis_cache = new BinaryAnalysisCache(
+                    sys_get_temp_dir() . '/reli-test-' . uniqid()
+                ),
+            ),
+            $process_memory_map_creator = ProcessMemoryMapCreator::create(),
+            $binary_analysis_cache,
+            new ProcExeReadlinkResolver(),
+        );
+        $memory_reader_for_finder = new MemoryReader();
+        $integer_reader = new LittleEndianReader();
+        $binary_fingerprint_creator = new BinaryFingerprintCreator($memory_reader_for_finder);
+        $tsrm_globals_resolver = new TsrmGlobalsResolver(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+        $tsrm_ls_cache_finder = new PhpTsrmLsCacheFinder(
+            $php_symbol_reader_creator,
+            $tsrm_globals_resolver,
+            $memory_reader_for_finder,
+            $integer_reader,
+            new Elf64Parser($integer_reader),
+            new CatFileReader(),
+            ProcessMemoryMapCreator::create(),
+            new ContainerAwarePathResolver(),
+            new ZendTypeReaderCreator(),
+            $binary_analysis_cache,
+            $binary_fingerprint_creator,
+        );
+        $php_globals_finder = new PhpGlobalsFinder(
+            $php_symbol_reader_creator,
+            $integer_reader,
+            $memory_reader_for_finder,
+            $tsrm_ls_cache_finder,
+            $tsrm_globals_resolver,
+            $binary_analysis_cache,
+            $process_memory_map_creator,
+            $binary_fingerprint_creator,
+        );
+
+        $executor_globals_address = $php_globals_finder->findExecutorGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+        $compiler_globals_address = $php_globals_finder->findCompilerGlobals(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version)
+        );
+
+        $memory_locations_collector = new MemoryLocationsCollector(
+            $memory_reader,
+            $type_reader_creator,
+            new PhpZendMemoryManagerChunkFinder(
+                ProcessMemoryMapCreator::create(),
+                $type_reader_creator,
+                $php_globals_finder
+            ),
+            ProcessMemoryMapCreator::create(),
+            new BinaryAnalysisCache(sys_get_temp_dir()),
+            new ContainerAwarePathResolver(),
+        );
+        $sink = new ArrayContextTreeSink();
+        $memory_locations_collector->collectAll(
+            new ProcessSpecifier($pid),
+            new TargetPhpSettings(php_version: $php_version),
+            $executor_globals_address,
+            $compiler_globals_address,
+            null,
+            null,
+            $sink,
+        );
+
+        $contexts = $sink->getResult();
+
+        // 1. vm_stack root branch must exist and be a VmStackContext.
+        $this->assertArrayHasKey(
+            'vm_stack',
+            $contexts,
+            'vm_stack must appear as a root branch'
+        );
+        $vm_stack = $contexts['vm_stack'];
+        $this->assertSame('VmStackContext', $vm_stack['#type'] ?? null);
+        $this->assertIsInt($vm_stack['#count'] ?? null);
+        $this->assertGreaterThan(
+            0,
+            $vm_stack['#count'],
+            'VmStackContext must report at least one live arena'
+        );
+
+        // 2. Each arena child must be a VmStackArenaContext carrying a
+        //    VmStackArenaHeaderMemoryLocation. At least one arena
+        //    should also carry an UnusedVmStackMemoryLocation (the
+        //    active arena's tail is empty space until the next push).
+        $arena_count = 0;
+        $arenas_with_header = 0;
+        $arenas_with_slack = 0;
+        $arena_node_ids = [];
+        foreach ($vm_stack as $key => $arena) {
+            if (!is_array($arena) || str_starts_with((string)$key, '#')) {
+                continue;
+            }
+            $arena_count++;
+            $this->assertSame('VmStackArenaContext', $arena['#type'] ?? null);
+            $arena_node_ids[(int)$arena['#node_id']] = true;
+            foreach ($arena['#locations'] ?? [] as $location) {
+                $short = (new \ReflectionClass($location))->getShortName();
+                if ($short === 'VmStackArenaHeaderMemoryLocation') {
+                    $arenas_with_header++;
+                }
+                if ($short === 'UnusedVmStackMemoryLocation') {
+                    $arenas_with_slack++;
+                }
+            }
+        }
+        $this->assertGreaterThan(0, $arena_count, 'at least one arena child');
+        $this->assertSame(
+            $arena_count,
+            $arenas_with_header,
+            'every arena must carry a VmStackArenaHeaderMemoryLocation'
+        );
+        $this->assertGreaterThan(
+            0,
+            $arenas_with_slack,
+            'at least one arena (typically the active one) must carry'
+            . ' an UnusedVmStackMemoryLocation for the tail bytes'
+        );
+
+        // 3. Every CallFrameContext in `call_frames` must carry a weak
+        //    `vm_stack_arena` edge into one of the emitted arenas.
+        $this->assertArrayHasKey(
+            'call_frames',
+            $contexts,
+            'call_frames root branch must exist'
+        );
+        $frames_seen = 0;
+        $weak_arena_edges = 0;
+        $weak_arena_edges_to_known_arena = 0;
+        $walk = static function (array $node) use (
+            &$walk,
+            &$frames_seen,
+            &$weak_arena_edges,
+            &$weak_arena_edges_to_known_arena,
+            $arena_node_ids,
+        ): void {
+            foreach ($node as $key => $value) {
+                if (!is_array($value) || str_starts_with((string)$key, '#')) {
+                    continue;
+                }
+                if (($value['#type'] ?? null) === 'CallFrameContext') {
+                    $frames_seen++;
+                    $edge = $value['vm_stack_arena'] ?? null;
+                    if (is_array($edge)) {
+                        if (($edge['#edge_strength'] ?? null) === 'weak'
+                            && isset($edge['#reference_node_id'])
+                        ) {
+                            $weak_arena_edges++;
+                            if (isset($arena_node_ids[(int)$edge['#reference_node_id']])) {
+                                $weak_arena_edges_to_known_arena++;
+                            }
+                        }
+                    }
+                }
+                $walk($value);
+            }
+        };
+        $walk($contexts['call_frames']);
+        $this->assertGreaterThan(
+            0,
+            $frames_seen,
+            'call_frames must contain at least one CallFrameContext'
+        );
+        $this->assertSame(
+            $frames_seen,
+            $weak_arena_edges,
+            'every CallFrameContext must carry a weak vm_stack_arena edge'
+        );
+        $this->assertSame(
+            $frames_seen,
+            $weak_arena_edges_to_known_arena,
+            'every weak vm_stack_arena edge must target a known arena node'
+        );
+    }
 }

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/MemoryLocationsCollectorTest.php
@@ -4277,7 +4277,8 @@ class MemoryLocationsCollectorTest extends BaseTestCase
                     $frames_seen++;
                     $edge = $value['vm_stack_arena'] ?? null;
                     if (is_array($edge)) {
-                        if (($edge['#edge_strength'] ?? null) === 'weak'
+                        if (
+                            ($edge['#edge_strength'] ?? null) === 'weak'
                             && isset($edge['#reference_node_id'])
                         ) {
                             $weak_arena_edges++;

--- a/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContextTest.php
+++ b/tests/Lib/PhpProcessReader/PhpMemoryReader/ReferenceContext/VmStackContextTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the reliforp/reli-prof package.
+ *
+ * (c) sji <sji@sj-i.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Reli\Lib\PhpProcessReader\PhpMemoryReader\ReferenceContext;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the `#count` attribute on {@see VmStackContext} to the
+ * constructor-supplied value. The arena children are emitted via
+ * `$ctx->emitNode($arena_context, $vm_stack_parent, ...)` rather than
+ * `$vm_stack_context->add(...)`, so the trait-backed
+ * `$referencing_contexts` slot stays empty and a
+ * `count($this->referencing_contexts)` here would always read zero.
+ */
+class VmStackContextTest extends TestCase
+{
+    public function testDefaultCountIsZero(): void
+    {
+        $context = new VmStackContext();
+        $this->assertSame(
+            ['#count' => 0],
+            iterator_to_array((function (iterable $iterable): \Generator {
+                yield from $iterable;
+            })($context->getContexts())),
+        );
+    }
+
+    public function testCountReflectsConstructorArg(): void
+    {
+        $context = new VmStackContext(arena_count: 192);
+        $attrs = (function (iterable $i): array {
+            $out = [];
+            foreach ($i as $k => $v) {
+                $out[$k] = $v;
+            }
+            return $out;
+        })($context->getContexts());
+
+        $this->assertSame(192, $attrs['#count'] ?? null);
+    }
+
+    public function testCountIsIndependentOfAddedReferences(): void
+    {
+        // Even if a caller wires children through the trait's add()
+        // API (production code does NOT — it uses emitNode against the
+        // sink directly), the attribute should still come from the
+        // constructor argument, since that is the authoritative count
+        // collectAll() recorded.
+        $context = new VmStackContext(arena_count: 3);
+        $stub = $this->createStub(ReferenceContext::class);
+        $context->add('0', $stub);
+        $context->add('1', $stub);
+
+        $attrs = iterator_to_array((function (iterable $i): \Generator {
+            yield from $i;
+        })($context->getContexts()));
+        $this->assertSame(3, $attrs['#count']);
+    }
+}


### PR DESCRIPTION
## Summary

This change improves memory accounting for PHP's VM stack by introducing explicit tracking of VM stack arenas and refining how call frame sizes are calculated. It adds a new tree branch for VM stack arenas with weak edges from frames to their containing arenas, enabling accurate per-frame and per-arena slack accounting without double-counting.

## Key Changes

- **VM Stack Arena Tracking**: Introduced `VmStackContext` and `VmStackArenaContext` to represent the linked list of VM stack arenas and individual arenas respectively. Each arena is emitted as a tree node with metadata (address, size, used, slack).

- **Arena Header and Slack Locations**: Added `VmStackArenaHeaderMemoryLocation` and `UnusedVmStackMemoryLocation` to partition each arena into:
  - Struct header (sized from ZendTypeReader)
  - Per-frame allocations (via CallFrameHeaderMemoryLocation)
  - Unused slack (end - top)
  
  This ensures `Σ frame_sizes + Σ slack = arena_size` with no overlap or gaps.

- **Weak Arena References**: Modified `EmitCallFrameJob` to emit weak (non-tree) edges from each call frame to the VM stack arena it physically resides in. The arena lookup table is populated up-front by `MemoryLocationsCollector::collectAll()` before any frame jobs run.

- **Improved Frame Size Calculation**: Enhanced `EmitCallFrameJob::collectCallFrameHeader()` to accept an optional `$successor_frame_address` parameter. When provided, the frame size is extended to cover any allocations PHP made past the computed variable table end (e.g., extra zvals for named arguments), capped at a sane window to prevent corruption from affecting accounting.

- **Call Frame Chain Tracking**: Updated `EmitCallFramesJob` and memory limit violation recovery in `MemoryLocationsCollector` to pass successor frame addresses through the job queue, enabling accurate size calculation for all frames in both the live call stack and recovered OOM chains.

- **Variable Count Fix**: Corrected `ZendExecuteData::getTotalVariablesNum()` to clamp extra argument count to zero, fixing undercounting when call sites omit optional parameters.

## Implementation Details

- Arena lookup is stored as a sorted list of `[begin, end, node_id]` tuples in `CollectorContext::vm_stack_arena_lookup`, allowing linear scan for typical process arena counts (tens to a few hundred).
- The active arena's slack is computed using `max(struct_top, eg->vm_stack_top)` to reflect PHP's actual view rather than the struct's stale base pointer.
- Defensive clamping prevents corrupted dumps from causing accounting errors (e.g., hwm past arena end collapses slack to full arena).
- The recovered call frame chain from memory limit violations is leaf-first, so successor addresses are computed as `frames[i-1]` for non-leaf frames.

https://claude.ai/code/session_01UAKUXCXb9rdGEw5TuhEwDF